### PR TITLE
[max] Update max version to 25.2

### DIFF
--- a/mojoproject.toml
+++ b/mojoproject.toml
@@ -1,7 +1,8 @@
 [project]
 authors = ["ZHU Yuhao 朱宇浩 <dr.yuhao.zhu@outlook.com>"]
-channels = ["https://conda.modular.com/max-nightly", "https://conda.modular.com/max", "https://repo.prefix.dev/modular-community", "conda-forge"]
-description = "A fixed-point decimal arithmetic library written in Mojo 🔥"
+channels = ["https://conda.modular.com/max", "https://repo.prefix.dev/modular-community", "conda-forge"]
+# channels = ["https://conda.modular.com/max-nightly", "https://conda.modular.com/max", "https://repo.prefix.dev/modular-community", "conda-forge"]
+description = "A comprehensive decimal and integer mathematics library for Mojo"
 license = "Apache-2.0"
 name = "decimojo"
 platforms = ["osx-arm64", "linux-64"]
@@ -9,7 +10,7 @@ readme = "README.md"
 version = "0.1.0"
 
 [dependencies]
-max = ">=25.2,<25.3"
+max = ">=25.2"
 
 [tasks]
 # format the code


### PR DESCRIPTION
This pull request includes changes to the `mojoproject.toml` file, focusing on updating project metadata and dependencies.

Project metadata updates:

* Updated the project description to "A comprehensive decimal and integer mathematics library for Mojo" from "A fixed-point decimal arithmetic library written in Mojo 🔥".
* Commented out the nightly channel URL in the `channels` list, simplifying the active channels to "https://conda.modular.com/max", "https://repo.prefix.dev/modular-community", and "conda-forge".

Dependency updates:

* Modified the version constraint for the `max` dependency to ">=25.2" from ">=25.2,<25.3".