### PR TITLE
[cli] Enable power operator, built-in functions, constants, and output formatting

### DIFF
--- a/docs/readme_unreleased.md
+++ b/docs/readme_unreleased.md
@@ -20,7 +20,7 @@ Decimo provides an arbitrary-precision integer and decimal library for Mojo. It 
 
 For Pythonistas, `decimo.BInt` to Mojo is like `int` to Python, and `decimo.Decimal` to Mojo is like `decimal.Decimal` to Python.
 
-The core types are:
+The core types are[^auxiliary]:
 
 - An arbitrary-precision signed integer type `BInt`[^bigint], which is a Mojo-native equivalent of Python's `int`.
 - An arbitrary-precision decimal implementation (`Decimal`) allowing for calculations with unlimited digits and decimal places[^arbitrary], which is a Mojo-native equivalent of Python's `decimal.Decimal`.
@@ -32,11 +32,19 @@ The core types are:
 | `Decimal` | `BDec`, `BigDecimal` | Equivalent to Python's `decimal.Decimal` | Base-10^9               |
 | `Dec128`  | `Decimal128`         | 128-bit fixed-precision decimal type     | Triple 32-bit words     |
 
-The auxiliary types include a base-10 arbitrary-precision signed integer type (`BigInt10`) and a base-10 arbitrary-precision unsigned integer type (`BigUInt`) supporting unlimited digits[^bigint10]. `BigUInt` is used as the internal representation for `BigInt10` and `Decimal`.
-
 ---
 
 **Decimo** combines "**Deci**mal" and "**Mo**jo" - reflecting its purpose and implementation language. "Decimo" is also a Latin word meaning "tenth" and is the root of the word "decimal".
+
+---
+
+Decimo also includes a command-line calculator application that supports arbitrary-precision calculations, powered by the `decimo` and `argmojo` libraries.
+
+You can use it to evaluate complex mathematical expressions with high precision directly from your terminal. For example:
+
+```bash
+./decimo "2^10 + sqrt(pi) * ln(e^3) - root(125, 3) / abs(-5) + sin(pi/2)" -p 50 --sci
+```
 
 ---
 
@@ -99,7 +107,7 @@ Then, you can install Decimo using any of these methods:
 
 The following table summarizes the package versions and their corresponding Mojo versions:
 
-| libary     | version | Mojo version  | package manager |
+| library    | version | Mojo version  | package manager |
 | ---------- | ------- | ------------- | --------------- |
 | `decimojo` | v0.1.0  | ==25.1        | magic           |
 | `decimojo` | v0.2.0  | ==25.2        | magic           |
@@ -110,6 +118,7 @@ The following table summarizes the package versions and their corresponding Mojo
 | `decimojo` | v0.6.0  | ==0.25.7      | pixi            |
 | `decimojo` | v0.7.0  | ==0.26.1      | pixi            |
 | `decimo`   | v0.8.0  | ==0.26.1      | pixi            |
+| `decimo`   | v0.9.0  | ==0.26.1      | pixi            |
 
 ## Quick start
 
@@ -370,5 +379,6 @@ This repository and its contributions are licensed under the Apache License v2.0
 
 [^fixed]: The `Decimal128` type can represent values with up to 29 significant digits and a maximum of 28 digits after the decimal point. When a value exceeds the maximum representable value (`2^96 - 1`), Decimo either raises an error or rounds the value to fit within these constraints. For example, the significant digits of `8.8888888888888888888888888888` (29 eights total with 28 after the decimal point) exceeds the maximum representable value (`2^96 - 1`) and is automatically rounded to `8.888888888888888888888888889` (28 eights total with 27 after the decimal point). Decimo's `Decimal128` type is similar to `System.Decimal` (C#/.NET), `rust_decimal` in Rust, `DECIMAL/NUMERIC` in SQL Server, etc.
 [^bigint]: The `BigInt` implementation uses a base-2^32 representation with a little-endian format, where the least significant word is stored at index 0. Each word is a `UInt32`, allowing for efficient storage and arithmetic operations on large integers. This design choice optimizes performance for binary computations while still supporting arbitrary precision.
