### PR TITLE
[decimal] Add engineering notation and delimiter to `to_string` of `BigDecimal`

### DIFF
--- a/docs/plans/api_roadmap.md
+++ b/docs/plans/api_roadmap.md
@@ -62,7 +62,7 @@ Methods that BigDecimal should have but currently lacks:
 | `copy()`                         | **MISSING**  | **Add** — explicit deep copy method                                                            |
 | `number_of_significant_digits()` | **MISSING**  | **Add** — count of significant digits in the coefficient                                       |
 | `is_positive()`                  | **MISSING**  | **Add** — BigInt has it, BigDecimal should too                                                 |
-| `to_scientific_string()`         | **Partial**  | **Add** as convenience alias (currently via `to_string(scientific_notation=True)`)             |
+| `to_scientific_string()`         | **Partial**  | **Add** as convenience alias (currently via `to_string(scientific=True)`)                      |
 | `__divmod__()`                   | **MISSING**  | **Add** — BigInt has it                                                                        |
 | `Int` overloads for operators    | **RESOLVED** | Mojo's `@implicit` handles this — `BigDecimal("1.5") + 1` already works                        |
 | `__ifloordiv__` / `__imod__`     | **MISSING**  | **Add** — complete the augmented assignment set                                                |

--- a/src/cli/main.mojo
+++ b/src/cli/main.mojo
@@ -41,6 +41,7 @@ fn main() raises:
     )
 
     # Output formatting flags
+    # Mutually exclusive: scientific, engineering
     cmd.add_arg(
         Arg("scientific", help="Output in scientific notation (e.g. 1.23E+10)")
         .long("scientific")

--- a/src/decimo/bigint/bigint.mojo
+++ b/src/decimo/bigint/bigint.mojo
@@ -468,15 +468,15 @@ struct BigInt(
 
     fn __str__(self) -> String:
         """Returns a decimal string representation of the BigInt."""
-        return self.to_decimal_string()
+        return self.to_string()
 
     fn __repr__(self) -> String:
         """Returns a debug representation of the BigInt."""
-        return 'BigInt("' + self.to_decimal_string() + '")'
+        return 'BigInt("' + self.to_string() + '")'
 
     fn write_to[W: Writer](self, mut writer: W):
         """Writes the decimal string representation to a writer."""
-        writer.write(self.to_decimal_string())
+        writer.write(self.to_string())
 
     # ===------------------------------------------------------------------=== #
     # Type-transfer or output methods that are not dunders
@@ -545,7 +545,7 @@ struct BigInt(
 
         return BigInt10(raw_words=decimal_words^, sign=self.sign)
 
-    fn to_decimal_string(self, line_width: Int = 0) -> String:
+    fn to_string(self, line_width: Int = 0) -> String:
         """Returns the decimal string representation of the BigInt.
 
         Uses divide-and-conquer base conversion for large numbers (O(M(n)·log n))
@@ -598,6 +598,13 @@ struct BigInt(
 
         return result^
 
+    fn to_decimal_string(self, line_width: Int = 0) -> String:
+        """Returns the decimal string representation of the BigInt.
+
+        Deprecated: Use ``to_string(line_width=...)`` instead.
+        """
+        return self.to_string(line_width=line_width)
+
     fn to_string_with_separators(self, separator: String = "_") -> String:
         """Returns string representation of the BigInt with separators.
 
@@ -608,7 +615,7 @@ struct BigInt(
             The string representation of the BigInt with separators.
         """
 
-        var result = self.to_decimal_string()
+        var result = self.to_string()
         var start_idx = 0
         if self.sign:
             start_idx = 1  # Skip the minus sign
@@ -1292,9 +1299,9 @@ struct BigInt(
         result += sep_line + "\n"
 
         # number line
-        var string_of_number = self.to_decimal_string(
-            line_width=value_width
-        ).split("\n")
+        var string_of_number = self.to_string(line_width=value_width).split(
+            "\n"
+        )
         result += "number:" + String(" ") * (col - len("number:"))
         for i in range(len(string_of_number)):
             if i > 0:

--- a/tests/bigint/test_bigint_string_format.mojo
+++ b/tests/bigint/test_bigint_string_format.mojo
@@ -1,6 +1,6 @@
 """
 Test BigInt string formatting: to_string_with_separators,
-to_decimal_string with line_width, number_of_digits, and __repr__.
+to_string with line_width, number_of_digits, and __repr__.
 """
 
 import testing
@@ -32,26 +32,26 @@ fn test_to_string_with_separators() raises:
 
 
 # ===----------------------------------------------------------------------=== #
-# Test: to_decimal_string with line_width
+# Test: to_string with line_width
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_to_decimal_string_line_width() raises:
-    """Test to_decimal_string with line_width parameter."""
+fn test_to_string_line_width() raises:
+    """Test to_string with line_width parameter."""
     # Default: no wrapping
     var val = BigInt("12345678901234567890")
-    testing.assert_equal(val.to_decimal_string(), "12345678901234567890")
+    testing.assert_equal(val.to_string(), "12345678901234567890")
 
     # line_width=10: "1234567890\n1234567890"
-    var wrapped = val.to_decimal_string(line_width=10)
+    var wrapped = val.to_string(line_width=10)
     testing.assert_equal(wrapped, "1234567890\n1234567890")
 
     # line_width=5: "12345\n67890\n12345\n67890"
-    var wrapped5 = val.to_decimal_string(line_width=5)
+    var wrapped5 = val.to_string(line_width=5)
     testing.assert_equal(wrapped5, "12345\n67890\n12345\n67890")
 
     # Short string: no wrapping needed
-    testing.assert_equal(BigInt(42).to_decimal_string(line_width=10), "42")
+    testing.assert_equal(BigInt(42).to_string(line_width=10), "42")
 
 
 # ===----------------------------------------------------------------------=== #


### PR DESCRIPTION
Updates string-formatting APIs and CLI/docs to support newer BigDecimal `to_string` options while aligning BigInt’s string conversion naming with the rest of the numeric types.

**Changes:**
- Rename BigInt’s `to_decimal_string` usage to `to_string` (including dunders and writer output).
- Clarify CLI formatting flags as mutually exclusive (scientific vs engineering).
- Update API roadmap documentation to reflect `to_string(scientific=True)` naming.