### PR TITLE
[integer][BigInt2] Add methods for GCD, extended GCD, etc

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -67,7 +67,7 @@ Other changes:
 ### 📚 Documentation and testing
 
 - Refactor the test files for `BigDecimal` (PR #93).
-- Refactor the test files for `BigInt10` (PR #106).
+- Refactor the test files for `BigInt` (PR #106).
 
 ## 20250701 (v0.4.1)
 
@@ -75,7 +75,7 @@ Version 0.4.1 of DeciMojo introduces implicit type conversion between built-in i
 
 ### ⭐️ New
 
-Now DeciMojo supports implicit type conversion between built-in integeral types (`Int`, `UInt`, `Int8`, `UInt8`, `Int16`, `UInt16`, `Int32`, `UInt32`, `Int64`, `UInt64`, `Int128`,`UInt128`, `Int256`, and `UInt256`) and the arbitrary-precision types (`BigUInt`, `BigInt10`, and `BigDecimal`). This allows you to use these built-in types directly in arithmetic operations with `BigInt10` and `BigUInt` without explicit conversion. The merged type will always be the most compatible one (PR #89, PR #90).
+Now DeciMojo supports implicit type conversion between built-in integeral types (`Int`, `UInt`, `Int8`, `UInt8`, `Int16`, `UInt16`, `Int32`, `UInt32`, `Int64`, `UInt64`, `Int128`,`UInt128`, `Int256`, and `UInt256`) and the arbitrary-precision types (`BigUInt`, `BigInt`, and `BigDecimal`). This allows you to use these built-in types directly in arithmetic operations with `BigInt` and `BigUInt` without explicit conversion. The merged type will always be the most compatible one (PR #89, PR #90).
 
 For example, you can now do the following:
 
@@ -121,24 +121,24 @@ c = 3.14159265358979323
 
 ### 🦋 Changed
 
-Optimize the case when you increase the value of a `BigInt10` object in-place by 1, *i.e.*, `i += 1`. This allows you to iterate faster (PR #89). For example, we can compute the time taken to iterate from `0` to `1_000_000` using `BigInt10` and compare it with the built-in `Int` type:
+Optimize the case when you increase the value of a `BigInt` object in-place by 1, *i.e.*, `i += 1`. This allows you to iterate faster (PR #89). For example, we can compute the time taken to iterate from `0` to `1_000_000` using `BigInt` and compare it with the built-in `Int` type:
 
 ```mojo
 from decimojo.prelude import *
 
 fn main() raises:
-    i = BigInt10(0)
-    end = BigInt10(1_000_000)
+    i = BigInt(0)
+    end = BigInt(1_000_000)
     while i < end:
         print(i)
         i += 1
 ```
 
-| scenario          | Time taken |
-| ----------------- | ---------- |
-| v0.4.0 `BigInt10` | 1.102s     |
-| v0.4.1 `BigInt10` | 0.912s     |
-| Built-in `Int`    | 0.893s     |
+| scenario        | Time taken |
+| --------------- | ---------- |
+| v0.4.0 `BigInt` | 1.102s     |
+| v0.4.1 `BigInt` | 0.912s     |
+| Built-in `Int`  | 0.893s     |
 
 ### 🛠️ Fixed
 
@@ -181,15 +181,15 @@ DeciMojo v0.3.0 introduces the arbitrary-precision `BigDecimal` type with compre
 
 ## 20250401 (v0.2.0)
 
-Version 0.2.0 marks a significant expansion of DeciMojo with the introduction of `BigInt10` and `BigUInt` types, providing unlimited precision integer arithmetic to complement the existing fixed-precision `Decimal` type. Core arithmetic functions for the `Decimal` type have been completely rewritten using Mojo 25.2's `UInt128`, delivering substantial performance improvements. This release also extends mathematical capabilities with advanced operations including logarithms, exponentials, square roots, and n-th roots for the `Decimal` type. The codebase has been reorganized into a more modular structure, enhancing maintainability and extensibility. With comprehensive test coverage, improved documentation in multiple languages, and optimized memory management, v0.2.0 represents a major advancement in both functionality and performance for numerical computing in Mojo.
+Version 0.2.0 marks a significant expansion of DeciMojo with the introduction of `BigInt` and `BigUInt` types, providing unlimited precision integer arithmetic to complement the existing fixed-precision `Decimal` type. Core arithmetic functions for the `Decimal` type have been completely rewritten using Mojo 25.2's `UInt128`, delivering substantial performance improvements. This release also extends mathematical capabilities with advanced operations including logarithms, exponentials, square roots, and n-th roots for the `Decimal` type. The codebase has been reorganized into a more modular structure, enhancing maintainability and extensibility. With comprehensive test coverage, improved documentation in multiple languages, and optimized memory management, v0.2.0 represents a major advancement in both functionality and performance for numerical computing in Mojo.
 
 ### ⭐️ New
 
-- Add comprehensive `BigInt10` and `BigUInt` implementation with unlimited precision integer arithmetic.
-- Implement full arithmetic operations for `BigInt10` and `BigUInt`: addition, subtraction, multiplication, division, modulo and power operations.
+- Add comprehensive `BigInt` and `BigUInt` implementation with unlimited precision integer arithmetic.
+- Implement full arithmetic operations for `BigInt` and `BigUInt`: addition, subtraction, multiplication, division, modulo and power operations.
 - Support both floor division (round toward negative infinity) and truncate division (round toward zero) semantics for mathematical correctness.
-- Add complete comparison operations for `BigInt10` with proper handling of negative values.
-- Implement efficient string representation and parsing for `BigInt10` and `BigUInt`.
+- Add complete comparison operations for `BigInt` with proper handling of negative values.
+- Implement efficient string representation and parsing for `BigInt` and `BigUInt`.
 - Add advanced mathematical operations for `Decimal`: square root and n-th root.
 - Add logarithm functions for `Decimal`: natural logarithm, base-10 logarithm, and logarithm with arbitrary base.
 - Add exponential function and power function with arbitrary exponents for `Decimal`.
@@ -217,8 +217,8 @@ Version 0.2.0 marks a significant expansion of DeciMojo with the introduction of
 
 ### 📚 Documentation and testing
 
-- Add comprehensive test suite for `BigInt10` and `BigUInt` with over 200 test cases covering all operations and edge cases.
-- Create detailed API documentation for both `Decimal` and `BigInt10`.
+- Add comprehensive test suite for `BigInt` and `BigUInt` with over 200 test cases covering all operations and edge cases.
+- Create detailed API documentation for both `Decimal` and `BigInt`.
 - Add performance comparison benchmarks between DeciMojo and Python's decimal/int implementation.
 - Update multi-language documentation to include all new functionality (English and Chinese).
 - Include clear explanations of division semantics and other potentially confusing numerical concepts.

--- a/docs/readme_unreleased.md
+++ b/docs/readme_unreleased.md
@@ -21,19 +21,25 @@ For Pythonistas, you can think of DeciMojo as a Mojo-native implementation of Py
 
 The core types are:
 
-- A base-2 arbitrary-precision signed integer type (`BigInt2`) using a little-endian representation with `UInt32` words[^bigint2]. It is a drop-in replacement for Python's `int` in Mojo. It features comprehensive arithmetic operations, comparison functions, and supports extremely large integer calculations efficiently. It beats Python's `int` in most tested cases.
-- An arbitrary-precision decimal implementation (`BigDecimal`) allowing for calculations with unlimited digits and decimal places[^arbitrary]. It provides a complete set of arithmetic operations, comparisons, and mathematical functions like logarithms, exponentiation, roots, trigonometric functions, etc. It also supports rounding modes and conversions to/from built-in types.
-- A 128-bit fixed-point decimal implementation (`Decimal128`) supporting up to 29 significant digits with a maximum of 28 decimal places[^fixed]. It features a complete set of mathematical functions including logarithms, exponentiation, roots, etc.
+- An arbitrary-precision signed integer type `BInt`[^bigint2], which is a drop-in replacement for Python's `int` in Mojo.
+- An arbitrary-precision decimal implementation (`Decimal`) allowing for calculations with unlimited digits and decimal places[^arbitrary], which is a drop-in replacement for Python's `decimal.Decimal` in Mojo.
+- A 128-bit fixed-point decimal implementation (`Dec128`) supporting up to 29 significant digits with a maximum of 28 decimal places[^fixed].
 
-The auxiliary types include a base-10 arbitrary-precision signed integer type (`BigInt10`) and a base-10 arbitrary-precision unsigned integer type (`BigUInt`) supporting unlimited digits[^bigint10]. They feature comprehensive arithmetic operations, comparison functions, and support extremely large integer calculations efficiently. `BigUInt` is used as the internal representation for `BigInt10` and `BigDecimal`.
+The auxiliary types include a base-10 arbitrary-precision signed integer type (`BigInt10`) and a base-10 arbitrary-precision unsigned integer type (`BigUInt`) supporting unlimited digits[^bigint10]. `BigUInt` is used as the internal representation for `BigInt10` and `Decimal`.
+
+| Type      | Other names          | Information                              | Internal representation |
+| --------- | -------------------- | ---------------------------------------- | ----------------------- |
+| `BInt`    | `BigInt`             | Equivalent to Python's `int`             | Base-2^32               |
+| `Decimal` | `BDec`, `BigDecimal` | Equivalent to Python's `decimal.Decimal` | Base-10^9               |
+| `Dec`     | `Decimal128`         | 128-bit fixed-precision decimal type     | Triple 32-bit words     |
+
+---
 
 This repository includes [TOMLMojo](./docs/readme_tomlmojo.md), a lightweight TOML parser in pure Mojo. It parses configuration files and test data, supporting basic types, arrays, and nested tables. While created for DeciMojo's testing framework, it offers general-purpose structured data parsing with a clean, simple API.
 
-| type         | alias             | information                            | internal representation  |
-| ------------ | ----------------- | -------------------------------------- | ------------------------ |
-| `BigInt2`    | `BInt`            | 2^32-based arbitrary-precision integer | `List[UInt32]`, `Bool`   |
-| `BigDecimal` | `BDec`, `Decimal` | 10^9-based arbitrary-precision decimal | `BigUInt`, `Int`, `Bool` |
-| `Decimal128` | `Dec128`          | 128-bit fixed-precision decimal        | `UInt32` * 4             |
+---
+
+DeciMojo was initially a personal project of Yuhao Zhu and the repo was under his personal Github account. From v0.7.0, it was moved to the MojoMath organization to encourage more community contributions and to better reflect its mission of providing high-quality mathematical tools for the Mojo ecosystem.
 
 ## Installation
 
@@ -81,15 +87,15 @@ from decimojo import *
 
 This will import the following types or aliases into your namespace:
 
-- `BigInt10` (alias `BInt`): A base-10^9 arbitrary-precision signed integer type.
-- `Decimal` or `BDec` (aliases of `BigDecimal`): An arbitrary-precision decimal type.
+- `BInt` (alias of `BigInt`): An arbitrary-precision signed integer type, equivalent to Python's `int`.
+- `Decimal` or `BDec` (aliases of `BigDecimal`): An arbitrary-precision decimal type, equivalent to Python's `decimal.Decimal`.
 - `Dec128` (alias of `Decimal128`): A 128-bit fixed-precision decimal type.
 - `RoundingMode`: An enumeration for rounding modes.
 - `ROUND_DOWN`, `ROUND_HALF_UP`, `ROUND_HALF_EVEN`, `ROUND_UP`: Constants for common rounding modes.
 
 ---
 
-Here are some examples showcasing the arbitrary-precision feature of the `BigDecimal` type (aliases: `BDec` and `Decimal`). For some mathematical operations, the default precision (number of significant digits) is set to `36`. You can change the precision by passing the `precision` argument to the function. This default precision will be configurable globally in future when Mojo supports global variables.
+Here are some examples showcasing the arbitrary-precision feature of the `Decimal` type. For some mathematical operations, the default precision (number of significant digits) is set to `36`. You can change the precision by passing the `precision` argument to the function. This default precision will be configurable globally in future when Mojo supports global variables.
 
 ```mojo
 from decimojo.prelude import *
@@ -287,15 +293,15 @@ This project draws inspiration from several established decimal implementations 
 
 DeciMojo combines "Deci" and "Mojo" - reflecting its purpose and implementation language. "Deci" (from Latin "decimus" meaning "tenth") highlights our focus on the decimal numeral system that humans naturally use for counting and calculations.
 
-Although the name emphasizes decimals with fractional parts, DeciMojo embraces the full spectrum of decimal mathematics. Our `BigInt10` type, while handling only integers, is designed specifically for the decimal numeral system with its base-10 internal representation. This approach offers optimal performance while maintaining human-readable decimal semantics, contrasting with binary-focused libraries. Furthermore, `BigInt10` serves as the foundation for our `BigDecimal` implementation, enabling arbitrary-precision calculations across both integer and fractional domains.
-
 The name ultimately emphasizes our mission: bringing precise, reliable decimal calculations to the Mojo ecosystem, addressing the fundamental need for exact arithmetic that floating-point representations cannot provide.
 
 ## Status
 
-Rome wasn't built in a day. DeciMojo is currently under active development. It has successfully progressed through the **"make it work"** phase and is now well into the **"make it right"** phase with many optimizations already in place. Bug reports and feature requests are welcome! If you encounter issues, please [file them here](https://github.com/mojomath/decimojo/issues).
+Rome wasn't built in a day. DeciMojo is currently under active development. It has successfully progressed through the **"make it work"** phase and the **"make it right"**, and is now well into the **"make it fast"** phase.
 
-Regular benchmarks against Python's `decimal` module are available in the `bench/` folder, documenting both the performance advantages and the few specific operations where different approaches are needed.
+The `BInt` type is fully implemented and optimized. It has been benchmarked against Python's `int` and demonstrates superior performance in most cases.
+
+Bug reports and feature requests are welcome! If you encounter issues, please [file them here](https://github.com/mojomath/decimojo/issues).
 
 ## Tests and benches
 

--- a/src/decimojo/__init__.mojo
+++ b/src/decimojo/__init__.mojo
@@ -36,3 +36,6 @@ from .rounding_mode import (
     ROUND_HALF_EVEN,
     ROUND_UP,
 )
+
+# Core functions
+from .bigint2.number_theory import gcd, lcm, extended_gcd, mod_inverse, mod_pow

--- a/src/decimojo/bigint2/bigint2.mojo
+++ b/src/decimojo/bigint2/bigint2.mojo
@@ -1092,6 +1092,57 @@ struct BigInt2(
         decimojo.bigint2.bitwise.bitwise_xor_inplace(self, other)
 
     # ===------------------------------------------------------------------=== #
+    # Number-theoretic methods
+    # ===------------------------------------------------------------------=== #
+
+    @always_inline
+    fn gcd(self, other: Self) -> Self:
+        """Returns the greatest common divisor of self and other."""
+        return decimojo.bigint2.number_theory.gcd(self, other)
+
+    @always_inline
+    fn extended_gcd(self, other: Self) raises -> Tuple[Self, Self, Self]:
+        """Returns a tuple (g, x, y) such that g = gcd(self, other) and
+        self*x + other*y = g.
+
+        This is useful for solving linear Diophantine equations and for
+        computing modular inverses.
+
+        Returns:
+            A tuple (g, x, y) where g is the gcd of self and other, and
+            x and y are the coefficients satisfying the equation.
+        """
+        return decimojo.bigint2.number_theory.extended_gcd(self, other)
+
+    @always_inline
+    fn lcm(self, other: Self) raises -> Self:
+        """Returns the least common multiple of self and other."""
+        return decimojo.bigint2.number_theory.lcm(self, other)
+
+    @always_inline
+    fn mod_pow(self, exponent: Self, modulus: Self) raises -> Self:
+        """Returns (self ** exponent) % modulus efficiently using modular
+        exponentiation.
+        """
+        return decimojo.bigint2.number_theory.mod_pow(self, exponent, modulus)
+
+    @always_inline
+    fn mod_pow(self, exponent: Int, modulus: Self) raises -> Self:
+        """Returns (self ** exponent) % modulus efficiently using modular
+        exponentiation.
+        """
+        return decimojo.bigint2.number_theory.mod_pow(
+            self, Self.from_int(exponent), modulus
+        )
+
+    @always_inline
+    fn mod_inverse(self, modulus: Self) raises -> Self:
+        """Returns the modular inverse of self modulo modulus, i.e. a number x
+        such that (self * x) % modulus == 1.
+        """
+        return decimojo.bigint2.number_theory.mod_inverse(self, modulus)
+
+    # ===------------------------------------------------------------------=== #
     # Instance query methods
     # ===------------------------------------------------------------------=== #
 


### PR DESCRIPTION
This PR adds methods for GCD, extended GCD, and modular arithmetics in the `BigInt2` struct.