### PR TITLE
[integer][BigInt2] Update conversion from 10-based integer to 2-based integer

### DIFF
--- a/src/decimojo/str.mojo
+++ b/src/decimojo/str.mojo
@@ -17,7 +17,6 @@
 """String parsing and manipulation functions."""
 
 from algorithm import vectorize
-from memory import UnsafePointer
 
 
 fn parse_numeric_string(
@@ -162,7 +161,8 @@ fn parse_numeric_string(
             if in_exponent:
                 if exponent_sign_read:
                     raise Error(
-                        "Exponent sign must appear before exponent digits."
+                        "Exponent sign can only appear once,"
+                        " before exponent digits."
                     )
                 exponent_sign_read = True
             else:
@@ -179,7 +179,8 @@ fn parse_numeric_string(
             if in_exponent:
                 if exponent_sign_read:
                     raise Error(
-                        "Exponent sign must appear before exponent digits."
+                        "Exponent sign can only appear once,"
+                        " before exponent digits."
                     )
                 exponent_sign_read = True
             else:


### PR DESCRIPTION
Updates BigInt2 decimal-string parsing/conversion to better support very large inputs and documents/validates the new behavior via tests and benchmark notes.

**Changes:**
- Adjusts BigInt2’s divide-and-conquer (D&C) from_string base-case threshold and tweaks D&C power-table/combine implementation.
- Adds a targeted test to exercise the D&C from_string entry threshold (>10,000 digits) and cross-checks against BigInt10.
- Updates parsing error messages and benchmark/roadmap documentation to reflect the new from_string behavior/performance.
