### PR TITLE
[decimal][tests] Add tests for `root()` and `power()` of `BigDecimal`

### DIFF
--- a/src/decimojo/bigdecimal/bigdecimal.mojo
+++ b/src/decimojo/bigdecimal/bigdecimal.mojo
@@ -622,12 +622,17 @@ struct BigDecimal:
         precision: Int,
         rounding_mode: RoundingMode,
         remove_extra_digit_due_to_rounding: Bool,
+        fill_zeros_to_precision: Bool,
     ) raises:
         """Rounds the number to the specified precision in-place.
         See `rounding.round_to_precision()` for more information.
         """
         decimojo.bigdecimal.rounding.round_to_precision(
-            self, precision, rounding_mode, remove_extra_digit_due_to_rounding
+            self,
+            precision,
+            rounding_mode,
+            remove_extra_digit_due_to_rounding,
+            fill_zeros_to_precision,
         )
 
     # ===------------------------------------------------------------------=== #

--- a/src/decimojo/bigdecimal/exponential.mojo
+++ b/src/decimojo/bigdecimal/exponential.mojo
@@ -71,7 +71,7 @@ fn power(
                 " base)"
             )
         else:
-            return BigDecimal(BigUInt.ZERO, precision, False)
+            return BigDecimal(BigUInt.ZERO, 0, False)
 
     if exponent.coefficient.is_zero():
         return BigDecimal(BigUInt.ONE, 0, False)  # x^0 = 1
@@ -86,6 +86,7 @@ fn power(
             precision,
             rounding_mode=RoundingMode.ROUND_HALF_EVEN,
             remove_extra_digit_due_to_rounding=True,
+            fill_zeros_to_precision=False,
         )
         return result^
 
@@ -111,7 +112,12 @@ fn power(
     if base.sign and exponent.is_integer() and exponent.is_odd():
         exp_result.sign = True
 
-    exp_result.round_to_precision(precision, RoundingMode.ROUND_HALF_EVEN, True)
+    exp_result.round_to_precision(
+        precision,
+        rounding_mode=RoundingMode.ROUND_HALF_EVEN,
+        remove_extra_digit_due_to_rounding=True,
+        fill_zeros_to_precision=False,
+    )
     return exp_result^
 
 
@@ -151,13 +157,19 @@ fn integer_power(
             result = result * current_power
             # Round to avoid coefficient explosion
             result.round_to_precision(
-                working_precision, RoundingMode.ROUND_DOWN, False
+                working_precision,
+                rounding_mode=RoundingMode.ROUND_DOWN,
+                remove_extra_digit_due_to_rounding=False,
+                fill_zeros_to_precision=False,
             )
 
         current_power = current_power * current_power
         # Round to avoid coefficient explosion
         current_power.round_to_precision(
-            working_precision, RoundingMode.ROUND_DOWN, False
+            working_precision,
+            rounding_mode=RoundingMode.ROUND_DOWN,
+            remove_extra_digit_due_to_rounding=False,
+            fill_zeros_to_precision=False,
         )
 
         exp_value.floor_divide_inplace_by_2()
@@ -168,7 +180,12 @@ fn integer_power(
             result, working_precision
         )
 
-    result.round_to_precision(precision, RoundingMode.ROUND_HALF_EVEN, False)
+    result.round_to_precision(
+        precision,
+        rounding_mode=RoundingMode.ROUND_HALF_EVEN,
+        remove_extra_digit_due_to_rounding=False,
+        fill_zeros_to_precision=False,
+    )
     return result^
 
 
@@ -252,6 +269,7 @@ fn root(x: BigDecimal, n: BigDecimal, precision: Int) raises -> BigDecimal:
         precision=precision,
         rounding_mode=RoundingMode.ROUND_HALF_EVEN,
         remove_extra_digit_due_to_rounding=True,
+        fill_zeros_to_precision=True,
     )
 
     return result^
@@ -299,6 +317,7 @@ fn integer_root(
             precision,
             rounding_mode=RoundingMode.ROUND_HALF_EVEN,
             remove_extra_digit_due_to_rounding=True,
+            fill_zeros_to_precision=False,
         )
         return result^
 
@@ -342,6 +361,7 @@ fn integer_root(
         precision=precision,
         rounding_mode=RoundingMode.ROUND_HALF_EVEN,
         remove_extra_digit_due_to_rounding=True,
+        fill_zeros_to_precision=False,
     )
 
     return result^
@@ -534,6 +554,7 @@ fn sqrt(x: BigDecimal, precision: Int) raises -> BigDecimal:
                 precision=expected_ndigits_of_result,
                 rounding_mode=RoundingMode.ROUND_DOWN,
                 remove_extra_digit_due_to_rounding=False,
+                fill_zeros_to_precision=False,
             )
             guess.scale = (x.scale + 1) // 2
 