+[^auxiliary]: The auxiliary types include a base-10 arbitrary-precision signed integer type (`BigInt10`) and a base-10 arbitrary-precision unsigned integer type (`BigUInt`) supporting unlimited digits[^bigint10]. `BigUInt` is used as the internal representation for `BigInt10` and `Decimal`.
 [^bigint10]: The BigInt10 implementation uses a base-10 representation for users (maintaining decimal semantics), while internally using an optimized base-10^9 storage system for efficient calculations. This approach balances human-readable decimal operations with high-performance computing. It provides both floor division (round toward negative infinity) and truncate division (round toward zero) semantics, enabling precise handling of division operations with correct mathematical behavior regardless of operand signs.
 [^arbitrary]: Built on top of our completed BigInt10 implementation, BigDecimal will support arbitrary precision for both the integer and fractional parts, similar to `decimal` and `mpmath` in Python, `java.math.BigDecimal` in Java, etc.

--- a/docs/readme_unreleased.md
+++ b/docs/readme_unreleased.md
@@ -43,7 +43,7 @@ Decimo also includes a command-line calculator application that supports arbitra
 You can use it to evaluate complex mathematical expressions with high precision directly from your terminal. For example:
 
 ```bash
-./decimo "2^10 + sqrt(pi) * ln(e^3) - root(125, 3) / abs(-5) + sin(pi/2)" -p 50 --sci
+./decimo "2^10 + sqrt(pi) * ln(e^3) - root(125, 3) / abs(-5) + sin(pi/2)" -p 50 --scientific
 ```
 
 ---

--- a/src/cli/calculator/__init__.mojo
+++ b/src/cli/calculator/__init__.mojo
@@ -37,6 +37,10 @@ from .tokenizer import (
     TOKEN_LPAREN,
     TOKEN_RPAREN,
     TOKEN_UNARY_MINUS,
+    TOKEN_CARET,
+    TOKEN_FUNC,
+    TOKEN_CONST,
+    TOKEN_COMMA,
 )
 from .parser import parse_to_rpn
 from .evaluator import evaluate_rpn, evaluate

--- a/src/cli/calculator/evaluator.mojo
+++ b/src/cli/calculator/evaluator.mojo
@@ -48,10 +48,11 @@ fn _call_func(name: String, mut stack: List[BDec], precision: Int) raises:
     and push the result back.
 
     Single-argument functions:
-        sqrt, cbrt, ln, log, log10, exp, sin, cos, tan, cot, csc, abs
+        sqrt, cbrt, ln, log10, exp, sin, cos, tan, cot, csc, abs
 
     Two-argument functions:
