### PR TITLE
[decimal] Implement `exp()` for `BigDecimal`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
-# DeciMojo
+# DeciMojo <!-- omit in toc -->
 
 A comprehensive decimal and integer mathematics library for [Mojo](https://www.modular.com/mojo).
 
 **[中文·漢字»](https://zhuyuhao.com/decimojo/docs/readme_zht.html)**　|　**[Repository on GitHub»](https://github.com/forfudan/decimojo)**  | **[Changelog](https://zhuyuhao.com/decimojo/docs/changelog.html)**
+
+- [Overview](#overview)
+- [Installation](#installation)
+- [Quick start](#quick-start)
+- [Objective](#objective)
+- [Nomenclature](#nomenclature)
+- [Status](#status)
+- [Tests and benches](#tests-and-benches)
+- [Citation](#citation)
+- [License](#license)
 
 ## Overview
 
@@ -168,7 +178,7 @@ The name ultimately emphasizes our mission: bringing precise, reliable decimal c
 
 Rome wasn't built in a day. DeciMojo is currently under active development. For the 128-bit `Decimal` type, it has successfully progressed through the **"make it work"** phase and is now well into the **"make it right"** phase with many optimizations already in place. Bug reports and feature requests are welcome! If you encounter issues, please [file them here](https://github.com/forfudan/decimojo/issues).
 
-### Make it Work ✅ (COMPLETED)
+### Make it Work ✅ (COMPLETED)  <!-- omit in toc -->
 
 - Core decimal implementation with a robust 128-bit representation (96-bit coefficient + 32-bit flags)
 - Comprehensive arithmetic operations (+, -, *, /, %, **) with proper overflow handling
@@ -176,7 +186,7 @@ Rome wasn't built in a day. DeciMojo is currently under active development. For 
 - Proper representation of special values (NaN, Infinity)
 - Full suite of comparison operators with correct decimal semantics
 
-### Make it Right 🔄 (MOSTLY COMPLETED)
+### Make it Right 🔄 (MOSTLY COMPLETED) <!-- omit in toc -->
 
 - Reorganized codebase with modular structure (decimal, arithmetics, comparison, exponential).
 - Edge case handling for all operations (division by zero, zero to negative power).
@@ -186,7 +196,7 @@ Rome wasn't built in a day. DeciMojo is currently under active development. For 
 - Proper implementation of traits (Absable, Comparable, Floatable, Roundable, etc).
 - **BigInt and BigUInt** implementations with complete arithmetic operations, proper division semantics (floor and truncate), and support for arbitrary-precision calculations.
 
-### Make it Fast ⚡ (SIGNIFICANT PROGRESS)
+### Make it Fast ⚡ (SIGNIFICANT PROGRESS) <!-- omit in toc -->
 
 DeciMojo delivers exceptional performance compared to Python's `decimal` module while maintaining precise calculations. This performance difference stems from fundamental design choices:
 
@@ -202,7 +212,7 @@ This architectural difference explains our benchmarking results:
 
 Regular benchmarks against Python's `decimal` module are available in the `bench/` folder, documenting both the performance advantages and the few specific operations where different approaches are needed.
 
-### Future Extensions 🚀 (PLANNED)
+### Future Extensions 🚀 (PLANNED) <!-- omit in toc -->
 
 - **BigDecimal**: 🔄 **IN PROGRESS** - Arbitrary-precision decimal type with configurable precision[^arbitrary].
 - **BigComplex**: 📝 **PLANNED** - Arbitrary-precision complex number type built on BigDecimal.

--- a/benches/bigdecimal/bench.mojo
+++ b/benches/bigdecimal/bench.mojo
@@ -3,6 +3,7 @@ from bench_bigdecimal_subtract import main as bench_sub
 from bench_bigdecimal_multiply import main as bench_multiply
 from bench_bigdecimal_divide import main as bench_divide
 from bench_bigdecimal_sqrt import main as bench_sqrt
+from bench_bigdecimal_exp import main as bench_exp
 from bench_bigdecimal_scale_up_by_power_of_10 import main as bench_scale_up
 
 
@@ -17,6 +18,7 @@ sub:         Subtract
 mul:         Multiply
 div:         Divide (true divide)
 sqrt:        Square root
+exp:         Exponential
 all:         Run all benchmarks
 q:           Exit
 =========================================
@@ -35,12 +37,15 @@ scaleup:     Scale up by power of 10
         bench_divide()
     elif command == "sqrt":
         bench_sqrt()
+    elif command == "exp":
+        bench_exp()
     elif command == "all":
         bench_add()
         bench_sub()
         bench_multiply()
         bench_divide()
         bench_sqrt()
+        bench_exp()
     elif command == "q":
         return
     elif command == "scaleup":

--- a/benches/bigdecimal/bench_bigdecimal_exp.mojo
+++ b/benches/bigdecimal/bench_bigdecimal_exp.mojo
@@ -1,0 +1,670 @@
+"""
+Comprehensive benchmarks for BigDecimal exponential function (exp).
+Compares performance against Python's decimal module with diverse test cases.
+"""
+
+from decimojo import BigDecimal, RoundingMode
+from python import Python, PythonObject
+from time import perf_counter_ns
+import time
+import os
+from collections import List
+
+
+fn open_log_file() raises -> PythonObject:
+    """
+    Creates and opens a log file with a timestamp in the filename.
+
+    Returns:
+        A file object opened for writing.
+    """
+    var python = Python.import_module("builtins")
+    var datetime = Python.import_module("datetime")
+
+    # Create logs directory if it doesn't exist
+    var log_dir = "./logs"
+    if not os.path.exists(log_dir):
+        os.makedirs(log_dir)
+
+    # Generate a timestamp for the filename
+    var timestamp = String(datetime.datetime.now().isoformat())
+    var log_filename = log_dir + "/benchmark_bigdecimal_exp_" + timestamp + ".log"
+
+    print("Saving benchmark results to:", log_filename)
+    return python.open(log_filename, "w")
+
+
+fn log_print(msg: String, log_file: PythonObject) raises:
+    """
+    Prints a message to both the console and the log file.
+
+    Args:
+        msg: The message to print.
+        log_file: The file object to write to.
+    """
+    print(msg)
+    log_file.write(msg + "\n")
+    log_file.flush()  # Ensure the message is written immediately
+
+
+fn run_benchmark_exp(
+    name: String,
+    value: String,
+    iterations: Int,
+    log_file: PythonObject,
+    mut speedup_factors: List[Float64],
+) raises:
+    """
+    Run a benchmark comparing Mojo BigDecimal exp with Python Decimal exp.
+
+    Args:
+        name: Name of the benchmark case.
+        value: String representation of the number to calculate the exp of.
+        iterations: Number of iterations to run.
+        log_file: File object for logging results.
+        speedup_factors: Mojo List to store speedup factors for averaging.
+    """
+    log_print("\nBenchmark:          " + name, log_file)
+    log_print("Value:              " + value, log_file)
+
+    # Set up Mojo and Python values
+    var mojo_value = BigDecimal(value)
+    var pydecimal = Python.import_module("decimal")
+    var py_value = pydecimal.Decimal(value)
+
+    # Execute the operations once to verify correctness
+    try:
+        var mojo_result = mojo_value.exp()
+        var py_result = py_value.exp()
+
+        # Display results for verification
+        log_print("Mojo result:        " + String(mojo_result), log_file)
+        log_print("Python result:      " + String(py_result), log_file)
+
+        # Benchmark Mojo implementation
+        var t0 = perf_counter_ns()
+        for _ in range(iterations):
+            # _ = mojo_value.exp()
+            _ = mojo_value.exp()
+        var mojo_time = (perf_counter_ns() - t0) / iterations
+        if mojo_time == 0:
+            mojo_time = 1  # Prevent division by zero
+
+        # Benchmark Python implementation
+        t0 = perf_counter_ns()
+        for _ in range(iterations):
+            _ = py_value.exp()
+        var python_time = (perf_counter_ns() - t0) / iterations
+
+        # Calculate speedup factor
+        var speedup = python_time / mojo_time
+        speedup_factors.append(Float64(speedup))
+
+        # Print results with speedup comparison
+        log_print(
+            "Mojo exp:           " + String(mojo_time) + " ns per iteration",
+            log_file,
+        )
+        log_print(
+            "Python exp:         " + String(python_time) + " ns per iteration",
+            log_file,
+        )
+        log_print("Speedup factor:     " + String(speedup), log_file)
+    except e:
+        log_print("Error occurred during benchmark: " + String(e), log_file)
+        log_print("Skipping this benchmark case", log_file)
+
+
+fn main() raises:
+    # Open log file
+    var log_file = open_log_file()
+    var datetime = Python.import_module("datetime")
+
+    # Create a Mojo List to store speedup factors for averaging later
+    var speedup_factors = List[Float64]()
+
+    # Display benchmark header with system information
+    log_print(
+        "=== DeciMojo BigDecimal Exponential (exp) Benchmark ===", log_file
+    )
+    log_print("Time: " + String(datetime.datetime.now().isoformat()), log_file)
+
+    # Try to get system info
+    try:
+        var platform = Python.import_module("platform")
+        log_print(
+            "System: "
+            + String(platform.system())
+            + " "
+            + String(platform.release()),
+            log_file,
+        )
+        log_print("Processor: " + String(platform.processor()), log_file)
+        log_print(
+            "Python version: " + String(platform.python_version()), log_file
+        )
+    except:
+        log_print("Could not retrieve system information", log_file)
+
+    var iterations = 100
+    var pydecimal = Python().import_module("decimal")
+
+    # Set Python decimal precision to match Mojo's
+    pydecimal.getcontext().prec = 28
+    log_print(
+        "Python decimal precision: " + String(pydecimal.getcontext().prec),
+        log_file,
+    )
+    log_print("Mojo decimal precision: 28", log_file)
+
+    # Define benchmark cases
+    log_print(
+        "\nRunning decimal exp benchmarks with "
+        + String(iterations)
+        + " iterations each",
+        log_file,
+    )
+
+    # === BASIC EXPONENTIAL TESTS ===
+
+    # Case 1: exp(0)
+    run_benchmark_exp(
+        "exp(0)",
+        "0",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 2: exp(1)
+    run_benchmark_exp(
+        "exp(1)",
+        "1",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 3: exp(-1)
+    run_benchmark_exp(
+        "exp(-1)",
+        "-1",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 4: exp(2)
+    run_benchmark_exp(
+        "exp(2)",
+        "2",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 5: exp(-2)
+    run_benchmark_exp(
+        "exp(-2)",
+        "-2",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # === SCALE AND PRECISION TESTS ===
+
+    # Case 6: exp(0.1)
+    run_benchmark_exp(
+        "exp(0.1)",
+        "0.1",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 7: exp(-0.1)
+    run_benchmark_exp(
+        "exp(-0.1)",
+        "-0.1",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 8: exp(0.01)
+    run_benchmark_exp(
+        "exp(0.01)",
+        "0.01",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 9: exp(-0.01)
+    run_benchmark_exp(
+        "exp(-0.01)",
+        "-0.01",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 10: exp(0.5)
+    run_benchmark_exp(
+        "exp(0.5)",
+        "0.5",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # === LARGE NUMBER TESTS ===
+
+    # Case 11: exp(10)
+    run_benchmark_exp(
+        "exp(10)",
+        "10",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 12: exp(-10)
+    run_benchmark_exp(
+        "exp(-10)",
+        "-10",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 13: exp(100)
+    run_benchmark_exp(
+        "exp(100)",
+        "100",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 14: exp(-100)
+    run_benchmark_exp(
+        "exp(-100)",
+        "-100",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # === SMALL NUMBER TESTS ===
+
+    # Case 15: exp(0.0001)
+    run_benchmark_exp(
+        "exp(0.0001)",
+        "0.0001",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 16: exp(-0.0001)
+    run_benchmark_exp(
+        "exp(-0.0001)",
+        "-0.0001",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 17: exp(1e-10)
+    run_benchmark_exp(
+        "exp(1e-10)",
+        "1e-10",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 18: exp(-1e-10)
+    run_benchmark_exp(
+        "exp(-1e-10)",
+        "-1e-10",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # === SCIENTIFIC NOTATION TESTS ===
+
+    # Case 19: exp(1.234e2)
+    run_benchmark_exp(
+        "exp(1.234e2)",
+        "1.234e2",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 20: exp(-1.234e2)
+    run_benchmark_exp(
+        "exp(-1.234e2)",
+        "-1.234e2",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 21: exp(1.234e-2)
+    run_benchmark_exp(
+        "exp(1.234e-2)",
+        "1.234e-2",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 22: exp(-1.234e-2)
+    run_benchmark_exp(
+        "exp(-1.234e-2)",
+        "-1.234e-2",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # === SPECIAL VALUE TESTS ===
+
+    # Case 23: exp(PI)
+    run_benchmark_exp(
+        "exp(PI)",
+        "3.14159265358979323846264338328",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 24: exp(-PI)
+    run_benchmark_exp(
+        "exp(-PI)",
+        "-3.14159265358979323846264338328",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 25: exp(E)
+    run_benchmark_exp(
+        "exp(E)",
+        "2.71828182845904523536028747135",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 26: exp(-E)
+    run_benchmark_exp(
+        "exp(-E)",
+        "-2.71828182845904523536028747135",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 27: exp(0.6931471805599453) # ln(2)
+    run_benchmark_exp(
+        "exp(ln(2))",
+        "0.6931471805599453",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 28: exp(-0.6931471805599453) # -ln(2)
+    run_benchmark_exp(
+        "exp(-ln(2))",
+        "-0.6931471805599453",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # === MORE EDGE CASES ===
+
+    # Case 29: exp(very small positive)
+    run_benchmark_exp(
+        "exp(very small positive)",
+        "0.000000000000000000000000001",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 30: exp(very small negative)
+    run_benchmark_exp(
+        "exp(very small negative)",
+        "-0.000000000000000000000000001",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 31: exp(large positive)
+    run_benchmark_exp(
+        "exp(large positive)",
+        "50",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 32: exp(large negative)
+    run_benchmark_exp(
+        "exp(large negative)",
+        "-50",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 33: exp(near max double)
+    run_benchmark_exp(
+        "exp(near max double)",
+        "709",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 34: exp(near min double)
+    run_benchmark_exp(
+        "exp(near min double)",
+        "-709",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 35: exp(1000)
+    run_benchmark_exp(
+        "exp(1000)",
+        "1000",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 36: exp(-1000)
+    run_benchmark_exp(
+        "exp(-1000)",
+        "-1000",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 37: exp(10000)
+    run_benchmark_exp(
+        "exp(10000)",
+        "10000",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 38: exp(-10000)
+    run_benchmark_exp(
+        "exp(-10000)",
+        "-10000",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 39: exp(100000)
+    run_benchmark_exp(
+        "exp(100000)",
+        "100000",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 40: exp(-100000)
+    run_benchmark_exp(
+        "exp(-100000)",
+        "-100000",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 41: exp(1000000)
+    run_benchmark_exp(
+        "exp(1000000)",
+        "1000000",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 42: exp(-1000000)
+    run_benchmark_exp(
+        "exp(-1000000)",
+        "-1000000",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 43: exp(10000000)
+    run_benchmark_exp(
+        "exp(10000000)",
+        "10000000",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 44: exp(-10000000)
+    run_benchmark_exp(
+        "exp(-10000000)",
+        "-10000000",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 45: exp(100000000)
+    run_benchmark_exp(
+        "exp(100000000)",
+        "100000000",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 46: exp(-100000000)
+    run_benchmark_exp(
+        "exp(-100000000)",
+        "-100000000",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 47: exp(1000000000)
+    run_benchmark_exp(
+        "exp(1000000000)",
+        "1000000000",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 48: exp(-1000000000)
+    run_benchmark_exp(
+        "exp(-1000000000)",
+        "-1000000000",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 49: exp(10000000000)
+    run_benchmark_exp(
+        "exp(10000000000)",
+        "10000000000",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Case 50: exp(-10000000000)
+    run_benchmark_exp(
+        "exp(-10000000000)",
+        "-10000000000",
+        iterations,
+        log_file,
+        speedup_factors,
+    )
+
+    # Calculate average speedup factor (ignoring any cases that might have failed)
+    if len(speedup_factors) > 0:
+        var sum_speedup: Float64 = 0.0
+        for i in range(len(speedup_factors)):
+            sum_speedup += speedup_factors[i]
+        var average_speedup = sum_speedup / Float64(len(speedup_factors))
+
+        # Display summary
+        log_print(
+            "\n=== BigDecimal Exponential (exp) Benchmark Summary ===", log_file
+        )
+        log_print(
+            "Benchmarked:        "
+            + String(len(speedup_factors))
+            + " different exp cases",
+            log_file,
+        )
+        log_print(
+            "Each case ran:    " + String(iterations) + " iterations", log_file
+        )
+        log_print(
+            "Average speedup:  " + String(average_speedup) + "×", log_file
+        )
+
+        # List all speedup factors
+        log_print("\nIndividual speedup factors:", log_file)
+        for i in range(len(speedup_factors)):
+            log_print(
+                String("Case {}: {}×").format(
+                    i + 1, round(speedup_factors[i], 2)
+                ),
+                log_file,
+            )
+    else:
+        log_print("\nNo valid benchmark cases were completed", log_file)
+
+    # Close the log file
+    log_file.close()
+    print("Benchmark completed. Log file closed.")

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -3,4 +3,6 @@
 This is a to-do list for Yuhao's personal use.
 
 - [x] (#31) The `exp()` function performs slower than Python's counterpart in specific cases. Detailed investigation reveals the bottleneck stems from multiplication operations between decimals with significant fractional components. These operations currently rely on UInt256 arithmetic, which introduces performance overhead. Optimization of the `multiply()` function is required to address these performance bottlenecks, particularly for high-precision decimal multiplication with many digits after the decimal point.
+- [ ] When Mojo supports global variables, implement a global variable for the `BigDecimal` class to store the precision of the decimal number. This will allow users to set the precision globally, rather than having to set it for each function of the `BigDecimal` class.
 - [ ] Implement different methods for augmented arithmetic assignments to improve memeory-efficiency and performance.
+- [ ] Implement a method `remove_trailing_zeros` for `BigUInt`.

--- a/src/decimojo/bigdecimal/bigdecimal.mojo
+++ b/src/decimojo/bigdecimal/bigdecimal.mojo
@@ -27,6 +27,7 @@ from memory import UnsafePointer
 import testing
 
 from decimojo.rounding_mode import RoundingMode
+from decimojo.bigdecimal.rounding import round_to_precision
 
 alias BigDec = BigDecimal
 alias BDec = BigDecimal
@@ -537,6 +538,11 @@ struct BigDecimal:
         return decimojo.bigdecimal.comparison.compare_absolute(self, other)
 
     @always_inline
+    fn exp(self, precision: Int = 28) raises -> Self:
+        """Returns the exponential of the BigDecimal number."""
+        return decimojo.bigdecimal.exponential.exp(self, precision)
+
+    @always_inline
     fn max(self, other: Self) raises -> Self:
         """Returns the maximum of two BigDecimal numbers."""
         return decimojo.bigdecimal.comparison.max(self, other)
@@ -558,6 +564,20 @@ struct BigDecimal:
         """
         return decimojo.bigdecimal.arithmetics.true_divide(
             self, other, precision
+        )
+
+    @always_inline
+    fn round_to_precision(
+        mut self,
+        precision: Int,
+        rounding_mode: RoundingMode,
+        remove_extra_digit_due_to_rounding: Bool,
+    ) raises:
+        """Rounds the number to the specified precision in-place.
+        See `rounding.round_to_precision()` for more information.
+        """
+        decimojo.bigdecimal.rounding.round_to_precision(
+            self, precision, rounding_mode, remove_extra_digit_due_to_rounding
         )
 
     # ===------------------------------------------------------------------=== #

--- a/src/decimojo/bigdecimal/exponential.mojo
+++ b/src/decimojo/bigdecimal/exponential.mojo
@@ -239,16 +239,16 @@ fn exp(x: BigDecimal, precision: Int = 28) raises -> BigDecimal:
             # Round intermediates to working precision to avoid explosion
             if i % 3 == 2:  # Every few iterations
                 result.round_to_precision(
-                    precision=precision,
+                    precision=working_precision,
                     rounding_mode=RoundingMode.ROUND_HALF_EVEN,
                     remove_extra_digit_due_to_rounding=True,
                 )
 
-            result.round_to_precision(
-                precision=precision,
-                rounding_mode=RoundingMode.ROUND_HALF_EVEN,
-                remove_extra_digit_due_to_rounding=True,
-            )
+        result.round_to_precision(
+            precision=precision,
+            rounding_mode=RoundingMode.ROUND_HALF_EVEN,
+            remove_extra_digit_due_to_rounding=True,
+        )
 
         return result^
 

--- a/src/decimojo/bigdecimal/exponential.mojo
+++ b/src/decimojo/bigdecimal/exponential.mojo
@@ -14,6 +14,10 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
+# ===----------------------------------------------------------------------=== #
+# Power and root functions
+# ===----------------------------------------------------------------------=== #
+
 """Implements exponential functions for the BigDecimal type."""
 
 from decimojo.bigdecimal.bigdecimal import BigDecimal
@@ -136,10 +140,14 @@ fn sqrt(x: BigDecimal, precision: Int = 28) raises -> BigDecimal:
     # TODO: This can be done even earlier in the process
     if guess.coefficient.ith_digit(0) == 0:
         var guess_coefficient_without_trailing_zeros = guess.coefficient.remove_trailing_digits_with_rounding(
-            guess.coefficient.number_of_trailing_zeros()
+            guess.coefficient.number_of_trailing_zeros(),
+            rounding_mode=RoundingMode.ROUND_DOWN,
+            remove_extra_digit_due_to_rounding=False,
         )
         var x_coefficient_without_trailing_zeros = x.coefficient.remove_trailing_digits_with_rounding(
-            x.coefficient.number_of_trailing_zeros()
+            x.coefficient.number_of_trailing_zeros(),
+            rounding_mode=RoundingMode.ROUND_DOWN,
+            remove_extra_digit_due_to_rounding=False,
         )
         if (
             guess_coefficient_without_trailing_zeros
@@ -152,8 +160,142 @@ fn sqrt(x: BigDecimal, precision: Int = 28) raises -> BigDecimal:
             guess.coefficient = (
                 guess.coefficient.remove_trailing_digits_with_rounding(
                     guess.coefficient.number_of_digits()
-                    - expected_ndigits_of_result
+                    - expected_ndigits_of_result,
+                    rounding_mode=RoundingMode.ROUND_DOWN,
+                    remove_extra_digit_due_to_rounding=False,
                 )
             )
 
     return guess^
+
+
+# ===----------------------------------------------------------------------=== #
+# Exponential functions
+# ===----------------------------------------------------------------------=== #
+
+
+fn exp(x: BigDecimal, precision: Int = 28) raises -> BigDecimal:
+    """Calculate the natural exponential of x (e^x) to the specified precision.
+
+    Args:
+        x: The exponent value.
+        precision: Desired precision in significant digits.
+
+    Returns:
+        The natural exponential of x (e^x) to the specified precision.
+
+    Notes:
+        Uses optimized algorithm combining:
+        - Range reduction.
+        - Taylor series.
+        - Precision tracking.
+    """
+    # Extra working precision to ensure final result accuracy
+    alias BUFFER_DIGITS = 5
+    var working_precision = precision + BUFFER_DIGITS
+
+    # Handle special cases
+    if x.coefficient.is_zero():
+        return BigDecimal(
+            BigUInt.ONE, x.scale, x.sign
+        )  # e^0 = 1, return with same scale and sign
+
+    # For very large positive values, result will overflow BigDecimal capacity
+    # Calculate rough estimate to detect overflow early
+    if not x.sign and x.scale <= -40:  # x > 10^40
+        raise Error("Error in `exp`: Result too large to represent")
+
+    # For very large negative values, result will be effectively zero
+    if x.sign and x.scale <= -40:  # x < -10^40
+        return BigDecimal(
+            BigUInt.ONE, precision, False
+        )  # Return very small number
+
+    # Handle negative x using identity: exp(-x) = 1/exp(x)
+    if x.sign:
+        var pos_result = exp(-x, precision + 2)
+        return BigDecimal(BigUInt.ONE, 0, False).true_divide(
+            pos_result, precision
+        )
+
+    # Range reduction for faster convergence
+    # If x > 1, use exp(x) = exp(x/2)²
+    if x > BigDecimal(BigUInt.ONE, 0, False):
+        # Find k where 2^k > x
+        var k = 0
+        var threshold = BigDecimal(BigUInt.ONE, 0, False)
+        while threshold <= x:
+            threshold = threshold + threshold  # Multiply by 2
+            k += 1
+
+        # Calculate exp(x/2^k)
+        var reduced_x = x.true_divide(threshold, working_precision)
+        var reduced_exp = exp_taylor_series(reduced_x, working_precision)
+
+        # Square result k times: exp(x) = exp(x/2^k)^(2^k)
+        var result = reduced_exp
+        for i in range(k):
+            result = result * result
+            # Round intermediates to working precision to avoid explosion
+            if i % 3 == 2:  # Every few iterations
+                result.round_to_precision(
+                    precision=precision,
+                    rounding_mode=RoundingMode.ROUND_HALF_EVEN,
+                    remove_extra_digit_due_to_rounding=True,
+                )
+
+            result.round_to_precision(
+                precision=precision,
+                rounding_mode=RoundingMode.ROUND_HALF_EVEN,
+                remove_extra_digit_due_to_rounding=True,
+            )
+
+        return result^
+
+    # For small values, use Taylor series directly
+    var result = exp_taylor_series(x, precision)
+
+    result.round_to_precision(
+        precision=precision,
+        rounding_mode=RoundingMode.ROUND_HALF_EVEN,
+        remove_extra_digit_due_to_rounding=True,
+    )
+
+    return result^
+
+
+fn exp_taylor_series(x: BigDecimal, precision: Int) raises -> BigDecimal:
+    """Calculate exp(x) using Taylor series for |x| <= 1."""
+    # Theoretical number of terms needed based on precision
+    # For |x| ≤ 1, error after n terms is approximately |x|^(n+1)/(n+1)!
+    # We need |x|^(n+1)/(n+1)! < 10^(-precision)
+    # For x=1, we need approximately n ≈ precision * ln(10) ≈ precision * 2.3
+    var max_number_of_terms = Int(precision * 2.5) + 1
+
+    # Required precision for term smaller than minimum contribution
+    var min_term_precision = BigDecimal(BigUInt.ONE, precision + 1, False)
+
+    var result = BigDecimal(BigUInt.ONE, 0, False)
+    var term = BigDecimal(BigUInt.ONE, 0, False)
+    var factorial = BigUInt.ONE
+    var n = BigUInt.ONE
+
+    # Calculate Taylor series: 1 + x + x²/2! + x³/3! + ...
+    for _ in range(1, max_number_of_terms):
+        # Calculate next term: x^i/i!
+        term = term * x
+        factorial = factorial * n
+        n += BigUInt.ONE
+
+        var next_term = term.true_divide(
+            BigDecimal(factorial, 0, False), precision + 5
+        )
+
+        # Add term to result
+        result += next_term
+
+        # Check if we've reached desired precision
+        if next_term.compare_absolute(min_term_precision) < 0:
+            break
+
+    return result^

--- a/src/decimojo/bigdecimal/rounding.mojo
+++ b/src/decimojo/bigdecimal/rounding.mojo
@@ -1,0 +1,56 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright 2025 Yuhao Zhu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""
+Implements functions for mathematical operations on Decimal objects.
+"""
+
+from decimojo.bigdecimal.bigdecimal import BigDecimal
+
+# ===------------------------------------------------------------------------===#
+# Rounding
+# ===------------------------------------------------------------------------===#
+
+
+fn round_to_precision(
+    mut number: BigDecimal,
+    precision: Int,
+    rounding_mode: RoundingMode,
+    remove_extra_digit_due_to_rounding: Bool,
+) raises:
+    """Rounds the number to the specified precision in-place.
+
+    Args:
+        number: The number to round.
+        precision: Number of precision digits to round to.
+            Defaults to 28.
+        rounding_mode: Rounding mode to use.
+            RoundingMode.ROUND_DOWN: Round down.
+            RoundingMode.ROUND_UP: Round up.
+            RoundingMode.ROUND_HALF_UP: Round half up.
+            RoundingMode.ROUND_HALF_EVEN: Round half even.
+        remove_extra_digit_due_to_rounding: If True, remove an trailing.
+            digit if the rounding mode result in an extra digit.
+    """
+
+    var ndigits_coefficient = number.coefficient.number_of_digits()
+    var ndigits_to_remove = ndigits_coefficient - precision
+    number.coefficient = number.coefficient.remove_trailing_digits_with_rounding(
+        ndigits=ndigits_to_remove,
+        rounding_mode=rounding_mode,
+        remove_extra_digit_due_to_rounding=remove_extra_digit_due_to_rounding,
+    )
+    number.scale -= ndigits_to_remove

--- a/src/decimojo/biguint/biguint.mojo
+++ b/src/decimojo/biguint/biguint.mojo
@@ -609,6 +609,9 @@ struct BigUInt(Absable, IntableRaising, Writable):
 
     @always_inline
     fn __iadd__(mut self, other: Self) raises:
+        """Adds `other` to `self` in place.
+        See `add_inplace()` for more information.
+        """
         decimojo.biguint.arithmetics.add_inplace(self, other)
 
     @always_inline
@@ -665,6 +668,14 @@ struct BigUInt(Absable, IntableRaising, Writable):
     # ===------------------------------------------------------------------=== #
     # Mathematical methods that do not implement a trait (not a dunder)
     # ===------------------------------------------------------------------=== #
+
+    @always_inline
+    fn add_inplace_by_1(mut self) raises:
+        """Adds 1 to this number in place.
+        It is equal to `self += 1`.
+        See `add_inplace_by_1()` for more information.
+        """
+        decimojo.biguint.arithmetics.add_inplace_by_1(self)
 
     @always_inline
     fn floor_divide(self, other: Self) raises -> Self:
@@ -928,19 +939,20 @@ struct BigUInt(Absable, IntableRaising, Writable):
     fn remove_trailing_digits_with_rounding(
         self,
         ndigits: Int,
-        rounding_mode: RoundingMode = RoundingMode.ROUND_DOWN,
-        remove_extra_digit_due_to_rounding: Bool = False,
+        rounding_mode: RoundingMode,
+        remove_extra_digit_due_to_rounding: Bool,
     ) raises -> Self:
         """Removes trailing digits from the BigUInt.
 
         Args:
             ndigits: The number of digits to remove.
             rounding_mode: The rounding mode to use.
-                Default is RoundingMode.ROUND_DOWN, which is the same as
-                `scale_down_by_power_of_10()`.
+                RoundingMode.ROUND_DOWN: Round down.
+                RoundingMode.ROUND_UP: Round up.
+                RoundingMode.ROUND_HALF_UP: Round half up.
+                RoundingMode.ROUND_HALF_EVEN: Round half even.
             remove_extra_digit_due_to_rounding: If True, remove an trailing
                 digit if the rounding mode result in an extra digit.
-                Default is False.
 
         Returns:
             The BigUInt with the trailing digits removed.
@@ -956,10 +968,8 @@ struct BigUInt(Absable, IntableRaising, Writable):
                 "Error in `remove_trailing_digits()`: The number of digits to"
                 " remove is negative"
             )
-
         if ndigits == 0:
             return self
-
         if ndigits > self.number_of_digits():
             raise Error(
                 "Error in `remove_trailing_digits()`: The number of digits to"
@@ -995,7 +1005,7 @@ struct BigUInt(Absable, IntableRaising, Writable):
             )
 
         if round_up:
-            result = result + BigUInt.ONE
+            result.add_inplace_by_1()
             # Check whether rounding results in extra digit
             if result.is_power_of_10():
                 if remove_extra_digit_due_to_rounding:


### PR DESCRIPTION
This pull request includes several updates to the `DeciMojo` project, focusing on enhancing the documentation, adding new functionality, and improving performance. The most important changes are summarized below:

### Documentation Enhancements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R16): Updated table of contents and added `<!-- omit in toc -->` comments to headings to improve navigation and readability. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L171-R189) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L189-R199) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L205-R215)

### New Functionality:
* [`src/decimojo/bigdecimal/bigdecimal.mojo`](diffhunk://#diff-be2f9b2702fd15952546e17fe94a64c22902a0e4678bfd9cb925269647923db4R540-R544): Added `exp` method to the `BigDecimal` struct to calculate the exponential of a `BigDecimal` number.
* [`src/decimojo/bigdecimal/rounding.mojo`](diffhunk://#diff-2d08304d5c7273c47523b98f68714e1c980a59b7c4f0a9bf444ffca9435afa17R1-R56): Implemented `round_to_precision` function for rounding `BigDecimal` numbers to a specified precision.
* [`benches/bigdecimal/bench.mojo`](diffhunk://#diff-96175f1000f81fe074f70a9adc4b39cd3f2dac8e85d30aa7efed9fc02b46e5ecR6): Added benchmarks for the new exponential function. [[1]](diffhunk://#diff-96175f1000f81fe074f70a9adc4b39cd3f2dac8e85d30aa7efed9fc02b46e5ecR6) [[2]](diffhunk://#diff-96175f1000f81fe074f70a9adc4b39cd3f2dac8e85d30aa7efed9fc02b46e5ecR21) [[3]](diffhunk://#diff-96175f1000f81fe074f70a9adc4b39cd3f2dac8e85d30aa7efed9fc02b46e5ecR40-R48)

### Performance Improvements:
* [`src/decimojo/biguint/arithmetics.mojo`](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL44-R71): Optimized `add` and `add_inplace` functions for `BigUInt` by adding short-circuit cases and an optimized method for adding 1. [[1]](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL44-R71) [[2]](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL91-R133) [[3]](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cR167-R181)

### Miscellaneous:
* [`docs/todo.md`](diffhunk://#diff-d84697334acf64fe5d67dfd34f6370dca462f602aa3a720711eae12bf8dd153dR6-R8): Added new to-do items for future enhancements, including implementing a global precision variable for `BigDecimal` and adding a `remove_trailing_zeros` method for `BigUInt`.
* [`src/decimojo/bigdecimal/exponential.mojo`](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcR17-R20): Added detailed implementation for the `exp` function and supporting Taylor series calculation. [[1]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcR17-R20) [[2]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcL139-R150) [[3]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcL155-R301)

These changes collectively improve the functionality, performance, and documentation of the `DeciMojo` library.