@@ -616,12 +637,14 @@ fn exp(x: BigDecimal, precision: Int) raises -> BigDecimal:
                 precision=working_precision,
                 rounding_mode=RoundingMode.ROUND_HALF_UP,
                 remove_extra_digit_due_to_rounding=False,
+                fill_zeros_to_precision=False,
             )
 
         result.round_to_precision(
             precision=precision,
             rounding_mode=RoundingMode.ROUND_HALF_EVEN,
             remove_extra_digit_due_to_rounding=False,
+            fill_zeros_to_precision=False,
         )
 
         # var t_after_scale_up = time.perf_counter_ns()
@@ -651,6 +674,7 @@ fn exp(x: BigDecimal, precision: Int) raises -> BigDecimal:
         precision=precision,
         rounding_mode=RoundingMode.ROUND_HALF_EVEN,
         remove_extra_digit_due_to_rounding=True,
+        fill_zeros_to_precision=False,
     )
 
     return result^
@@ -697,6 +721,7 @@ fn exp_taylor_series(
             precision=minimum_precision,
             rounding_mode=RoundingMode.ROUND_HALF_UP,
             remove_extra_digit_due_to_rounding=False,
+            fill_zeros_to_precision=False,
         )
         n += BigUInt.ONE
 
@@ -713,6 +738,7 @@ fn exp_taylor_series(
         precision=minimum_precision,
         rounding_mode=RoundingMode.ROUND_HALF_UP,
         remove_extra_digit_due_to_rounding=False,
+        fill_zeros_to_precision=False,
     )
     # print("DEBUG: final result", result)
 
@@ -813,6 +839,7 @@ fn ln(x: BigDecimal, precision: Int) raises -> BigDecimal:
         precision=precision,
         rounding_mode=RoundingMode.ROUND_HALF_EVEN,
         remove_extra_digit_due_to_rounding=True,
+        fill_zeros_to_precision=False,
     )
 
     return result^
@@ -992,6 +1019,7 @@ fn ln_series_expansion(
         precision=working_precision,
         rounding_mode=RoundingMode.ROUND_DOWN,
         remove_extra_digit_due_to_rounding=False,
+        fill_zeros_to_precision=False,
     )
     return result^
 
@@ -1042,6 +1070,7 @@ fn compute_ln2(working_precision: Int) raises -> BigDecimal:
             precision=working_precision,
             rounding_mode=RoundingMode.ROUND_DOWN,
             remove_extra_digit_due_to_rounding=False,
+            fill_zeros_to_precision=False,
         )
         return result^
 
@@ -1070,6 +1099,7 @@ fn compute_ln2(working_precision: Int) raises -> BigDecimal:
         precision=working_precision,
         rounding_mode=RoundingMode.ROUND_DOWN,
         remove_extra_digit_due_to_rounding=False,
+        fill_zeros_to_precision=False,
     )
     return result^
 

