### PR TITLE
[decimal] Add tests for `subtract()` of `BigDecimal`

### DIFF
--- a/mojoproject.toml
+++ b/mojoproject.toml
@@ -31,7 +31,7 @@ test = "magic run package && magic run mojo test tests --filter"
 t = "clear && magic run package && magic run mojo test tests --filter"
 
 # benches
-bench_dec = "magic run package && cd benches/decimal && magic run mojo -I ../ bench.mojo && cd ../.. && magic run clean"
-bench_bint = "magic run package && cd benches/bigint && magic run mojo -I ../ bench.mojo && cd ../.. && magic run clean"
-bench_buint = "magic run package && cd benches/biguint && magic run mojo -I ../ bench.mojo && cd ../.. && magic run clean"
-bench_bdec = "magic run package && cd benches/bigdecimal && magic run mojo -I ../ bench.mojo && cd ../.. && magic run clean"
+bench_dec = "clear && magic run package && cd benches/decimal && magic run mojo -I ../ bench.mojo && cd ../.. && magic run clean"
+bench_bint = "clear && magic run package && cd benches/bigint && magic run mojo -I ../ bench.mojo && cd ../.. && magic run clean"
+bench_buint = "clear && magic run package && cd benches/biguint && magic run mojo -I ../ bench.mojo && cd ../.. && magic run clean"
+bench_bdec = "clear && magic run package && cd benches/bigdecimal && magic run mojo -I ../ bench.mojo && cd ../.. && magic run clean"

--- a/tests/bigdecimal/test_bigdecimal_arithmetics.mojo
+++ b/tests/bigdecimal/test_bigdecimal_arithmetics.mojo
@@ -85,10 +85,80 @@ fn test_add() raises:
     testing.assert_equal(failed, 0, "All addition tests should pass")
 
 
+fn test_subtract() raises:
+    """Test BigDecimal subtraction with various test cases."""
+    print("------------------------------------------------------")
+    print("Testing BigDecimal subtraction...")
+
+    # Debug TOML parsing
+    var toml = parse_file(file_path)
+    print("TOML file loaded successfully")
+
+    # Check what root keys are available
+    print("Available root keys:")
+    for key in toml.root.keys():
+        print("  - " + key[])
+
+    # Try to access the specific section
+    try:
+        var section = toml.get_array_of_tables("subtraction_tests")
+        print("Found subtraction_tests with", len(section), "entries")
+    except e:
+        print("Error accessing subtraction_tests:", String(e))
+
+    # Load test cases from TOML file
+    var test_cases = load_test_cases(file_path, "subtraction_tests")
+    print("Loaded", len(test_cases), "test cases for subtraction")
+
+    # Track test results
+    var passed = 0
+    var failed = 0
+
+    # Run all test cases in a loop
+    for i in range(len(test_cases)):
+        var test_case = test_cases[i]
+        var a = BigDecimal(test_case.a)
+        var b = BigDecimal(test_case.b)
+        var expected = BigDecimal(test_case.expected)
+        var result = a - b
+
+        try:
+            # Using String comparison for easier debugging
+            testing.assert_equal(
+                String(result), String(expected), test_case.description
+            )
+            # print("✓ Case", i + 1, ":", test_case.description)
+            passed += 1
+        except e:
+            print(
+                "✗ Case",
+                i + 1,
+                "failed:",
+                test_case.description,
+                "\n  Input:",
+                test_case.a,
+                "-",
+                test_case.b,
+                "\n  Expected:",
+                test_case.expected,
+                "\n  Got:",
+                String(result),
+                "\n  Error:",
+                String(e),
+            )
+            failed += 1
+
+    print("BigDecimal subtraction tests:", passed, "passed,", failed, "failed")
+    testing.assert_equal(failed, 0, "All subtraction tests should pass")
+
+
 fn main() raises:
     print("Running BigDecimal arithmetic tests")
 
     # Run addition tests
     test_add()
