### PR TITLE
[decimal] Implement `as_tuple()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,15 +67,15 @@ The following table summarizes the package versions and their corresponding Mojo
 
 | libary     | version | Mojo version  | package manager |
 | ---------- | ------- | ------------- | --------------- |
-| `decimojo` | 0.1.0   | ==25.1        | magic           |
-| `decimojo` | 0.2.0   | ==25.2        | magic           |
-| `decimojo` | 0.3.0   | ==25.2        | magic           |
-| `decimojo` | 0.3.1   | >=25.2, <25.4 | pixi            |
-| `decimojo` | 0.4.x   | ==25.4        | pixi            |
-| `decimojo` | 0.5.0   | ==25.5        | pixi            |
-| `decimojo` | 0.6.0   | ==0.25.7      | pixi            |
-| `decimojo` | 0.7.0   | ==0.26.1      | pixi            |
-| `decimo`   | 0.8.0   | ==0.26.1      | pixi            |
+| `decimojo` | v0.1.0  | ==25.1        | magic           |
+| `decimojo` | v0.2.0  | ==25.2        | magic           |
+| `decimojo` | v0.3.0  | ==25.2        | magic           |
+| `decimojo` | v0.3.1  | >=25.2, <25.4 | pixi            |
+| `decimojo` | v0.4.x  | ==25.4        | pixi            |
+| `decimojo` | v0.5.0  | ==25.5        | pixi            |
+| `decimojo` | v0.6.0  | ==0.25.7      | pixi            |
+| `decimojo` | v0.7.0  | ==0.26.1      | pixi            |
+| `decimo`   | v0.8.0  | ==0.26.1      | pixi            |
 
 ## Quick start
 

--- a/docs/plans/api_roadmap.md
+++ b/docs/plans/api_roadmap.md
@@ -86,7 +86,7 @@ These are the gaps vs Python's `decimal.Decimal`, prioritized by user impact.
 
 | Method                              | What It Does                                             | Notes                                                                                                    |
 | ----------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `as_tuple()`                        | Returns `(sign, coefficient, exponent)`                  | ✓ **DONE** — returns `(sign: Bool, digits: List[UInt8], exponent: Int)` matching Python's `DecimalTuple` |
+| `as_tuple()`                        | Returns `(sign, digits, exponent)`                       | ✓ **DONE** — returns `(sign: Bool, digits: List[UInt8], exponent: Int)` matching Python's `DecimalTuple` |
 | `adjusted()`                        | Returns adjusted exponent (= exponent + len(digits) - 1) | Useful for formatting and comparison.                                                                    |
 | `copy_abs()`                        | Returns `abs(self)`                                      | Alias for `__abs__()`. Trivial to add.                                                                   |
 | `copy_negate()`                     | Returns `-self`                                          | Alias for `__neg__()`. Trivial to add.                                                                   |

--- a/docs/plans/api_roadmap.md
+++ b/docs/plans/api_roadmap.md
@@ -25,8 +25,8 @@ These inconsistencies will confuse users who use both types in the same codebase
 
 | Concept  | BigDecimal                                                                                                                                              | BigInt                                                      | Status                                                                                            |
 | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| Equality | ~~`equals()` / `not_equals()`~~ → `equal()` / `not_equal()`                                                                                             | `equal()` / `not_equal()`                                   | ✅ **DONE** — old aliases removed                                                                  |
-| Ordering | ~~`less_than()` / `greater_than()` / `less_than_or_equal()` / `greater_than_or_equal()`~~ → `less()` / `greater()` / `less_equal()` / `greater_equal()` | `less()` / `greater()` / `less_equal()` / `greater_equal()` | ✅ **DONE** — old aliases removed                                                                  |
+| Equality | ~~`equals()` / `not_equals()`~~ → `equal()` / `not_equal()`                                                                                             | `equal()` / `not_equal()`                                   | ✓ **DONE** — old aliases removed                                                                  |
+| Ordering | ~~`less_than()` / `greater_than()` / `less_than_or_equal()` / `greater_than_or_equal()`~~ → `less()` / `greater()` / `less_equal()` / `greater_equal()` | `less()` / `greater()` / `less_equal()` / `greater_equal()` | ✓ **DONE** — old aliases removed                                                                  |
 | Division | `true_divide()`                                                                                                                                         | N/A                                                         | `true_divide` is aligned with `__truediv__` dunder. Maybe add an alias `divide()` for convenience |
 
 ### 1.2 Field Access vs Method Access
@@ -43,27 +43,27 @@ BigDecimal exposes internal state via direct field access (`self.scale`, `self.c
 
 Methods that BigDecimal should have but currently lacks:
 
