### PR TITLE
[decimal] Remove some deprecated function aliases + Add several useful methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,15 +67,15 @@ The following table summarizes the package versions and their corresponding Mojo
 
 | libary     | version | Mojo version  | package manager |
 | ---------- | ------- | ------------- | --------------- |
-| `decimojo` | v0.1.0  | ==25.1        | magic           |
-| `decimojo` | v0.2.0  | ==25.2        | magic           |
-| `decimojo` | v0.3.0  | ==25.2        | magic           |
-| `decimojo` | v0.3.1  | >=25.2, <25.4 | pixi            |
-| `decimojo` | v0.4.x  | ==25.4        | pixi            |
-| `decimojo` | v0.5.0  | ==25.5        | pixi            |
-| `decimojo` | v0.6.0  | ==0.25.7      | pixi            |
-| `decimojo` | v0.7.0  | ==0.26.1      | pixi            |
-| `decimo`   | v0.8.0  | ==0.26.1      | pixi            |
+| `decimojo` | 0.1.0   | ==25.1        | magic           |
+| `decimojo` | 0.2.0   | ==25.2        | magic           |
+| `decimojo` | 0.3.0   | ==25.2        | magic           |
+| `decimojo` | 0.3.1   | >=25.2, <25.4 | pixi            |
+| `decimojo` | 0.4.x   | ==25.4        | pixi            |
+| `decimojo` | 0.5.0   | ==25.5        | pixi            |
+| `decimojo` | 0.6.0   | ==0.25.7      | pixi            |
+| `decimojo` | 0.7.0   | ==0.26.1      | pixi            |
+| `decimo`   | 0.8.0   | ==0.26.1      | pixi            |
 
 ## Quick start
 

--- a/docs/plans/cli_calculator.md
+++ b/docs/plans/cli_calculator.md
@@ -263,7 +263,7 @@ Format the final `BigDecimal` result based on CLI flags:
 2. Add function call parsing (`sqrt(...)`, `ln(...)`, etc.).
 3. Add multi-argument function support (`root(x, n)`).
 4. Add built-in constants (`pi`, `e`).
-5. Add output formatting flags (`--sci`, `--eng`, `--pad-to-precision`).
+5. Add output formatting flags (`--scientific` or `-s`, `--engineering` or `-e`, `--pad-to-precision` or `-P`).
 
 ### Phase 3: Polish
 

--- a/src/decimo/bigdecimal/comparison.mojo
+++ b/src/decimo/bigdecimal/comparison.mojo
@@ -140,38 +140,6 @@ fn greater_equal(x1: BigDecimal, x2: BigDecimal) -> Bool:
     return compare(x1, x2) >= 0
 
 
-# Backward-compatible aliases
-fn equals(x1: BigDecimal, x2: BigDecimal) -> Bool:
-    """Alias for `equal()`. Deprecated: use `equal()` instead."""
-    return equal(x1, x2)
-
-
-fn not_equals(x1: BigDecimal, x2: BigDecimal) -> Bool:
-    """Alias for `not_equal()`. Deprecated: use `not_equal()` instead."""
-    return not_equal(x1, x2)
-
-
-fn less_than(x1: BigDecimal, x2: BigDecimal) -> Bool:
-    """Alias for `less()`. Deprecated: use `less()` instead."""
-    return less(x1, x2)
-
-
-fn less_than_or_equal(x1: BigDecimal, x2: BigDecimal) -> Bool:
-    """Alias for `less_equal()`. Deprecated: use `less_equal()` instead."""
-    return less_equal(x1, x2)
-
-
-fn greater_than(x1: BigDecimal, x2: BigDecimal) -> Bool:
-    """Alias for `greater()`. Deprecated: use `greater()` instead."""
-    return greater(x1, x2)
-
-
-fn greater_than_or_equal(x1: BigDecimal, x2: BigDecimal) -> Bool:
-    """Alias for `greater_equal()`. Deprecated: use `greater_equal()` instead.
-    """
-    return greater_equal(x1, x2)
-
-
 fn max(x1: BigDecimal, x2: BigDecimal) -> BigDecimal:
     """Returns the maximum of x1 and x2."""
     if compare(x1, x2) >= 0:


### PR DESCRIPTION
This PR updates Decimo’s BigDecimal API surface by removing deprecated comparison aliases and adding convenience/ergonomic methods to `BigDecimal`, alongside keeping planning docs in sync with the new capabilities.

**Changes:**
- Removed deprecated free-function comparison aliases in `bigdecimal/comparison.mojo` (e.g., `equals`, `less_than`, etc.).
- Added several `BigDecimal` methods: scientific/engineering string helpers, reflected true division (`__rtruediv__`), `is_positive()`, and digit-counting methods.
- Updated planning/docs (CLI flags, API roadmap) and adjusted README version formatting.