### PR TITLE
[errors] Improve error handling by using `DeciMojoError` type

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 # SCM syntax highlighting & preventing 3-way merges
 pixi.lock merge=binary linguist-language=YAML linguist-generated=true
 magic.lock merge=binary linguist-language=YAML linguist-generated=true
+
+# Force LF (Unix-style) line endings
+* text=auto eol=lf

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 version = "0.5.0"
 
 [dependencies]
-max = ">25.4"
+max = ">=25.5, <25.6"
 
 [tasks]
 # format the code

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 version = "0.5.0"
 
 [dependencies]
-max = ">=25.5, <25.6"
+mojo = "*"
 
 [tasks]
 # format the code

--- a/src/decimojo/bigint/bigint.mojo
+++ b/src/decimojo/bigint/bigint.mojo
@@ -29,6 +29,7 @@ import decimojo.bigint.arithmetics
 import decimojo.bigint.comparison
 from decimojo.bigdecimal.bigdecimal import BigDecimal
 from decimojo.biguint.biguint import BigUInt
+from decimojo.errors import DeciMojoError
 import decimojo.str
 
 # Type aliases
@@ -463,24 +464,44 @@ struct BigInt(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __add__(self, other: Self) raises -> Self:
+    fn __add__(self, other: Self) -> Self:
         return decimojo.bigint.arithmetics.add(self, other)
 
     @always_inline
-    fn __sub__(self, other: Self) raises -> Self:
+    fn __sub__(self, other: Self) -> Self:
         return decimojo.bigint.arithmetics.subtract(self, other)
 
     @always_inline
-    fn __mul__(self, other: Self) raises -> Self:
+    fn __mul__(self, other: Self) -> Self:
         return decimojo.bigint.arithmetics.multiply(self, other)
 
     @always_inline
     fn __floordiv__(self, other: Self) raises -> Self:
-        return decimojo.bigint.arithmetics.floor_divide(self, other)
+        try:
+            return decimojo.bigint.arithmetics.floor_divide(self, other)
+        except e:
+            raise Error(
+                DeciMojoError(
+                    message=None,
+                    function="BigInt.__floordiv__()",
+                    file="src/decimojo/bigint/bigint.mojo",
+                    previous_error=e,
+                )
+            )
 
     @always_inline
     fn __mod__(self, other: Self) raises -> Self:
-        return decimojo.bigint.arithmetics.floor_modulo(self, other)
+        try:
+            return decimojo.bigint.arithmetics.floor_modulo(self, other)
+        except e:
+            raise Error(
+                DeciMojoError(
+                    message=None,
+                    function="BigInt.__mod__()",
+                    file="src/decimojo/bigint/bigint.mojo",
+                    previous_error=e,
+                )
+            )
 
     @always_inline
     fn __pow__(self, exponent: Self) raises -> Self:
@@ -493,15 +514,15 @@ struct BigInt(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __radd__(self, other: Self) raises -> Self:
+    fn __radd__(self, other: Self) -> Self:
         return decimojo.bigint.arithmetics.add(self, other)
 
     @always_inline
-    fn __rsub__(self, other: Self) raises -> Self:
+    fn __rsub__(self, other: Self) -> Self:
         return decimojo.bigint.arithmetics.subtract(other, self)
 
     @always_inline
-    fn __rmul__(self, other: Self) raises -> Self:
+    fn __rmul__(self, other: Self) -> Self:
         return decimojo.bigint.arithmetics.multiply(self, other)
 
     @always_inline
@@ -524,11 +545,11 @@ struct BigInt(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __iadd__(mut self, other: Self) raises:
+    fn __iadd__(mut self, other: Self):
         decimojo.bigint.arithmetics.add_inplace(self, other)
 
     @always_inline
-    fn __iadd__(mut self, other: Int) raises:
+    fn __iadd__(mut self, other: Int):
         # Optimize the case `i += 1`
         if (self >= 0) and (other >= 0) and (other <= 999_999_999):
             decimojo.biguint.arithmetics.add_inplace_by_uint32(
@@ -538,11 +559,11 @@ struct BigInt(
             decimojo.bigint.arithmetics.add_inplace(self, other)
 
     @always_inline
-    fn __isub__(mut self, other: Self) raises:
+    fn __isub__(mut self, other: Self):
         self = decimojo.bigint.arithmetics.subtract(self, other)
 
     @always_inline
-    fn __imul__(mut self, other: Self) raises:
+    fn __imul__(mut self, other: Self):
         self = decimojo.bigint.arithmetics.multiply(self, other)
 
     @always_inline

--- a/src/decimojo/biguint/arithmetics.mojo
+++ b/src/decimojo/biguint/arithmetics.mojo
@@ -1515,7 +1515,7 @@ fn floor_divide(x: BigUInt, y: BigUInt) raises -> BigUInt:
         raise Error(
             ZeroDivisionError(
                 file="src/decimojo/biguint/arithmetics.mojo",
-                function="floor_divide",
+                function="floor_divide()",
                 message="Division by zero",
                 previous_error=None,
             )
@@ -2711,8 +2711,9 @@ fn floor_modulo(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
         The remainder of x1 being divided by x2.
 
     Raises:
-        Error: If `floor_divide()` raises a ZeroDivisionError.
-        Error: If `subtract()` raises an OverflowError.
+        ZeroDivisionError: If the divisor is zero.
+        Error: If `floor_divide()` raises an error.
+        Error: If `subtract()` raises an error.
 
     Notes:
         It is equal to floored modulo for positive numbers.
@@ -2723,7 +2724,14 @@ fn floor_modulo(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
             len(x2.words) == 1,
             "truncate_modulo(): leading zero words",
         )
-        raise Error("Error in `truncate_modulo`: Division by zero")
+        raise Error(
+            ZeroDivisionError(
+                file="src/decimojo/biguint/arithmetics.py",
+                function="floor_modulo()",
+                message="Division by zero",
+                previous_error=None,
+            )
+        )
 
     # CASE: Dividend is zero
     if x1.is_zero():
@@ -2864,15 +2872,26 @@ fn floor_divide_modulo(
         The quotient of x1 / x2, truncated toward zero and the remainder.
 
     Raises:
-        ValueError: If the divisor is zero.
+        Error: If `floor_divide()` raises an error.
+        Error: If `subtract()` raises an error.
 
     Notes:
         It is equal to truncated division for positive numbers.
     """
 
-    var quotient = floor_divide(x1, x2)
-    var remainder = subtract(x1, multiply(x2, quotient))
-    return (quotient^, remainder^)
+    try:
+        var quotient = floor_divide(x1, x2)
+        var remainder = subtract(x1, multiply(x2, quotient))
+        return (quotient^, remainder^)
+    except e:
+        raise Error(
+            DeciMojoError(
+                file="src/decimojo/biguint/arithmetics.py",
+                function="floor_divide_modulo()",
+                message=None,
+                previous_error=e,
+            )
+        )
 
 
 # ===----------------------------------------------------------------------=== #
@@ -3031,10 +3050,25 @@ fn normalize_borrows(mut x: BigUInt):
 
 
 fn power_of_10(n: Int) raises -> BigUInt:
-    """Calculates 10^n efficiently."""
+    """Calculates 10^n efficiently for non-negative n.
+
+    Args:
+        n: The exponent, must be non-negative.
+
+    Returns:
+        A BigUInt representing 10 raised to the power of n.
+
+    Raises:
+        DeciMojoError: If n is negative.
+    """
     if n < 0:
         raise Error(
-            "biguint.arithmetics.power_of_10(): Negative exponent not supported"
+            DeciMojoError(
+                file="src/decimojo/biguint/arithmetics.py",
+                function="power_of_10()",
+                message="Negative exponent not supported",
+                previous_error=None,
+            )
         )
 
     if n == 0:

--- a/src/decimojo/biguint/arithmetics.mojo
+++ b/src/decimojo/biguint/arithmetics.mojo
@@ -24,6 +24,7 @@ from memory import memcpy, memset_zero
 
 from decimojo.biguint.biguint import BigUInt
 import decimojo.biguint.comparison
+from decimojo.errors import DeciMojoError, OverflowError, ZeroDivisionError
 from decimojo.rounding_mode import RoundingMode
 
 alias CUTOFF_KARATSUBA = 64
@@ -98,8 +99,12 @@ fn negative(x: BigUInt) raises -> BigUInt:
             len(x.words) == 1, "negative(): leading zero words"
         )
         raise Error(
-            "biguint.arithmetics.negative(): Negative of non-zero unsigned"
-            " integer is undefined"
+            OverflowError(
+                file="src/decimojo/biguint/arithmetics.mojo",
+                function="negative()",
+                message="Negative of non-zero unsigned integer is undefined",
+                previous_error=None,
+            )
         )
     return BigUInt()  # Return zero
 
@@ -480,7 +485,7 @@ fn subtract_school(x: BigUInt, y: BigUInt) raises -> BigUInt:
         y: The second unsigned integer (subtrahend).
 
     Raises:
-        Error: If y is greater than x, resulting in an underflow.
+        OverflowError: If y is greater than x.
 
     Returns:
         The result of subtracting y from x.
@@ -505,7 +510,17 @@ fn subtract_school(x: BigUInt, y: BigUInt) raises -> BigUInt:
         # |x| = |y|
         return BigUInt()  # Return zero
     if comparison_result < 0:
-        raise Error("biguint.arithmetics.subtract(): Underflow due to x < y")
+        raise Error(
+            OverflowError(
+                file="src/decimojo/biguint/arithmetics.mojo",
+                function="subtract_school()",
+                message=(
+                    "biguint.arithmetics.subtract(): Result is negative due to"
+                    " x < y"
+                ),
+                previous_error=None,
+            )
+        )
 
     # Now it is safe to subtract the smaller number from the larger one
     # The result will have no more words than the first number
@@ -554,7 +569,7 @@ fn subtract_simd(x: BigUInt, y: BigUInt) raises -> BigUInt:
         y: The second unsigned integer (subtrahend).
 
     Raises:
-        Error: If y is greater than x, resulting in an underflow.
+        OverflowError: If y is greater than x.
 
     Returns:
         The result of subtracting y from x.
@@ -592,7 +607,17 @@ fn subtract_simd(x: BigUInt, y: BigUInt) raises -> BigUInt:
         # |x| = |y|
         return BigUInt()  # Return zero
     if comparison_result < 0:
-        raise Error("biguint.arithmetics.subtract(): Underflow due to x < y")
+        raise Error(
+            OverflowError(
+                file="src/decimojo/biguint/arithmetics.mojo",
+                function="subtract()",
+                message=(
+                    "biguint.arithmetics.subtract(): Result is negative due to"
+                    " x < y"
+                ),
+                previous_error=None,
+            )
+        )
 
     # Now it is safe to subtract the smaller number from the larger one
     # The result will have no more words than the first number
@@ -648,7 +673,15 @@ fn subtract_inplace(mut x: BigUInt, y: BigUInt) raises -> None:
         x.words[0] = UInt32(0)  # Result is zero
     elif comparison_result < 0:
         raise Error(
-            "biguint.arithmetics.subtract_inplace(): Underflow due to x < y"
+            OverflowError(
+                file="src/decimojo/biguint/arithmetics.mojo",
+                function="subtract_inplace()",
+                message=(
+                    "biguint.arithmetics.subtract(): Result is negative due to"
+                    " x < y"
+                ),
+                previous_error=None,
+            )
         )
 
     # Now it is safe to subtract the smaller number from the larger one
@@ -1479,7 +1512,14 @@ fn floor_divide(x: BigUInt, y: BigUInt) raises -> BigUInt:
 
     # CASE: y is zero
     if y.is_zero():
-        raise Error("biguint.arithmetics.floor_divide(): Division by zero")
+        raise Error(
+            ZeroDivisionError(
+                file="src/decimojo/biguint/arithmetics.mojo",
+                function="floor_divide",
+                message="Division by zero",
+                previous_error=None,
+            )
+        )
 
     # CASE: Dividend is zero
     if x.is_zero():
@@ -2671,7 +2711,8 @@ fn floor_modulo(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
         The remainder of x1 being divided by x2.
 
     Raises:
-        ValueError: If the divisor is zero.
+        Error: If `floor_divide()` raises a ZeroDivisionError.
+        Error: If `subtract()` raises an OverflowError.
 
     Notes:
         It is equal to floored modulo for positive numbers.
@@ -2700,10 +2741,32 @@ fn floor_modulo(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
         return x1
 
     # Calculate quotient with truncation
-    var quotient = floor_divide(x1, x2)
+    var quotient: BigUInt
+    try:
+        quotient = floor_divide(x1, x2)
+    except e:
+        raise Error(
+            DeciMojoError(
+                file="src/decimojo/biguint/arithmetics.py",
+                function="floor_modulo()",
+                message=None,
+                previous_error=e,
+            )
+        )
 
     # Calculate remainder: dividend - (divisor * quotient)
-    var remainder = subtract(x1, multiply(x2, quotient))
+    var remainder: BigUInt
+    try:
+        remainder = subtract(x1, multiply(x2, quotient))
+    except e:
+        raise Error(
+            DeciMojoError(
+                file="src/decimojo/biguint/arithmetics.py",
+                function="floor_modulo()",
+                message=None,
+                previous_error=e,
+            )
+        )
 
     return remainder^
 
@@ -2713,8 +2776,28 @@ fn truncate_modulo(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
     """Returns the remainder of two BigUInt numbers, truncating toward zero.
     It is equal to floored modulo for unsigned numbers.
     See `floor_modulo` for more details.
+
+    Args:
+        x1: The dividend.
+        x2: The divisor.
+
+    Returns:
+        The remainder of x1 being divided by x2.
+
+    Raises:
+        Error: If `floor_modulo()` raises an OverflowError.
     """
-    return floor_modulo(x1, x2)
+    try:
+        return floor_modulo(x1, x2)
+    except e:
+        raise Error(
+            DeciMojoError(
+                file="src/decimojo/biguint/arithmetics.py",
+                function="truncate_modulo()",
+                message=None,
+                previous_error=e,
+            )
+        )
 
 
 fn ceil_modulo(x1: BigUInt, x2: BigUInt) raises -> BigUInt:

--- a/src/decimojo/biguint/biguint.mojo
+++ b/src/decimojo/biguint/biguint.mojo
@@ -27,6 +27,7 @@ from memory import UnsafePointer, memcpy
 
 import decimojo.biguint.arithmetics
 import decimojo.biguint.comparison
+from decimojo.errors import OverflowError
 import decimojo.str
 
 # Type aliases
@@ -260,8 +261,13 @@ struct BigUInt(
         for word in words:
             if word > UInt32(999_999_999):
                 raise Error(
-                    "Error in `BigUInt.from_list()`: Word value exceeds maximum"
-                    " value of 999_999_999"
+                    OverflowError(
+                        message=(
+                            "Word value exceeds maximum value of 999_999_999"
+                        ),
+                        function="BigUInt.from_list()",
+                        file="src/decimojo/biguint/biguint.mojo",
+                    )
                 )
 
         return Self(words^)
@@ -292,8 +298,13 @@ struct BigUInt(
         for word in words:
             if word > UInt32(999_999_999):
                 raise Error(
-                    "Error in `BigUInt.__init__()`: Word value exceeds maximum"
-                    " value of 999_999_999"
+                    OverflowError(
+                        message=(
+                            "Word value exceeds maximum value of 999_999_999"
+                        ),
+                        function="BigUInt.from_words()",
+                        file="src/decimojo/biguint/biguint.mojo",
+                    )
                 )
             else:
                 list_of_words.append(word)
@@ -1524,7 +1535,7 @@ struct BigUInt(
         rounding_mode: RoundingMode,
         remove_extra_digit_due_to_rounding: Bool,
     ) raises -> Self:
-        """Removes trailing digits from the BigUInt.
+        """Removes trailing digits from the BigUInt with rounding.
 
         Args:
             ndigits: The number of digits to remove.

--- a/src/decimojo/biguint/biguint.mojo
+++ b/src/decimojo/biguint/biguint.mojo
@@ -30,6 +30,7 @@ import decimojo.biguint.comparison
 from decimojo.errors import (
     DeciMojoError,
     ConversionError,
+    ValueError,
     IndexError,
     OverflowError,
 )
@@ -1051,7 +1052,17 @@ struct BigUInt(
 
     @always_inline
     fn __sub__(self, other: Self) raises -> Self:
-        return decimojo.biguint.arithmetics.subtract(self, other)
+        try:
+            return decimojo.biguint.arithmetics.subtract(self, other)
+        except e:
+            raise Error(
+                DeciMojoError(
+                    file="src/decimojo/biguint/biguint.mojo",
+                    function="BigUInt.__sub__(other: Self)",
+                    message=None,
+                    previous_error=e,
+                )
+            )
 
     @always_inline
     fn __mul__(self, other: Self) -> Self:
@@ -1059,28 +1070,88 @@ struct BigUInt(
 
     @always_inline
     fn __floordiv__(self, other: Self) raises -> Self:
-        return decimojo.biguint.arithmetics.floor_divide(self, other)
+        try:
+            return decimojo.biguint.arithmetics.floor_divide(self, other)
+        except e:
+            raise Error(
+                DeciMojoError(
+                    file="src/decimojo/biguint/biguint.mojo",
+                    function="BigUInt.__floordiv__(other: Self)",
+                    message=None,
+                    previous_error=e,
+                )
+            )
 
     @always_inline
     fn __ceildiv__(self, other: Self) raises -> Self:
         """Returns the result of ceiling division."""
-        return decimojo.biguint.arithmetics.ceil_divide(self, other)
+        try:
+            return decimojo.biguint.arithmetics.ceil_divide(self, other)
+        except e:
+            raise Error(
+                DeciMojoError(
+                    file="src/decimojo/biguint/biguint.mojo",
+                    function="BigUInt.__ceildiv__(other: Self)",
+                    message=None,
+                    previous_error=e,
+                )
+            )
 
     @always_inline
     fn __mod__(self, other: Self) raises -> Self:
-        return decimojo.biguint.arithmetics.floor_modulo(self, other)
+        try:
+            return decimojo.biguint.arithmetics.floor_modulo(self, other)
+        except e:
+            raise Error(
+                DeciMojoError(
+                    file="src/decimojo/biguint/biguint.mojo",
+                    function="BigUInt.__mod__(other: Self)",
+                    message=None,
+                    previous_error=e,
+                )
+            )
 
     @always_inline
     fn __divmod__(self, other: Self) raises -> Tuple[Self, Self]:
-        return decimojo.biguint.arithmetics.floor_divide_modulo(self, other)
+        try:
+            return decimojo.biguint.arithmetics.floor_divide_modulo(self, other)
+        except e:
+            raise Error(
+                DeciMojoError(
+                    file="src/decimojo/biguint/biguint.mojo",
+                    function="BigUInt.__divmod__(other: Self)",
+                    message=None,
+                    previous_error=e,
+                )
+            )
 
     @always_inline
     fn __pow__(self, exponent: Self) raises -> Self:
-        return self.power(exponent)
+        try:
+            return self.power(exponent)
+        except e:
+            raise Error(
+                DeciMojoError(
+                    file="src/decimojo/biguint/biguint.mojo",
+                    function="BigUInt.__pow__(exponent: Self)",
+                    message=None,
+                    previous_error=e,
+                )
+            )
 
     @always_inline
     fn __pow__(self, exponent: Int) raises -> Self:
-        return self.power(exponent)
+        try:
+            return self.power(exponent)
+        except e:
+            raise Error(
+                DeciMojoError(
+                    file="src/decimojo/biguint/biguint.mojo",
+                    function="BigUInt.__pow__(exponent: Int)",
+                    message=None,
+                    previous_error=e,
+                )
+            )
 
     # ===------------------------------------------------------------------=== #
     # Basic binary right-side arithmetic operation dunders
@@ -1281,7 +1352,7 @@ struct BigUInt(
         decimojo.biguint.arithmetics.multiply_inplace_by_power_of_ten(self, n)
 
     @always_inline
-    fn floor_divide_by_power_of_ten(self, n: Int) raises -> Self:
+    fn floor_divide_by_power_of_ten(self, n: Int) -> Self:
         """Returns the result of floored dividing this number by 10^n (n>=0).
         It is equal to removing the last n digits of the number.
         See `floor_divide_by_power_of_ten()` for more information.
@@ -1619,7 +1690,7 @@ struct BigUInt(
             The ith least significant digit of the BigUInt.
 
         Raises:
-            Error: If the index is negative.
+            IndexError: If the index is negative.
         """
         if i < 0:
             raise Error(
@@ -1731,6 +1802,9 @@ struct BigUInt(
         Returns:
             The BigUInt with the trailing digits removed.
 
+        Raises:
+            ValueError: If the number of digits to remove is negative.
+
         Notes:
 
         Rounding can result in an extra digit. Exmaple: remove last 1 digit of
@@ -1739,19 +1813,38 @@ struct BigUInt(
         """
         if ndigits < 0:
             raise Error(
-                "Error in `remove_trailing_digits()`: The number of digits to"
-                " remove is negative"
+                ValueError(
+                    file="src/decimojo/biguint/biguint.mojo",
+                    function="BigUInt.remove_trailing_digits_with_rounding()",
+                    message=(
+                        "The number of digits to remove is negative: "
+                        + String(ndigits)
+                    ),
+                    previous_error=None,
+                )
             )
         if ndigits == 0:
             return self
         if ndigits > self.number_of_digits():
             raise Error(
-                "Error in `remove_trailing_digits()`: The number of digits to"
-                " remove is larger than the number of digits in the BigUInt"
+                ValueError(
+                    file="src/decimojo/biguint/biguint.mojo",
+                    function="BigUInt.remove_trailing_digits_with_rounding()",
+                    message=(
+                        "The number of digits to remove is larger than the "
+                        "number of digits in the BigUInt: "
+                        + String(ndigits)
+                        + " > "
+                        + String(self.number_of_digits())
+                    ),
+                    previous_error=None,
+                )
             )
 
         # floor_divide_by_power_of_ten is the same as removing the last n digits
-        var result = self.floor_divide_by_power_of_ten(ndigits)
+        var result = decimojo.biguint.arithmetics.floor_divide_by_power_of_ten(
+            self, ndigits
+        )
         var round_up: Bool = False
 
         if rounding_mode == RoundingMode.ROUND_DOWN:
@@ -1775,7 +1868,12 @@ struct BigUInt(
                     round_up = self.ith_digit(ndigits) % 2 == 1
         else:
             raise Error(
-                "Error in `remove_trailing_digits()`: Unknown rounding mode"
+                ValueError(
+                    file="src/decimojo/biguint/biguint.mojo",
+                    function="BigUInt.remove_trailing_digits_with_rounding()",
+                    message=("Unknown rounding mode: " + String(rounding_mode)),
+                    previous_error=None,
+                )
             )
 
         if round_up:
@@ -1785,7 +1883,7 @@ struct BigUInt(
             # Check whether rounding results in extra digit
             if result.is_power_of_10():
                 if remove_extra_digit_due_to_rounding:
-                    result = result.floor_divide_by_power_of_ten(
-                        1,
+                    result = decimojo.biguint.arithmetics.floor_divide_by_power_of_ten(
+                        result, 1
                     )
         return result^

--- a/src/decimojo/biguint/biguint.mojo
+++ b/src/decimojo/biguint/biguint.mojo
@@ -267,6 +267,7 @@ struct BigUInt(
                         ),
                         function="BigUInt.from_list()",
                         file="src/decimojo/biguint/biguint.mojo",
+                        previous_error=None,
                     )
                 )
 
@@ -304,6 +305,7 @@ struct BigUInt(
                         ),
                         function="BigUInt.from_words()",
                         file="src/decimojo/biguint/biguint.mojo",
+                        previous_error=None,
                     )
                 )
             else:

--- a/src/decimojo/biguint/biguint.mojo
+++ b/src/decimojo/biguint/biguint.mojo
@@ -722,9 +722,24 @@ struct BigUInt(
 
     fn __int__(self) raises -> Int:
         """Returns the number as Int.
-        See `to_int()` for more information.
+
+        Returns:
+            The number as Int.
+
+        Raises:
+            Error: If to_int() raises an error.
         """
-        return self.to_int()
+        try:
+            return self.to_int()
+        except e:
+            raise Error(
+                DeciMojoError(
+                    file="src/decimojo/biguint/biguint.mojo",
+                    function="BigUInt.__int__()",
+                    message=None,
+                    previous_error=e,
+                )
+            )
 
     fn __str__(self) -> String:
         """Returns string representation of the BigUInt.

--- a/src/decimojo/biguint/biguint.mojo
+++ b/src/decimojo/biguint/biguint.mojo
@@ -1380,8 +1380,8 @@ struct BigUInt(
             exponent: The exponent to raise the number to.
 
         Returns:
-            OverflowError: If the exponent is negative.
-            OverflowError: If the exponent is too large.
+            ValueError: If the exponent is negative.
+            ValueError: If the exponent is too large.
 
         Raises:
             Error: If the exponent is negative.
@@ -1389,7 +1389,7 @@ struct BigUInt(
         """
         if exponent < 0:
             raise Error(
-                OverflowError(
+                ValueError(
                     file="src/decimojo/biguint/biguint.mojo",
                     function="BigUInt.power(exponent: Int)",
                     message=(
@@ -1407,7 +1407,7 @@ struct BigUInt(
 
         if exponent >= 1_000_000_000:
             raise Error(
-                OverflowError(
+                ValueError(
                     file="src/decimojo/biguint/biguint.mojo",
                     function="BigUInt.power(exponent: Int)",
                     message=(
@@ -1438,14 +1438,14 @@ struct BigUInt(
             exponent: The exponent to raise the number to.
 
         Raises:
-            OverflowError: If the exponent is too large.
+            ValueError: If the exponent is too large.
 
         Returns:
             The result of raising this number to the power of `exponent`.
         """
         if len(exponent.words) > 1:
             raise Error(
-                OverflowError(
+                ValueError(
                     file="src/decimojo/biguint/biguint.mojo",
                     function="BigUInt.power(exponent: BigUInt)",
                     message=(

--- a/src/decimojo/errors.mojo
+++ b/src/decimojo/errors.mojo
@@ -18,40 +18,71 @@
 Implement error handling for DeciMojo.
 """
 
+alias OverflowError = DeciMojoError[error_type="OverflowError"]
+alias IndexError = DeciMojoError[error_type="IndexError"]
+alias KeyError = DeciMojoError[error_type="KeyError"]
+alias ZeroDivisionError = DeciMojoError[error_type="ZeroDivisionError"]
 
-struct DeciError(Stringable):
-    var error_type: String
-    var message: String
-    var function: String
+alias HEADER_OF_ERROR_MESSAGE = """
+---------------------------------------------------------------------------
+DeciMojoError                             Traceback (most recent call last)
+"""
+
+
+struct DeciMojoError[error_type: String](Stringable, Writable):
     var file: String
-    var line: Int
+    var function: String
+    var message: Optional[String]
 
     fn __init__(
         out self,
-        error_type: String,
-        message: String,
-        function: String,
         file: String,
-        line: Int,
+        function: String,
+        message: Optional[String],
     ):
-        self.error_type = error_type
-        self.message = message
-        self.function = function
         self.file = file
-        self.line = line
+        self.function = function
+        self.message = message
 
     fn __str__(self) -> String:
-        return (
-            "Traceback (most recent call last):\n"
-            + '  File "'
-            + String(self.file)
-            + '", line '
-            + String(self.line)
-            + " in "
-            + String(self.function)
-            + "\n"
-            + String(self.error_type)
-            + ": "
-            + String(self.message)
-            + '"'
-        )
+        if self.message is None:
+            return (
+                "Traceback (most recent call last):\n"
+                + '  File "'
+                + self.file
+                + '"'
+                + " in "
+                + self.function
+                + "\n\n"
+            )
+
+        else:
+            return (
+                "Traceback (most recent call last):\n"
+                + '  File "'
+                + self.file
+                + '"'
+                + " in "
+                + self.function
+                + "\n\n"
+                + String(error_type)
+                + ": "
+                + self.message.value()
+                + "\n"
+            )
+
+    fn write_to[W: Writer](self, mut writer: W):
+        writer.write('File "')
+        writer.write(self.file)
+        writer.write('"')
+        writer.write(" in ")
+        writer.write(self.function)
+        if self.message is None:
+            writer.write("\n\n")
+        else:
+            writer.write("\n\n")
+            writer.write(error_type)
+            writer.write(": ")
+            writer.write(self.message.value())
+            writer.write('"')
+            writer.write("\n")

--- a/src/decimojo/errors.mojo
+++ b/src/decimojo/errors.mojo
@@ -15,13 +15,65 @@
 # ===----------------------------------------------------------------------=== #
 
 """
-Implement error handling for DeciMojo.
+Implements error handling for DeciMojo.
 """
 
 alias OverflowError = DeciMojoError[error_type="OverflowError"]
+"""Type for overflow errors in DeciMojo.
+
+Fields:
+
+file: The file where the error occurred.\\
+function: The function where the error occurred.\\
+message: An optional message describing the error.\\
+previous_error: An optional previous error that caused this error.
+"""
+
 alias IndexError = DeciMojoError[error_type="IndexError"]
+"""Type for index errors in DeciMojo.
+
+Fields:
+
+file: The file where the error occurred.\\
+function: The function where the error occurred.\\
+message: An optional message describing the error.\\
+previous_error: An optional previous error that caused this error.
+"""
+
 alias KeyError = DeciMojoError[error_type="KeyError"]
+"""Type for key errors in DeciMojo.
+
+Fields:
+
+file: The file where the error occurred.\\
+function: The function where the error occurred.\\
+message: An optional message describing the error.\\
+previous_error: An optional previous error that caused this error.
+"""
+
 alias ZeroDivisionError = DeciMojoError[error_type="ZeroDivisionError"]
+
+"""Type for divided-by-zero errors in DeciMojo.
+
+Fields:
+
+file: The file where the error occurred.\\
+function: The function where the error occurred.\\
+message: An optional message describing the error.\\
+previous_error: An optional previous error that caused this error.
+"""
+
+alias ConversionError = DeciMojoError[error_type="ConversionError"]
+
+"""Type for conversion errors in DeciMojo.
+
+Fields:
+
+file: The file where the error occurred.\\
+function: The function where the error occurred.\\
+message: An optional message describing the error.\\
+previous_error: An optional previous error that caused this error.
+"""
 
 alias HEADER_OF_ERROR_MESSAGE = """
 ---------------------------------------------------------------------------
@@ -32,6 +84,19 @@ DeciMojoError                             Traceback (most recent call last)
 struct DeciMojoError[error_type: String = "DeciMojoError"](
     Stringable, Writable
 ):
+    """Base type for all DeciMojo errors.
+
+    Parameters:
+        error_type: The type of the error, e.g., "OverflowError", "IndexError".
+
+    Fields:
+
+    file: The file where the error occurred.\\
+    function: The function where the error occurred.\\
+    message: An optional message describing the error.\\
+    previous_error: An optional previous error that caused this error.
+    """
+
     var file: String
     var function: String
     var message: Optional[String]
@@ -99,7 +164,6 @@ struct DeciMojoError[error_type: String = "DeciMojoError"](
             writer.write(error_type)
             writer.write(": ")
             writer.write(self.message.value())
-            writer.write('"')
             writer.write("\n")
         if self.previous_error is not None:
             writer.write("\n")

--- a/src/decimojo/errors.mojo
+++ b/src/decimojo/errors.mojo
@@ -53,6 +53,18 @@ message: An optional message describing the error.\\
 previous_error: An optional previous error that caused this error.
 """
 
+alias ValueError = DeciMojoError[error_type="ValueError"]
+"""Type for value errors in DeciMojo.
+
+Fields:
+
+file: The file where the error occurred.\\
+function: The function where the error occurred.\\ 
+message: An optional message describing the error.\\
+previous_error: An optional previous error that caused this error.
+"""
+
+
 alias ZeroDivisionError = DeciMojoError[error_type="ZeroDivisionError"]
 
 """Type for divided-by-zero errors in DeciMojo.

--- a/src/decimojo/errors.mojo
+++ b/src/decimojo/errors.mojo
@@ -29,20 +29,30 @@ DeciMojoError                             Traceback (most recent call last)
 """
 
 
-struct DeciMojoError[error_type: String](Stringable, Writable):
+struct DeciMojoError[error_type: String = "DeciMojoError"](
+    Stringable, Writable
+):
     var file: String
     var function: String
     var message: Optional[String]
+    var previous_error: Optional[String]
 
     fn __init__(
         out self,
         file: String,
         function: String,
         message: Optional[String],
+        previous_error: Optional[Error],
     ):
         self.file = file
         self.function = function
         self.message = message
+        if previous_error is None:
+            self.previous_error = None
+        else:
+            self.previous_error = "\n".join(
+                previous_error.value().as_string_slice().split("\n")[3:]
+            )
 
     fn __str__(self) -> String:
         if self.message is None:
@@ -72,13 +82,18 @@ struct DeciMojoError[error_type: String](Stringable, Writable):
             )
 
     fn write_to[W: Writer](self, mut writer: W):
+        writer.write("\n")
+        writer.write(("-" * 75))
+        writer.write("\n")
+        writer.write(error_type.ljust(42, " "))
+        writer.write("Traceback (most recent call last)\n")
         writer.write('File "')
         writer.write(self.file)
         writer.write('"')
         writer.write(" in ")
         writer.write(self.function)
         if self.message is None:
-            writer.write("\n\n")
+            writer.write("\n")
         else:
             writer.write("\n\n")
             writer.write(error_type)
@@ -86,3 +101,6 @@ struct DeciMojoError[error_type: String](Stringable, Writable):
             writer.write(self.message.value())
             writer.write('"')
             writer.write("\n")
+        if self.previous_error is not None:
+            writer.write("\n")
+            writer.write(self.previous_error.value())

--- a/src/decimojo/errors.mojo
+++ b/src/decimojo/errors.mojo
@@ -18,6 +18,8 @@
 Implements error handling for DeciMojo.
 """
 
+from pathlib.path import cwd
+
 alias OverflowError = DeciMojoError[error_type="OverflowError"]
 """Type for overflow errors in DeciMojo.
 
@@ -148,14 +150,20 @@ struct DeciMojoError[error_type: String = "DeciMojoError"](
 
     fn write_to[W: Writer](self, mut writer: W):
         writer.write("\n")
-        writer.write(("-" * 75))
+        writer.write(("-" * 80))
         writer.write("\n")
-        writer.write(error_type.ljust(42, " "))
+        writer.write(error_type.ljust(47, " "))
         writer.write("Traceback (most recent call last)\n")
         writer.write('File "')
+        try:
+            writer.write(String(cwd()))
+        except e:
+            pass
+        finally:
+            writer.write("/")
         writer.write(self.file)
-        writer.write('"')
-        writer.write(" in ")
+        writer.write('"\n')
+        writer.write("----> ")
         writer.write(self.function)
         if self.message is None:
             writer.write("\n")

--- a/src/tomlmojo/tokenizer.mojo
+++ b/src/tomlmojo/tokenizer.mojo
@@ -21,7 +21,6 @@ needed for test case parsing.
 """
 
 alias WHITESPACE = " \t"
-alias NEWLINE = "\n"
 alias COMMENT_START = "#"
 alias QUOTE = '"'
 alias LITERAL_QUOTE = "'"
@@ -208,7 +207,16 @@ struct Tokenizer:
     fn _skip_comment(mut self):
         """Skip comment lines."""
         if self.current_char == COMMENT_START:
-            while self.current_char and self.current_char not in NEWLINE:
+            while self.current_char:
+                # Stop at LF or CR
+                if self.current_char == "\n":
+                    break
+                if self.current_char == "\r":
+                    # If next char is \n, treat as CRLF and break
+                    if self._get_char(self.position.index + 1) == "\n":
+                        break
+                    else:
+                        break
                 self._advance()
 
     fn _read_string(mut self) -> Token:
@@ -296,10 +304,32 @@ struct Tokenizer:
             self._skip_comment()
             return self.next_token()
 
-        if self.current_char in NEWLINE:
+        # Handle CRLF and LF newlines
+        if self.current_char == "\r":
+            # Check for CRLF
+            if self._get_char(self.position.index + 1) == "\n":
+                token = Token(
+                    TokenType.NEWLINE,
+                    "\r\n",
+                    self.position.line,
+                    self.position.column,
+                )
+                self._advance()  # Skip \r
+                self._advance()  # Skip \n
+                return token
+            else:
+                token = Token(
+                    TokenType.NEWLINE,
+                    "\r",
+                    self.position.line,
+                    self.position.column,
+                )
+                self._advance()
+                return token
+        elif self.current_char == "\n":
             token = Token(
                 TokenType.NEWLINE,
-                self.current_char,
+                "\n",
                 self.position.line,
                 self.position.column,
             )

--- a/src/tomlmojo/tokenizer.mojo
+++ b/src/tomlmojo/tokenizer.mojo
@@ -21,7 +21,7 @@ needed for test case parsing.
 """
 
 alias WHITESPACE = " \t"
-alias NEWLINE = "\n\r"
+alias NEWLINE = "\n"
 alias COMMENT_START = "#"
 alias QUOTE = '"'
 alias LITERAL_QUOTE = "'"
@@ -85,7 +85,7 @@ struct TokenType(Copyable, Movable):
     alias ARRAY_OF_TABLES_START = TokenType.array_of_tables_start()
     alias EQUAL = TokenType.equal()
     alias COMMA = TokenType.comma()
-    alias NEWLINE = TokenType.newline()  # Renamed to avoid conflict with NEWLINE constant
+    alias NEWLINE = TokenType.newline()
     alias DOT = TokenType.dot()
     alias EOF = TokenType.eof()
     alias ERROR = TokenType.error()


### PR DESCRIPTION
This pull request introduces significant improvements and error handling enhancements for arithmetic operations in the `BigInt` and `BigUInt` types. Key changes include the removal of the `raises` keyword from function signatures, the addition of structured error handling using custom error types, and improvements to the implementation of arithmetic operations to ensure correctness and maintainability.

### Improved Error Handling

* Introduced custom error types such as `DeciMojoError`, `OverflowError`, and `ZeroDivisionError` across the codebase for more structured and descriptive error reporting. For example, division and modulo operations now raise `ZeroDivisionError` when dividing by zero.

* Replaced generic error messages with detailed exceptions that include contextual information such as the file, function, and previous error, improving debugging and traceability.

### Update TOML parser

* Updated the TOML parser by allowing parsing CRLF TOML files.

### Enhancements to Arithmetic Operations

* Removed the `raises` keyword from all arithmetic function signatures in `src/decimojo/bigint/arithmetics.mojo` and `src/decimojo/biguint/arithmetics.mojo`. This simplifies the function definitions while maintaining error handling through explicit exceptions.

* Updated the `add_inplace`, `subtract`, and `multiply` functions in `src/decimojo/bigint/arithmetics.mojo` to use helper functions like `negative` and `subtract_inplace_no_check` for better clarity and modularity.

### Updates to BigInt Struct Methods

* Updated operator overloading methods (e.g., `__add__`, `__sub__`, `__mul__`) in `src/decimojo/bigint/bigint.mojo` to remove the `raises` keyword and include structured error handling where applicable.

* Enhanced in-place operators like `__iadd__` and `__isub__` to directly call the updated arithmetic functions, ensuring consistency with the new error handling approach.

### Codebase-Wide Improvements

* Added `.gitattributes` configuration to enforce LF (Unix-style) line endings for consistency across the project.

* Improved modularity by importing `DeciMojoError` in relevant files such as `src/decimojo/bigint/bigint.mojo` and `src/decimojo/biguint/arithmetics.mojo`.
These changes collectively improve the robustness, readability, and maintainability of the codebase while introducing a more structured approach to error handling for arithmetic operations.