### PR TITLE
[integer][BInt2] Implement divide-and-conquer base conversion from BInt2 to String

### DIFF
--- a/src/decimojo/bigint2/arithmetics.mojo
+++ b/src/decimojo/bigint2/arithmetics.mojo
@@ -964,7 +964,6 @@ fn _shift_right_words(
 
 
 # ===----------------------------------------------------------------------=== #
-# Burnikel-Ziegler division
 # Burnikel-Ziegler division (slice-based)
 # Recursive divide-and-conquer for large operands.
 # Passes word-list bounds through the recursion to avoid copying the large
@@ -1149,7 +1148,14 @@ fn _divmod_knuth_d_from_slices(
     if len_a_eff <= 0:
         return ([UInt32(0)], [UInt32(0)])
     if len_b_eff <= 0:
-        raise Error("Division by zero in B-Z base case")
+        raise Error(
+            DeciMojoError(
+                file="src/decimojo/bigint2/arithmetics",
+                function="_divmod_knuth_d_from_slices()",
+                message="Division by zero in B-Z base case",
+                previous_error=None,
+            )
+        )
 
     # Single-word divisor fast path
     if len_b_eff == 1:


### PR DESCRIPTION
Implements a new high-performance decimal string conversion path for `BigInt2`, replacing the prior `BigInt10`-conversion approach for large values and documenting the benchmark impact.

**Changes:**
- Updated `BigInt2.to_decimal_string()` to use a divide-and-conquer (D&C) base conversion for large magnitudes, with a small-number fallback based on repeated division by 10^9.
- Added a large-operand floor-division test intended to exercise the Burnikel–Ziegler dispatch path.
- Improved one division-by-zero error to raise a structured `DeciMojoError`, and refreshed benchmark documentation.