### PR TITLE
[integer][BigInt2] Optimize `to_string()`

### DIFF
--- a/tests/bigint2/test_bigint2_new_features.mojo
+++ b/tests/bigint2/test_bigint2_new_features.mojo
@@ -677,7 +677,7 @@ fn test_from_string_dc_path() raises:
         msg="[D&C from_string] 10501-digit D&C matches BigInt10 path",
     )
 
-    # Test a non-trivial large number: 7 followed by 10499 zeros then 123456789
+    # Test a non-trivial large number: 7 followed by 10490 zeros then 123456789
     # Build the decimal string directly to avoid expensive power() + to_string
     var s2 = String("7") + String("0") * 10490 + String("123456789")
     var a2 = BigInt2(s2)


### PR DESCRIPTION
This PR implements micro-optimizations for `to_string` conversion in BigInt2. The optimizations focus on both the simple O(n²) and divide-and-conquer base conversion paths, achieving significant performance improvements across all size ranges.

**Changes:**
- Added fast paths for 1-word and 2-word values that delegate directly to native integer-to-string conversion
- Optimized the simple conversion path with raw pointer usage, div_len tracking, and byte buffer output
- Optimized the D&C path by improving power table construction and using byte buffers for string concatenation