### PR TITLE
[integer] Implement `floor_divide_by_power_of_billion()`

### DIFF
--- a/src/decimojo/bigdecimal/arithmetics.mojo
+++ b/src/decimojo/bigdecimal/arithmetics.mojo
@@ -180,7 +180,6 @@ fn multiply(x1: BigDecimal, x2: BigDecimal) -> BigDecimal:
     )
 
 
-# TODO: Optimize when divided by power of 10
 fn true_divide(
     x: BigDecimal, y: BigDecimal, precision: Int
 ) raises -> BigDecimal:
@@ -270,8 +269,7 @@ fn true_divide_fast(
             x.coefficient, extra_words
         )
     elif extra_words < 0:
-        # TODO: Replace this with `floor_divide_by_power_of_billion()`
-        coef_x = decimojo.biguint.arithmetics.floor_divide_by_power_of_ten(
+        coef_x = decimojo.biguint.arithmetics.floor_divide_by_power_of_billion(
             x.coefficient, -extra_words * 9
         )
     else:


### PR DESCRIPTION
This pull request introduces several updates to the `decimojo` library, focusing on improving numerical operations with `BigUInt` and `BigDecimal` types. Key changes include replacing a placeholder function with a more optimized implementation, adding debug assertions to enforce non-negative input constraints, and introducing a new utility function for division by powers of a billion.

### Improvements to numerical operations:

* **Optimized division by powers of a billion**: Replaced the placeholder call to `floor_divide_by_power_of_ten` with the newly implemented `floor_divide_by_power_of_billion` in `true_divide_fast` for better performance.

* **New utility function**: Added `floor_divide_by_power_of_billion`, which efficiently removes the last `n` words of a `BigUInt`, equivalent to dividing by `(10^9)^n`. This function handles edge cases and includes debug assertions.

### Input validation and robustness:

* **Debug assertions for non-negative inputs**: Added debug assertions to ensure that input parameters `n` are non-negative in functions such as `multiply_by_power_of_ten`, `multiply_inplace_by_power_of_ten`, `multiply_by_power_of_billion`, `multiply_inplace_by_power_of_billion`, and `floor_divide_by_power_of_ten`. These assertions improve code reliability during development and testing.

* **Updated handling of zero or negative `n`**: Modified behavior in several functions to return the input unchanged when `n <= 0`, ensuring consistent and predictable results.

These changes collectively enhance the library's performance, robustness, and maintainability.