-| Method                           | Status       | Action                                                                                         |
-| -------------------------------- | ------------ | ---------------------------------------------------------------------------------------------- |
-| `as_tuple()`                     | **MISSING**  | **Add** — returns `(sign: Bool, coefficient: BigUInt, exponent: Int)`                          |
-| `copy()`                         | ✅ **DONE**   | Implemented — used internally by `__pos__`, `__round__`, etc.                                  |
-| `number_of_significant_digits()` | **MISSING**  | **Add** — count of significant digits in the coefficient                                       |
-| `is_positive()`                  | **MISSING**  | **Add** — BigInt has it, BigDecimal should too                                                 |
-| `to_scientific_string()`         | **Partial**  | **Add** as convenience alias (currently via `to_string(scientific=True)`)                      |
-| `__divmod__()`                   | ✅ **DONE**   | Implemented                                                                                    |
-| `Int` overloads for operators    | **RESOLVED** | Mojo's `@implicit` handles this — `BigDecimal("1.5") + 1` already works                        |
-| `__ifloordiv__` / `__imod__`     | ✅ **DONE**   | Implemented                                                                                    |
-| `__rtruediv__`                   | **MISSING**  | **Add** — complete the reflected operator set                                                  |
-| Debug repr returning String      | Prints only  | **Improve** — `print_internal_representation()` should also have a variant that returns String |
+| Method                           | Status       | Action                                                                                                    |
+| -------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------- |
+| `as_tuple()`                     | ✓ **DONE**   | Implemented — returns `(sign: Bool, digits: List[UInt8], exponent: Int)` matching Python's `DecimalTuple` |
+| `copy()`                         | ✓ **DONE**   | Implemented — used internally by `__pos__`, `__round__`, etc.                                             |
+| `number_of_significant_digits()` | ~~REMOVED~~  | Removed — identical to `number_of_digits()`; not a Python API                                             |
+| `is_positive()`                  | ✓ **DONE**   | Implemented                                                                                               |
+| `to_scientific_string()`         | ✓ **DONE**   | Added — convenience alias for `to_string(scientific=True)`                                                |
+| `__divmod__()`                   | ✓ **DONE**   | Implemented                                                                                               |
+| `Int` overloads for operators    | **RESOLVED** | Mojo's `@implicit` handles this — `BigDecimal("1.5") + 1` already works                                   |
+| `__ifloordiv__` / `__imod__`     | ✓ **DONE**   | Implemented                                                                                               |
+| `__rtruediv__`                   | ✓ **DONE**   | Implemented                                                                                               |
+| Debug repr returning String      | Prints only  | **Improve** — `print_internal_representation()` should also have a variant that returns String            |
 
 ### 1.4 Missing Parity: BigInt vs BigDecimal
 
 | Method                        | BigInt   | BigDecimal  | Action                                                              |
 | ----------------------------- | -------- | ----------- | ------------------------------------------------------------------- |
-| `is_positive()`               | ✅ Has it | **MISSING** | Add to BigDecimal                                                   |
-| `__bool__()`                  | ✅ Done   | ✅ Done      | —                                                                   |
+| `is_positive()`               | ✓ Has it | ✓ Done      | —                                                                   |
+| `__bool__()`                  | ✓ Done   | ✓ Done      | —                                                                   |
 | `to_string_with_separators()` | Has it   | **MISSING** | Nice to have on BigDecimal too (can use `to_string(delimiter=...)`) |
-| `number_of_digits()`          | Has it   | **MISSING** | Add to BigDecimal (number of digits in coefficient)                 |
+| `number_of_digits()`          | Has it   | ✓ Done      | —                                                                   |
 
 ---
 
@@ -73,33 +73,33 @@ These are the gaps vs Python's `decimal.Decimal`, prioritized by user impact.
 
 ### 2.1 HIGH Priority — Dunders That Pythonistas Expect
 
