### PR TITLE
[integer][decimal] Allows implicit type conversion and type merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,67 @@ For the latest development version, clone the [GitHub repository](https://github
 
 ## Quick start
 
+Here are some examples showcasing the arbitrary-precision feature of the `BigDecimal` type.
+
+```mojo
+from decimojo import BDec, RM
+
+
+fn main() raises:
+    var PRECISION = 100
+    var a = BDec("123456789.123456789")
+    var b = BDec("1234.56789")
+    print(a.sqrt(precision=PRECISION))
+    # 11111.11106611111096943055498174930232833813065468909453818857935956641682120364106016272519460988485
+    print(a.power(b, precision=PRECISION))
+    # 3.346361102419080234023813540078946868219632448203078657310495672766009862564151996325555496759911131748170844123475135377098326591508239654961E+9989
+    print(a.log(b, precision=PRECISION))
+    # 2.617330026656548299907884356415293977170848626010103229392408225981962436022623783231699264341492663671325580092077394824180414301026578169909
+```
+
+Here is a comprehensive quick-start guide showcasing each major function of the `BigInt` type.
+
+```mojo
+from decimojo import BigInt, BInt
+# BInt is an alias for BigInt
+
+fn main() raises:
+    # === Construction ===
+    var a = BigInt("12345678901234567890")         # From string
+    var b = BInt(12345)                            # From integer
+    
+    # === Basic Arithmetic ===
+    print(a + b)                                   # Addition: 12345678901234580235
+    print(a - b)                                   # Subtraction: 12345678901234555545
+    print(a * b)                                   # Multiplication: 152415787814108380241050
+    
+    # === Division Operations ===
+    print(a // b)                                  # Floor division: 999650944609516
+    print(a.truncate_divide(b))                    # Truncate division: 999650944609516
+    print(a % b)                                   # Modulo: 9615
+    
+    # === Power Operation ===
+    print(BInt(2).power(10))                     # Power: 1024
+    print(BInt(2) ** 10)                         # Power (using ** operator): 1024
+    
+    # === Comparison ===
+    print(a > b)                                   # Greater than: True
+    print(a == BInt("12345678901234567890"))     # Equality: True
+    print(a.is_zero())                             # Check for zero: False
+    
+    # === Type Conversions ===
+    print(a.to_str())                              # To string: "12345678901234567890"
+    
+    # === Sign Handling ===
+    print(-a)                                      # Negation: -12345678901234567890
+    print(abs(BInt("-12345678901234567890")))    # Absolute value: 12345678901234567890
+    print(a.is_negative())                         # Check if negative: False
+
+    # === Extremely large numbers ===
+    # 3600 digits // 1800 digits
+    print(BInt("123456789" * 400) // BInt("987654321" * 200))
+```
+
 Here is a comprehensive quick-start guide showcasing each major function of the `Decimal` type.
 
 ```mojo
@@ -117,67 +178,6 @@ fn main() raises:
 ```
 
 [Click here for 8 key examples](https://zhuyuhao.com/decimojo/docs/examples) highlighting the most important features of the `Decimal` type.
-
-Here are some examples showcasing the arbitrary-precision feature of the `BigDecimal` type.
-
-```mojo
-from decimojo import BDec, RM
-
-
-fn main() raises:
-    var PRECISION = 100
-    var a = BDec("123456789.123456789")
-    var b = BDec("1234.56789")
-    print(a.sqrt(precision=PRECISION))
-    # 11111.11106611111096943055498174930232833813065468909453818857935956641682120364106016272519460988485
-    print(a.power(b, precision=PRECISION))
-    # 3.346361102419080234023813540078946868219632448203078657310495672766009862564151996325555496759911131748170844123475135377098326591508239654961E+9989
-    print(a.log(b, precision=PRECISION))
-    # 2.617330026656548299907884356415293977170848626010103229392408225981962436022623783231699264341492663671325580092077394824180414301026578169909
-```
-
-Here is a comprehensive quick-start guide showcasing each major function of the `BigInt` type.
-
-```mojo
-from decimojo import BigInt, BInt
-# BInt is an alias for BigInt
-
-fn main() raises:
-    # === Construction ===
-    var a = BigInt("12345678901234567890")         # From string
-    var b = BInt(12345)                            # From integer
-    
-    # === Basic Arithmetic ===
-    print(a + b)                                   # Addition: 12345678901234580235
-    print(a - b)                                   # Subtraction: 12345678901234555545
-    print(a * b)                                   # Multiplication: 152415787814108380241050
-    
-    # === Division Operations ===
-    print(a // b)                                  # Floor division: 999650944609516
-    print(a.truncate_divide(b))                    # Truncate division: 999650944609516
-    print(a % b)                                   # Modulo: 9615
-    
-    # === Power Operation ===
-    print(BInt(2).power(10))                     # Power: 1024
-    print(BInt(2) ** 10)                         # Power (using ** operator): 1024
-    
-    # === Comparison ===
-    print(a > b)                                   # Greater than: True
-    print(a == BInt("12345678901234567890"))     # Equality: True
-    print(a.is_zero())                             # Check for zero: False
-    
-    # === Type Conversions ===
-    print(a.to_str())                              # To string: "12345678901234567890"
-    
-    # === Sign Handling ===
-    print(-a)                                      # Negation: -12345678901234567890
-    print(abs(BInt("-12345678901234567890")))    # Absolute value: 12345678901234567890
-    print(a.is_negative())                         # Check if negative: False
-
-    # === Extremely large numbers ===
-    # 3600 digits // 1800 digits
-    print(BInt("123456789" * 400) // BInt("987654321" * 200))
-```
 
 ## Objective
 

--- a/src/decimojo/bigdecimal/exponential.mojo
+++ b/src/decimojo/bigdecimal/exponential.mojo
@@ -512,7 +512,7 @@ fn sqrt(x: BigDecimal, precision: Int) raises -> BigDecimal:
     if odd_ndigits_frac_part:
         value = value * UInt128(10)
     var sqrt_value = decimojo.utility.sqrt(value)
-    var sqrt_value_biguint = BigUInt.from_scalar(sqrt_value)
+    var sqrt_value_biguint = BigUInt.from_unsigned_integral_scalar(sqrt_value)
     guess = BigDecimal(
         sqrt_value_biguint,
         sqrt_value_biguint.number_of_digits() - ndigits_int_part_sqrt,

--- a/src/decimojo/bigint/bigint.mojo
+++ b/src/decimojo/bigint/bigint.mojo
@@ -27,9 +27,10 @@ from memory import UnsafePointer
 import testing
 import time
 
-from decimojo.biguint.biguint import BigUInt
 import decimojo.bigint.arithmetics
 import decimojo.bigint.comparison
+from decimojo.bigdecimal.bigdecimal import BigDecimal
+from decimojo.biguint.biguint import BigUInt
 import decimojo.str
 
 # Type aliases
@@ -125,7 +126,8 @@ struct BigInt(Absable, IntableRaising, Representable, Stringable, Writable):
         self.magnitude = BigUInt(List[UInt32](elements=words^))
         self.sign = sign
 
-    fn __init__(out self, value: Int) raises:
+    @implicit
+    fn __init__(out self, value: Int):
         """Initializes a BigInt from an Int.
         See `from_int()` for more information.
         """
@@ -476,32 +478,28 @@ struct BigInt(Absable, IntableRaising, Representable, Stringable, Writable):
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __radd__(self, other: Int) raises -> Self:
-        return decimojo.bigint.arithmetics.add(self, Self.from_int(other))
+    fn __radd__(self, other: Self) raises -> Self:
+        return decimojo.bigint.arithmetics.add(self, other)
 
     @always_inline
-    fn __rsub__(self, other: Int) raises -> Self:
-        return decimojo.bigint.arithmetics.subtract(Self.from_int(other), self)
+    fn __rsub__(self, other: Self) raises -> Self:
+        return decimojo.bigint.arithmetics.subtract(other, self)
 
     @always_inline
-    fn __rmul__(self, other: Int) raises -> Self:
-        return decimojo.bigint.arithmetics.multiply(self, Self.from_int(other))
+    fn __rmul__(self, other: Self) raises -> Self:
+        return decimojo.bigint.arithmetics.multiply(self, other)
 
     @always_inline
-    fn __rfloordiv__(self, other: Int) raises -> Self:
-        return decimojo.bigint.arithmetics.floor_divide(
-            Self.from_int(other), self
-        )
+    fn __rfloordiv__(self, other: Self) raises -> Self:
+        return decimojo.bigint.arithmetics.floor_divide(other, self)
 
     @always_inline
-    fn __rmod__(self, other: Int) raises -> Self:
-        return decimojo.bigint.arithmetics.floor_modulo(
-            Self.from_int(other), self
-        )
+    fn __rmod__(self, other: Self) raises -> Self:
+        return decimojo.bigint.arithmetics.floor_modulo(other, self)
 
     @always_inline
-    fn __rpow__(self, base: Int) raises -> Self:
-        return Self(base).power(self)
+    fn __rpow__(self, base: Self) raises -> Self:
+        return base.power(self)
 
     # ===------------------------------------------------------------------=== #
     # Basic binary augmented arithmetic assignments dunders
@@ -620,6 +618,14 @@ struct BigInt(Absable, IntableRaising, Representable, Stringable, Writable):
     fn __ne__(self, other: Int) -> Bool:
         """Returns True if self != other."""
         return decimojo.bigint.comparison.not_equal(self, Self.from_int(other))
+
+    # ===------------------------------------------------------------------=== #
+    # Other dunders
+    # ===------------------------------------------------------------------=== #
+
+    fn __merge_with__[other_type: __type_of(BigDecimal)](self) -> BigDecimal:
+        "Merges this BigInt with a BigDecimal into a BigDecimal."
+        return BigDecimal(self)
 
     # ===------------------------------------------------------------------=== #
     # Mathematical methods that do not implement a trait (not a dunder)

--- a/src/decimojo/biguint/biguint.mojo
+++ b/src/decimojo/biguint/biguint.mojo
@@ -137,6 +137,7 @@ struct BigUInt(Absable, IntableRaising, Stringable, Writable):
         """
         self = Self.from_int(value)
 
+    @implicit
     fn __init__(out self, value: Scalar):
         """Initializes a BigUInt from an unsigned integral scalar.
         See `from_unsigned_integral_scalar()` for more information.


### PR DESCRIPTION
This pull request introduces significant updates to `BigDecimal`, `BigInt`, and `BigUInt` structures in the `decimojo` library. The changes add implicit constructors for better usability, refine initialization methods, and improve type handling for integral and floating-point scalars.

### Enhancements to `BigDecimal`:
* [`src/decimojo/bigdecimal/bigdecimal.mojo`](diffhunk://#diff-be2f9b2702fd15952546e17fe94a64c22902a0e4678bfd9cb925269647923db4R85-R125): Added implicit constructors for `BigUInt`, `BigInt`, `Int`, and integral scalars, enabling seamless initialization of `BigDecimal` objects from these types.
* [`src/decimojo/bigdecimal/bigdecimal.mojo`](diffhunk://#diff-be2f9b2702fd15952546e17fe94a64c22902a0e4678bfd9cb925269647923db4L160-R207): Replaced the `from_scalar` method with `from_integral_scalar` and introduced `from_float` for better handling of integral and floating-point scalars. Improved constraints and error handling for scalar type validation. [[1]](diffhunk://#diff-be2f9b2702fd15952546e17fe94a64c22902a0e4678bfd9cb925269647923db4L160-R207) [[2]](diffhunk://#diff-be2f9b2702fd15952546e17fe94a64c22902a0e4678bfd9cb925269647923db4L174-R237)
* [`src/decimojo/bigdecimal/bigdecimal.mojo`](diffhunk://#diff-be2f9b2702fd15952546e17fe94a64c22902a0e4678bfd9cb925269647923db4R488-R519): Added right-side arithmetic dunders (`__radd__`, `__rsub__`, etc.) for `BigDecimal`, enabling more flexible cross-type operations.

### Enhancements to `BigInt`:
* [`src/decimojo/bigint/bigint.mojo`](diffhunk://#diff-d65a756a58e3387a2b30bbe88308c3b318d71d2116b2870ac0a44109729e554bR73-R78): Added implicit constructors for `BigUInt`, `Int`, and integral scalars, simplifying the initialization of `BigInt` objects. [[1]](diffhunk://#diff-d65a756a58e3387a2b30bbe88308c3b318d71d2116b2870ac0a44109729e554bR73-R78) [[2]](diffhunk://#diff-d65a756a58e3387a2b30bbe88308c3b318d71d2116b2870ac0a44109729e554bR145-R161)
* [`src/decimojo/bigint/bigint.mojo`](diffhunk://#diff-d65a756a58e3387a2b30bbe88308c3b318d71d2116b2870ac0a44109729e554bL236-R277): Introduced `from_integral_scalar` for handling integral scalars, replacing `from_uint128` with improved constraints and validation.

### Minor Refinements:
* [`src/decimojo/bigdecimal/exponential.mojo`](diffhunk://#diff-8edc842002d08323642db57f775ff7f626be068d55cb55bbe637e215f68ed8bcL515-R515): Updated the `sqrt` function to use `BigUInt.from_unsigned_integral_scalar`, ensuring consistent handling of unsigned integral scalars.
* [`src/decimojo/bigint/bigint.mojo`](diffhunk://#diff-d65a756a58e3387a2b30bbe88308c3b318d71d2116b2870ac0a44109729e554bL84-R91): Marked certain initialization methods as unsafe and added warnings in their documentation to encourage users to use safer alternatives. [[1]](diffhunk://#diff-d65a756a58e3387a2b30bbe88308c3b318d71d2116b2870ac0a44109729e554bL84-R91) [[2]](diffhunk://#diff-d65a756a58e3387a2b30bbe88308c3b318d71d2116b2870ac0a44109729e554bL103-R111)

These changes collectively improve the usability, readability, and robustness of the `decimojo` library, making it more intuitive for developers working with arbitrary-precision arithmetic.