### PR TITLE
[integer] Refine normalization of `BigUInt` division so that correction is no longer needed

### DIFF
--- a/src/decimojo/bigdecimal/arithmetics.mojo
+++ b/src/decimojo/bigdecimal/arithmetics.mojo
@@ -278,7 +278,7 @@ fn true_divide(
     # Scale up the dividend to ensure sufficient precision
     var scaled_x1 = x1.coefficient
     if additional_digits > 0:
-        scaled_x1 = scaled_x1.scale_up_by_power_of_10(additional_digits)
+        scaled_x1.scale_up_inplace_by_power_of_10(additional_digits)
 
     # Perform division
     var quotient: BigUInt
@@ -382,7 +382,7 @@ fn true_divide_inexact(
     # Scale up the dividend to ensure sufficient precision
     var scaled_x1 = x1.coefficient
     if buffer_digits > 0:
-        scaled_x1 = scaled_x1.scale_up_by_power_of_10(buffer_digits)
+        scaled_x1.scale_up_inplace_by_power_of_10(buffer_digits)
 
     # Perform division
     var quotient: BigUInt = scaled_x1 // x2.coefficient

--- a/src/decimojo/biguint/biguint.mojo
+++ b/src/decimojo/biguint/biguint.mojo
@@ -1074,6 +1074,13 @@ struct BigUInt(Absable, IntableRaising, Stringable, Writable):
         return decimojo.biguint.arithmetics.scale_up_by_power_of_10(self, n)
 
     @always_inline
+    fn scale_up_inplace_by_power_of_10(mut self, n: Int):
+        """Multiplies this number in-place by 10^n (n>=0).
+        See `scale_up_inplace_by_power_of_10()` for more information.
+        """
+        decimojo.biguint.arithmetics.scale_up_inplace_by_power_of_10(self, n)
+
+    @always_inline
     fn scale_down_by_power_of_10(self, n: Int) raises -> Self:
         """Returns the result of floored dividing this number by 10^n (n>=0).
         It is equal to removing the last n digits of the number.

--- a/src/decimojo/biguint/biguint.mojo
+++ b/src/decimojo/biguint/biguint.mojo
@@ -43,7 +43,7 @@ struct BigUInt(Absable, IntableRaising, Stringable, Writable):
 
     Internal Representation:
 
-    Use base-10^9 representation for the unsigned integer.
+    Use base-10^9 (base-billion) representation for the unsigned integer.
     BigUInt uses a dynamic structure in memory, which contains:
     An pointer to an array of UInt32 words for the coefficient on the heap,
     which can be of arbitrary length stored in little-endian order.
@@ -52,6 +52,9 @@ struct BigUInt(Absable, IntableRaising, Stringable, Writable):
     The value of the BigUInt is calculated as follows:
 
     x = x[0] * 10^0 + x[1] * 10^9 + x[2] * 10^18 + ... x[n] * 10^(9n)
+
+    You can think of the BigUInt as a list base-billion digits, where each
+    digit is ranging from 0 to 999_999_999.
     """
 
     var words: List[UInt32]
@@ -60,6 +63,14 @@ struct BigUInt(Absable, IntableRaising, Stringable, Writable):
     # ===------------------------------------------------------------------=== #
     # Constants
     # ===------------------------------------------------------------------=== #
+
+    # TODO: Make these constants global, e.g., decimojo.BASE
+    alias BASE = 1_000_000_000
+    """The base used for the BigUInt representation."""
+    alias BASE_MAX = 999_999_999
+    """The maximum value of a single word in the BigUInt representation."""
+    alias BASE_HALF = 500_000_000
+    """Half of the base used for the BigUInt representation."""
 
     alias ZERO = Self.zero()
     alias ONE = Self.one()
@@ -841,6 +852,11 @@ struct BigUInt(Absable, IntableRaising, Stringable, Writable):
     @always_inline
     fn __floordiv__(self, other: Self) raises -> Self:
         return decimojo.biguint.arithmetics.floor_divide(self, other)
+
+    @always_inline
+    fn __ceildiv__(self, other: Self) raises -> Self:
+        """Returns the result of ceiling division."""
+        return decimojo.biguint.arithmetics.ceil_divide(self, other)
 
     @always_inline
     fn __mod__(self, other: Self) raises -> Self:


### PR DESCRIPTION
This pull request focuses on optimizing arithmetic operations for `BigUInt` in the `decimojo` library. The changes primarily involve replacing hardcoded constants (e.g., `1_000_000_000`) with the `BigUInt.BASE` and `BigUInt.BASE_MAX` properties, introducing in-place scaling methods, and improving normalization logic for division operations. These updates enhance code maintainability, readability, and performance.

### Division improvements:
* Enhanced normalization logic in `floor_divide` by introducing a table-based lookup for determining the number of digits to shift, improving quotient estimation accuracy. (`[src/decimojo/biguint/arithmetics.mojoL931-R1037](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL931-R1037)`)
* Although no correction is expected to occur, still kept the correction attempts counter in `floor_divide_general` to prevent infinite loops during quotient estimation. (`[src/decimojo/biguint/arithmetics.mojoL991-R1098](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL991-R1098)`)

### Updates to scaling methods:
* Replaced `scale_up_by_power_of_10` and `scale_up_by_power_of_billion` with their in-place equivalents (`scale_up_inplace_by_power_of_10` and `scale_up_inplace_by_power_of_billion`) across multiple functions, reducing redundant object creation. (`[[1]](diffhunk://#diff-f79534f4e7fdd891932ce9d015c50bd3c8a72c4a1689f0cb55524490ffc0458dL281-R281)`, `[[2]](diffhunk://#diff-f79534f4e7fdd891932ce9d015c50bd3c8a72c4a1689f0cb55524490ffc0458dL385-R385)`, `[[3]](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL621-R621)`, `[[4]](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL640-R640)`, `[[5]](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL700-R701)`, `[[6]](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL807-R880)`, `[[7]](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL991-R1098)`)

### Transition to `BigUInt.BASE` and `BigUInt.BASE_MAX`:
* Replaced hardcoded constants `1_000_000_000` and `999_999_999` with `BigUInt.BASE` and `BigUInt.BASE_MAX` in arithmetic operations (e.g., addition, subtraction, multiplication, division) to improve flexibility and reduce magic numbers. (`[[1]](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL204-R205)`, `[[2]](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL231-R236)`, `[[3]](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL260-R261)`, `[[4]](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL274-R274)`, `[[5]](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL330-R330)`, `[[6]](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL372-R372)`, `[[7]](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL531-R532)`, `[[8]](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL728-L735)`, `[[9]](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL782-R863)`, `[[10]](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL916-R986)`, `[[11]](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL1063-R1176)`, `[[12]](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL1090-R1185)`, `[[13]](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL1111-R1206)`, `[[14]](diffhunk://#diff-95a5c66e5957fff2a2a8a2710ffb11a4ad7d0bddaf3bc11d075d62ddaa8b915cL1136-R1231)`)