-| Method                                     | What It Does                                     | Notes                                                                |
-| ------------------------------------------ | ------------------------------------------------ | -------------------------------------------------------------------- |
-| **`__bool__(self) -> Bool`**               | `if x:` — True if nonzero                        | ✅ **DONE**                                                           |
-| **`__pos__(self) -> Self`**                | `+x` — unary plus                                | ✅ **DONE**                                                           |
-| **`__divmod__(self, other) -> Tuple`**     | `divmod(a, b)`                                   | ✅ **DONE**                                                           |
-| **`__ceil__` / `__floor__` / `__trunc__`** | `math.ceil(x)`, `math.floor(x)`, `math.trunc(x)` | ✅ **DONE**                                                           |
-| **`__rtruediv__(self, other) -> Self`**    | `1 / x` where x is BigDecimal                    | Still **MISSING**. `Int.__truediv__(BigDecimal)` fails without this. |
-| **`__hash__(self) -> UInt`**               | Hashable                                         | **MISSING**. Can wait for Mojo's Hashable trait maturity.            |
+| Method                                     | What It Does                                     | Notes                                                     |
+| ------------------------------------------ | ------------------------------------------------ | --------------------------------------------------------- |
+| **`__bool__(self) -> Bool`**               | `if x:` — True if nonzero                        | ✓ **DONE**                                                |
+| **`__pos__(self) -> Self`**                | `+x` — unary plus                                | ✓ **DONE**                                                |
+| **`__divmod__(self, other) -> Tuple`**     | `divmod(a, b)`                                   | ✓ **DONE**                                                |
+| **`__ceil__` / `__floor__` / `__trunc__`** | `math.ceil(x)`, `math.floor(x)`, `math.trunc(x)` | ✓ **DONE**                                                |
+| **`__rtruediv__(self, other) -> Self`**    | `1 / x` where x is BigDecimal                    | ✓ **DONE**                                                |
+| **`__hash__(self) -> UInt`**               | Hashable                                         | **MISSING**. Can wait for Mojo's Hashable trait maturity. |
 
 ### 2.2 MEDIUM Priority — Named Methods for Python Migration
 