+
+    # Run subtraction tests
+    test_subtract()
 
     print("All BigDecimal arithmetic tests passed!")

--- a/tests/bigdecimal/test_data/bigdecimal_arithmetics.toml
+++ b/tests/bigdecimal/test_data/bigdecimal_arithmetics.toml
@@ -308,3 +308,323 @@ a = "0.0425"
 b = "0.0015"
 expected = "0.0440"
 description = "Interest rate calculation"
+
+# ===----------------------------------------------------------------------=== #
+# Test cases for BigDecimal subtraction
+# ===----------------------------------------------------------------------=== #
+# === BASIC SUBTRACTION TESTS ===
+[[subtraction_tests]]
+a = "100"
+b = "42"
+expected = "58"
+description = "Simple integer subtraction"
+
+[[subtraction_tests]]
+a = "5.85"
+b = "2.71"
+expected = "3.14"
+description = "Simple decimal subtraction"
+
+[[subtraction_tests]]
+a = "0"
+b = "0"
+expected = "0"
+description = "Zero minus zero"
+
+[[subtraction_tests]]
+a = "1"
+b = "0"
+expected = "1"
+description = "Subtraction with zero"
+
+[[subtraction_tests]]
+a = "123.456"
+b = "0"
+expected = "123.456"
+description = "Decimal minus zero"
+
+# === DIFFERENT SCALE TESTS ===
+[[subtraction_tests]]
+a = "10.2345"
+b = "5.67"
+expected = "4.5645"
+description = "Subtraction with different scales"
+
+[[subtraction_tests]]
+a = "5.23456789012345678901234567"
+b = "1.6"
+expected = "3.63456789012345678901234567"
+description = "Subtraction with very different scales"
+
+[[subtraction_tests]]
+a = "10.000"
+b = "0.001"
+expected = "9.999"
+description = "Subtraction with borrowing"
+
+[[subtraction_tests]]
+a = "1000000.000000"
+b = "0.000001"
+expected = "999999.999999"
+description = "Subtraction causing scale reduction"
+
+[[subtraction_tests]]
+a = "3.000000000000000000000000003"
+b = "2.000000000000000000000000002"
+expected = "1.000000000000000000000000001"
+description = "Subtraction with high precision"
+
+# === SIGN COMBINATION TESTS ===
+[[subtraction_tests]]
+a = "-1"
+b = "-2"
+expected = "1"
+description = "Negative minus negative"
+
+[[subtraction_tests]]
+a = "10"
+b = "-3.14"
+expected = "13.14"
+description = "Positive minus negative (becomes addition)"
+
+[[subtraction_tests]]
+a = "-10"
+b = "3.14"
+expected = "-13.14"
+description = "Negative minus positive"
+
+[[subtraction_tests]]
+a = "50"
+b = "60.5"
+expected = "-10.5"
+description = "Subtraction resulting in negative"
+
+[[subtraction_tests]]
+a = "123.456"
+b = "123.456"
+expected = "0.000"
+description = "Subtraction resulting in zero"
+
+[[subtraction_tests]]
+a = "0.0000001"
+b = "0.00000005"
+expected = "0.00000005"
+description = "Subtraction near zero (small difference)"
+
+# === LARGE NUMBER TESTS ===
+[[subtraction_tests]]
+a = "10000000000000000000000000000"
+b = "1"
+expected = "9999999999999999999999999999"
+description = "Large integer subtraction"
+
+[[subtraction_tests]]
+a = "-9999999999999999999999999999"
+b = "1"
+expected = "-10000000000000000000000000000"
+description = "Large negative minus positive"
+
+[[subtraction_tests]]
+a = "100000000000000000000.00000000"
+b = "0.00000001"
+expected = "99999999999999999999.99999999"
+description = "Very large decimal subtraction with borrowing"
+
+[[subtraction_tests]]
+a = "10000000000000000000000000"
+b = "0.00000000000000000000000001"
+expected = "9999999999999999999999999.99999999999999999999999999"
+description = "Very large minus very small"
+
+# === SMALL NUMBER TESTS ===
+[[subtraction_tests]]
+a = "0.0000000000000000000000003"
+b = "0.0000000000000000000000002"
+expected = "0.0000000000000000000000001"
+description = "Very small positive values"
+
+[[subtraction_tests]]
+a = "-0.0000000000000000000000003"
+b = "-0.0000000000000000000000002"
+expected = "-0.0000000000000000000000001"
+description = "Very small negative values (negative minus negative)"
+
+[[subtraction_tests]]
+a = "-0.0000000000000000000000002"
+b = "-0.0000000000000000000000003"
+expected = "0.0000000000000000000000001"
+description = "Very small negative values (smaller negative minus larger negative)"
+
+[[subtraction_tests]]
+a = "0.00000000003"
+b = "0.000000000000000000001"
+expected = "0.000000000029999999999"
+description = "Small values with different scales"
+
+# === SCIENTIFIC NOTATION TESTS ===
+[[subtraction_tests]]
+a = "1.23e5"
+b = "4.56e4"
+expected = "77400"
+description = "Subtraction with scientific notation"
+
+[[subtraction_tests]]
+a = "1.23e-10"
+b = "4.56e-11"
+expected = "0.0000000000774"
+description = "Subtraction with negative exponents"
+
+[[subtraction_tests]]
+a = "4.56e10"
+b = "1.23e-10"
+expected = "45599999999.999999999877"
+description = "Subtraction with extreme exponent difference"
+
+# === SPECIAL CASES ===
+[[subtraction_tests]]
+a = "3.14159265358979323846"
+b = "2.71828182845904523536"
+expected = "0.42331082513074800310"
+description = "Subtraction of mathematical constants (PI - E)"
+
+[[subtraction_tests]]
+a = "1.00000000000000000000000000"
+b = "0.33333333333333333333333333"
+expected = "0.66666666666666666666666667"
+description = "Subtraction with repeating pattern"
+
+[[subtraction_tests]]
+a = "1.000000000000000000"
+b = "0.500000000000000001"
+expected = "0.499999999999999999"
+description = "Subtraction resulting in almost half"
+
+[[subtraction_tests]]
+a = "10.00000000000000000000000000"
+b = "9.99999999999999999999999999"
+expected = "0.00000000000000000000000001"
+description = "Subtraction with many borrows"
+
+# === FINANCIAL SCENARIOS ===
+[[subtraction_tests]]
+a = "10542.75"
+b = "3621.50"
+expected = "6921.25"
+description = "Financial numbers (dollars and cents)"
+
+[[subtraction_tests]]
+a = "0.10"
+b = "0.01"
+expected = "0.09"
+description = "Financial numbers (cents)"
+
+[[subtraction_tests]]
+a = "100.00"
+b = "0.01"
+expected = "99.99"
+description = "Financial subtraction with borrowing"
+
+# === PRECISION BOUNDARY TESTS ===
+[[subtraction_tests]]
+a = "1000000000000000000.0000000"
+b = "0.0000001"
+expected = "999999999999999999.9999999"
+description = "Subtraction with rounding at precision boundary"
+
+[[subtraction_tests]]
+a = "3.3000000000000000000000000"
+b = "2.2000000000000000000000000"
+expected = "1.1000000000000000000000000"
+description = "Subtraction with trailing zeros"
+
+[[subtraction_tests]]
+a = "0.125"
+b = "0.0625"
+expected = "0.0625"
+description = "Subtraction of binary-friendly values (1/8 - 1/16)"
+
+[[subtraction_tests]]
+a = "0.3"
+b = "0.2"
+expected = "0.1"
+description = "Simple tenths subtraction"
+
+# === ADDITIONAL EDGE CASES ===
+[[subtraction_tests]]
+a = "0.000000000000000000000000010"
+b = "0.000000000000000000000000001"
+expected = "0.000000000000000000000000009"
+description = "Subtraction near zero with precision limit"
+
+[[subtraction_tests]]
+a = "0.0"
+b = "0.0"
+expected = "0.0"
+description = "Zero minus zero with decimal point"
+
+[[subtraction_tests]]
+a = "0.142857142857142857142857"
+b = "0.076923076923076923076923"
+expected = "0.065934065934065934065934"
+description = "Subtraction of recurring decimals (1/7 - 1/13)"
+
+[[subtraction_tests]]
+a = "0"
+b = "-0"
+expected = "0"
+description = "Zero minus negative zero"
+
+[[subtraction_tests]]
+a = "3E6"
+b = "2000000"
+expected = "1000000"
+description = "Subtraction with E notation"
+
+[[subtraction_tests]]
+a = "1.79769313486231570E+308"
+b = "10"
+expected = "179769313486231569999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999990"
+description = "Subtraction near max double precision"
+
+[[subtraction_tests]]
+a = "9.9999999999999999999999"
+b = "9.9999999999999999999999"
+expected = "0.0000000000000000000000"
+description = "Exact cancellation of large numbers"
+
+[[subtraction_tests]]
+a = "1111111110111111111.111111110111111110"
+b = "987654321098765432.123456789098765432"
+expected = "123456789012345678.987654321012345678"
+description = "Complex subtraction with different digit patterns"
+
+# === SPECIFIC APPLICATION DOMAINS ===
+[[subtraction_tests]]
+a = "37.7749"
+b = "37.7748"
+expected = "0.0001"
+description = "GPS coordinates (latitude difference)"
+
+[[subtraction_tests]]
+a = "98.6"
+b = "37.0"
+expected = "61.6"
+description = "Temperature conversion (F - C)"
+
+[[subtraction_tests]]
+a = "1000.50"
+b = "243.22"
+expected = "757.28"
+description = "Bank balance calculation"
+
+[[subtraction_tests]]
+a = "987654321987654321.987654321"
+b = "0.000000000000000000000000001"
+expected = "987654321987654321.987654320999999999999999999"
+description = "Subtraction with extreme scale difference"
+
+[[subtraction_tests]]
+a = "0.0440"
+b = "0.0015"
+expected = "0.0425"
+description = "Interest rate calculation"