--- a/src/decimojo/bigdecimal/rounding.mojo
+++ b/src/decimojo/bigdecimal/rounding.mojo
@@ -30,6 +30,7 @@ fn round_to_precision(
     precision: Int,
     rounding_mode: RoundingMode,
     remove_extra_digit_due_to_rounding: Bool,
+    fill_zeros_to_precision: Bool,
 ) raises:
     """Rounds the number to the specified precision in-place.
 
@@ -44,6 +45,7 @@ fn round_to_precision(
             RoundingMode.ROUND_HALF_EVEN: Round half even.
         remove_extra_digit_due_to_rounding: If True, remove an trailing.
             digit if the rounding mode result in an extra digit.
+        fill_zeros_to_precision: If True, fill zeros to the precision.
     """
 
     var ndigits_coefficient = number.coefficient.number_of_digits()
@@ -53,8 +55,11 @@ fn round_to_precision(
         return
 
     if ndigits_to_remove < 0:
-        number = number.extend_precision(precision_diff=-ndigits_to_remove)
-        return
+        if fill_zeros_to_precision:
+            number = number.extend_precision(precision_diff=-ndigits_to_remove)
+            return
+        else:
+            return
 
     number.coefficient = (
         number.coefficient.remove_trailing_digits_with_rounding(

--- a/tests/bigdecimal/test_bigdecimal_exponential.mojo
+++ b/tests/bigdecimal/test_bigdecimal_exponential.mojo
@@ -330,6 +330,117 @@ fn test_root_invalid_inputs() raises:
     )
 
 
+fn test_power() raises:
+    """Test BigDecimal power function with various test cases."""
+    print("------------------------------------------------------")
+    print("Testing BigDecimal power function...")
+
+    var pydecimal = Python.import_module("decimal")
+
+    # Load test cases from TOML file
+    var test_cases = load_test_cases_two_arguments(
+        exponential_file_path, "power_tests"
+    )
+    print("Loaded", len(test_cases), "test cases for power function")
+
+    # Track test results
+    var passed = 0
+    var failed = 0
+
+    # Run all test cases in a loop
+    for i in range(len(test_cases)):
+        var test_case = test_cases[i]
+        var base_value = BigDecimal(test_case.a)
+        var exponent = BigDecimal(test_case.b)
+        var expected = BigDecimal(test_case.expected)
+
+        # Calculate power
+        var result = base_value.power(exponent, precision=28)
+
+        try:
+            # Using String comparison for easier debugging
+            testing.assert_equal(
+                String(result), String(expected), test_case.description
+            )
+            passed += 1
+        except e:
+            print(
+                "=" * 50,
+                "\n",
+                i + 1,
+                "failed:",
+                test_case.description,
+                "\n  Base:",
+                test_case.a,
+                "\n  Exponent:",
+                test_case.b,
+                "\n  Expected:",
+                test_case.expected,
+                "\n  Got:",
+                String(result),
+                "\n  Python decimal result (for reference):",
+                String(
+                    pydecimal.Decimal(test_case.a)
+                    ** pydecimal.Decimal(test_case.b)
+                ),
+            )
+            failed += 1
+
+    print("BigDecimal power tests:", passed, "passed,", failed, "failed")
+    testing.assert_equal(failed, 0, "All power function tests should pass")
+
+
+fn test_power_invalid_inputs() raises:
+    """Test that power function with invalid inputs raises appropriate errors.
+    """
+    print("------------------------------------------------------")
+    print("Testing BigDecimal power with invalid inputs...")
+
+    # Test 1: 0^0 should raise an error (undefined)
+    var base1 = BigDecimal("0")
+    var exp1 = BigDecimal("0")
+    var exception_caught = False
+    try:
+        _ = base1.power(exp1, precision=28)
+        exception_caught = False
+    except:
+        exception_caught = True
+    testing.assert_true(exception_caught, "0^0 should raise an error")
+    print("✓ 0^0 correctly raises an error")
+
+    # Test 2: 0^-1 should raise an error (division by zero)
+    var base2 = BigDecimal("0")
+    var exp2 = BigDecimal("-1")
+    exception_caught = False
+    try:
+        _ = base2.power(exp2, precision=28)
+        exception_caught = False
+    except:
+        exception_caught = True
+    testing.assert_true(
+        exception_caught, "0 raised to a negative power should raise an error"
+    )
+    print("✓ 0 raised to a negative power correctly raises an error")
+
+    # Test 3: Negative number raised to a fractional power should raise an error
+    var base3 = BigDecimal("-2")
+    var exp3 = BigDecimal("0.5")
+    exception_caught = False
+    try:
+        _ = base3.power(exp3, precision=28)
+        exception_caught = False
+    except:
+        exception_caught = True
+    testing.assert_true(
+        exception_caught,
+        "Negative number raised to a fractional power should raise an error",
+    )
+    print(
+        "✓ Negative number raised to a fractional power correctly raises an"
+        " error"
+    )
+
+
 fn main() raises:
     print("Running BigDecimal exponential tests")
 
@@ -344,6 +455,12 @@ fn main() raises:
 
     # Test root with invalid inputs
     test_root_invalid_inputs()
+
+    # Run power tests
+    test_power()
+
+    # Test power with invalid inputs
+    test_power_invalid_inputs()
 
     # Run ln tests
     test_ln()

--- a/tests/bigdecimal/test_bigdecimal_exponential.mojo
+++ b/tests/bigdecimal/test_bigdecimal_exponential.mojo
@@ -12,7 +12,7 @@ from tomlmojo import parse_file
 alias exponential_file_path = "tests/bigdecimal/test_data/bigdecimal_exponential.toml"
 
 
-fn load_test_cases(
+fn load_test_cases_one_argument(
     file_path: String, table_name: String
 ) raises -> List[TestCase]:
     """Load test cases from a TOML file for a specific table."""
@@ -32,8 +32,30 @@ fn load_test_cases(
                 case_table["description"].as_string(),
             )
         )
+    return test_cases^
 
-    return test_cases
+
+fn load_test_cases_two_arguments(
+    file_path: String, table_name: String
+) raises -> List[TestCase]:
+    """Load test cases from a TOML file for a specific table."""
+    var toml = parse_file(file_path)
+    var test_cases = List[TestCase]()
+
+    # Get array of test cases
+    var cases_array = toml.get_array_of_tables(table_name)
+
+    for i in range(len(cases_array)):
+        var case_table = cases_array[i]
+        test_cases.append(
+            TestCase(
+                case_table["a"].as_string(),
+                case_table["b"].as_string(),
+                case_table["expected"].as_string(),
+                case_table["description"].as_string(),
+            )
+        )
+    return test_cases^
 
 
 fn test_sqrt() raises:
@@ -44,7 +66,9 @@ fn test_sqrt() raises:
     var pydecimal = Python.import_module("decimal")
 
     # Load test cases from TOML file
-    var test_cases = load_test_cases(exponential_file_path, "sqrt_tests")
+    var test_cases = load_test_cases_one_argument(
+        exponential_file_path, "sqrt_tests"
+    )
     print("Loaded", len(test_cases), "test cases for square root")
 
     # Track test results
@@ -116,7 +140,9 @@ fn test_ln() raises:
     var pydecimal = Python.import_module("decimal")
 
     # Load test cases from TOML file
-    var test_cases = load_test_cases(exponential_file_path, "ln_tests")
+    var test_cases = load_test_cases_one_argument(
+        exponential_file_path, "ln_tests"
+    )
     print("Loaded", len(test_cases), "test cases for natural logarithm")
 
     # Track test results
@@ -191,6 +217,119 @@ fn test_ln_invalid_inputs() raises:
     print("✓ ln of negative number correctly raises an error")
 
 
+fn test_root() raises:
+    """Test BigDecimal nth root with various test cases."""
+    print("------------------------------------------------------")
+    print("Testing BigDecimal root function...")
+
+    var pydecimal = Python.import_module("decimal")
+
+    # Load test cases from TOML file
+    var test_cases = load_test_cases_two_arguments(
+        exponential_file_path, "root_tests"
+    )
+    print("Loaded", len(test_cases), "test cases for root function")
+
+    # Track test results
+    var passed = 0
+    var failed = 0
+
+    # Run all test cases in a loop
+    for i in range(len(test_cases)):
+        var test_case = test_cases[i]
+        var base_value = BigDecimal(test_case.a)
+        var root_value = BigDecimal(test_case.b)
+        var expected = BigDecimal(test_case.expected)
+
+        # Calculate nth root
+        var result = base_value.root(root_value, precision=28)
+
+        try:
+            # Using String comparison for easier debugging
+            testing.assert_equal(
+                String(result), String(expected), test_case.description
+            )
+            passed += 1
+        except e:
+            print(
+                "=" * 50,
+                "\n",
+                i + 1,
+                "failed:",
+                test_case.description,
+                "\n  Base:",
+                test_case.a,
+                "\n  Root:",
+                test_case.b,
+                "\n  Expected:",
+                test_case.expected,
+                "\n  Got:",
+                String(result),
+                "\n  Python decimal result (for reference):",
+                String(
+                    pydecimal.Decimal(test_case.a)
+                    ** (pydecimal.Decimal(1) / pydecimal.Decimal(test_case.b))
+                ),
+            )
+            failed += 1
+
+    print("BigDecimal root tests:", passed, "passed,", failed, "failed")
+    testing.assert_equal(failed, 0, "All root function tests should pass")
+
+
+fn test_root_invalid_inputs() raises:
+    """Test that root function with invalid inputs raises appropriate errors."""
+    print("------------------------------------------------------")
+    print("Testing BigDecimal root with invalid inputs...")
+
+    # Test 1: 0th root should raise an error
+    var a1 = BigDecimal("16")
+    var n1 = BigDecimal("0")
+    var exception_caught = False
+    try:
+        _ = a1.root(n1, precision=28)
+        exception_caught = False
+    except:
+        exception_caught = True
+    testing.assert_true(exception_caught, "0th root should raise an error")
+    print("✓ 0th root correctly raises an error")
+
+    # Test 2: Even root of negative number should raise an error
+    var a2 = BigDecimal("-16")
+    var n2 = BigDecimal("2")
+    exception_caught = False
+    try:
+        _ = a2.root(n2, precision=28)
+        exception_caught = False
+    except:
+        exception_caught = True
+    testing.assert_true(
+        exception_caught, "Even root of negative number should raise an error"
+    )
+    print("✓ Even root of negative number correctly raises an error")
+
+    # Test 3: Fractional root with even denominator of negative number should raise an error
+    var a3 = BigDecimal("-16")
+    var n3 = BigDecimal("2.5")  # 5/2, denominator is even
+    exception_caught = False
+    try:
+        _ = a3.root(n3, precision=28)
+        exception_caught = False
+    except:
+        exception_caught = True
+    testing.assert_true(
+        exception_caught,
+        (
+            "Fractional root with even denominator of negative number should"
+            " raise an error"
+        ),
+    )
+    print(
+        "✓ Fractional root with even denominator of negative number correctly"
+        " raises an error"
+    )
+
+
 fn main() raises:
     print("Running BigDecimal exponential tests")
 
@@ -199,6 +338,12 @@ fn main() raises:
 
     # Test sqrt of negative number
     test_negative_sqrt()
+
+    # Run root tests
+    test_root()
+
+    # Test root with invalid inputs
+    test_root_invalid_inputs()
 
     # Run ln tests
     test_ln()

--- a/tests/bigdecimal/test_data/bigdecimal_exponential.toml
+++ b/tests/bigdecimal/test_data/bigdecimal_exponential.toml
@@ -287,3 +287,172 @@ description = "Natural logarithm of φ (golden ratio)"
 input = "1.414213562373095048801688724"
 expected = "0.3465735902799726547086160606"
 description = "Natural logarithm of √2"
+
+# === ROOT TESTS ===
+# Testing different roots (both integer and fractional)
+
+[[root_tests]]
+a = "64"
+b = "2"
+expected = "8"
+description = "Square root of 64"
+
+[[root_tests]]
+a = "27"
+b = "3"
+expected = "3.000000000000000000000000000"
+description = "Cube root of 27"
+
+[[root_tests]]
+a = "-27"
+b = "3"
+expected = "-3.000000000000000000000000000"
+description = "Cube root of negative number"
+
+[[root_tests]]
+a = "16"
+b = "4"
+expected = "2.000000000000000000000000000"
+description = "4th root of 16"
+
+[[root_tests]]
+a = "32"
+b = "5"
+expected = "2.000000000000000000000000000"
+description = "5th root of 32"
+
+[[root_tests]]
+a = "64"
+b = "6"
+expected = "2.000000000000000000000000000"
+description = "6th root of 64"
+
+[[root_tests]]
+a = "128"
+b = "7"
+expected = "2.000000000000000000000000000"
+description = "7th root of 128"
+
+[[root_tests]]
+a = "256"
+b = "8"
+expected = "2.000000000000000000000000000"
+description = "8th root of 256"
+
+[[root_tests]]
+a = "1024"
+b = "10"
+expected = "2.000000000000000000000000000"
+description = "10th root of 1024"
+
+[[root_tests]]
+a = "1000000"
+b = "6"
+expected = "10.00000000000000000000000000"
+description = "6th root of one million"
+
+[[root_tests]]
+a = "0"
+b = "3"
+expected = "0"
+description = "Root of zero"
+
+[[root_tests]]
+a = "1"
+b = "99"
+expected = "1"
+description = "Any root of 1"
+
+# Fractional roots
+[[root_tests]]
+a = "16"
+b = "0.5"
+expected = "256.0000000000000000000000000"
+description = "Fractional root (0.5 is power of 2)"
+
+[[root_tests]]
+a = "27"
+b = "1.5"
+expected = "9.000000000000000000000000000"
+description = "Fractional root (x^(3/2))"
+
+[[root_tests]]
+a = "16"
+b = "2.5"
+expected = "3.031433133020796164694519603"
+description = "Fractional root (nth root where n=2.5)"
+
+[[root_tests]]
+a = "100"
+b = "2.5"
+expected = "6.309573444801932494343601366"
+description = "Fractional root of perfect power"
+
+# Negative roots (reciprocal of positive roots)
+[[root_tests]]
+a = "16"
+b = "-2"
+expected = "0.25"
+description = "Negative root (reciprocal of square root)"
+
+[[root_tests]]
+a = "27"
+b = "-3"
+expected = "0.3333333333333333333333333333"
+description = "Negative root (reciprocal of cube root)"
+
+# Special cases and edge cases
+[[root_tests]]
+a = "0.25"
+b = "2"
+expected = "0.5"
+description = "Root of number less than 1"
+
+[[root_tests]]
+a = "0.0625"
+b = "4"
+expected = "0.5000000000000000000000000000"
+description = "Higher root of number less than 1"
+
+[[root_tests]]
+a = "0.000001"
+b = "3"
+expected = "0.01000000000000000000000000000"
+description = "Root of very small number"
+
+[[root_tests]]
+a = "1000000000000000000000000"
+b = "6"
+expected = "10000.00000000000000000000000"
+description = "Root of very large number"
+
+[[root_tests]]
+a = "2"
+b = "1"
+expected = "2.000000000000000000000000000"
+description = "First root (identity)"
+
+[[root_tests]]
+a = "3.14159265358979323846264338328"
+b = "2"
+expected = "1.772453850905516027298167483"
+description = "Root of π"
+
+[[root_tests]]
+a = "2.71828182845904523536028747135"
+b = "3"
+expected = "1.395612425086089528628125320"
+description = "Root of e"
+
+# Extreme precision tests
+[[root_tests]]
+a = "12345.6789"
+b = "2"
+expected = "111.1111106055555544054166614"
+description = "High precision square root"
+
+[[root_tests]]
+a = "1.0001"
+b = "10000"
+expected = "1.000000009999500083325834158"
+description = "Very high root close to 1"

--- a/tests/bigdecimal/test_data/bigdecimal_exponential.toml
+++ b/tests/bigdecimal/test_data/bigdecimal_exponential.toml
@@ -367,7 +367,7 @@ description = "Any root of 1"
 [[root_tests]]
 a = "16"
 b = "0.5"
-expected = "256.0000000000000000000000000"
+expected = "256"
 description = "Fractional root (0.5 is power of 2)"
 
 [[root_tests]]
@@ -429,7 +429,7 @@ description = "Root of very large number"
 [[root_tests]]
 a = "2"
 b = "1"
-expected = "2.000000000000000000000000000"
+expected = "2"
 description = "First root (identity)"
 
 [[root_tests]]
@@ -456,3 +456,126 @@ a = "1.0001"
 b = "10000"
 expected = "1.000000009999500083325834158"
 description = "Very high root close to 1"
+
+# === POWER TESTS ===
+# Testing power function with various base and exponent combinations
+
+[[power_tests]]
+a = "2"
+b = "3"
+expected = "8"
+description = "Integer base, integer exponent (2^3)"
+
+[[power_tests]]
+a = "10"
+b = "2"
+expected = "100"
+description = "Power of 10 (10^2)"
+
+[[power_tests]]
+a = "2.5"
+b = "2"
+expected = "6.25"
+description = "Decimal base, integer exponent (2.5^2)"
+
+[[power_tests]]
+a = "4"
+b = "0.5"
+expected = "2.000000000000000000000000000"
+description = "Integer base, fractional exponent (4^0.5 = sqrt(4))"
+
+[[power_tests]]
+a = "9"
+b = "0.5"
+expected = "3.000000000000000000000000000"
+description = "Integer base, fractional exponent (9^0.5 = sqrt(9))"
+
+[[power_tests]]
+a = "27"
+b = "0.3333333333333333333333333333"
+expected = "3.000000000000000000000000000"
+description = "Integer base, fractional exponent (27^(1/3) = cube root of 27)"
+
+[[power_tests]]
+a = "2"
+b = "10"
+expected = "1024"
+description = "Small base, large exponent (2^10)"
+
+[[power_tests]]
+a = "1.5"
+b = "3"
+expected = "3.375"
+description = "Decimal base, integer exponent (1.5^3)"
+
+[[power_tests]]
+a = "0"
+b = "5"
+expected = "0"
+description = "Zero base, positive exponent"
+
+[[power_tests]]
+a = "1"
+b = "1000"
+expected = "1"
+description = "Base of 1, any exponent"
+
+[[power_tests]]
+a = "-2"
+b = "3"
+expected = "-8"
+description = "Negative base, odd exponent"
+
+[[power_tests]]
+a = "-2"
+b = "2"
+expected = "4"
+description = "Negative base, even exponent"
+
+[[power_tests]]
+a = "0.1"
+b = "2"
+expected = "0.01"
+description = "Decimal less than 1, integer exponent"
+
+[[power_tests]]
+a = "2"
+b = "-2"
+expected = "0.25"
+description = "Positive base, negative exponent"
+
+[[power_tests]]
+a = "4"
+b = "-0.5"
+expected = "0.5000000000000000000000000000"
+description = "Integer base, negative fractional exponent"
+
+[[power_tests]]
+a = "10"
+b = "-1"
+expected = "0.1"
+description = "Base 10, negative exponent"
+
+[[power_tests]]
+a = "3.14159"
+b = "2"
+expected = "9.8695877281"
+description = "Pi approximation squared"
+
+[[power_tests]]
+a = "2.71828"
+b = "3"
+expected = "20.085496391455552"
+description = "E approximation cubed"
+
+[[power_tests]]
+a = "1.5"
+b = "2.5"
+expected = "2.755675960631075360471944584"
+description = "Decimal base, decimal exponent"
+
+[[power_tests]]
+a = "1.5"
+b = "0"
+expected = "1"
+description = "Any base, zero exponent"


### PR DESCRIPTION
This pull request includes changes to the `decimojo` library, primarily focusing on the `BigDecimal` struct and its associated functions. The most significant changes involve adding a new parameter, `fill_zeros_to_precision`, to various functions to enhance the precision handling of `BigDecimal` operations. Additionally, the test suite has been updated to accommodate these changes.

Enhancements to `BigDecimal` precision handling:

* [`src/decimojo/bigdecimal/bigdecimal.mojo`](diffhunk://#diff-be2f9b2702fd15952546e17fe94a64c22902a0e4678bfd9cb925269647923db4R625-R635): Added `fill_zeros_to_precision` parameter to the `round_to_precision` method in the `BigDecimal` struct.
* [`src/decimojo/bigdecimal/exponential.mojo`](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcL74-R74): Updated various functions (`power`, `integer_power`, `root`, `integer_root`, `sqrt`, `exp`, `exp_taylor_series`, `ln`, `ln_series_expansion`, `compute_ln2`) to include the new `fill_zeros_to_precision` parameter. [[1]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcL74-R74) [[2]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcR89) [[3]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcL114-R120) [[4]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcL154-R172) [[5]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcL171-R188) [[6]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcR272) [[7]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcR320) [[8]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcR364) [[9]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcR557) [[10]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcR640-R647) [[11]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcR677) [[12]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcR724) [[13]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcR741) [[14]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcR842) [[15]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcR1022) [[16]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcR1073) [[17]](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcR1102)
* [`src/decimojo/bigdecimal/rounding.mojo`](diffhunk://#diff-2d08304d5c7273c47523b98f68714e1c980a59b7c4f0a9bf444ffca9435afa17R33): Modified the `round_to_precision` function to handle the new `fill_zeros_to_precision` parameter. [[1]](diffhunk://#diff-2d08304d5c7273c47523b98f68714e1c980a59b7c4f0a9bf444ffca9435afa17R33) [[2]](diffhunk://#diff-2d08304d5c7273c47523b98f68714e1c980a59b7c4f0a9bf444ffca9435afa17R48) [[3]](diffhunk://#diff-2d08304d5c7273c47523b98f68714e1c980a59b7c4f0a9bf444ffca9435afa17R58-R62)

Updates to test suite:

* [`tests/bigdecimal/test_bigdecimal_exponential.mojo`](diffhunk://#diff-b51835bb15d2b09cefa96824aa9213239280d5ebcf401bcf97d7518d76788280L15-R15): Split the `load_test_cases` function into `load_test_cases_one_argument` and `load_test_cases_two_arguments` to better handle different test scenarios. Updated `test_sqrt` and `test_ln` functions to use the new `load_test_cases_one_argument` function. [[1]](diffhunk://#diff-b51835bb15d2b09cefa96824aa9213239280d5ebcf401bcf97d7518d76788280L15-R15) [[2]](diffhunk://#diff-b51835bb15d2b09cefa96824aa9213239280d5ebcf401bcf97d7518d76788280R35-R58) [[3]](diffhunk://#diff-b51835bb15d2b09cefa96824aa9213239280d5ebcf401bcf97d7518d76788280L47-R71) [[4]](diffhunk://#diff-b51835bb15d2b09cefa96824aa9213239280d5ebcf401bcf97d7518d76788280L119-R145)