### PR TITLE
[decimal] Optimize `multiply()` with `UInt128` and `UInt256`

### DIFF
--- a/mojoproject.toml
+++ b/mojoproject.toml
@@ -33,6 +33,10 @@ t = "clear && magic run test"
 bench = "magic run package && cd benches && magic run mojo bench.mojo && cd .."
 b = "clear && magic run bench"
 
+# individual bench files
+b_mul = "magic run package && cd benches && magic run mojo bench_multiply.mojo && cd .."
+b_div = "magic run package && cd benches && magic run mojo bench_divide.mojo && cd .."
+
 # before commit
 final = "magic run test && magic run bench"
 f = "clear && magic run final"

--- a/src/decimojo/decimal.mojo
+++ b/src/decimojo/decimal.mojo
@@ -1133,6 +1133,18 @@ struct Decimal(
         """Returns True if this Decimal is NaN (Not a Number)."""
         return (self.flags & Self.NAN_MASK) != 0
 
+    fn is_uint32able(self) -> Bool:
+        """
+        Returns True if the coefficient can be represented as a UInt32 value.
+        """
+        return self.high == 0 and self.mid == 0
+
+    fn is_uint64able(self) -> Bool:
+        """
+        Returns True if the coefficient can be represented as a UInt64 value.
+        """
+        return self.high == 0
+
     fn scale(self) -> Int:
         """Returns the scale (number of decimal places) of this Decimal."""
         return Int((self.flags & Self.SCALE_MASK) >> Self.SCALE_SHIFT)

--- a/src/decimojo/decimal.mojo
+++ b/src/decimojo/decimal.mojo
@@ -876,7 +876,7 @@ struct Decimal(
     fn __rsub__(self, other: Int) raises -> Self:
         return decimojo.subtract(Decimal(other), self)
 
-    fn __mul__(self, other: Decimal) -> Self:
+    fn __mul__(self, other: Decimal) raises -> Self:
         """
         Multiplies two Decimal values and returns a new Decimal containing the product.
         """
@@ -886,7 +886,7 @@ struct Decimal(
     fn __mul__(self, other: Float64) raises -> Self:
         return decimojo.multiply(self, Decimal(other))
 
-    fn __mul__(self, other: Int) -> Self:
+    fn __mul__(self, other: Int) raises -> Self:
         return decimojo.multiply(self, Decimal(other))
 
     fn __truediv__(self, other: Decimal) raises -> Self:

--- a/src/decimojo/maths/arithmetics.mojo
+++ b/src/decimojo/maths/arithmetics.mojo
@@ -463,7 +463,6 @@ fn multiply(x1: Decimal, x2: Decimal) raises -> Decimal:
             )
 
     # GENERAL CASES: Decimal multiplication with any scales
-    # TODO: Consider different sub-cases
 
     # SUB-CASE: Both operands are small
     # The bits of the product will not exceed 96 bits

--- a/src/decimojo/maths/arithmetics.mojo
+++ b/src/decimojo/maths/arithmetics.mojo
@@ -297,15 +297,19 @@ fn multiply(x1: Decimal, x2: Decimal) -> Decimal:
     Returns:
         A new Decimal containing the product of x1 and x2.
     """
-    # Special cases for zero
+    # SPECIAL CASE: zero
+    # Return zero while preserving the scale
     if x1.is_zero() or x2.is_zero():
-        # For zero, we need to preserve the scale
         var result = Decimal.ZERO()
         var result_scale = min(x1.scale() + x2.scale(), Decimal.MAX_PRECISION)
         result.flags = UInt32(
             (result_scale << Decimal.SCALE_SHIFT) & Decimal.SCALE_MASK
         )
         return result
+
+    # TODO: Consider different cases
+    # TODO: CASE 1: Both operands are UInt32able
+    # TODO: Perform 64-bit by 64-bit multiplication
 
     # Calculate the combined scale (sum of both scales)
     var combined_scale = x1.scale() + x2.scale()

--- a/src/decimojo/maths/arithmetics.mojo
+++ b/src/decimojo/maths/arithmetics.mojo
@@ -29,6 +29,7 @@ from decimojo.rounding_mode import RoundingMode
 # ===----------------------------------------------------------------------=== #
 
 
+# TODO: Like `multiply` use combined bits to determine the appropriate method
 fn add(x1: Decimal, x2: Decimal) raises -> Decimal:
     """
     Adds two Decimal values and returns a new Decimal containing the sum.

--- a/src/decimojo/maths/rounding.mojo
+++ b/src/decimojo/maths/rounding.mojo
@@ -29,7 +29,7 @@ from decimojo.rounding_mode import RoundingMode
 
 fn round(
     number: Decimal,
-    decimal_places: Int,
+    decimal_places: Int = 0,
     rounding_mode: RoundingMode = RoundingMode.HALF_EVEN(),
 ) -> Decimal:
     """
@@ -38,16 +38,24 @@ fn round(
     Args:
         number: The Decimal to round.
         decimal_places: Number of decimal places to round to.
-        rounding_mode: Rounding mode to use (defaults to HALF_EVEN/banker's rounding).
+            Defaults to 0.
+        rounding_mode: Rounding mode to use.
+            Defaults to HALF_EVEN/banker's rounding.
 
     Returns:
         A new Decimal rounded to the specified number of decimal places.
     """
     var current_scale = number.scale()
 
-    # If already at the desired scale, return a copy
+    # CASE: If already at the desired scale
+    # Return a copy
+    # round(Decimal("123.456"), 3) -> Decimal("123.456")
     if current_scale == decimal_places:
         return number
+
+    # TODO: CASE: If the number is an integer
+    # Return with more or less zeros until the desired scale
+    # round(Decimal("123"), 2) -> Decimal("123.00")
 
     # If we need more decimal places, scale up
     if decimal_places > current_scale:

--- a/src/decimojo/utility.mojo
+++ b/src/decimojo/utility.mojo
@@ -50,8 +50,8 @@ fn bitcast[dtype: DType](dec: Decimal) -> Scalar[dtype]:
 
 fn truncate_to_max[dtype: DType, //](value: Scalar[dtype]) -> Scalar[dtype]:
     """
-    Truncates a UInt256 or UInt128 value to maximum possible value of Decimal
-    coefficient with rounding.
+    Truncates a UInt256 or UInt128 value to be as closer to the max value of
+    Decimal coefficient (`2^96 - 1`) as possible with rounding.
     Uses banker's rounding (ROUND_HALF_EVEN) for any truncated digits.
     `792281625142643375935439503356` will be truncated to
     `7922816251426433759354395034`.
@@ -64,19 +64,19 @@ fn truncate_to_max[dtype: DType, //](value: Scalar[dtype]) -> Scalar[dtype]:
     Args:
         value: The UInt256 value to truncate.
 
+    Constraints:
+        `dtype` must be either `DType.uint128` or `DType.uint256`.
+
     Returns:
         The truncated UInt256 value, guaranteed to fit within 96 bits.
     """
 
     alias ValueType = Scalar[dtype]
 
-    # TODO: Make this compile-time check instead of rasing an error
-    # @parameter
-    # if (dtype != DType.uint128) and (dtype != DType.uint256):
-    #     raise Error(
-    #         "Error in `truncate_to_max`: dtype must be either uint128 or"
-    #         " uint256."
-    #     )
+    constrained[
+        dtype == DType.uint128 or dtype == DType.uint256,
+        "must be uint128 or uint256",
+    ]()
 
     # If the value is already less than the maximum possible value, return it
     if value <= ValueType(Decimal.MAX_AS_UINT128):

--- a/src/decimojo/utility.mojo
+++ b/src/decimojo/utility.mojo
@@ -85,7 +85,7 @@ fn truncate_to_max[dtype: DType, //](value: Scalar[dtype]) -> Scalar[dtype]:
     else:
         # Calculate how many digits we need to truncate
         # Calculate how many digits to keep (MAX_VALUE_DIGITS = 29)
-        var num_digits = number_of_significant_digits(value)
+        var num_digits = number_of_digits(value)
         var digits_to_remove = num_digits - Decimal.MAX_VALUE_DIGITS
 
         # Collect digits for rounding decision
@@ -248,7 +248,10 @@ fn truncate_to_digits[
         "must be uint128 or uint256",
     ]()
 
-    var num_significant_digits = number_of_significant_digits(value)
+    if num_digits < 0:
+        return 0
+
+    var num_significant_digits = number_of_digits(value)
     # If the number of digits is less than or equal to the specified digits,
     # return the value
     if num_significant_digits <= num_digits:
@@ -292,16 +295,49 @@ fn truncate_to_digits[
         return truncated_value
 
 
-fn number_of_significant_digits[dtype: DType, //](x: Scalar[dtype]) -> Int:
+fn number_of_digits[dtype: DType, //](owned value: Scalar[dtype]) -> Int:
     """
-    Returns the number of significant digits in a scalar value.
-    ***WARNING***: The input must be an integer.
+    Returns the number of (significant) digits in an intergral value.
+
+    Constraints:
+        `dtype` must be integral.
     """
-    var temp = x
-    var digit_count: Int = 0
 
-    while temp > 0:
-        temp //= 10
-        digit_count += 1
+    constrained[
+        dtype.is_integral(),
+        "must be intergral",
+    ]()
 
-    return digit_count
+    if value < 0:
+        value = -value
+
+    var count = 0
+    while value > 0:
+        value //= 10
+        count += 1
+
+    return count
+
+
+fn number_of_bits[dtype: DType, //](owned value: Scalar[dtype]) -> Int:
+    """
+    Returns the number of significant bits in an integer value.
+
+    Constraints:
+        `dtype` must be integral.
+    """
+
+    constrained[
+        dtype.is_integral(),
+        "must be intergral",
+    ]()
+
+    if value < 0:
+        value = -value
+
+    var count = 0
+    while value > 0:
+        value >>= 1
+        count += 1
+
+    return count

--- a/src/decimojo/utility.mojo
+++ b/src/decimojo/utility.mojo
@@ -219,7 +219,6 @@ fn truncate_to_digits[
     Therefore, we need to truncate the coefficient to 5 (`6 - (29 - 28)`) digits
     and round it to the nearest even number.
     The truncated ceofficient will be `23457`.
-    Note that `truncated_digits = 1` which is equal to `num_digits_to_keep = 1`.
     The final decimal value will be `0.0000000000000000000000023457`.
 
     When you want to apply a scale of 5 to the coefficient `234567`, it will be

--- a/tests/test_utility.mojo
+++ b/tests/test_utility.mojo
@@ -161,6 +161,63 @@ fn test_truncate_to_max_banker_rounding() raises:
     print("✓ All truncate_to_max banker's rounding tests passed!")
 
 
+fn test_truncate_to_digits() raises:
+    """Test the truncate_to_digits function for proper digit truncation and rounding.
+    """
+    print("Testing truncate_to_digits...")
+
+    # Test case 1: Value with more digits than to keep (round to nearest power of 10)
+    var case1 = UInt128(997)
+    var case1_expected = UInt128(1)
+    assert_equal(dm.utility.truncate_to_digits(case1, 0), case1_expected)
+
+    # Test case 2: Value with one more digit than to keep
+    var case2 = UInt128(234567)
+    var case2_expected = UInt128(23457)
+    assert_equal(dm.utility.truncate_to_digits(case2, 5), case2_expected)
+
+    # Test case 3: Value with fewer digits than to keep (should return original)
+    var case3 = UInt128(234567)
+    assert_equal(dm.utility.truncate_to_digits(case3, 29), case3)
+
+    # Test case 4: Test banker's rounding with 5 (round to even)
+    var case4a = UInt128(12345)  # Last digit is 5, preceding digit is even
+    var case4a_expected = UInt128(1234)
+    assert_equal(dm.utility.truncate_to_digits(case4a, 4), case4a_expected)
+
+    var case4b = UInt128(23455)  # Last digit is 5, preceding digit is odd
+    var case4b_expected = UInt128(2346)
+    assert_equal(dm.utility.truncate_to_digits(case4b, 4), case4b_expected)
+
+    # Test case 5: Rounding down (< 5)
+    var case5 = UInt128(12342)
+    var case5_expected = UInt128(1234)
+    assert_equal(dm.utility.truncate_to_digits(case5, 4), case5_expected)
+
+    # Test case 6: Rounding up (> 5)
+    var case6 = UInt128(12347)
+    var case6_expected = UInt128(1235)
+    assert_equal(dm.utility.truncate_to_digits(case6, 4), case6_expected)
+
+    # Test case 7: Zero input
+    var case7 = UInt128(0)
+    assert_equal(dm.utility.truncate_to_digits(case7, 5), UInt128(0))
+
+    # Test case 8: Single digit input
+    var case8 = UInt128(7)
+    assert_equal(dm.utility.truncate_to_digits(case8, 1), UInt128(7))
+    assert_equal(
+        dm.utility.truncate_to_digits(case8, 0), UInt128(1)
+    )  # Round to nearest power of 10
+
+    # Test case 9: Large value with UInt256
+    var case9 = UInt256(9876543210987654321)
+    var case9_expected = UInt256(987654321098765432)
+    assert_equal(dm.utility.truncate_to_digits(case9, 18), case9_expected)
+
+    print("✓ All truncate_to_digits tests passed!")
+
+
 fn test_bitcast() raises:
     """Test the bitcast utility function for direct memory bit conversion."""
     print("Testing utility.bitcast...")
@@ -204,7 +261,6 @@ fn test_bitcast() raises:
     print("✓ All bitcast tests passed!")
 
 
-# Update the test_all function to include the new test
 fn test_all() raises:
     """Run all tests for the utility module."""
     print("\n=== Running Utility Module Tests ===\n")
@@ -222,6 +278,9 @@ fn test_all() raises:
     print()
 
     test_bitcast()
+    print()
+
+    test_truncate_to_digits()
     print()
 
     print("✓✓✓ All utility module tests passed! ✓✓✓")

--- a/tests/test_utility.mojo
+++ b/tests/test_utility.mojo
@@ -6,39 +6,39 @@ from testing import assert_equal, assert_true
 import max
 
 from decimojo.prelude import *
-from decimojo.utility import truncate_to_max, number_of_significant_digits
+from decimojo.utility import truncate_to_max, number_of_digits
 
 
-fn test_number_of_significant_digits() raises:
-    """Tests for number_of_significant_digits function."""
-    print("Testing number_of_significant_digits...")
+fn test_number_of_digits() raises:
+    """Tests for number_of_digits function."""
+    print("Testing number_of_digits...")
 
     # Test with simple UInt128 values
-    assert_equal(number_of_significant_digits(UInt128(0)), 0)
-    assert_equal(number_of_significant_digits(UInt128(1)), 1)
-    assert_equal(number_of_significant_digits(UInt128(9)), 1)
-    assert_equal(number_of_significant_digits(UInt128(10)), 2)
-    assert_equal(number_of_significant_digits(UInt128(123)), 3)
-    assert_equal(number_of_significant_digits(UInt128(9999)), 4)
+    assert_equal(number_of_digits(UInt128(0)), 0)
+    assert_equal(number_of_digits(UInt128(1)), 1)
+    assert_equal(number_of_digits(UInt128(9)), 1)
+    assert_equal(number_of_digits(UInt128(10)), 2)
+    assert_equal(number_of_digits(UInt128(123)), 3)
+    assert_equal(number_of_digits(UInt128(9999)), 4)
 
     # Test with powers of 10
-    assert_equal(number_of_significant_digits(UInt128(10**6)), 7)
-    assert_equal(number_of_significant_digits(UInt128(10**12)), 13)
+    assert_equal(number_of_digits(UInt128(10**6)), 7)
+    assert_equal(number_of_digits(UInt128(10**12)), 13)
 
     # Test with UInt256 values
-    assert_equal(number_of_significant_digits(UInt256(0)), 0)
-    assert_equal(number_of_significant_digits(UInt256(123456789)), 9)
-    assert_equal(number_of_significant_digits(UInt256(10) ** 20), 21)
+    assert_equal(number_of_digits(UInt256(0)), 0)
+    assert_equal(number_of_digits(UInt256(123456789)), 9)
+    assert_equal(number_of_digits(UInt256(10) ** 20), 21)
 
     # Test with large values approaching UInt128 maximum
     var large_value = UInt128(Decimal.MAX_AS_UINT128)
-    assert_equal(number_of_significant_digits(large_value), 29)
+    assert_equal(number_of_digits(large_value), 29)
 
     # Test with values larger than UInt128 max (using UInt256)
     var very_large = UInt256(Decimal.MAX_AS_UINT128) * UInt256(10)
-    assert_equal(number_of_significant_digits(very_large), 30)
+    assert_equal(number_of_digits(very_large), 30)
 
-    print("✓ All number_of_significant_digits tests passed!")
+    print("✓ All number_of_digits tests passed!")
 
 
 fn test_truncate_to_max_below_max() raises:
@@ -265,7 +265,7 @@ fn test_all() raises:
     """Run all tests for the utility module."""
     print("\n=== Running Utility Module Tests ===\n")
 
-    test_number_of_significant_digits()
+    test_number_of_digits()
     print()
 
     test_truncate_to_max_below_max()


### PR DESCRIPTION
This pull request includes several changes in the `decimojo` project, focusing on enhancing the `multiply()` function with `UInt128` and `UInt256`. The performance of multiplication is significantly improved.

Enhancements to `Decimal` struct:

* [`src/decimojo/decimal.mojo`](diffhunk://#diff-c2178e6e0bbbbb0d3379f1513412224309d1232c444654e77abb5ce36b3a854fL879-R879): Added `raises` keyword to `__mul__` methods and introduced new methods `is_uint32able` and `is_uint64able` to check if the coefficient can be represented as `UInt32` or `UInt64` values. [[1]](diffhunk://#diff-c2178e6e0bbbbb0d3379f1513412224309d1232c444654e77abb5ce36b3a854fL879-R879) [[2]](diffhunk://#diff-c2178e6e0bbbbb0d3379f1513412224309d1232c444654e77abb5ce36b3a854fL889-R889) [[3]](diffhunk://#diff-c2178e6e0bbbbb0d3379f1513412224309d1232c444654e77abb5ce36b3a854fR1136-R1147)

Improvements to rounding functionality:

* [`src/decimojo/maths/rounding.mojo`](diffhunk://#diff-0ac5c3ceeb03613b760b1280d0b1ce25b00cb6ac43d0c1b05c10497531ca1c0eL32-R32): Modified the `round` function to include default values for `decimal_places` and updated comments for better clarity. [[1]](diffhunk://#diff-0ac5c3ceeb03613b760b1280d0b1ce25b00cb6ac43d0c1b05c10497531ca1c0eL32-R32) [[2]](diffhunk://#diff-0ac5c3ceeb03613b760b1280d0b1ce25b00cb6ac43d0c1b05c10497531ca1c0eL41-R59)

Updates to utility functions:

* [`src/decimojo/utility.mojo`](diffhunk://#diff-da25fdfe823defe67e23af758d622c196b0f00af1e89458410f91b222087edabL53-R54): Replaced `number_of_significant_digits` with `number_of_digits`, and added new functions `truncate_to_digits` and `number_of_bits` for better digit and bit manipulation. [[1]](diffhunk://#diff-da25fdfe823defe67e23af758d622c196b0f00af1e89458410f91b222087edabL53-R54) [[2]](diffhunk://#diff-da25fdfe823defe67e23af758d622c196b0f00af1e89458410f91b222087edabR67-R79) [[3]](diffhunk://#diff-da25fdfe823defe67e23af758d622c196b0f00af1e89458410f91b222087edabL88-R88) [[4]](diffhunk://#diff-da25fdfe823defe67e23af758d622c196b0f00af1e89458410f91b222087edabL179-R343)

Enhancements to testing:

* [`tests/test_utility.mojo`](diffhunk://#diff-158223fbfc6610e96570bcd325fe34fbe30e5be62cad102b7c3ed4f3618d302eL9-R41): Updated tests to reflect changes in utility functions, including new tests for `truncate_to_digits` and replacing tests for `number_of_significant_digits` with `number_of_digits`. [[1]](diffhunk://#diff-158223fbfc6610e96570bcd325fe34fbe30e5be62cad102b7c3ed4f3618d302eL9-R41) [[2]](diffhunk://#diff-158223fbfc6610e96570bcd325fe34fbe30e5be62cad102b7c3ed4f3618d302eR164-R220) [[3]](diffhunk://#diff-158223fbfc6610e96570bcd325fe34fbe30e5be62cad102b7c3ed4f3618d302eL207-R268) [[4]](diffhunk://#diff-158223fbfc6610e96570bcd325fe34fbe30e5be62cad102b7c3ed4f3618d302eR283-R285)

Additional changes:

* [`mojoproject.toml`](diffhunk://#diff-1b0ef62120bccf4c05a76e60e13fe686f33eb92d5897b3f05e0c3f8d737fc5c0R36-R39): Added individual benchmark commands for `bench_multiply.mojo` and `bench_divide.mojo`.