### PR DESCRIPTION
This pull request introduces several significant changes to the `mojoproject.toml` and `tests/bigdecimal` files, primarily adding new functionality for testing BigDecimal subtraction. The most important changes include the addition of a new test function for BigDecimal subtraction, updates to the test data, and minor modifications to existing commands.

### New functionality for BigDecimal subtraction:

* [`tests/bigdecimal/test_bigdecimal_arithmetics.mojo`](diffhunk://#diff-072ed46a8bb09c6e6a52a3d5466019af8860ed562fcc12e8a52dfca16a21a8bfR88-R163): Added a new function `test_subtract()` to test BigDecimal subtraction with various test cases. This includes loading test cases from a TOML file, running the tests, and validating the results.

### Updates to test data:

* [`tests/bigdecimal/test_data/bigdecimal_arithmetics.toml`](diffhunk://#diff-4544caef0a863355612643e4ce82284869e998c34034d1dad20903a27b9ab2d8R311-R630): Added a comprehensive set of test cases for BigDecimal subtraction, covering basic subtraction, different scales, sign combinations, large and small numbers, scientific notation, special cases, financial scenarios, precision boundaries, additional edge cases, and specific application domains.

### Minor modifications to existing commands:

* [`mojoproject.toml`](diffhunk://#diff-1b0ef62120bccf4c05a76e60e13fe686f33eb92d5897b3f05e0c3f8d737fc5c0L34-R37): Updated the commands for running benchmarks to include a `clear` command at the beginning, ensuring a clean slate before execution.