### PR TITLE
[decimal] simplifying initialization of `Decimal` and add `from_uint128()`

### DIFF
--- a/src/decimojo/maths/exp.mojo
+++ b/src/decimojo/maths/exp.mojo
@@ -141,19 +141,21 @@ fn sqrt(x: Decimal) raises -> Decimal:
     # For numbers with zero scale (true integers)
     if x_scale == 0:
         var float_sqrt = builtin_math.sqrt(Float64(x_coef))
-        guess = Decimal(UInt128(float_sqrt))
+        guess = Decimal.from_uint128(UInt128(float_sqrt))
         # print("DEBUG: scale = 0")
 
     # For numbers with even scale
     elif x_scale % 2 == 0:
         var float_sqrt = builtin_math.sqrt(Float64(x_coef))
-        guess = Decimal(UInt128(float_sqrt), scale=x_scale >> 1, sign=False)
+        guess = Decimal.from_uint128(
+            UInt128(float_sqrt), scale=x_scale >> 1, sign=False
+        )
         # print("DEBUG: scale is even")
 
     # For numbers with odd scale
     else:
         var float_sqrt = builtin_math.sqrt(Float64(x_coef)) * Float64(3.15625)
-        guess = Decimal(
+        guess = Decimal.from_uint128(
             UInt128(float_sqrt), scale=(x_scale + 1) >> 1, sign=False
         )
         # print("DEBUG: scale is odd")

--- a/src/decimojo/maths/rounding.mojo
+++ b/src/decimojo/maths/rounding.mojo
@@ -107,7 +107,7 @@ fn round(
 
             # In other cases, return the result
             else:
-                return Decimal(
+                return Decimal.from_uint128(
                     res_coef, scale=ndigits, sign=number.is_negative()
                 )
 
@@ -134,12 +134,16 @@ fn round(
         )
 
         if ndigits >= 0:
-            return Decimal(res_coef, scale=ndigits, sign=number.is_negative())
+            return Decimal.from_uint128(
+                res_coef, scale=ndigits, sign=number.is_negative()
+            )
 
         # if `ndigits` is negative and `ndigits_to_keep` >= 0, scale up the result
         elif ndigits_to_keep >= 0:
             res_coef *= UInt128(10) ** (-ndigits)
-            return Decimal(res_coef, scale=0, sign=number.is_negative())
+            return Decimal.from_uint128(
+                res_coef, scale=0, sign=number.is_negative()
+            )
 
         # if `ndigits` is negative and `ndigits_to_keep` < 0, return 0
         else:


### PR DESCRIPTION
This pull request includes significant refactoring and improvements to the `Decimal` struct in the `decimojo` library. The main changes involve simplifying the initialization of `Decimal` objects and adding a new method for creating `Decimal` instances from `UInt128` values.

Initialization Refactoring:

* Simplified the initialization logic by removing redundant constructors and consolidating the initialization process for `Int` and `UInt128` values.

New Method for `UInt128` Initialization:

* Added a new static method `from_uint128` to initialize a `Decimal` from a `UInt128` value, including validation for the value and scale.

Code Simplification:

* Updated existing methods to use the new `from_uint128` method for creating `Decimal` instances from `UInt128` values.
* Modified the `sqrt` function to use the new `from_uint128` method.
* Updated the `round` function to use the new `from_uint128` method.