### PR TITLE
[decimal] Implement `power` function for `BigDecimal`

### DIFF
--- a/docs/internal_notes.md
+++ b/docs/internal_notes.md
@@ -1,0 +1,3 @@
+# Internal Notes
+
+- For power functionality, `0.123456789 ** 1000`: `BigDecimal.power()`, Python's decimal, WolframAlpha give the same result, but `mpmath` gives a different result.

--- a/docs/internal_notes.md
+++ b/docs/internal_notes.md
@@ -1,3 +1,3 @@
 # Internal Notes
 
-- For power functionality, `0.123456789 ** 1000`: `BigDecimal.power()`, Python's decimal, WolframAlpha give the same result, but `mpmath` gives a different result.
+- For power functionality: `BigDecimal.power()`, Python's decimal, WolframAlpha give the same result, but `mpmath` gives a different result. Eample: `0.123456789 ** 1000`, `1234523894766789 ** 1098.1209848`.

--- a/src/decimojo/bigdecimal/arithmetics.mojo
+++ b/src/decimojo/bigdecimal/arithmetics.mojo
@@ -190,7 +190,7 @@ fn multiply(x1: BigDecimal, x2: BigDecimal) raises -> BigDecimal:
 
 # TODO: Optimize when divided by power of 10
 fn true_divide(
-    x1: BigDecimal, x2: BigDecimal, precision: Int = 28
+    x1: BigDecimal, x2: BigDecimal, precision: Int
 ) raises -> BigDecimal:
     """Returns the quotient of two numbers with specified precision.
 

--- a/src/decimojo/bigdecimal/bigdecimal.mojo
+++ b/src/decimojo/bigdecimal/bigdecimal.mojo
@@ -459,7 +459,16 @@ struct BigDecimal:
 
     @always_inline
     fn __truediv__(self, other: Self) raises -> Self:
-        return decimojo.bigdecimal.arithmetics.true_divide(self, other)
+        return decimojo.bigdecimal.arithmetics.true_divide(
+            self, other, precision=28
+        )
+
+    @always_inline
+    fn __pow__(self, exponent: Self) raises -> Self:
+        """Returns the result of exponentiation."""
+        return decimojo.bigdecimal.exponential.power(
+            self, exponent, precision=28
+        )
 
     # ===------------------------------------------------------------------=== #
     # Basic binary augmented arithmetic assignments dunders
@@ -482,7 +491,9 @@ struct BigDecimal:
 
     @always_inline
     fn __itruediv__(mut self, other: Self) raises:
-        self = decimojo.bigdecimal.arithmetics.true_divide(self, other)
+        self = decimojo.bigdecimal.arithmetics.true_divide(
+            self, other, precision=28
+        )
 
     # ===------------------------------------------------------------------=== #
     # Basic binary comparison operation dunders
@@ -592,6 +603,13 @@ struct BigDecimal:
         return decimojo.bigdecimal.arithmetics.true_divide_inexact(
             self, other, number_of_significant_digits
         )
+
+    @always_inline
+    fn power(self, exponent: Self, precision: Int) raises -> Self:
+        """Returns the result of exponentiation with the given precision.
+        See `exponential.power()` for more information.
+        """
+        return decimojo.bigdecimal.exponential.power(self, exponent, precision)
 
     @always_inline
     fn round_to_precision(
@@ -723,9 +741,30 @@ struct BigDecimal:
         print("----------------------------------------------")
 
     @always_inline
+    fn is_integer(self) -> Bool:
+        """Returns True if this number represents an integer value."""
+        var number_of_trailing_zeros = self.number_of_trailing_zeros()
+        if number_of_trailing_zeros >= self.scale:
+            return True
+        else:
+            return False
+
+    @always_inline
     fn is_negative(self) -> Bool:
         """Returns True if this number represents a negative value."""
         return self.sign
+
+    @always_inline
+    fn is_odd(self) raises -> Bool:
+        """Returns True if this number represents an odd value."""
+        if self.scale < 0:
+            return False
+
+        var cutoff_digit = self.coefficient.ith_digit(self.scale)
+        if cutoff_digit % 2 == 0:
+            return False
+        else:
+            return True
 
     @always_inline
     fn is_zero(self) -> Bool:

--- a/src/decimojo/bigdecimal/bigdecimal.mojo
+++ b/src/decimojo/bigdecimal/bigdecimal.mojo
@@ -548,6 +548,17 @@ struct BigDecimal:
         return decimojo.bigdecimal.exponential.ln(self, precision)
 
     @always_inline
+    fn log(self, base: Self, precision: Int = 28) raises -> Self:
+        """Returns the logarithm of the BigDecimal number with the given base.
+        """
+        return decimojo.bigdecimal.exponential.log(self, base, precision)
+
+    @always_inline
+    fn log10(self, precision: Int = 28) raises -> Self:
+        """Returns the base-10 logarithm of the BigDecimal number."""
+        return decimojo.bigdecimal.exponential.log10(self, precision)
+
+    @always_inline
     fn max(self, other: Self) raises -> Self:
         """Returns the maximum of two BigDecimal numbers."""
         return decimojo.bigdecimal.comparison.max(self, other)

--- a/src/decimojo/bigdecimal/exponential.mojo
+++ b/src/decimojo/bigdecimal/exponential.mojo
@@ -37,10 +37,6 @@ fn power(
 ) raises -> BigDecimal:
     """Raises a BigDecimal base to an arbitrary BigDecimal exponent power.
 