-        root(x, n)  — the n-th root of x.
+        root(x, n)   — the n-th root of x.
+        log(x, base) — logarithm of x with the given base.
     """
     if name == "root":
         # root(x, n): x was pushed first, then n
@@ -60,6 +61,15 @@ fn _call_func(name: String, mut stack: List[BDec], precision: Int) raises:
         var n_val = stack.pop()
         var x_val = stack.pop()
         stack.append(x_val.root(n_val, precision))
+        return
+
+    if name == "log":
+        # log(x, base): x was pushed first, then base
+        if len(stack) < 2:
+            raise Error("log() requires two arguments: log(x, base)")
+        var base_val = stack.pop()
+        var x_val = stack.pop()
+        stack.append(x_val.log(base_val, precision))
         return
 
     # All remaining functions take exactly one argument
@@ -73,8 +83,6 @@ fn _call_func(name: String, mut stack: List[BDec], precision: Int) raises:
         stack.append(a.cbrt(precision))
     elif name == "ln":
         stack.append(a.ln(precision))
-    elif name == "log":
-        stack.append(a.log10(precision))
     elif name == "log10":
         stack.append(a.log10(precision))
     elif name == "exp":
@@ -118,7 +126,7 @@ fn evaluate_rpn(rpn: List[Token], precision: Int) raises -> BDec:
             if rpn[i].value == "pi":
                 stack.append(BDec.pi(precision))
             elif rpn[i].value == "e":
-                stack.append(BDec.from_string("1").exp(precision))
+                stack.append(BDec.e(precision))
             else:
                 raise Error("Unknown constant: " + rpn[i].value)
 

--- a/src/cli/calculator/evaluator.mojo
+++ b/src/cli/calculator/evaluator.mojo
@@ -30,9 +30,74 @@ from .tokenizer import (
     TOKEN_STAR,
     TOKEN_SLASH,
     TOKEN_UNARY_MINUS,
+    TOKEN_CARET,
+    TOKEN_FUNC,
+    TOKEN_CONST,
 )
 from .parser import parse_to_rpn
 from .tokenizer import tokenize
+
+
+# ===----------------------------------------------------------------------=== #
+# Helper: dispatch a function call by name
+# ===----------------------------------------------------------------------=== #
+
+
+fn _call_func(name: String, mut stack: List[BDec], precision: Int) raises:
+    """Pop argument(s) from `stack`, call the named Decimo function,
+    and push the result back.
+
+    Single-argument functions:
+        sqrt, cbrt, ln, log, log10, exp, sin, cos, tan, cot, csc, abs
+
+    Two-argument functions:
+        root(x, n)  — the n-th root of x.
+    """
+    if name == "root":
+        # root(x, n): x was pushed first, then n
+        if len(stack) < 2:
+            raise Error("root() requires two arguments: root(x, n)")
+        var n_val = stack.pop()
+        var x_val = stack.pop()
+        stack.append(x_val.root(n_val, precision))
+        return
+
+    # All remaining functions take exactly one argument
+    if len(stack) < 1:
+        raise Error(name + "() requires one argument")
+    var a = stack.pop()
+
+    if name == "sqrt":
+        stack.append(a.sqrt(precision))
+    elif name == "cbrt":
+        stack.append(a.cbrt(precision))
+    elif name == "ln":
+        stack.append(a.ln(precision))
+    elif name == "log":
+        stack.append(a.log10(precision))
+    elif name == "log10":
+        stack.append(a.log10(precision))
+    elif name == "exp":
+        stack.append(a.exp(precision))
+    elif name == "sin":
+        stack.append(a.sin(precision))
+    elif name == "cos":
+        stack.append(a.cos(precision))
+    elif name == "tan":
+        stack.append(a.tan(precision))
+    elif name == "cot":
+        stack.append(a.cot(precision))
+    elif name == "csc":
+        stack.append(a.csc(precision))
+    elif name == "abs":
+        stack.append(abs(a))
+    else:
+        raise Error("Unknown function: " + name)
+
+
+# ===----------------------------------------------------------------------=== #
+# Evaluator
+# ===----------------------------------------------------------------------=== #
 
 
 fn evaluate_rpn(rpn: List[Token], precision: Int) raises -> BDec:
@@ -48,6 +113,14 @@ fn evaluate_rpn(rpn: List[Token], precision: Int) raises -> BDec:
 
         if kind == TOKEN_NUMBER:
             stack.append(BDec.from_string(rpn[i].value))
+
+        elif kind == TOKEN_CONST:
+            if rpn[i].value == "pi":
+                stack.append(BDec.pi(precision))
+            elif rpn[i].value == "e":
+                stack.append(BDec.from_string("1").exp(precision))
+            else:
+                raise Error("Unknown constant: " + rpn[i].value)
 
         elif kind == TOKEN_UNARY_MINUS:
             if len(stack) < 1:
@@ -82,6 +155,16 @@ fn evaluate_rpn(rpn: List[Token], precision: Int) raises -> BDec:
             var b = stack.pop()
             var a = stack.pop()
             stack.append(a.true_divide(b, precision))
+
+        elif kind == TOKEN_CARET:
+            if len(stack) < 2:
+                raise Error("Invalid expression: missing operand")
+            var b = stack.pop()
+            var a = stack.pop()
+            stack.append(a.power(b, precision))
+
+        elif kind == TOKEN_FUNC:
+            _call_func(rpn[i].value, stack, precision)
 
         else:
             raise Error("Unexpected token in RPN evaluation")

--- a/src/cli/main.mojo
+++ b/src/cli/main.mojo
@@ -22,7 +22,12 @@ fn main() raises:
 
     # Positional: the math expression
     cmd.add_arg(
-        Arg("expr", help="Math expression to evaluate (e.g. '100*12-23/17')")
+        Arg(
+            "expr",
+            help=(
+                "Math expression to evaluate (e.g. 'sqrt(abs(1.1*-12-23/17))')"
+            ),
+        )
         .positional()
         .required()
     )
@@ -35,8 +40,147 @@ fn main() raises:
         .default("50")
     )
 
+    # Output formatting flags
+    cmd.add_arg(
+        Arg("scientific", help="Output in scientific notation (e.g. 1.23E+10)")
+        .long("scientific")
+        .short("s")
+        .flag()
+    )
+    cmd.add_arg(
+        Arg(
+            "engineering",
+            help="Output in engineering notation (exponent multiple of 3)",
+        )
+        .long("engineering")
+        .short("e")
+        .flag()
+    )
+    cmd.add_arg(
+        Arg(
+            "pad",
+            help="Pad trailing zeros to the specified precision",
+        )
+        .long("pad")
+        .short("P")
+        .flag()
+    )
+
     var result = cmd.parse()
     var expr = result.get_string("expr")
     var precision = result.get_int("precision")
+    var scientific = result.get_flag("scientific")
+    var engineering = result.get_flag("engineering")
+    var pad = result.get_flag("pad")
 
-    print(evaluate(expr, precision))
+    var value = evaluate(expr, precision)
+
+    if scientific:
+        print(value.to_string(scientific_notation=True))
+    elif engineering:
+        print(_format_engineering(String(value)))
+    elif pad:
+        print(_pad_to_precision(String(value), precision))
+    else:
+        print(value)
+
+
+fn _format_engineering(plain: String) -> String:
+    """Format a plain decimal string in engineering notation.
+
+    Engineering notation is like scientific notation, but the exponent
+    is always a multiple of 3 (e.g. 1.23E+6, 123.456E-9).
+    """
+    # Handle sign
+    var s = plain
+    var sign = String("")
+    if len(s) > 0 and s[byte=0] == "-":
+        sign = "-"
+        s = String(s[1:])
+
+    # Separate integer and fractional parts
+    var dot_pos = -1
+    for i in range(len(s)):
+        if s[byte=i] == ".":
+            dot_pos = i
+            break
+
+    var integer_part: String
+    var frac_part: String
+    if dot_pos >= 0:
+        integer_part = String(s[:dot_pos])
+        frac_part = String(s[dot_pos + 1 :])
+    else:
+        integer_part = s
+        frac_part = String("")
+
+    # Build full digit string (without dot) and determine decimal position
+    var digits = integer_part + frac_part
+    var num_int_digits = len(integer_part)
+
+    # Strip leading zeros to find effective position
+    var first_nonzero = -1
+    for i in range(len(digits)):
+        if digits[byte=i] != "0":
+            first_nonzero = i
+            break
+
+    if first_nonzero == -1:
+        return "0"
+
+    # adjusted exponent = position of first significant digit from left
+    var exponent = num_int_digits - first_nonzero - 1
+
+    # Adjust exponent to be a multiple of 3
+    var eng_exp: Int
+    if exponent >= 0:
+        eng_exp = (exponent // 3) * 3
+    else:
+        eng_exp = -((-exponent + 2) // 3) * 3
+    var lead_digits = exponent - eng_exp + 1  # digits before decimal point
+
+    # Extract significant digits (from first_nonzero onward)
+    var sig = String(digits[first_nonzero:])
+    if len(sig) <= lead_digits:
+        # No fractional part needed
+        var result = sign + sig
+        if eng_exp != 0:
+            result += "E"
+            if eng_exp > 0:
+                result += "+"
+            result += String(eng_exp)
+        return result^
+    else:
+        var result = (
+            sign + String(sig[:lead_digits]) + "." + String(sig[lead_digits:])
+        )
+        if eng_exp != 0:
+            result += "E"
+            if eng_exp > 0:
+                result += "+"
+            result += String(eng_exp)
+        return result^
+
+
+fn _pad_to_precision(plain: String, precision: Int) -> String:
+    """Pad (or add) trailing zeros so the fractional part has exactly
+    `precision` digits.
+    """
+    if precision <= 0:
+        return plain
+
+    var dot_pos = -1
+    for i in range(len(plain)):
+        if plain[byte=i] == ".":
+            dot_pos = i
+            break
+
+    if dot_pos < 0:
+        # No decimal point — add one with `precision` zeros
+        return plain + "." + "0" * precision
+
+    var frac_len = len(plain) - dot_pos - 1
+    if frac_len >= precision:
+        return plain
+
+    return plain + "0" * (precision - frac_len)

--- a/src/cli/main.mojo
+++ b/src/cli/main.mojo
@@ -56,6 +56,7 @@ fn main() raises:
         .short("e")
         .flag()
     )
+    cmd.mutually_exclusive(["scientific", "engineering"])
     cmd.add_arg(
         Arg(
             "pad",
@@ -65,6 +66,18 @@ fn main() raises:
         .short("P")
         .flag()
     )
+    cmd.add_arg(
+        Arg(
+            "delimiter",
+            help=(
+                "Digit-group separator inserted every 3 digits"
+                " (e.g. '_' gives 1_234.567_89)"
+            ),
+        )
+        .long("delimiter")
+        .short("d")
+        .default("")
+    )
 
     var result = cmd.parse()
     var expr = result.get_string("expr")
@@ -72,94 +85,18 @@ fn main() raises:
     var scientific = result.get_flag("scientific")
     var engineering = result.get_flag("engineering")
     var pad = result.get_flag("pad")
+    var delimiter = result.get_string("delimiter")
 
     var value = evaluate(expr, precision)
 
     if scientific:
-        print(value.to_string(scientific_notation=True))
+        print(value.to_string(scientific=True, delimiter=delimiter))
     elif engineering:
-        print(_format_engineering(String(value)))
+        print(value.to_string(engineering=True, delimiter=delimiter))
     elif pad:
-        print(_pad_to_precision(String(value), precision))
+        print(_pad_to_precision(value.to_string(force_plain=True), precision))
     else:
-        print(value)
-
-
-fn _format_engineering(plain: String) -> String:
-    """Format a plain decimal string in engineering notation.
-
-    Engineering notation is like scientific notation, but the exponent
-    is always a multiple of 3 (e.g. 1.23E+6, 123.456E-9).
-    """
-    # Handle sign
-    var s = plain
-    var sign = String("")
-    if len(s) > 0 and s[byte=0] == "-":
-        sign = "-"
-        s = String(s[1:])
-
-    # Separate integer and fractional parts
-    var dot_pos = -1
-    for i in range(len(s)):
-        if s[byte=i] == ".":
-            dot_pos = i
-            break
-
-    var integer_part: String
-    var frac_part: String
-    if dot_pos >= 0:
-        integer_part = String(s[:dot_pos])
-        frac_part = String(s[dot_pos + 1 :])
-    else:
-        integer_part = s
-        frac_part = String("")
-
-    # Build full digit string (without dot) and determine decimal position
-    var digits = integer_part + frac_part
-    var num_int_digits = len(integer_part)
-
-    # Strip leading zeros to find effective position
-    var first_nonzero = -1
-    for i in range(len(digits)):
-        if digits[byte=i] != "0":
-            first_nonzero = i
-            break
-
-    if first_nonzero == -1:
-        return "0"
-
-    # adjusted exponent = position of first significant digit from left
-    var exponent = num_int_digits - first_nonzero - 1
-
-    # Adjust exponent to be a multiple of 3
-    var eng_exp: Int
-    if exponent >= 0:
-        eng_exp = (exponent // 3) * 3
-    else:
-        eng_exp = -((-exponent + 2) // 3) * 3
-    var lead_digits = exponent - eng_exp + 1  # digits before decimal point
-
-    # Extract significant digits (from first_nonzero onward)
-    var sig = String(digits[first_nonzero:])
-    if len(sig) <= lead_digits:
-        # No fractional part needed
-        var result = sign + sig
-        if eng_exp != 0:
-            result += "E"
-            if eng_exp > 0:
-                result += "+"
-            result += String(eng_exp)
-        return result^
-    else:
-        var result = (
-            sign + String(sig[:lead_digits]) + "." + String(sig[lead_digits:])
-        )
-        if eng_exp != 0:
-            result += "E"
-            if eng_exp > 0:
-                result += "+"
-            result += String(eng_exp)
-        return result^
+        print(value.to_string(delimiter=delimiter))
 
 
 fn _pad_to_precision(plain: String, precision: Int) -> String:

--- a/tests/cli/test_evaluator.mojo
+++ b/tests/cli/test_evaluator.mojo
@@ -309,6 +309,76 @@ fn test_ln_e_is_one() raises:
 
 
 # ===----------------------------------------------------------------------=== #
+# Tests: remaining functions (Phase 2 – smoke tests per function)
+# ===----------------------------------------------------------------------=== #
+
+
+fn test_cbrt_27() raises:
+    """cbrt(27) ≈ 3."""
+    var result = String(evaluate("cbrt(27)"))
+    testing.assert_true(
+        result == "3" or result.startswith("3."),
+        "cbrt(27) should be 3, got: " + result,
+    )
+
+
+fn test_log10_1000() raises:
+    """log10(1000) = 3."""
+    testing.assert_equal(String(evaluate("log10(1000)")), "3", "log10(1000)")
+
+
+fn test_log10_1() raises:
+    """log10(1) = 0."""
+    testing.assert_equal(String(evaluate("log10(1)")), "0", "log10(1)")
+
+
+fn test_log_base_2() raises:
+    """log(8, 2) ≈ 3."""
+    var result = String(evaluate("log(8, 2)"))
+    testing.assert_true(
+        result == "3" or result.startswith("3."),
+        "log(8,2) should be 3, got: " + result,
+    )
+
+
+fn test_log_base_100() raises:
+    """log(1000000, 100) ≈ 3."""
+    var result = String(evaluate("log(1000000, 100)"))
+    testing.assert_true(
+        result == "3" or result.startswith("3."),
+        "log(1000000,100) should be 3, got: " + result,
+    )
+
+
+fn test_cos_0() raises:
+    """cos(0) = 1."""
+    testing.assert_equal(String(evaluate("cos(0)")), "1", "cos(0)")
+
+
+fn test_tan_0() raises:
+    """tan(0) = 0."""
+    testing.assert_equal(String(evaluate("tan(0)")), "0", "tan(0)")
+
+
+fn test_cot_pi_over_4() raises:
+    """cot(pi/4) is very close to 1."""
+    var result = String(evaluate("cot(pi/4)", precision=20))
+    testing.assert_true(
+        result == "1" or result.startswith("1.") or result.startswith("0.9999"),
+        "cot(pi/4) ≈ 1: " + result,
+    )
+
+
+fn test_csc_pi_over_2() raises:
+    """csc(pi/2) is very close to 1."""
+    var result = String(evaluate("csc(pi/2)", precision=20))
+    testing.assert_true(
+        result == "1" or result.startswith("1.") or result.startswith("0.9999"),
+        "csc(pi/2) ≈ 1: " + result,
+    )
+
+
+# ===----------------------------------------------------------------------=== #
 # Main
 # ===----------------------------------------------------------------------=== #
 

--- a/tests/cli/test_evaluator.mojo
+++ b/tests/cli/test_evaluator.mojo
@@ -159,6 +159,156 @@ fn test_showcase_expression() raises:
 
 
 # ===----------------------------------------------------------------------=== #
+# Tests: power operator (Phase 2)
+# ===----------------------------------------------------------------------=== #
+
+
+fn test_power_simple() raises:
+    testing.assert_equal(String(evaluate("2^10")), "1024", "2^10")
+
+
+fn test_power_double_star() raises:
+    """** alias for ^."""
+    testing.assert_equal(String(evaluate("2**10")), "1024", "2**10")
+
+
+fn test_power_zero() raises:
+    testing.assert_equal(String(evaluate("5^0")), "1", "5^0")
+
+
+fn test_power_one() raises:
+    testing.assert_equal(String(evaluate("7^1")), "7", "7^1")
+
+
+fn test_power_large() raises:
+    """2^256 should produce the correct value."""
+    var result = String(evaluate("2^256"))
+    # BigDecimal may render this in scientific notation
+    testing.assert_true(
+        result.startswith(
+            "1.1579208923731619542357098500868790785326998466564"
+        ),
+        "2^256 starts correctly: " + result,
+    )
+
+
+fn test_power_right_associative() raises:
+    """2^3^2 = 2^(3^2) = 2^9 = 512."""
+    testing.assert_equal(String(evaluate("2^3^2")), "512", "2^3^2")
+
+
+fn test_power_with_subtraction() raises:
+    """10^2 - 1 = 99."""
+    testing.assert_equal(String(evaluate("10^2-1")), "99", "10^2-1")
+
+
+fn test_power_negative_exponent() raises:
+    """2^-3 = 0.125."""
+    testing.assert_equal(String(evaluate("2^-3")), "0.125", "2^-3")
+
+
+# ===----------------------------------------------------------------------=== #
+# Tests: built-in functions (Phase 2)
+# ===----------------------------------------------------------------------=== #
+
+
+fn test_sqrt_perfect() raises:
+    testing.assert_equal(String(evaluate("sqrt(9)")), "3", "sqrt(9)")
+
+
+fn test_sqrt_irrational() raises:
+    """Irrational sqrt(2) with precision 20."""
+    var result = String(evaluate("sqrt(2)", precision=20))
+    testing.assert_true(
+        result.startswith("1.414213562373095048"),
+        "sqrt(2) p=20 starts correctly: " + result,
+    )
+
+
+fn test_ln_1() raises:
+    testing.assert_equal(String(evaluate("ln(1)")), "0", "ln(1)")
+
+
+fn test_exp_0() raises:
+    testing.assert_equal(String(evaluate("exp(0)")), "1", "exp(0)")
+
+
+fn test_abs_negative() raises:
+    testing.assert_equal(String(evaluate("abs(-42)")), "42", "abs(-42)")
+
+
+fn test_abs_positive() raises:
+    testing.assert_equal(String(evaluate("abs(7)")), "7", "abs(7)")
+
+
+fn test_root_cube() raises:
+    """Cube root(27, 3) = 3."""
+    testing.assert_equal(String(evaluate("root(27, 3)")), "3", "root(27,3)")
+
+
+fn test_function_in_expression() raises:
+    """1 + sqrt(4) = 3."""
+    testing.assert_equal(String(evaluate("1+sqrt(4)")), "3", "1+sqrt(4)")
+
+
+fn test_nested_functions() raises:
+    """Nested sqrt(abs(-9)) = 3."""
+    testing.assert_equal(
+        String(evaluate("sqrt(abs(-9))")), "3", "sqrt(abs(-9))"
+    )
+
+
+fn test_function_with_power() raises:
+    """Power of sqrt(2)^2 should be very close to 2."""
+    var result = String(evaluate("sqrt(2)^2"))
+    testing.assert_true(
+        result.startswith("1.999999999999999999") or result.startswith("2"),
+        "sqrt(2)^2 should be close to 2: " + result,
+    )
+
+
+# ===----------------------------------------------------------------------=== #
+# Tests: built-in constants (Phase 2)
+# ===----------------------------------------------------------------------=== #
+
+
+fn test_pi_constant() raises:
+    """Constant pi with precision 20."""
+    var result = String(evaluate("pi", precision=20))
+    testing.assert_true(
+        result.startswith("3.1415926535897932"),
+        "pi p=20 starts correctly: " + result,
+    )
+
+
+fn test_e_constant() raises:
+    """Constant e with precision 20."""
+    var result = String(evaluate("e", precision=20))
+    testing.assert_true(
+        result.startswith("2.7182818284590452"),
+        "e p=20 starts correctly: " + result,
+    )
+
+
+fn test_pi_in_expression() raises:
+    """Expression 2*pi should start with 6.2831853..."""
+    var result = String(evaluate("2*pi", precision=20))
+    testing.assert_true(
+        result.startswith("6.283185307179586"),
+        "2*pi p=20: " + result,
+    )
+
+
+fn test_ln_e_is_one() raises:
+    """Expression ln(e) should be approximately 1."""
+    var result = String(evaluate("ln(e)", precision=20))
+    testing.assert_true(
+        result.startswith("1.0000000000000000000"),
+        "ln(e) ≈ 1",
+    )
+
+
+# ===----------------------------------------------------------------------=== #
 # Main
 # ===----------------------------------------------------------------------=== #
 


### PR DESCRIPTION
This PR extends the CLI calculator with Phase 2 features as defined in the cli_calculator plan: the `^` power operator, a full suite of mathematical functions, built-in constants (`pi`, `e`), multi-argument function support, and output formatting flags.