### PR TITLE
[integer][BigInt2] Optimize both the simple and D&C paths for `from_string`

### DIFF
--- a/tests/bigint2/test_bigint2_new_features.mojo
+++ b/tests/bigint2/test_bigint2_new_features.mojo
@@ -677,10 +677,12 @@ fn test_from_string_dc_path() raises:
         msg="[D&C from_string] 10501-digit D&C matches BigInt10 path",
     )
 
-    # Test a non-trivial large number: 7 * 10^10499 + 123456789
-    var a2 = BigInt2(7) * BigInt2(10).power(10499) + BigInt2(123456789)
-    var s2 = String(a2)
-    var b2 = BigInt2(s2)
+    # Test a non-trivial large number: 7 followed by 10499 zeros then 123456789
+    # Build the decimal string directly to avoid expensive power() + to_string
+    var s2 = String("7") + String("0") * 10490 + String("123456789")
+    var a2 = BigInt2(s2)
+    # Cross-check against an independent BigInt10-based reference
+    var b2 = BigInt2.from_bigint10(BigInt10(s2))
     testing.assert_true(
         a2 == b2,
         msg="[D&C from_string] 10500-digit non-trivial round-trip",


### PR DESCRIPTION
This PR optimizes both the simple and divide-and-conquer (D&C) paths for BigInt2's `from_string` conversion, achieving significant performance improvements across all input sizes. The optimizations include fast paths for small numbers, pre-allocation to eliminate dynamic growth, balanced splitting for better Karatsuba performance, and reduced power table overhead.

**Changes:**
- Added fast paths for ≤9 digits (single UInt32) and 10-19 digits (UInt64 → 1-2 words) to eliminate allocation overhead for small numbers
- Optimized simple conversion path with pre-allocation, pointer-based access, and aligned 9-digit chunk processing
- Improved D&C path with balanced splitting (largest 2^k ≤ digit_count/2) to keep operands within 3:1 ratio for optimal Karatsuba multiplication, reducing power table size and improving combine step efficiency

Performance comparison between `BigInt2` and `Python.int`.

Digits | Before | After | Change
-- | -- | -- | --
2 | 3.67× | 3.83× | ~same
9 | 3.60× | 3.50× | ~same
20 | 2.38× | 2.63× | +10%
50 | 1.33× | 2.40× | +80%
100 | 1.19× | 1.93× | +62%
200 | 0.94× | 1.10× | FIXED
500 | 1.18× | 1.24× | +5%
1000 | 1.06× | 1.10× | +4%
2000 | 1.04× | 1.11× | +7%
5000 | 1.13× | 1.12× | ~same
10000 | 1.16× | 1.06× | ~same
20000 | 0.83× | 0.98× | +18%
50000 | 0.81× | 1.00× | +23%

Results: Average 1.53× → 1.78× (+16%). Worst case 0.81× → 0.98×. All 14 benchmark sizes now ≥ 0.98× Python.