-    This function handles both integer and non-integer exponents using the
-    identity x^y = e^(y * ln(x)) for the general case, with optimizations
-    for integer exponents.
-
     Args:
         base: The base value to be raised to a power.
         exponent: The exponent to raise the base to.
@@ -52,6 +48,12 @@ fn power(
     Raises:
         Error: If base is negative and exponent is not an integer.
         Error: If base is zero and exponent is negative or zero.
+
+    Notes:
+
+    This function handles both integer and non-integer exponents using the
+    identity x^y = e^(y * ln(x)) for the general case, with optimizations
+    for integer exponents.
     """
     alias BUFFER_DIGITS = 9
     var working_precision = precision + BUFFER_DIGITS
@@ -113,7 +115,7 @@ fn power(
 fn integer_power(
     base: BigDecimal, exponent: BigDecimal, precision: Int
 ) raises -> BigDecimal:
-    """Optimized implementation for integer exponents using binary exponentiation.
+    """Raises a base to integer exponents using binary exponentiation.
 
     Args:
         base: The base value.
@@ -149,7 +151,6 @@ fn integer_power(
                 working_precision, RoundingMode.ROUND_DOWN, False
             )
 
-        # Square the current power for next bit
         current_power = current_power * current_power
         # Round to avoid coefficient explosion
         current_power.round_to_precision(

--- a/src/decimojo/bigdecimal/exponential.mojo
+++ b/src/decimojo/bigdecimal/exponential.mojo
@@ -164,7 +164,7 @@ fn integer_power(
             result, working_precision
         )
 
-    result.round_to_precision(precision, RoundingMode.ROUND_DOWN, False)
+    result.round_to_precision(precision, RoundingMode.ROUND_HALF_EVEN, False)
     return result^
 
 

--- a/src/decimojo/biguint/biguint.mojo
+++ b/src/decimojo/biguint/biguint.mojo
@@ -730,6 +730,13 @@ struct BigUInt(Absable, IntableRaising, Writable):
         return decimojo.biguint.arithmetics.divmod(self, other)
 
     @always_inline
+    fn floor_divide_inplace_by_2(mut self) raises:
+        """Divides this number by 2 in place.
+        See `floor_divide_inplace_by_2()` for more information.
+        """
+        decimojo.biguint.arithmetics.floor_divide_inplace_by_2(self)
+
+    @always_inline
     fn scale_up_by_power_of_10(self, n: Int) raises -> Self:
         """Returns the result of multiplying this number by 10^n (n>=0).
         See `scale_up_by_power_of_10()` for more information.


### PR DESCRIPTION
This pull request includes several updates to the `BigDecimal` and related arithmetic operations in the `decimojo` library. The changes primarily focus on adding new mathematical functions, optimizing existing methods, and improving precision handling.

### New Mathematical Functions:
* Added `power`, `log`, and `log10` functions to `BigDecimal` for exponentiation and logarithmic calculations. (`src/decimojo/bigdecimal/bigdecimal.mojo`, `src/decimojo/bigdecimal/exponential.mojo`) [[1]](diffhunk://#diff-be2f9b2702fd15952546e17fe94a64c22902a0e4678bfd9cb925269647923db4L462-R471) [[2]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcL30-R172) [[3]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcR592-R701)
* Introduced `is_integer` and `is_odd` methods to `BigDecimal` to check if the number is an integer or odd. (`src/decimojo/bigdecimal/bigdecimal.mojo`)

### Precision Handling Improvements:
* Modified the `true_divide` function to accept precision as a mandatory argument. (`src/decimojo/bigdecimal/arithmetics.mojo`)
* Updated various methods to ensure precision is consistently handled, including `__truediv__`, `__itruediv__`, and `power`. (`src/decimojo/bigdecimal/bigdecimal.mojo`) [[1]](diffhunk://#diff-be2f9b2702fd15952546e17fe94a64c22902a0e4678bfd9cb925269647923db4L462-R471) [[2]](diffhunk://#diff-be2f9b2702fd15952546e17fe94a64c22902a0e4678bfd9cb925269647923db4L485-R496) [[3]](diffhunk://#diff-be2f9b2702fd15952546e17fe94a64c22902a0e4678bfd9cb925269647923db4R607-R613)

### Optimization and Special Cases:
* Added precomputed values and special case handling for logarithmic functions to improve performance. (`src/decimojo/bigdecimal/exponential.mojo`) [[1]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcR792-R818) [[2]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcL556-R839)
* Introduced `floor_divide_inplace_by_2` method to `BigUInt` for efficient division by 2. (`src/decimojo/biguint/biguint.mojo`)

### Documentation Updates:
* Added internal notes to document the discrepancies in power function results between different libraries. (`docs/internal_notes.md`)