### PR TITLE
[decimal][bench] change return type of `coefficient()` to UInt128 + add benches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,7 @@ magic.lock
 tempCodeRunnerFile.mojo
 # macOS environments
 .DS_Store
+# log files
+*.log
 # local files
 /test*.mojo

--- a/README.md
+++ b/README.md
@@ -262,6 +262,13 @@ var area = pi * (radius ** 2)
 print("Circle area: " + String(area))  # Precisely calculated area
 ```
 
+## Tests and benches
+
+After cloning the repo onto your local disk, you can:
+
+- Use `magic run test` (or `maigic run t`) to run tests.
+- Use `magic run bench` (or `magic run b`) to generate logs for benchmarking tests agains `python.decimal` module. The log files are saved in `benches/logs/`.
+
 ## Related Projects
 
 I am also working on NuMojo, a library for numerical computing in Mojo 🔥 similar to NumPy, SciPy in Python. If you are also interested, you can [check it out here](https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo).

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project draws inspiration from several established decimal implementations 
 
 ## Status
 
-Rome is not built in one day. DeciMojo is currently under active development and appears to be between the **"make it work"** and **"make it right"** phases, leaning more toward the latter. Contributions, bug reports, and feature requests are welcome! If you encounter issues, please [file them here](https://github.com/forFudan/decimojo/issues).
+Rome is not built in one day. DeciMojo is currently under active development and appears to be between the **"make it work"** and **"make it right"** phases, leaning more toward the latter. Bug reports and feature requests are welcome! If you encounter issues, please [file them here](https://github.com/forFudan/decimojo/issues).
 
 ### Make it Work ✅ (MOSTLY COMPLETED)
 

--- a/benches/bench.mojo
+++ b/benches/bench.mojo
@@ -1,0 +1,11 @@
+from bench_add import main as bench_add
+from bench_subtract import main as bench_subtract
+from bench_multiply import main as bench_multiply
+from bench_divide import main as bench_divide
+
+
+fn main() raises:
+    bench_add()
+    bench_subtract()
+    bench_multiply()
+    bench_divide()

--- a/benches/bench_add.mojo
+++ b/benches/bench_add.mojo
@@ -1,0 +1,308 @@
+"""
+Comprehensive benchmarks for Decimal addition operations.
+Compares performance against Python's decimal module.
+"""
+
+from decimojo.prelude import *
+from python import Python, PythonObject
+from time import perf_counter_ns
+import time
+import os
+
+
+fn open_log_file() raises -> PythonObject:
+    """
+    Creates and opens a log file with a timestamp in the filename.
+
+    Returns:
+        A file object opened for writing.
+    """
+    var python = Python.import_module("builtins")
+
+    # Create logs directory with in /benches if it doesn't exist
+    var log_dir = "./logs"
+    if not os.path.exists(log_dir):
+        os.makedirs(log_dir)
+
+    # Generate a timestamp for the filename
+    var timestamp = String(time.perf_counter())
+    var log_filename = log_dir + "/benchmark_add_" + timestamp + ".log"
+
+    print("Saving benchmark results to:", log_filename)
+    return python.open(log_filename, "w")
+
+
+fn log_print(msg: String, log_file: PythonObject) raises:
+    """
+    Prints a message to both the console and the log file.
+
+    Args:
+        msg: The message to print.
+        log_file: The file object to write to.
+    """
+    print(msg)
+    log_file.write(msg + "\n")
+    log_file.flush()  # Ensure the message is written immediately
+
+
+fn run_benchmark(
+    name: String,
+    a_mojo: Decimal,
+    b_mojo: Decimal,
+    a_py: PythonObject,
+    b_py: PythonObject,
+    iterations: Int,
+    log_file: PythonObject,
+) raises:
+    """
+    Run a benchmark comparing Mojo Decimal addition with Python Decimal addition.
+
+    Args:
+        name: Name of the benchmark case.
+        a_mojo: First Mojo Decimal operand.
+        b_mojo: Second Mojo Decimal operand.
+        a_py: First Python Decimal operand.
+        b_py: Second Python Decimal operand.
+        iterations: Number of 1000-iteration runs to average.
+        log_file: File object for logging results.
+    """
+    log_print("\nBenchmark:       " + name, log_file)
+
+    # Verify correctness
+    var mojo_result = a_mojo + b_mojo
+    var py_result = a_py + b_py
+    log_print("Mojo result:     " + String(mojo_result), log_file)
+    log_print("Python result:   " + String(py_result), log_file)
+
+    # Benchmark Mojo implementation
+    var t0 = perf_counter_ns()
+    for _ in range(iterations):
+        _ = a_mojo + b_mojo
+    var mojo_time = (perf_counter_ns() - t0) / iterations
+
+    # Benchmark Python implementation
+    t0 = perf_counter_ns()
+    for _ in range(iterations):
+        _ = a_py + b_py
+    var python_time = (perf_counter_ns() - t0) / iterations
+
+    # Print results with speedup comparison
+    log_print(
+        "Mojo Decimal:    " + String(mojo_time) + " ns per iterations",
+        log_file,
+    )
+    log_print(
+        "Python Decimal:  " + String(python_time) + " ns per iteration",
+        log_file,
+    )
+    log_print("Speedup factor:  " + String(python_time / mojo_time), log_file)
+
+
+fn main() raises:
+    # Open log file
+    var log_file = open_log_file()
+
+    # Display benchmark header with system information
+    log_print("=== DeciMojo Addition Benchmark ===", log_file)
+    log_print("Time: " + String(time.perf_counter()), log_file)
+
+    # Try to get system info
+    try:
+        var platform = Python.import_module("platform")
+        log_print(
+            "System: "
+            + String(platform.system())
+            + " "
+            + String(platform.release()),
+            log_file,
+        )
+        log_print("Processor: " + String(platform.processor()), log_file)
+        log_print(
+            "Python version: " + String(platform.python_version()), log_file
+        )
+    except:
+        log_print("Could not retrieve system information", log_file)
+
+    var iterations = 1000
+    var pydecimal = Python().import_module("decimal")
+
+    # Set Python decimal precision to match Mojo's
+    pydecimal.getcontext().prec = 28
+    log_print(
+        "Python decimal precision: " + String(pydecimal.getcontext().prec),
+        log_file,
+    )
+    log_print(
+        "Mojo decimal precision: " + String(Decimal.MAX_PRECISION), log_file
+    )
+
+    # Define benchmark cases
+    log_print(
+        "\nRunning addition benchmarks with "
+        + String(iterations)
+        + " iterations each",
+        log_file,
+    )
+
+    # Case 1: Simple integers
+    var case1_a_mojo = Decimal("12345")
+    var case1_b_mojo = Decimal("67890")
+    var case1_a_py = pydecimal.Decimal("12345")
+    var case1_b_py = pydecimal.Decimal("67890")
+    run_benchmark(
+        "Simple integers",
+        case1_a_mojo,
+        case1_b_mojo,
+        case1_a_py,
+        case1_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 2: Simple decimals (few decimal places)
+    var case2_a_mojo = Decimal("123.45")
+    var case2_b_mojo = Decimal("67.89")
+    var case2_a_py = pydecimal.Decimal("123.45")
+    var case2_b_py = pydecimal.Decimal("67.89")
+    run_benchmark(
+        "Simple decimals",
+        case2_a_mojo,
+        case2_b_mojo,
+        case2_a_py,
+        case2_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 3: High-precision decimals
+    var case3_a_mojo = Decimal("0.123456789012345678901234567")
+    var case3_b_mojo = Decimal("0.987654321098765432109876543")
+    var case3_a_py = pydecimal.Decimal("0.123456789012345678901234567")
+    var case3_b_py = pydecimal.Decimal("0.987654321098765432109876543")
+    run_benchmark(
+        "High-precision decimals",
+        case3_a_mojo,
+        case3_b_mojo,
+        case3_a_py,
+        case3_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 4: Different scales
+    var case4_a_mojo = Decimal("123.4")
+    var case4_b_mojo = Decimal("67.89")
+    var case4_a_py = pydecimal.Decimal("123.4")
+    var case4_b_py = pydecimal.Decimal("67.89")
+    run_benchmark(
+        "Different scales",
+        case4_a_mojo,
+        case4_b_mojo,
+        case4_a_py,
+        case4_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 5: Numbers requiring carrying
+    var case5_a_mojo = Decimal("999.99")
+    var case5_b_mojo = Decimal("0.01")
+    var case5_a_py = pydecimal.Decimal("999.99")
+    var case5_b_py = pydecimal.Decimal("0.01")
+    run_benchmark(
+        "Numbers requiring carrying",
+        case5_a_mojo,
+        case5_b_mojo,
+        case5_a_py,
+        case5_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 6: Very large numbers
+    var case6_a_mojo = Decimal("79228162514264337593543950334")  # MAX - 1
+    var case6_b_mojo = Decimal("1")
+    var case6_a_py = pydecimal.Decimal("79228162514264337593543950334")
+    var case6_b_py = pydecimal.Decimal("1")
+    run_benchmark(
+        "Very large numbers",
+        case6_a_mojo,
+        case6_b_mojo,
+        case6_a_py,
+        case6_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 7: Very small numbers
+    var case7_a_mojo = Decimal(
+        "0." + "0" * 27 + "1"
+    )  # Smallest positive decimal
+    var case7_b_mojo = Decimal("0." + "0" * 27 + "2")
+    var case7_a_py = pydecimal.Decimal("0." + "0" * 27 + "1")
+    var case7_b_py = pydecimal.Decimal("0." + "0" * 27 + "2")
+    run_benchmark(
+        "Very small numbers",
+        case7_a_mojo,
+        case7_b_mojo,
+        case7_a_py,
+        case7_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 8: Addition with zero
+    var case8_a_mojo = Decimal("123.456")
+    var case8_b_mojo = Decimal("0")
+    var case8_a_py = pydecimal.Decimal("123.456")
+    var case8_b_py = pydecimal.Decimal("0")
+    run_benchmark(
+        "Addition with zero",
+        case8_a_mojo,
+        case8_b_mojo,
+        case8_a_py,
+        case8_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 9: Negative numbers
+    var case9_a_mojo = Decimal("123.45")
+    var case9_b_mojo = Decimal("-67.89")
+    var case9_a_py = pydecimal.Decimal("123.45")
+    var case9_b_py = pydecimal.Decimal("-67.89")
+    run_benchmark(
+        "Negative numbers",
+        case9_a_mojo,
+        case9_b_mojo,
+        case9_a_py,
+        case9_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 10: Addition resulting in zero
+    var case10_a_mojo = Decimal("123.45")
+    var case10_b_mojo = Decimal("-123.45")
+    var case10_a_py = pydecimal.Decimal("123.45")
+    var case10_b_py = pydecimal.Decimal("-123.45")
+    run_benchmark(
+        "Addition resulting in zero",
+        case10_a_mojo,
+        case10_b_mojo,
+        case10_a_py,
+        case10_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Display summary
+    log_print("\n=== Addition Benchmark Summary ===", log_file)
+    log_print("Benchmarked:      10 different addition cases", log_file)
+    log_print(
+        "Each case ran:    " + String(iterations) + " iterations", log_file
+    )
+
+    # Close the log file
+    log_file.close()
+    print("Benchmark completed. Log file closed.")

--- a/benches/bench_divide.mojo
+++ b/benches/bench_divide.mojo
@@ -1,0 +1,309 @@
+"""
+Comprehensive benchmarks for Decimal division operations.
+Compares performance against Python's decimal module.
+"""
+
+from decimojo.prelude import *
+from python import Python, PythonObject
+from time import perf_counter_ns
+import time
+import os
+
+
+fn open_log_file() raises -> PythonObject:
+    """
+    Creates and opens a log file with a timestamp in the filename.
+
+    Returns:
+        A file object opened for writing.
+    """
+    var python = Python.import_module("builtins")
+
+    # Create logs directory if it doesn't exist
+    var log_dir = "./logs"
+    if not os.path.exists(log_dir):
+        os.makedirs(log_dir)
+
+    # Generate a timestamp for the filename
+    var timestamp = String(time.perf_counter())
+    var log_filename = log_dir + "/benchmark_divide_" + timestamp + ".log"
+
+    print("Saving benchmark results to:", log_filename)
+    return python.open(log_filename, "w")
+
+
+fn log_print(msg: String, log_file: PythonObject) raises:
+    """
+    Prints a message to both the console and the log file.
+
+    Args:
+        msg: The message to print.
+        log_file: The file object to write to.
+    """
+    print(msg)
+    log_file.write(msg + "\n")
+    log_file.flush()  # Ensure the message is written immediately
+
+
+fn run_benchmark(
+    name: String,
+    a_mojo: Decimal,
+    b_mojo: Decimal,
+    a_py: PythonObject,
+    b_py: PythonObject,
+    iterations: Int,
+    log_file: PythonObject,
+) raises:
+    """
+    Run a benchmark comparing Mojo Decimal division with Python Decimal division.
+
+    Args:
+        name: Name of the benchmark case.
+        a_mojo: First Mojo Decimal operand (dividend).
+        b_mojo: Second Mojo Decimal operand (divisor).
+        a_py: First Python Decimal operand.
+        b_py: Second Python Decimal operand.
+        iterations: Number of iterations to run.
+        log_file: File object for logging results.
+    """
+    log_print("\nBenchmark:       " + name, log_file)
+
+    # Verify correctness
+    var mojo_result = a_mojo / b_mojo
+    var py_result = a_py / b_py
+    log_print("Mojo result:     " + String(mojo_result), log_file)
+    log_print("Python result:   " + String(py_result), log_file)
+
+    # Benchmark Mojo implementation
+    var t0 = perf_counter_ns()
+    for _ in range(iterations):
+        _ = a_mojo / b_mojo
+    var mojo_time = (perf_counter_ns() - t0) / iterations
+
+    # Benchmark Python implementation
+    t0 = perf_counter_ns()
+    for _ in range(iterations):
+        _ = a_py / b_py
+    var python_time = (perf_counter_ns() - t0) / iterations
+
+    # Print results with speedup comparison
+    log_print(
+        "Mojo Decimal:    " + String(mojo_time) + " ns per iteration",
+        log_file,
+    )
+    log_print(
+        "Python Decimal:  " + String(python_time) + " ns per iteration",
+        log_file,
+    )
+    log_print("Speedup factor:  " + String(python_time / mojo_time), log_file)
+
+
+fn main() raises:
+    # Open log file
+    var log_file = open_log_file()
+
+    # Display benchmark header with system information
+    log_print("=== DeciMojo Division Benchmark ===", log_file)
+    log_print("Time: " + String(time.perf_counter()), log_file)
+
+    # Try to get system info
+    try:
+        var platform = Python.import_module("platform")
+        log_print(
+            "System: "
+            + String(platform.system())
+            + " "
+            + String(platform.release()),
+            log_file,
+        )
+        log_print("Processor: " + String(platform.processor()), log_file)
+        log_print(
+            "Python version: " + String(platform.python_version()), log_file
+        )
+    except:
+        log_print("Could not retrieve system information", log_file)
+
+    var iterations = 1000
+    var pydecimal = Python().import_module("decimal")
+
+    # Set Python decimal precision to match Mojo's
+    pydecimal.getcontext().prec = 28
+    log_print(
+        "Python decimal precision: " + String(pydecimal.getcontext().prec),
+        log_file,
+    )
+    log_print(
+        "Mojo decimal precision: " + String(Decimal.MAX_PRECISION), log_file
+    )
+
+    # Define benchmark cases
+    log_print(
+        "\nRunning division benchmarks with "
+        + String(iterations)
+        + " iterations each",
+        log_file,
+    )
+
+    # Case 1: Simple integer division with no remainder
+    var case1_a_mojo = Decimal("100")
+    var case1_b_mojo = Decimal("4")
+    var case1_a_py = pydecimal.Decimal("100")
+    var case1_b_py = pydecimal.Decimal("4")
+    run_benchmark(
+        "Integer division (no remainder)",
+        case1_a_mojo,
+        case1_b_mojo,
+        case1_a_py,
+        case1_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 2: Division with simple decimals
+    var case2_a_mojo = Decimal("10.5")
+    var case2_b_mojo = Decimal("2.5")
+    var case2_a_py = pydecimal.Decimal("10.5")
+    var case2_b_py = pydecimal.Decimal("2.5")
+    run_benchmark(
+        "Simple decimal division",
+        case2_a_mojo,
+        case2_b_mojo,
+        case2_a_py,
+        case2_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 3: Division with repeating decimal result
+    var case3_a_mojo = Decimal("10")
+    var case3_b_mojo = Decimal("3")
+    var case3_a_py = pydecimal.Decimal("10")
+    var case3_b_py = pydecimal.Decimal("3")
+    run_benchmark(
+        "Division with repeating decimal",
+        case3_a_mojo,
+        case3_b_mojo,
+        case3_a_py,
+        case3_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 4: Division by one (identity)
+    var case4_a_mojo = Decimal("123.45")
+    var case4_b_mojo = Decimal("1")
+    var case4_a_py = pydecimal.Decimal("123.45")
+    var case4_b_py = pydecimal.Decimal("1")
+    run_benchmark(
+        "Division by one",
+        case4_a_mojo,
+        case4_b_mojo,
+        case4_a_py,
+        case4_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 5: Division of zero by non-zero
+    var case5_a_mojo = Decimal("0")
+    var case5_b_mojo = Decimal("123.45")
+    var case5_a_py = pydecimal.Decimal("0")
+    var case5_b_py = pydecimal.Decimal("123.45")
+    run_benchmark(
+        "Division of zero",
+        case5_a_mojo,
+        case5_b_mojo,
+        case5_a_py,
+        case5_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 6: Division with negative numbers
+    var case6_a_mojo = Decimal("123.45")
+    var case6_b_mojo = Decimal("-2")
+    var case6_a_py = pydecimal.Decimal("123.45")
+    var case6_b_py = pydecimal.Decimal("-2")
+    run_benchmark(
+        "Division with negative numbers",
+        case6_a_mojo,
+        case6_b_mojo,
+        case6_a_py,
+        case6_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 7: Division with very small divisor
+    var case7_a_mojo = Decimal("1")
+    var case7_b_mojo = Decimal("0.0001")
+    var case7_a_py = pydecimal.Decimal("1")
+    var case7_b_py = pydecimal.Decimal("0.0001")
+    run_benchmark(
+        "Division by very small number",
+        case7_a_mojo,
+        case7_b_mojo,
+        case7_a_py,
+        case7_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 8: Division with high precision
+    var case8_a_mojo = Decimal("0.1234567890123456789")
+    var case8_b_mojo = Decimal("0.0987654321098765432")
+    var case8_a_py = pydecimal.Decimal("0.1234567890123456789")
+    var case8_b_py = pydecimal.Decimal("0.0987654321098765432")
+    run_benchmark(
+        "High precision division",
+        case8_a_mojo,
+        case8_b_mojo,
+        case8_a_py,
+        case8_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 9: Division resulting in a power of 10
+    var case9_a_mojo = Decimal("10")
+    var case9_b_mojo = Decimal("0.001")
+    var case9_a_py = pydecimal.Decimal("10")
+    var case9_b_py = pydecimal.Decimal("0.001")
+    run_benchmark(
+        "Division resulting in power of 10",
+        case9_a_mojo,
+        case9_b_mojo,
+        case9_a_py,
+        case9_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 10: Division of very large by very large
+    var case10_a_mojo = Decimal("9" * 20)  # 20 nines
+    var case10_b_mojo = Decimal("9" * 10)  # 10 nines
+    var case10_a_py = pydecimal.Decimal("9" * 20)
+    var case10_b_py = pydecimal.Decimal("9" * 10)
+    run_benchmark(
+        "Division of very large numbers",
+        case10_a_mojo,
+        case10_b_mojo,
+        case10_a_py,
+        case10_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Display summary
+    log_print("\n=== Division Benchmark Summary ===", log_file)
+    log_print("Benchmarked:      10 different division cases", log_file)
+    log_print(
+        "Each case ran:    " + String(iterations) + " iterations", log_file
+    )
+    log_print(
+        "Performance:      See detailed results above for each case", log_file
+    )
+
+    # Close the log file
+    log_file.close()
+    print("Benchmark completed. Log file closed.")

--- a/benches/bench_multiply.mojo
+++ b/benches/bench_multiply.mojo
@@ -1,0 +1,309 @@
+"""
+Comprehensive benchmarks for Decimal multiplication operations.
+Compares performance against Python's decimal module.
+"""
+
+from decimojo.prelude import *
+from python import Python, PythonObject
+from time import perf_counter_ns
+import time
+import os
+
+
+fn open_log_file() raises -> PythonObject:
+    """
+    Creates and opens a log file with a timestamp in the filename.
+
+    Returns:
+        A file object opened for writing.
+    """
+    var python = Python.import_module("builtins")
+
+    # Create logs directory if it doesn't exist
+    var log_dir = "./logs"
+    if not os.path.exists(log_dir):
+        os.makedirs(log_dir)
+
+    # Generate a timestamp for the filename
+    var timestamp = String(time.perf_counter())
+    var log_filename = log_dir + "/benchmark_multiply_" + timestamp + ".log"
+
+    print("Saving benchmark results to:", log_filename)
+    return python.open(log_filename, "w")
+
+
+fn log_print(msg: String, log_file: PythonObject) raises:
+    """
+    Prints a message to both the console and the log file.
+
+    Args:
+        msg: The message to print.
+        log_file: The file object to write to.
+    """
+    print(msg)
+    log_file.write(msg + "\n")
+    log_file.flush()  # Ensure the message is written immediately
+
+
+fn run_benchmark(
+    name: String,
+    a_mojo: Decimal,
+    b_mojo: Decimal,
+    a_py: PythonObject,
+    b_py: PythonObject,
+    iterations: Int,
+    log_file: PythonObject,
+) raises:
+    """
+    Run a benchmark comparing Mojo Decimal multiplication with Python Decimal multiplication.
+
+    Args:
+        name: Name of the benchmark case.
+        a_mojo: First Mojo Decimal operand.
+        b_mojo: Second Mojo Decimal operand.
+        a_py: First Python Decimal operand.
+        b_py: Second Python Decimal operand.
+        iterations: Number of iterations to run.
+        log_file: File object for logging results.
+    """
+    log_print("\nBenchmark:       " + name, log_file)
+
+    # Verify correctness
+    var mojo_result = a_mojo * b_mojo
+    var py_result = a_py * b_py
+    log_print("Mojo result:     " + String(mojo_result), log_file)
+    log_print("Python result:   " + String(py_result), log_file)
+
+    # Benchmark Mojo implementation
+    var t0 = perf_counter_ns()
+    for _ in range(iterations):
+        _ = a_mojo * b_mojo
+    var mojo_time = (perf_counter_ns() - t0) / iterations
+
+    # Benchmark Python implementation
+    t0 = perf_counter_ns()
+    for _ in range(iterations):
+        _ = a_py * b_py
+    var python_time = (perf_counter_ns() - t0) / iterations
+
+    # Print results with speedup comparison
+    log_print(
+        "Mojo Decimal:    " + String(mojo_time) + " ns per iteration",
+        log_file,
+    )
+    log_print(
+        "Python Decimal:  " + String(python_time) + " ns per iteration",
+        log_file,
+    )
+    log_print("Speedup factor:  " + String(python_time / mojo_time), log_file)
+
+
+fn main() raises:
+    # Open log file
+    var log_file = open_log_file()
+
+    # Display benchmark header with system information
+    log_print("=== DeciMojo Multiplication Benchmark ===", log_file)
+    log_print("Time: " + String(time.perf_counter()), log_file)
+
+    # Try to get system info
+    try:
+        var platform = Python.import_module("platform")
+        log_print(
+            "System: "
+            + String(platform.system())
+            + " "
+            + String(platform.release()),
+            log_file,
+        )
+        log_print("Processor: " + String(platform.processor()), log_file)
+        log_print(
+            "Python version: " + String(platform.python_version()), log_file
+        )
+    except:
+        log_print("Could not retrieve system information", log_file)
+
+    var iterations = 1000
+    var pydecimal = Python().import_module("decimal")
+
+    # Set Python decimal precision to match Mojo's
+    pydecimal.getcontext().prec = 28
+    log_print(
+        "Python decimal precision: " + String(pydecimal.getcontext().prec),
+        log_file,
+    )
+    log_print(
+        "Mojo decimal precision: " + String(Decimal.MAX_PRECISION), log_file
+    )
+
+    # Define benchmark cases
+    log_print(
+        "\nRunning multiplication benchmarks with "
+        + String(iterations)
+        + " iterations each",
+        log_file,
+    )
+
+    # Case 1: Small integers
+    var case1_a_mojo = Decimal("12")
+    var case1_b_mojo = Decimal("34")
+    var case1_a_py = pydecimal.Decimal("12")
+    var case1_b_py = pydecimal.Decimal("34")
+    run_benchmark(
+        "Small integers",
+        case1_a_mojo,
+        case1_b_mojo,
+        case1_a_py,
+        case1_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 2: Simple decimals
+    var case2_a_mojo = Decimal("12.34")
+    var case2_b_mojo = Decimal("5.67")
+    var case2_a_py = pydecimal.Decimal("12.34")
+    var case2_b_py = pydecimal.Decimal("5.67")
+    run_benchmark(
+        "Simple decimals",
+        case2_a_mojo,
+        case2_b_mojo,
+        case2_a_py,
+        case2_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 3: Different scales
+    var case3_a_mojo = Decimal("12.3")
+    var case3_b_mojo = Decimal("4.56")
+    var case3_a_py = pydecimal.Decimal("12.3")
+    var case3_b_py = pydecimal.Decimal("4.56")
+    run_benchmark(
+        "Different scales",
+        case3_a_mojo,
+        case3_b_mojo,
+        case3_a_py,
+        case3_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 4: Multiplication by zero
+    var case4_a_mojo = Decimal("123.45")
+    var case4_b_mojo = Decimal("0")
+    var case4_a_py = pydecimal.Decimal("123.45")
+    var case4_b_py = pydecimal.Decimal("0")
+    run_benchmark(
+        "Multiplication by zero",
+        case4_a_mojo,
+        case4_b_mojo,
+        case4_a_py,
+        case4_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 5: Multiplication by one
+    var case5_a_mojo = Decimal("123.45")
+    var case5_b_mojo = Decimal("1")
+    var case5_a_py = pydecimal.Decimal("123.45")
+    var case5_b_py = pydecimal.Decimal("1")
+    run_benchmark(
+        "Multiplication by one",
+        case5_a_mojo,
+        case5_b_mojo,
+        case5_a_py,
+        case5_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 6: Negative numbers
+    var case6_a_mojo = Decimal("12.34")
+    var case6_b_mojo = Decimal("-5.67")
+    var case6_a_py = pydecimal.Decimal("12.34")
+    var case6_b_py = pydecimal.Decimal("-5.67")
+    run_benchmark(
+        "Negative numbers",
+        case6_a_mojo,
+        case6_b_mojo,
+        case6_a_py,
+        case6_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 7: High precision
+    var case7_a_mojo = Decimal("0.12345678901234567")
+    var case7_b_mojo = Decimal("0.98765432109876543")
+    var case7_a_py = pydecimal.Decimal("0.12345678901234567")
+    var case7_b_py = pydecimal.Decimal("0.98765432109876543")
+    run_benchmark(
+        "High precision multiplication",
+        case7_a_mojo,
+        case7_b_mojo,
+        case7_a_py,
+        case7_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 8: Large integer multiplication
+    var case8_a_mojo = Decimal("123456789")
+    var case8_b_mojo = Decimal("987654321")
+    var case8_a_py = pydecimal.Decimal("123456789")
+    var case8_b_py = pydecimal.Decimal("987654321")
+    run_benchmark(
+        "Large integer multiplication",
+        case8_a_mojo,
+        case8_b_mojo,
+        case8_a_py,
+        case8_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 9: Fractional multiplication resulting in very small scale
+    var case9_a_mojo = Decimal("0.01")
+    var case9_b_mojo = Decimal("0.01")
+    var case9_a_py = pydecimal.Decimal("0.01")
+    var case9_b_py = pydecimal.Decimal("0.01")
+    run_benchmark(
+        "Fractional multiplication",
+        case9_a_mojo,
+        case9_b_mojo,
+        case9_a_py,
+        case9_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 10: Powers of 10
+    var case10_a_mojo = Decimal("10")
+    var case10_b_mojo = Decimal("10")
+    var case10_a_py = pydecimal.Decimal("10")
+    var case10_b_py = pydecimal.Decimal("10")
+    run_benchmark(
+        "Powers of 10",
+        case10_a_mojo,
+        case10_b_mojo,
+        case10_a_py,
+        case10_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Display summary
+    log_print("\n=== Multiplication Benchmark Summary ===", log_file)
+    log_print("Benchmarked:      10 different multiplication cases", log_file)
+    log_print(
+        "Each case ran:    " + String(iterations) + " iterations", log_file
+    )
+    log_print(
+        "Performance:      See detailed results above for each case", log_file
+    )
+
+    # Close the log file
+    log_file.close()
+    print("Benchmark completed. Log file closed.")

--- a/benches/bench_subtract.mojo
+++ b/benches/bench_subtract.mojo
@@ -1,0 +1,306 @@
+"""
+Comprehensive benchmarks for Decimal subtraction operations.
+Compares performance against Python's decimal module.
+"""
+
+from decimojo.prelude import *
+from python import Python, PythonObject
+from time import perf_counter_ns
+import time
+import os
+
+
+fn open_log_file() raises -> PythonObject:
+    """
+    Creates and opens a log file with a timestamp in the filename.
+
+    Returns:
+        A file object opened for writing.
+    """
+    var python = Python.import_module("builtins")
+
+    # Create logs directory with in /benches if it doesn't exist
+    var log_dir = "./logs"
+    if not os.path.exists(log_dir):
+        os.makedirs(log_dir)
+
+    # Generate a timestamp for the filename
+    var timestamp = String(time.perf_counter())
+    var log_filename = log_dir + "/benchmark_subtract_" + timestamp + ".log"
+
+    print("Saving benchmark results to:", log_filename)
+    return python.open(log_filename, "w")
+
+
+fn log_print(msg: String, log_file: PythonObject) raises:
+    """
+    Prints a message to both the console and the log file.
+
+    Args:
+        msg: The message to print.
+        log_file: The file object to write to.
+    """
+    print(msg)
+    log_file.write(msg + "\n")
+    log_file.flush()  # Ensure the message is written immediately
+
+
+fn run_benchmark(
+    name: String,
+    a_mojo: Decimal,
+    b_mojo: Decimal,
+    a_py: PythonObject,
+    b_py: PythonObject,
+    iterations: Int,
+    log_file: PythonObject,
+) raises:
+    """
+    Run a benchmark comparing Mojo Decimal subtraction with Python Decimal subtraction.
+
+    Args:
+        name: Name of the benchmark case.
+        a_mojo: First Mojo Decimal operand (minuend).
+        b_mojo: Second Mojo Decimal operand (subtrahend).
+        a_py: First Python Decimal operand.
+        b_py: Second Python Decimal operand.
+        iterations: Number of iterations to run.
+        log_file: File object for logging results.
+    """
+    log_print("\nBenchmark:       " + name, log_file)
+
+    # Verify correctness
+    var mojo_result = a_mojo - b_mojo
+    var py_result = a_py - b_py
+    log_print("Mojo result:     " + String(mojo_result), log_file)
+    log_print("Python result:   " + String(py_result), log_file)
+
+    # Benchmark Mojo implementation
+    var t0 = perf_counter_ns()
+    for _ in range(iterations):
+        _ = a_mojo - b_mojo
+    var mojo_time = (perf_counter_ns() - t0) / iterations
+
+    # Benchmark Python implementation
+    t0 = perf_counter_ns()
+    for _ in range(iterations):
+        _ = a_py - b_py
+    var python_time = (perf_counter_ns() - t0) / iterations
+
+    # Print results with speedup comparison
+    log_print(
+        "Mojo Decimal:    " + String(mojo_time) + " ns per iteration",
+        log_file,
+    )
+    log_print(
+        "Python Decimal:  " + String(python_time) + " ns per iteration",
+        log_file,
+    )
+    log_print("Speedup factor:  " + String(python_time / mojo_time), log_file)
+
+
+fn main() raises:
+    # Open log file
+    var log_file = open_log_file()
+
+    # Display benchmark header with system information
+    log_print("=== DeciMojo Subtraction Benchmark ===", log_file)
+    log_print("Time: " + String(time.perf_counter()), log_file)
+
+    # Try to get system info
+    try:
+        var platform = Python.import_module("platform")
+        log_print(
+            "System: "
+            + String(platform.system())
+            + " "
+            + String(platform.release()),
+            log_file,
+        )
+        log_print("Processor: " + String(platform.processor()), log_file)
+        log_print(
+            "Python version: " + String(platform.python_version()), log_file
+        )
+    except:
+        log_print("Could not retrieve system information", log_file)
+
+    var iterations = 1000
+    var pydecimal = Python().import_module("decimal")
+
+    # Set Python decimal precision to match Mojo's
+    pydecimal.getcontext().prec = 28
+    log_print(
+        "Python decimal precision: " + String(pydecimal.getcontext().prec),
+        log_file,
+    )
+    log_print(
+        "Mojo decimal precision: " + String(Decimal.MAX_PRECISION), log_file
+    )
+
+    # Define benchmark cases
+    log_print(
+        "\nRunning subtraction benchmarks with "
+        + String(iterations)
+        + " iterations each",
+        log_file,
+    )
+
+    # Case 1: Simple integer subtraction
+    var case1_a_mojo = Decimal("12345")
+    var case1_b_mojo = Decimal("6789")
+    var case1_a_py = pydecimal.Decimal("12345")
+    var case1_b_py = pydecimal.Decimal("6789")
+    run_benchmark(
+        "Simple integers",
+        case1_a_mojo,
+        case1_b_mojo,
+        case1_a_py,
+        case1_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 2: Simple decimals with same scale
+    var case2_a_mojo = Decimal("123.45")
+    var case2_b_mojo = Decimal("67.89")
+    var case2_a_py = pydecimal.Decimal("123.45")
+    var case2_b_py = pydecimal.Decimal("67.89")
+    run_benchmark(
+        "Simple decimals (same scale)",
+        case2_a_mojo,
+        case2_b_mojo,
+        case2_a_py,
+        case2_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 3: Decimals with different scales
+    var case3_a_mojo = Decimal("123.4")
+    var case3_b_mojo = Decimal("67.89")
+    var case3_a_py = pydecimal.Decimal("123.4")
+    var case3_b_py = pydecimal.Decimal("67.89")
+    run_benchmark(
+        "Decimals with different scales",
+        case3_a_mojo,
+        case3_b_mojo,
+        case3_a_py,
+        case3_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 4: Subtraction resulting in negative number
+    var case4_a_mojo = Decimal("67.89")
+    var case4_b_mojo = Decimal("123.45")
+    var case4_a_py = pydecimal.Decimal("67.89")
+    var case4_b_py = pydecimal.Decimal("123.45")
+    run_benchmark(
+        "Subtraction resulting in negative",
+        case4_a_mojo,
+        case4_b_mojo,
+        case4_a_py,
+        case4_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 5: Subtraction with negative number (a - (-b) = a + b)
+    var case5_a_mojo = Decimal("123.45")
+    var case5_b_mojo = Decimal("-67.89")
+    var case5_a_py = pydecimal.Decimal("123.45")
+    var case5_b_py = pydecimal.Decimal("-67.89")
+    run_benchmark(
+        "Subtracting a negative",
+        case5_a_mojo,
+        case5_b_mojo,
+        case5_a_py,
+        case5_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 6: Requiring borrow across multiple digits
+    var case6_a_mojo = Decimal("10000.00")
+    var case6_b_mojo = Decimal("0.01")
+    var case6_a_py = pydecimal.Decimal("10000.00")
+    var case6_b_py = pydecimal.Decimal("0.01")
+    run_benchmark(
+        "Requiring borrow across multiple digits",
+        case6_a_mojo,
+        case6_b_mojo,
+        case6_a_py,
+        case6_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 7: Subtraction with small difference
+    var case7_a_mojo = Decimal("1.0000001")
+    var case7_b_mojo = Decimal("1.0000000")
+    var case7_a_py = pydecimal.Decimal("1.0000001")
+    var case7_b_py = pydecimal.Decimal("1.0000000")
+    run_benchmark(
+        "Small difference",
+        case7_a_mojo,
+        case7_b_mojo,
+        case7_a_py,
+        case7_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 8: High precision subtraction
+    var case8_a_mojo = Decimal("0.123456789012345678901234567")
+    var case8_b_mojo = Decimal("0.023456789012345678901234567")
+    var case8_a_py = pydecimal.Decimal("0.123456789012345678901234567")
+    var case8_b_py = pydecimal.Decimal("0.023456789012345678901234567")
+    run_benchmark(
+        "High precision subtraction",
+        case8_a_mojo,
+        case8_b_mojo,
+        case8_a_py,
+        case8_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 9: Subtraction resulting in zero
+    var case9_a_mojo = Decimal("123.45")
+    var case9_b_mojo = Decimal("123.45")
+    var case9_a_py = pydecimal.Decimal("123.45")
+    var case9_b_py = pydecimal.Decimal("123.45")
+    run_benchmark(
+        "Subtraction resulting in zero",
+        case9_a_mojo,
+        case9_b_mojo,
+        case9_a_py,
+        case9_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Case 10: Very large numbers subtraction
+    var case10_a_mojo = Decimal("79228162514264337593543950334")  # MAX - 1
+    var case10_b_mojo = Decimal("79228162514264337593543950333")  # MAX - 2
+    var case10_a_py = pydecimal.Decimal("79228162514264337593543950334")
+    var case10_b_py = pydecimal.Decimal("79228162514264337593543950333")
+    run_benchmark(
+        "Very large numbers",
+        case10_a_mojo,
+        case10_b_mojo,
+        case10_a_py,
+        case10_b_py,
+        iterations,
+        log_file,
+    )
+
+    # Display summary
+    log_print("\n=== Subtraction Benchmark Summary ===", log_file)
+    log_print("Benchmarked:      10 different subtraction cases", log_file)
+    log_print(
+        "Each case ran:    " + String(iterations) + " iterations", log_file
+    )
+
+    # Close the log file
+    log_file.close()
+    print("Benchmark completed. Log file closed.")

--- a/decimojo/decimal.mojo
+++ b/decimojo/decimal.mojo
@@ -25,6 +25,7 @@ Implements basic object methods for working with decimal numbers.
 from .rounding_mode import RoundingMode
 
 
+@register_passable
 struct Decimal(
     Absable,
     Comparable,
@@ -586,15 +587,6 @@ struct Decimal(
     fn __copyinit__(out self, other: Self):
         """
         Initializes a Decimal by copying another Decimal.
-        """
-        self.low = other.low
-        self.mid = other.mid
-        self.high = other.high
-        self.flags = other.flags
-
-    fn __moveinit__(out self, owned other: Self):
-        """
-        Initializes a Decimal by moving from another Decimal.
         """
         self.low = other.low
         self.mid = other.mid

--- a/decimojo/decimal.mojo
+++ b/decimojo/decimal.mojo
@@ -1096,17 +1096,22 @@ struct Decimal(
         else:
             return 0
 
-    fn _internal_representation(value: Decimal):
+    fn internal_representation(value: Decimal):
         # Show internal representation details
         print("\nInternal Representation Details:")
         print("--------------------------------")
         print("Decimal:       ", value)
-        print("low:           ", value.low)
-        print("mid:           ", value.mid)
-        print("high:          ", value.high)
         print("coefficient:   ", value.coefficient())
         print("scale:         ", value.scale())
         print("is negative:   ", value.is_negative())
+        print("is zero:       ", value.is_zero())
+        print("low:           ", value.low)
+        print("mid:           ", value.mid)
+        print("high:          ", value.high)
+        print("low byte:      ", hex(value.low))
+        print("mid byte:      ", hex(value.mid))
+        print("high byte:     ", hex(value.high))
+        print("flags byte:    ", hex(value.flags))
         print("--------------------------------")
 
     fn _scale_down(

--- a/decimojo/maths/arithmetics.mojo
+++ b/decimojo/maths/arithmetics.mojo
@@ -352,22 +352,9 @@ fn true_divide(x1: Decimal, x2: Decimal) raises -> Decimal:
                 if (
                     new_remainder[0] == "-"
                 ):  # Negative result means we've gone too far
-                    print(
-                        (
-                            "DEBUG: Subtraction would be negative, stopping at"
-                            " digit"
-                        ),
-                        digit,
-                    )
                     break
                 remainder = new_remainder
                 digit += 1
-                print(
-                    "DEBUG: Subtracted divisor, digit =",
-                    digit,
-                    ", remainder =",
-                    remainder,
-                )
 
         # Add digit to quotient
         quotient += String(digit)
@@ -391,12 +378,6 @@ fn true_divide(x1: Decimal, x2: Decimal) raises -> Decimal:
         quotient = "0"
     elif leading_zeros > 0:
         quotient = quotient[leading_zeros:]
-        print(
-            "DEBUG: Removed",
-            leading_zeros,
-            "leading zeros, quotient =",
-            quotient,
-        )
 
     # Handle trailing zeros for exact division
     var trailing_zeros = 0
@@ -409,12 +390,6 @@ fn true_divide(x1: Decimal, x2: Decimal) raises -> Decimal:
 
         if trailing_zeros > 0:
             quotient = quotient[: len(quotient) - trailing_zeros]
-            print(
-                "DEBUG: Removed",
-                trailing_zeros,
-                "trailing zeros, quotient =",
-                quotient,
-            )
 
     # Calculate decimal point position
     var dividend_scientific_exponent = x1.scientific_exponent()

--- a/decimojo/maths/arithmetics.mojo
+++ b/decimojo/maths/arithmetics.mojo
@@ -272,16 +272,12 @@ fn true_divide(x1: Decimal, x2: Decimal) raises -> Decimal:
         Error: If x2 is zero.
     """
 
-    print("DEBUG: Starting division of", x1, "by", x2)
-
     # Check for division by zero
     if x2.is_zero():
-        print("DEBUG: Division by zero detected")
         raise Error("Error in `__truediv__`: Division by zero")
 
     # Special case: if dividend is zero, return zero with appropriate scale
     if x1.is_zero():
-        print("DEBUG: Dividend is zero, returning zero with appropriate scale")
         var result = Decimal.ZERO()
         var result_scale = max(0, x1.scale() - x2.scale())
         result.flags = UInt32(
@@ -296,29 +292,19 @@ fn true_divide(x1: Decimal, x2: Decimal) raises -> Decimal:
         and x1.high == x2.high
         and x1.scale() == x2.scale()
     ):
-        print("DEBUG: Identical numbers detected, returning 1")
         return Decimal.ONE()
 
     # Determine sign of result (positive if signs are the same, negative otherwise)
     var result_is_negative = x1.is_negative() != x2.is_negative()
-    print(
-        "DEBUG: Result will be",
-        "negative" if result_is_negative else "positive",
-    )
 
     # Get coefficients as strings (absolute values)
     var dividend_coef = String(x1.coefficient())
     var divisor_coef = String(x2.coefficient())
-    print("DEBUG: Dividend coefficient:", dividend_coef)
-    print("DEBUG: Divisor coefficient:", divisor_coef)
-    print("DEBUG: Dividend scale:", x1.scale())
-    print("DEBUG: Divisor scale:", x2.scale())
 
     # Use string-based division to avoid overflow with large numbers
 
     # Determine precision needed for calculation
     var working_precision = Decimal.LEN_OF_MAX_VALUE + 1  # +1 for potential rounding
-    print("DEBUG: Working precision:", working_precision)
 
     # Perform long division algorithm
     var quotient = String("")
@@ -328,20 +314,16 @@ fn true_divide(x1: Decimal, x2: Decimal) raises -> Decimal:
     var processed_all_dividend = False
     var number_of_significant_digits_of_quotient = 0
 
-    print("DEBUG: Starting long division algorithm")
     while number_of_significant_digits_of_quotient < working_precision:
         # Grab next digit from dividend if available
         if current_pos < len(dividend_coef):
             remainder += dividend_coef[current_pos]
             current_pos += 1
-            print("DEBUG: Added digit from dividend, remainder =", remainder)
         else:
             # If we've processed all dividend digits, add a zero
             if not processed_all_dividend:
                 processed_all_dividend = True
-                print("DEBUG: Processed all dividend digits")
             remainder += "0"
-            print("DEBUG: Added trailing zero, remainder =", remainder)
 
         # Remove leading zeros from remainder for cleaner comparison
         var remainder_start = 0
@@ -351,7 +333,6 @@ fn true_divide(x1: Decimal, x2: Decimal) raises -> Decimal:
         ):
             remainder_start += 1
         remainder = remainder[remainder_start:]
-        print("DEBUG: Removed leading zeros, remainder =", remainder)
 
         # Compare remainder with divisor to determine next quotient digit
         digit = 0
@@ -362,13 +343,9 @@ fn true_divide(x1: Decimal, x2: Decimal) raises -> Decimal:
             len(remainder) == len(divisor_coef) and remainder >= divisor_coef
         ):
             can_subtract = True
-            print("DEBUG: Remainder is >= divisor, can subtract")
-        else:
-            print("DEBUG: Remainder is < divisor, adding 0 to quotient")
 
         if can_subtract:
             # Find how many times divisor goes into remainder
-            print("DEBUG: Finding how many times divisor goes into remainder")
             while True:
                 # Try to subtract divisor from remainder
                 var new_remainder = _subtract_strings(remainder, divisor_coef)
@@ -397,20 +374,9 @@ fn true_divide(x1: Decimal, x2: Decimal) raises -> Decimal:
         number_of_significant_digits_of_quotient = len(
             decimojo.str._remove_leading_zeros(quotient)
         )
-        print("DEBUG: Added digit", digit, "to quotient:", quotient)
-        print(
-            "DEBUG: Significant digits in quotient:",
-            number_of_significant_digits_of_quotient,
-        )
 
     # Check if division is exact
     var is_exact = remainder == "0" and current_pos >= len(dividend_coef)
-    print(
-        "DEBUG: Division is",
-        "exact" if is_exact else "not exact",
-        "remainder =",
-        remainder,
-    )
 
     # Remove leading zeros
     var leading_zeros = 0
@@ -423,7 +389,6 @@ fn true_divide(x1: Decimal, x2: Decimal) raises -> Decimal:
     if leading_zeros == len(quotient):
         # All zeros, keep just one
         quotient = "0"
-        print("DEBUG: Quotient is all zeros, setting to '0'")
     elif leading_zeros > 0:
         quotient = quotient[leading_zeros:]
         print(
@@ -455,22 +420,14 @@ fn true_divide(x1: Decimal, x2: Decimal) raises -> Decimal:
     var dividend_scientific_exponent = x1.scientific_exponent()
     var divisor_scientific_exponent = x2.scientific_exponent()
     var result_scientific_exponent = dividend_scientific_exponent - divisor_scientific_exponent
-    print("DEBUG: Dividend scientific exponent:", dividend_scientific_exponent)
-    print("DEBUG: Divisor scientific exponent:", divisor_scientific_exponent)
-    print("DEBUG: Result scientific exponent:", result_scientific_exponent)
 
     if decimojo.str._remove_trailing_zeros(
         dividend_coef
     ) < decimojo.str._remove_trailing_zeros(divisor_coef):
         # If dividend < divisor, result < 1
         result_scientific_exponent -= 1
-        print(
-            "DEBUG: Dividend < divisor, adjusted result exponent to:",
-            result_scientific_exponent,
-        )
 
     var decimal_pos = result_scientific_exponent + 1
-    print("DEBUG: Decimal position:", decimal_pos)
 
     # Format result with decimal point
     var result_str = String("")
@@ -480,29 +437,23 @@ fn true_divide(x1: Decimal, x2: Decimal) raises -> Decimal:
         # For example, decimal_pos = -1
         # 1234 -> 0.1234
         result_str = "0." + "0" * (-decimal_pos) + quotient
-        print("DEBUG: Result < 1, formatted as:", result_str)
     elif decimal_pos >= len(quotient):
         # All digits are to the left of the decimal point
         # For example, decimal_pos = 5
         # 1234 -> 12340
         result_str = quotient + "0" * (decimal_pos - len(quotient))
-        print("DEBUG: All digits left of decimal, formatted as:", result_str)
     else:
         # Insert decimal point within the digits
         # For example, decimal_pos = 2
         # 1234 -> 12.34
         result_str = quotient[:decimal_pos] + "." + quotient[decimal_pos:]
-        print("DEBUG: Inserting decimal point, formatted as:", result_str)
 
     # Apply sign
     if result_is_negative and result_str != "0":
         result_str = "-" + result_str
-        print("DEBUG: Applied negative sign, result:", result_str)
 
     # Convert to Decimal and return
-    print("DEBUG: Final string result:", result_str)
     var result = Decimal(result_str)
-    print("DEBUG: Converted to Decimal:", result)
 
     return result
 

--- a/mojoproject.toml
+++ b/mojoproject.toml
@@ -13,7 +13,7 @@ version = "0.1.0"
 format = "magic run mojo format ./"
 
 # compile the package
-package = "magic run format && magic run mojo package decimojo && cp decimojo.mojopkg ./tests/ && rm decimojo.mojopkg"
+package = "magic run format && magic run mojo package decimojo && cp decimojo.mojopkg ./tests/ && cp decimojo.mojopkg ./benches/ && rm decimojo.mojopkg"
 p = "clear && magic run package"
 
 # debugs (run the testing files only)
@@ -21,11 +21,15 @@ debug = "magic run package && magic run mojo tests/*.mojo"
 d = "clear && magic run debug"
 
 # tests (use the mojo testing tool)
-test = "magic run package && magic run mojo test tests -I ."
+test = "magic run package && magic run mojo test tests"
 t = "clear && magic run test"
 
+# benches
+bench = "magic run package && cd benches && magic run mojo *.mojo && cd .."
+b = "clear && magic run bench"
+
 # before commit
-final = "magic run test"
+final = "magic run test && magic run bench"
 f = "clear && magic run final"
 
 [dependencies]

--- a/mojoproject.toml
+++ b/mojoproject.toml
@@ -25,7 +25,7 @@ test = "magic run package && magic run mojo test tests"
 t = "clear && magic run test"
 
 # benches
-bench = "magic run package && cd benches && magic run mojo *.mojo && cd .."
+bench = "magic run package && cd benches && magic run mojo bench.mojo && cd .."
 b = "clear && magic run bench"
 
 # before commit


### PR DESCRIPTION
## `coefficient()` returns `UInt128`

This PR changes the return type of `coefficient()` from `String` to `UInt128` because Mojo now supports `UInt128` type in the nightly version.

Fix other functions for this change.

Renew some functions to get significant digits of coefficients by using `UInt128` instead of `String`.

Renew the `__float__` and `__int__` methods.

## Bench

This PR introduces a comprehensive benchmarking suite for the `DeciMojo` library, comparing its performance with Python's `decimal` module. The changes include adding new benchmark scripts for various arithmetic operations and updating the documentation to guide users on running these benchmarks.

### Documentation Updates:
* Added a new section in `README.md` to explain how to run tests and benchmarks using the `magic` command.