### PR TITLE
[decimal] Use Chudnovsky with binary splitting to calculate pi

### DIFF
--- a/docs/internal_notes.md
+++ b/docs/internal_notes.md
@@ -1,3 +1,10 @@
 # Internal Notes
 
+## Values and results
+
 - For power functionality: `BigDecimal.power()`, Python's decimal, WolframAlpha give the same result, but `mpmath` gives a different result. Eample: `0.123456789 ** 1000`, `1234523894766789 ** 1098.1209848`.
+
+## Time complexity
+
+- #94. Implementing pi() with Machin's formula. Time taken for precision 2048: 33.580649 seconds.
+- #95. Implementing pi() with Chudnovsky algorithm (binary splitting). Time taken for precision 2048: 1.771954 seconds.


### PR DESCRIPTION
This pull request introduces significant improvements to the `BigDecimal` library by optimizing the calculation of π (pi) for high precision and documenting the performance characteristics of different algorithms. The main changes include replacing Machin's formula with the Chudnovsky algorithm for faster computation, introducing binary splitting for efficiency, and adding internal notes on time complexity and algorithm results.

### Optimizations for π Calculation:

* [`src/decimojo/bigdecimal/constants.mojo`](diffhunk://#diff-41cd4654562f4a78c9b73f60941a2f1e1d8509a3dc8a93469408e4a5456619f2R154-R289): Replaced Machin's formula with the Chudnovsky algorithm for π calculation, leveraging binary splitting for higher precision and faster computation. Added caching logic to store precomputed values for precision ≤ 1024.
* [`src/decimojo/bigdecimal/constants.mojo`](diffhunk://#diff-41cd4654562f4a78c9b73f60941a2f1e1d8509a3dc8a93469408e4a5456619f2R154-R289): Introduced helper functions `pi_chudnovsky_binary_split`, `chudnovsky_split`, and `compute_m_k_rational` to implement the Chudnovsky algorithm efficiently.

### Documentation Updates:

* [`docs/internal_notes.md`](diffhunk://#diff-6da6b2e1a170d4269cd7863de3fd61fd4098c67fc788deb68bbe6f0f18b98d24R3-R10): Added a section describing time complexity and performance results for π calculation using Machin's formula and the Chudnovsky algorithm.

### Code Cleanup:

* [`src/decimojo/bigdecimal/constants.mojo`](diffhunk://#diff-41cd4654562f4a78c9b73f60941a2f1e1d8509a3dc8a93469408e4a5456619f2L196-L197): Removed redundant code related to Machin's formula for π, including unused variables and outdated comments.