-| Method                              | What It Does                                             | Notes                                                                                               |
-| ----------------------------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `as_tuple()`                        | Returns `(sign, digits_tuple, exponent)`                 | Python returns a named tuple. We should return `(sign: Bool, coefficient: BigUInt, exponent: Int)`. |
-| `adjusted()`                        | Returns adjusted exponent (= exponent + len(digits) - 1) | Useful for formatting and comparison.                                                               |
-| `copy_abs()`                        | Returns `abs(self)`                                      | Alias for `__abs__()`. Trivial to add.                                                              |
-| `copy_negate()`                     | Returns `-self`                                          | Alias for `__neg__()`. Trivial to add.                                                              |
-| `copy_sign(other)`                  | Returns self with the sign of other                      | One-liner.                                                                                          |
-| `same_quantum(other)`               | True if both have same exponent/scale                    | Useful for financial code.                                                                          |
-| `normalize()`                       | Already exists                                           | ✓                                                                                                   |
-| `to_eng_string()`                   | Engineering notation (exponent multiple of 3)            | Nice for scientific users.                                                                          |
-| `to_integral_value(rounding)`       | Round to integer, keep as Decimal                        | `round(ndigits=0)` is close but not identical (doesn't strip trailing zeros).                       |
-| `max_mag(other)` / `min_mag(other)` | Max/min by absolute value                                | `compare_absolute` exists; this is a convenience.                                                   |
-| `remainder_near(other)`             | IEEE 754 remainder                                       | Different from `%` (truncated).                                                                     |
-| `logb()`                            | Returns adjusted exponent as Decimal                     | Different from `adjusted()` (returns Decimal, not Int).                                             |
-| `fma(a, b)`                         | `self * a + b` without intermediate rounding             | Important for numerical algorithms.                                                                 |
-| `scaleb(n)`                         | Multiply by 10^n efficiently                             | Useful for scale manipulation.                                                                      |
+| Method                              | What It Does                                             | Notes                                                                                                    |
+| ----------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `as_tuple()`                        | Returns `(sign, coefficient, exponent)`                  | ✓ **DONE** — returns `(sign: Bool, digits: List[UInt8], exponent: Int)` matching Python's `DecimalTuple` |
+| `adjusted()`                        | Returns adjusted exponent (= exponent + len(digits) - 1) | Useful for formatting and comparison.                                                                    |
+| `copy_abs()`                        | Returns `abs(self)`                                      | Alias for `__abs__()`. Trivial to add.                                                                   |
+| `copy_negate()`                     | Returns `-self`                                          | Alias for `__neg__()`. Trivial to add.                                                                   |
+| `copy_sign(other)`                  | Returns self with the sign of other                      | One-liner.                                                                                               |
+| `same_quantum(other)`               | True if both have same exponent/scale                    | Useful for financial code.                                                                               |
+| `normalize()`                       | Already exists                                           | ✓                                                                                                        |
+| `to_eng_string()`                   | Engineering notation (exponent multiple of 3)            | ✓ **DONE** — alias for `to_string(engineering=True)`                                                     |
+| `to_integral_value(rounding)`       | Round to integer, keep as Decimal                        | `round(ndigits=0)` is close but not identical (doesn't strip trailing zeros).                            |
+| `max_mag(other)` / `min_mag(other)` | Max/min by absolute value                                | `compare_absolute` exists; this is a convenience.                                                        |
+| `remainder_near(other)`             | IEEE 754 remainder                                       | Different from `%` (truncated).                                                                          |
+| `logb()`                            | Returns adjusted exponent as Decimal                     | Different from `adjusted()` (returns Decimal, not Int).                                                  |
+| `fma(a, b)`                         | `self * a + b` without intermediate rounding             | Important for numerical algorithms.                                                                      |
+| `scaleb(n)`                         | Multiply by 10^n efficiently                             | Useful for scale manipulation.                                                                           |
 
 ### 2.3 LOW Priority — Completeness
 
@@ -123,9 +123,9 @@ These are the gaps vs Python's `decimal.Decimal`, prioritized by user impact.
 
 | Method                                     | What It Does                 | Notes                                                                                                                                               |
 | ------------------------------------------ | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`__bool__(self) -> Bool`**               | `if n:` — True if nonzero    | ✅ **DONE**                                                                                                                                          |
-| **`__pos__(self) -> Self`**                | `+n` — returns self          | ✅ **DONE**                                                                                                                                          |
-| **`__ceil__` / `__floor__` / `__trunc__`** | All return self for integers | ✅ **DONE**                                                                                                                                          |
+| **`__bool__(self) -> Bool`**               | `if n:` — True if nonzero    | ✓ **DONE**                                                                                                                                          |
+| **`__pos__(self) -> Self`**                | `+n` — returns self          | ✓ **DONE**                                                                                                                                          |
+| **`__ceil__` / `__floor__` / `__trunc__`** | All return self for integers | ✓ **DONE**                                                                                                                                          |
 | **`bit_count(self) -> Int`**               | Popcount (number of 1-bits)  | **MISSING**. Python 3.10+. Useful.                                                                                                                  |
 | **`__float__(self) -> Float64`**           | Float conversion             | **MISSING**. Python's `float(n)`. Useful for interop.                                                                                               |
 | **`__pow__(self, exp, mod)`**              | 3-arg pow                    | Python's `pow(base, exp, mod)`. `mod_pow` exists but not via the dunder. **Mojo may not support 3-arg **pow** yet — keep `mod_pow` as workaround.** |
@@ -154,12 +154,12 @@ These are the gaps vs Python's `decimal.Decimal`, prioritized by user impact.
 
 | Mode              | Python Name       | Status |
 | ----------------- | ----------------- | ------ |
-| `ROUND_DOWN`      | `ROUND_DOWN`      | ✅ Done |
-| `ROUND_UP`        | `ROUND_UP`        | ✅ Done |
-| `ROUND_HALF_UP`   | `ROUND_HALF_UP`   | ✅ Done |
-| `ROUND_HALF_EVEN` | `ROUND_HALF_EVEN` | ✅ Done |
-| `ROUND_CEILING`   | `ROUND_CEILING`   | ✅ Done |
-| `ROUND_FLOOR`     | `ROUND_FLOOR`     | ✅ Done |
+| `ROUND_DOWN`      | `ROUND_DOWN`      | ✓ Done |
+| `ROUND_UP`        | `ROUND_UP`        | ✓ Done |
+| `ROUND_HALF_UP`   | `ROUND_HALF_UP`   | ✓ Done |
+| `ROUND_HALF_EVEN` | `ROUND_HALF_EVEN` | ✓ Done |
+| `ROUND_CEILING`   | `ROUND_CEILING`   | ✓ Done |
+| `ROUND_FLOOR`     | `ROUND_FLOOR`     | ✓ Done |
 
 ### Missing: 2 modes
 
@@ -283,17 +283,17 @@ BigInt has `to_string_with_separators()`. This should be extended to BigDecimal.
 > Updated after audit on 2026-02-27. Items already completed are removed.
 > Last updated: 2026-02-27 (Tier 1 completed).
 
-### ✅ Tier 1: Completed
+### ✓ Tier 1: Completed
 
-1. ✅ **Naming cleanup** — removed old aliases `equals`/`not_equals`/`less_than`/`greater_than`/`less_than_or_equal`/`greater_than_or_equal` from BigDecimal `comparison.mojo`
-2. ✅ **`__rtruediv__()`** on BigDecimal — `1 / some_decimal` now works
-3. ✅ **`is_positive()`** on BigDecimal
-4. ✅ **`number_of_significant_digits()`** and **`number_of_digits()`** on BigDecimal
-5. ✅ **`to_scientific_string()`** and **`to_eng_string()`** on BigDecimal
+1. ✓ **Naming cleanup** — removed old aliases `equals`/`not_equals`/`less_than`/`greater_than`/`less_than_or_equal`/`greater_than_or_equal` from BigDecimal `comparison.mojo`
+2. ✓ **`__rtruediv__()`** on BigDecimal — `1 / some_decimal` now works
+3. ✓ **`is_positive()`** on BigDecimal
+4. ✓ **`number_of_digits()`** on BigDecimal (`number_of_significant_digits()` removed — identical behavior, not a Python API)
+5. ✓ **`to_scientific_string()`** and **`to_eng_string()`** on BigDecimal
 
 ### Tier 2: Important (Remaining)
 
-1. **`as_tuple()`** on BigDecimal — returns `(sign: Bool, coefficient: BigUInt, exponent: Int)`
+1. ✓ **`as_tuple()`** on BigDecimal — returns `(sign: Bool, digits: List[UInt8], exponent: Int)` matching Python's `DecimalTuple`
 2. **`copy_abs()` / `copy_negate()` / `copy_sign(other)`** on BigDecimal
 3. **`adjusted()`** on BigDecimal — returns adjusted exponent (= `exponent + len(digits) - 1`)
 4. **`same_quantum(other)`** on BigDecimal
@@ -342,9 +342,9 @@ For tracking against the above:
 ✓ __mul__          ✓ __ne__           ✓ __neg__          ✓ __pos__
 ✓ __pow__          ✓ __radd__         ✓ __repr__         ✓ __rfloordiv__
 ✓ __rmod__         ✓ __rmul__         ✓ __round__        ✓ __rpow__
-✓ __rsub__         ✗ __rtruediv__     ✓ __str__          ✓ __sub__
+✓ __rsub__         ✓ __rtruediv__     ✓ __str__          ✓ __sub__
 ✓ __truediv__      ✓ __trunc__
-✗ adjusted         ✗ as_integer_ratio ✗ as_tuple         ✗ canonical
+✗ adjusted         ✗ as_integer_ratio ✓ as_tuple         ✗ canonical
 ✓ compare          ✗ conjugate        ✗ copy_abs         ✗ copy_negate
 ✗ copy_sign        ✓ exp              ✗ fma              ✗ is_canonical
 ✗ is_finite        ✓ is_integer       ✗ is_nan           ✗ is_normal
@@ -355,5 +355,5 @@ For tracking against the above:
 ✗ next_plus        ✗ next_toward      ✓ normalize        ✗ number_class
 ✓ quantize         ✗ radix            ✗ remainder_near   ✗ rotate
 ✗ same_quantum     ✗ scaleb           ✗ shift            ✓ sqrt
-△ to_eng_string    ✗ to_integral_exact ✗ to_integral_value
+✓ to_eng_string    ✗ to_integral_exact ✗ to_integral_value
 ```

--- a/tests/bigdecimal/test_bigdecimal_methods.mojo
+++ b/tests/bigdecimal/test_bigdecimal_methods.mojo
@@ -1,0 +1,331 @@
+"""
+Tests for BigDecimal utility methods added in v0.8.x:
+  - is_positive()
+  - __rtruediv__()
+  - to_scientific_string() / to_eng_string()
+  - number_of_digits()
+"""
+
+import testing
+from decimo.bigdecimal.bigdecimal import BigDecimal
+
+
+# ===----------------------------------------------------------------------=== #
+# is_positive()
+# ===----------------------------------------------------------------------=== #
+
+
+fn test_is_positive_positive_values() raises:
+    """Positive values return True."""
+    testing.assert_true(BigDecimal("1").is_positive())
+    testing.assert_true(BigDecimal("0.001").is_positive())
+    testing.assert_true(BigDecimal("999999999999999999").is_positive())
+    testing.assert_true(BigDecimal("1E+50").is_positive())
+
+
+fn test_is_positive_negative_values() raises:
+    """Negative values return False."""
+    testing.assert_false(BigDecimal("-1").is_positive())
+    testing.assert_false(BigDecimal("-0.001").is_positive())
+    testing.assert_false(BigDecimal("-1E+50").is_positive())
+
+
+fn test_is_positive_zero() raises:
+    """Zero is not positive."""
+    testing.assert_false(BigDecimal("0").is_positive())
+    testing.assert_false(BigDecimal("0.000").is_positive())
+
+
+fn test_is_positive_matches_bigint_semantics() raises:
+    """is_positive() is strictly positive (zero excluded), matching BigInt."""
+    var pos = BigDecimal("1")
+    var neg = BigDecimal("-1")
+    var zero = BigDecimal("0")
+    testing.assert_true(pos.is_positive())
+    testing.assert_false(neg.is_positive())
+    testing.assert_false(zero.is_positive())
+    # Consistency: is_positive and is_negative are mutually exclusive, and
+    # both false for zero.
+    testing.assert_false(pos.is_negative())
+    testing.assert_true(neg.is_negative())
+    testing.assert_false(zero.is_negative())
+
+
+# ===----------------------------------------------------------------------=== #
+# __rtruediv__()
+# ===----------------------------------------------------------------------=== #
+
+
+fn test_rtruediv_basic() raises:
+    """Int / BigDecimal dispatches via __rtruediv__."""
+    # 1 / 2  -> 0.5
+    var result = BigDecimal("1") / BigDecimal("2")
+    # Now test __rtruediv__ path: BigDecimal("2").__rtruediv__(BigDecimal("1"))
+    var lhs = BigDecimal("1")
+    var rhs = BigDecimal("2")
+    var r = rhs.__rtruediv__(lhs)
+    testing.assert_equal(String(r), String(result), "1 / 2 via __rtruediv__")
+
+
+fn test_rtruediv_integer_numerator() raises:
+    """Verify 1 / x == x.__rtruediv__(1)."""
+    var x = BigDecimal("4")
+    var expected = BigDecimal("1") / x
+    var got = x.__rtruediv__(BigDecimal("1"))
+    testing.assert_equal(String(got), String(expected))
+
+
+fn test_rtruediv_negative() raises:
+    """-1 / 2 == BigDecimal('2').__rtruediv__(BigDecimal('-1'))."""
+    var x = BigDecimal("2")
+    var got = x.__rtruediv__(BigDecimal("-1"))
+    var expected = BigDecimal("-1") / BigDecimal("2")
+    testing.assert_equal(String(got), String(expected))
+
+
+fn test_rtruediv_symmetry() raises:
+    """a / b == b.__rtruediv__(a) for various pairs."""
+    var pairs = List[Tuple[String, String]]()
+    pairs.append(("10", "3"))
+    pairs.append(("1", "7"))
+    pairs.append(("100", "6"))
+    pairs.append(("-5", "2"))
+    for pair in pairs:
+        var a = BigDecimal(pair[][0])
+        var b = BigDecimal(pair[][1])
+        var direct = a / b
+        var reflected = b.__rtruediv__(a)
+        testing.assert_equal(
+            String(direct),
+            String(reflected),
+            "a/b == b.__rtruediv__(a) for a=" + pair[][0] + ", b=" + pair[][1],
+        )
+
+
+# ===----------------------------------------------------------------------=== #
+# to_scientific_string()
+# ===----------------------------------------------------------------------=== #
+
+
+fn test_to_scientific_string_basic() raises:
+    """Basic scientific notation examples."""
+    testing.assert_equal(
+        BigDecimal("123456.789").to_scientific_string(), "1.23456789E+5"
+    )
+    testing.assert_equal(
+        BigDecimal("0.00123").to_scientific_string(), "1.23E-3"
+    )
+    testing.assert_equal(BigDecimal("1").to_scientific_string(), "1")
+    testing.assert_equal(BigDecimal("10").to_scientific_string(), "1E+1")
+
+
+fn test_to_scientific_string_trailing_zeros_stripped() raises:
+    """Trailing zeros are stripped in scientific notation."""
+    # "1.23000" stored as coefficient=123000, scale=5
+    var v = BigDecimal("1.23000")
+    var s = v.to_scientific_string()
+    # Should not end with trailing zeros
+    testing.assert_equal(s, "1.23E+0")
+
+
+fn test_to_scientific_string_negative() raises:
+    """Negative numbers keep the minus sign."""
+    testing.assert_equal(
+        BigDecimal("-0.00123").to_scientific_string(), "-1.23E-3"
+    )
+
+
+fn test_to_scientific_string_zero() raises:
+    """Zero renders correctly."""
+    testing.assert_equal(BigDecimal("0").to_scientific_string(), "0")
+
+
+# ===----------------------------------------------------------------------=== #
+# to_eng_string()
+# ===----------------------------------------------------------------------=== #
+
+
+fn test_to_eng_string_basic() raises:
+    """Engineering notation: exponent is a multiple of 3."""
+    testing.assert_equal(
+        BigDecimal("123456.789").to_eng_string(), "123.456789E+3"
+    )
+    testing.assert_equal(BigDecimal("0.00123").to_eng_string(), "1.23E-3")
+    testing.assert_equal(BigDecimal("1000000").to_eng_string(), "1E+6")
+
+
+fn test_to_eng_string_trailing_zeros_stripped() raises:
+    """Trailing zeros are stripped in engineering notation."""
+    var v = BigDecimal("1230.00")
+    var s = v.to_eng_string()
+    # Should not have trailing zeros in mantissa
+    testing.assert_false(
+        s.startswith("1230.00"), "trailing zeros should be stripped: " + s
+    )
+
+
+fn test_to_eng_string_negative() raises:
+    """Negative numbers keep the minus sign."""
+    var s = BigDecimal("-123456").to_eng_string()
+    testing.assert_true(s.startswith("-"), "negative sign preserved: " + s)
+
+
+fn test_to_eng_string_is_alias() raises:
+    """to_eng_string() returns the same as to_string(engineering=True)."""
+    var values = List[String]()
+    values.append("123456.789")
+    values.append("0.00123")
+    values.append("-9.99E+10")
+    values.append("0")
+    for v in values:
+        var d = BigDecimal(v[])
+        testing.assert_equal(
+            d.to_eng_string(),
+            d.to_string(engineering=True),
+            "to_eng_string() == to_string(engineering=True) for " + v[],
+        )
+
+
+fn test_to_scientific_string_is_alias() raises:
+    """to_scientific_string() returns the same as to_string(scientific=True)."""
+    var values = List[String]()
+    values.append("123456.789")
+    values.append("0.00123")
+    values.append("-9.99E+10")
+    values.append("0")
+    for v in values:
+        var d = BigDecimal(v[])
+        testing.assert_equal(
+            d.to_scientific_string(),
+            d.to_string(scientific=True),
+            "to_scientific_string() == to_string(scientific=True) for " + v[],
+        )
+
+
+# ===----------------------------------------------------------------------=== #
+# number_of_digits()
+# ===----------------------------------------------------------------------=== #
+
+
+fn test_number_of_digits_basic() raises:
+    """number_of_digits() counts all coefficient digits."""
+    testing.assert_equal(BigDecimal("123.456").number_of_digits(), 6)
+    testing.assert_equal(BigDecimal("0.00123").number_of_digits(), 3)
+    # Trailing zeros in fractional part are stored in the coefficient
+    testing.assert_equal(BigDecimal("100.00").number_of_digits(), 5)
+    testing.assert_equal(BigDecimal("100").number_of_digits(), 3)
+    testing.assert_equal(BigDecimal("1.0000").number_of_digits(), 5)
+
+
+fn test_number_of_digits_zero() raises:
+    """Zero has one digit."""
+    testing.assert_equal(BigDecimal("0").number_of_digits(), 1)
+    testing.assert_equal(BigDecimal("0.0").number_of_digits(), 1)
+
+
+fn test_number_of_digits_after_normalize() raises:
+    """After normalize(), trailing zeros are stripped, reducing digit count."""
+    # "1.0000" normalizes to "1" (coefficient = 1, scale = 0)
+    var one_with_zeros = BigDecimal("1.0000")
+    testing.assert_equal(one_with_zeros.number_of_digits(), 5)
+    var normalized = one_with_zeros.normalize()
+    testing.assert_equal(normalized.number_of_digits(), 1)
+
+
+fn test_number_of_digits_zero_normalize() raises:
+    """Normalizing zero keeps 1 digit."""
+    var z = BigDecimal("0")
+    testing.assert_equal(z.number_of_digits(), 1)
+    var zn = z.normalize()
+    testing.assert_equal(zn.number_of_digits(), 1)
+
+
+fn test_number_of_digits_large_integer() raises:
+    """Large integers keep all digits in the coefficient."""
+    var big = BigDecimal("100")
+    testing.assert_equal(big.number_of_digits(), 3)
+    # normalize() removes trailing zeros: coefficient becomes 1, scale=-2
+    var big_norm = big.normalize()
+    testing.assert_equal(big_norm.number_of_digits(), 1)
+
+
+# ===----------------------------------------------------------------------=== #
+# as_tuple()
+# ===----------------------------------------------------------------------=== #
+
+
+fn test_as_tuple_positive_decimal() raises:
+    """7.25 → (False, [7,2,5], -2)."""
+    var t = BigDecimal("7.25").as_tuple()
+    testing.assert_false(t[0], "sign should be False for positive")
+    testing.assert_equal(len(t[1]), 3, "digits length")
+    testing.assert_equal(Int(t[1][0]), 7)
+    testing.assert_equal(Int(t[1][1]), 2)
+    testing.assert_equal(Int(t[1][2]), 5)
+    testing.assert_equal(t[2], -2, "exponent")
+
+
+fn test_as_tuple_negative_decimal() raises:
+    """-0.001 → (True, [1], -3)."""
+    var t = BigDecimal("-0.001").as_tuple()
+    testing.assert_true(t[0], "sign should be True for negative")
+    testing.assert_equal(len(t[1]), 1)
+    testing.assert_equal(Int(t[1][0]), 1)
+    testing.assert_equal(t[2], -3, "exponent")
+
+
+fn test_as_tuple_integer() raises:
+    """12345 → (False, [1,2,3,4,5], 0)."""
+    var t = BigDecimal("12345").as_tuple()
+    testing.assert_false(t[0])
+    testing.assert_equal(len(t[1]), 5)
+    testing.assert_equal(Int(t[1][0]), 1)
+    testing.assert_equal(Int(t[1][4]), 5)
+    testing.assert_equal(t[2], 0)
+
+
+fn test_as_tuple_scientific_positive_exp() raises:
+    """1E+5 → (False, [1], 5)."""
+    var t = BigDecimal("1E+5").as_tuple()
+    testing.assert_false(t[0])
+    testing.assert_equal(len(t[1]), 1)
+    testing.assert_equal(Int(t[1][0]), 1)
+    testing.assert_equal(t[2], 5)
+
+
+fn test_as_tuple_zero() raises:
+    """0 → (False, [0], 0)."""
+    var t = BigDecimal("0").as_tuple()
+    testing.assert_false(t[0], "zero is not negative")
+    testing.assert_equal(len(t[1]), 1)
+    testing.assert_equal(Int(t[1][0]), 0)
+    testing.assert_equal(t[2], 0)
+
+
+fn test_as_tuple_reconstruct() raises:
+    """Round-trip: reconstruct BigDecimal from (sign, digits, exponent)."""
+    var values = List[String]()
+    values.append("123.456")
+    values.append("-0.001")
+    values.append("12345")
+    values.append("0")
+    for v in values:
+        var d = BigDecimal(v[])
+        var t = d.as_tuple()
+        # Rebuild coefficient string from digit list
+        var coef_str = String()
+        for i in range(len(t[1])):
+            coef_str += String(Int(t[1][i]))
+        # exponent = -scale  =>  scale = -exponent
+        var reconstructed = BigDecimal(
+            BigUInt(coef_str), scale=-t[2], sign=t[0]
+        )
+        testing.assert_equal(
+            String(reconstructed),
+            String(d),
+            "round-trip for " + v[],
+        )
+
+
+fn main() raises:
+    testing.TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Adds a Python-compatible `as_tuple()` API to `BigDecimal` and updates docs/tests to reflect recent BigDecimal utility-method additions/removals.

**Changes:**
- Implement `BigDecimal.as_tuple()` returning `(sign, digits, exponent)` aligned with Python `decimal.Decimal.as_tuple()`.
- Add a new BigDecimal methods test module including coverage for `as_tuple()` and other recently added helpers.
- Update roadmap/README documentation to reflect completed items and version formatting.