### PR TITLE
[docs] Update descriptions and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,24 @@ fn main() raises:
 
 [Click here for 8 key examples](https://zhuyuhao.com/decimojo/docs/examples) highlighting the most important features of the `Decimal` type.
 
+Here are some examples showcasing the arbitrary-precision feature of the `BigDecimal` type.
+
+```mojo
+from decimojo import BDec, RM
+
+
+fn main() raises:
+    var PRECISION = 100
+    var a = BDec("123456789.123456789")
+    var b = BDec("1234.56789")
+    print(a.sqrt(precision=PRECISION))
+    # 11111.11106611111096943055498174930232833813065468909453818857935956641682120364106016272519460988485
+    print(a.power(b, precision=PRECISION))
+    # 3.346361102419080234023813540078946868219632448203078657310495672766009862564151996325555496759911131748170844123475135377098326591508239654961E+9989
+    print(a.log(b, precision=PRECISION))
+    # 2.617330026656548299907884356415293977170848626010103229392408225981962436022623783231699264341492663671325580092077394824180414301026578169909
+```
+
 Here is a comprehensive quick-start guide showcasing each major function of the `BigInt` type.
 
 ```mojo

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DeciMojo <!-- omit in toc -->
 
-A comprehensive decimal and integer mathematics library for [Mojo](https://www.modular.com/mojo).
+An arbitrary-precision decimal and integer mathematics library for [Mojo](https://www.modular.com/mojo).
 
 **[中文·漢字»](https://zhuyuhao.com/decimojo/docs/readme_zht.html)**　|　**[Repository on GitHub»](https://github.com/forfudan/decimojo)**  | **[Changelog](https://zhuyuhao.com/decimojo/docs/changelog.html)**
 
@@ -16,13 +16,13 @@ A comprehensive decimal and integer mathematics library for [Mojo](https://www.m
 
 ## Overview
 
-DeciMojo provides a comprehensive decimal and integer mathematics library for Mojo, delivering exact calculations for financial modeling, scientific computing, and applications where floating-point approximation errors are unacceptable. Beyond basic arithmetic, the library includes advanced mathematical functions with guaranteed precision.
+DeciMojo provides an arbitrary-precision decimal and integer mathematics library for Mojo, delivering exact calculations for financial modeling, scientific computing, and applications where floating-point approximation errors are unacceptable. Beyond basic arithmetic, the library includes advanced mathematical functions with guaranteed precision.
 
 The core types are:
 
-- A 128-bit fixed-point decimal implementation (`Decimal`) supporting up to 29 significant digits with a maximum of 28 decimal places[^fixed]. It features a complete set of mathematical functions including logarithms, exponentiation, roots, and trigonometric operations.
+- A 128-bit fixed-point decimal implementation (`Decimal`) supporting up to 29 significant digits with a maximum of 28 decimal places[^fixed]. It features a complete set of mathematical functions including logarithms, exponentiation, roots, etc.
+- An arbitrary-precision decimal implementation `BigDecimal` allowing for calculations with unlimited digits and decimal places[^arbitrary].
 - A base-10 arbitrary-precision signed integer type (`BigInt`) and a base-10 arbitrary-precision unsigned integer type (`BigUInt`) supporting unlimited digits[^integer]. It features comprehensive arithmetic operations, comparison functions, and supports extremely large integer calculations efficiently.
-- An arbitrary-precision decimal implementation `BigDecimal` allowing for calculations with unlimited digits and decimal places[^arbitrary]. It is currently under active development.
 
 This repository includes [TOMLMojo](https://github.com/forfudan/decimojo/tree/main/src/tomlmojo), a lightweight TOML parser in pure Mojo. It parses configuration files and test data, supporting basic types, arrays, and nested tables. While created for DeciMojo's testing framework, it offers general-purpose structured data parsing with a clean, simple API.
 
@@ -232,7 +232,7 @@ If you find DeciMojo useful for your research, consider listing it in your citat
 @software{Zhu.2025,
     author       = {Zhu, Yuhao},
     year         = {2025},
-    title        = {A comprehensive decimal and integer mathematics library for Mojo},
+    title        = {An arbitrary-precision decimal and integer mathematics library for Mojo},
     url          = {https://github.com/forfudan/decimojo},
     version      = {0.2.0},
     note         = {Computer Software}

--- a/mojoproject.toml
+++ b/mojoproject.toml
@@ -2,7 +2,7 @@
 authors = ["ZHU Yuhao 朱宇浩 <dr.yuhao.zhu@outlook.com>"]
 channels = ["https://conda.modular.com/max", "https://repo.prefix.dev/modular-community", "conda-forge"]
 # channels = ["https://conda.modular.com/max-nightly", "https://conda.modular.com/max", "https://repo.prefix.dev/modular-community", "conda-forge"]
-description = "A comprehensive decimal and integer mathematics library for Mojo"
+description = "An arbitrary-precision decimal and integer mathematics library for Mojo"
 license = "Apache-2.0"
 name = "decimojo"
 platforms = ["osx-arm64", "linux-64"]

--- a/src/decimojo/decimal/arithmetics.mojo
+++ b/src/decimojo/decimal/arithmetics.mojo
@@ -1,7 +1,4 @@
 # ===----------------------------------------------------------------------=== #
-# DeciMojo: A fixed-point decimal arithmetic library in Mojo
-# https://github.com/forfudan/decimojo
-#
 # Copyright 2025 Yuhao Zhu
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/decimojo/decimal/comparison.mojo
+++ b/src/decimojo/decimal/comparison.mojo
@@ -1,7 +1,4 @@
 # ===----------------------------------------------------------------------=== #
-# DeciMojo: A fixed-point decimal arithmetic library in Mojo
-# https://github.com/forfudan/decimojo
-#
 # Copyright 2025 Yuhao Zhu
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/decimojo/decimal/constants.mojo
+++ b/src/decimojo/decimal/constants.mojo
@@ -1,7 +1,4 @@
 # ===----------------------------------------------------------------------=== #
-# DeciMojo: A fixed-point decimal arithmetic library in Mojo
-# https://github.com/forfudan/decimojo
-#
 # Copyright 2025 Yuhao Zhu
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/decimojo/decimal/decimal.mojo
+++ b/src/decimojo/decimal/decimal.mojo
@@ -1,7 +1,4 @@
 # ===----------------------------------------------------------------------=== #
-# DeciMojo: A fixed-point decimal arithmetic library in Mojo
-# https://github.com/forfudan/decimojo
-#
 # Copyright 2025 Yuhao Zhu
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/decimojo/decimal/rounding.mojo
+++ b/src/decimojo/decimal/rounding.mojo
@@ -1,7 +1,4 @@
 # ===----------------------------------------------------------------------=== #
-# DeciMojo: A fixed-point decimal arithmetic library in Mojo
-# https://github.com/forfudan/decimojo
-#
 # Copyright 2025 Yuhao Zhu
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/decimojo/decimal/special.mojo
+++ b/src/decimojo/decimal/special.mojo
@@ -1,7 +1,4 @@
 # ===----------------------------------------------------------------------=== #
-# DeciMojo: A fixed-point decimal arithmetic library in Mojo
-# https://github.com/forfudan/decimojo
-#
 # Copyright 2025 Yuhao Zhu
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This pull request includes changes to the `README.md` file to update the description of the DeciMojo library, and the removal of redundant comments in several source files. The most important changes include updating the library's description to reflect its arbitrary-precision capabilities and adding examples for the `BigDecimal` type.

Updates to documentation:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Updated the library description to "an arbitrary-precision decimal and integer mathematics library for Mojo" and added examples showcasing the `BigDecimal` type. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-L25) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R118-R135) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L235-R253)

Removal of redundant comments:

* [`src/decimojo/decimal/arithmetics.mojo`](diffhunk://#diff-f2387e2cfccb5298d597dc06df2ad0f7a3b3b06adba58a42e3d76f191dd81047L2-L4): Removed redundant comments about the library being a fixed-point decimal arithmetic library.
* [`src/decimojo/decimal/comparison.mojo`](diffhunk://#diff-12a6ed9e6c33dbdaa3748e5d1a8207a1cfc8b6276e60a004ad2c64f021a85ce4L2-L4): Removed redundant comments about the library being a fixed-point decimal arithmetic library.
* [`src/decimojo/decimal/constants.mojo`](diffhunk://#diff-45464c98d8c92c0be8b36702b1858a52a81c685e8532c9ee7c982e836a2c5460L2-L4): Removed redundant comments about the library being a fixed-point decimal arithmetic library.
* [`src/decimojo/decimal/decimal.mojo`](diffhunk://#diff-1ab60e45dd70a69f9afe8ce4823a9afd672a608cfc5d5e2047af040ed140eff5L2-L4): Removed redundant comments about the library being a fixed-point decimal arithmetic library.
* [`src/decimojo/decimal/rounding.mojo`](diffhunk://#diff-b027dfaa29cb1832f940c4e4146c423fdf730985310d4acf2028273a433c9bb6L2-L4): Removed redundant comments about the library being a fixed-point decimal arithmetic library.
* [`src/decimojo/decimal/special.mojo`](diffhunk://#diff-0ae815391fe87724efc692a750077ebcffff5fbd2c45e759e3f9ff48c0e4a36aL2-L4): Removed redundant comments about the library being a fixed-point decimal arithmetic library.

Update to project description:

* [`mojoproject.toml`](diffhunk://#diff-1b0ef62120bccf4c05a76e60e13fe686f33eb92d5897b3f05e0c3f8d737fc5c0L5-R5): Updated the project description to "an arbitrary-precision decimal and integer mathematics library for Mojo."