### PR TITLE
[decimal] Change `exponent()` to `adjusted()` +  `copy_abs()` + `copy_negate()` + `copy_sign()`

### DIFF
--- a/docs/plans/api_roadmap.md
+++ b/docs/plans/api_roadmap.md
@@ -87,10 +87,10 @@ These are the gaps vs Python's `decimal.Decimal`, prioritized by user impact.
 | Method                              | What It Does                                             | Notes                                                                                                    |
 | ----------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
 | `as_tuple()`                        | Returns `(sign, digits, exponent)`                       | ✓ **DONE** — returns `(sign: Bool, digits: List[UInt8], exponent: Int)` matching Python's `DecimalTuple` |
-| `adjusted()`                        | Returns adjusted exponent (= exponent + len(digits) - 1) | Useful for formatting and comparison.                                                                    |
-| `copy_abs()`                        | Returns `abs(self)`                                      | Alias for `__abs__()`. Trivial to add.                                                                   |
-| `copy_negate()`                     | Returns `-self`                                          | Alias for `__neg__()`. Trivial to add.                                                                   |
-| `copy_sign(other)`                  | Returns self with the sign of other                      | One-liner.                                                                                               |
+| `adjusted()`                        | Returns adjusted exponent (= exponent + len(digits) - 1) | ✅ **DONE** — alias for `exponent()`.                                                                     |
+| `copy_abs()`                        | Returns `abs(self)`                                      | ✅ **DONE** — alias for `__abs__()`.                                                                      |
+| `copy_negate()`                     | Returns `-self`                                          | ✅ **DONE** — alias for `__neg__()`.                                                                      |
+| `copy_sign(other)`                  | Returns self with the sign of other                      | ✅ **DONE**.                                                                                              |
 | `same_quantum(other)`               | True if both have same exponent/scale                    | Useful for financial code.                                                                               |
 | `normalize()`                       | Already exists                                           | ✓                                                                                                        |
 | `to_eng_string()`                   | Engineering notation (exponent multiple of 3)            | ✓ **DONE** — alias for `to_string(engineering=True)`                                                     |
@@ -294,8 +294,8 @@ BigInt has `to_string_with_separators()`. This should be extended to BigDecimal.
 ### Tier 2: Important (Remaining)
 
 1. ✓ **`as_tuple()`** on BigDecimal — returns `(sign: Bool, digits: List[UInt8], exponent: Int)` matching Python's `DecimalTuple`
-2. **`copy_abs()` / `copy_negate()` / `copy_sign(other)`** on BigDecimal
-3. **`adjusted()`** on BigDecimal — returns adjusted exponent (= `exponent + len(digits) - 1`)
+2. ✅ **`copy_abs()` / `copy_negate()` / `copy_sign(other)`** on BigDecimal
+3. ✅ **`adjusted()`** on BigDecimal — renamed from `exponent()` to match Python's `Decimal.adjusted()`
 4. **`same_quantum(other)`** on BigDecimal
 5. **`ROUND_HALF_DOWN`** rounding mode
 6. **`scaleb(n)`** on BigDecimal — multiply by 10^n efficiently
@@ -344,9 +344,9 @@ For tracking against the above:
 ✓ __rmod__         ✓ __rmul__         ✓ __round__        ✓ __rpow__
 ✓ __rsub__         ✓ __rtruediv__     ✓ __str__          ✓ __sub__
 ✓ __truediv__      ✓ __trunc__
-✗ adjusted         ✗ as_integer_ratio ✓ as_tuple         ✗ canonical
-✓ compare          ✗ conjugate        ✗ copy_abs         ✗ copy_negate
-✗ copy_sign        ✓ exp              ✗ fma              ✗ is_canonical
+✓ adjusted         ✗ as_integer_ratio ✓ as_tuple         ✗ canonical
+✓ compare          ✗ conjugate        ✓ copy_abs         ✓ copy_negate
+✓ copy_sign        ✓ exp              ✗ fma              ✗ is_canonical
 ✗ is_finite        ✓ is_integer       ✗ is_nan           ✗ is_normal
 ✗ is_signed        ✗ is_snan          ✗ is_subnormal     ✗ is_qnan
 ✓ ln               ✓ log10            ✗ logb             ✗ logical_and

--- a/docs/plans/api_roadmap.md
+++ b/docs/plans/api_roadmap.md
@@ -87,7 +87,7 @@ These are the gaps vs Python's `decimal.Decimal`, prioritized by user impact.
 | Method                              | What It Does                                             | Notes                                                                                                    |
 | ----------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
 | `as_tuple()`                        | Returns `(sign, digits, exponent)`                       | ✓ **DONE** — returns `(sign: Bool, digits: List[UInt8], exponent: Int)` matching Python's `DecimalTuple` |
-| `adjusted()`                        | Returns adjusted exponent (= exponent + len(digits) - 1) | ✅ **DONE** — alias for `exponent()`.                                                                     |
+| `adjusted()`                        | Returns adjusted exponent (= exponent + len(digits) - 1) | ✅ **DONE** — renamed from former `exponent()` method.                                                    |
 | `copy_abs()`                        | Returns `abs(self)`                                      | ✅ **DONE** — alias for `__abs__()`.                                                                      |
 | `copy_negate()`                     | Returns `-self`                                          | ✅ **DONE** — alias for `__neg__()`.                                                                      |
 | `copy_sign(other)`                  | Returns self with the sign of other                      | ✅ **DONE**.                                                                                              |

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -1355,12 +1355,16 @@ struct BigDecimal(
     # ===------------------------------------------------------------------=== #
 
     fn adjusted(self) -> Int:
-        """Returns the adjusted exponent.
+        """Returns the adjusted exponent, matching Python's
+        `decimal.Decimal.adjusted()`.
 
         This is the exponent of the number when written with a single leading
         digit in scientific notation.  Equivalently,
         `as_tuple_exponent + number_of_digits - 1` where `as_tuple_exponent`
         is `-scale`.
+
+        For zero, the adjusted exponent is always 0 regardless of scale,
+        matching Python's behavior.
 
         Examples:
 
@@ -1369,8 +1373,11 @@ struct BigDecimal(
         BigDecimal("0.00123").adjusted()  # -3  (1.23E-3)
         BigDecimal("100").adjusted()      # 2   (1E+2)
         BigDecimal("1").adjusted()        # 0   (1E0)
+        BigDecimal("0.00").adjusted()     # 0   (zero has no order of magnitude)
         ```
         """
+        if self.coefficient.is_zero():
+            return 0
         return self.coefficient.number_of_digits() - 1 - self.scale
 
     fn as_tuple(self) -> Tuple[Bool, List[UInt8], Int]:

--- a/tests/bigdecimal/test_bigdecimal_methods.mojo
+++ b/tests/bigdecimal/test_bigdecimal_methods.mojo
@@ -420,8 +420,11 @@ fn test_adjusted_basic() raises:
 
 
 fn test_adjusted_zero() raises:
-    """Zero has adjusted exponent 0."""
+    """Zero has adjusted exponent 0 regardless of scale."""
     testing.assert_equal(BigDecimal("0").adjusted(), 0)
+    testing.assert_equal(BigDecimal("0.00").adjusted(), 0)
+    testing.assert_equal(BigDecimal("0.000000").adjusted(), 0)
+    testing.assert_equal(BigDecimal("0E+10").adjusted(), 0)
 
 
 fn test_adjusted_scientific() raises:

--- a/tests/bigdecimal/test_bigdecimal_methods.mojo
+++ b/tests/bigdecimal/test_bigdecimal_methods.mojo
@@ -5,6 +5,8 @@ Tests for BigDecimal utility methods added in v0.8.x:
   - to_scientific_string() / to_eng_string()
   - number_of_digits()
   - as_tuple()
+  - copy_abs() / copy_negate() / copy_sign()
+  - adjusted()
 """
 
 import testing
@@ -319,6 +321,114 @@ fn test_as_tuple_reconstruct() raises:
             String(d),
             "round-trip for " + values[vi],
         )
+
+
+# ===----------------------------------------------------------------------=== #
+# copy_abs() / copy_negate() / copy_sign()
+# ===----------------------------------------------------------------------=== #
+
+
+fn test_copy_abs_positive() raises:
+    """Positive value unchanged."""
+    var x = BigDecimal("3.14")
+    testing.assert_equal(String(x.copy_abs()), "3.14")
+
+
+fn test_copy_abs_negative() raises:
+    """Negative value becomes positive."""
+    var x = BigDecimal("-3.14")
+    testing.assert_equal(String(x.copy_abs()), "3.14")
+
+
+fn test_copy_abs_zero() raises:
+    """Zero stays zero."""
+    testing.assert_equal(String(BigDecimal("0").copy_abs()), "0")
+
+
+fn test_copy_abs_matches_abs() raises:
+    """Verify copy_abs() == abs(x)."""
+    var x = BigDecimal("-42.5")
+    testing.assert_equal(String(x.copy_abs()), String(x.__abs__()))
+
+
+fn test_copy_negate_positive() raises:
+    """Positive becomes negative."""
+    testing.assert_equal(String(BigDecimal("3.14").copy_negate()), "-3.14")
+
+
+fn test_copy_negate_negative() raises:
+    """Negative becomes positive."""
+    testing.assert_equal(String(BigDecimal("-3.14").copy_negate()), "3.14")
+
+
+fn test_copy_negate_zero() raises:
+    """Negating zero."""
+    var z = BigDecimal("0").copy_negate()
+    # Zero negated — coefficient is still 0
+    testing.assert_true(z.is_zero())
+
+
+fn test_copy_negate_matches_neg() raises:
+    """Verify copy_negate() == -x."""
+    var x = BigDecimal("42.5")
+    testing.assert_equal(String(x.copy_negate()), String(x.__neg__()))
+
+
+fn test_copy_sign_positive_to_negative() raises:
+    """Copy sign of negative onto positive value."""
+    var x = BigDecimal("3.14")
+    var y = BigDecimal("-1")
+    testing.assert_equal(String(x.copy_sign(y)), "-3.14")
+
+
+fn test_copy_sign_negative_to_positive() raises:
+    """Copy sign of positive onto negative value."""
+    var x = BigDecimal("-3.14")
+    var y = BigDecimal("1")
+    testing.assert_equal(String(x.copy_sign(y)), "3.14")
+
+
+fn test_copy_sign_same_sign() raises:
+    """Same sign leaves value unchanged."""
+    var x = BigDecimal("3.14")
+    var y = BigDecimal("99")
+    testing.assert_equal(String(x.copy_sign(y)), "3.14")
+
+
+fn test_copy_sign_zero_source() raises:
+    """Zero takes sign of other."""
+    var x = BigDecimal("0")
+    var y = BigDecimal("-5")
+    var result = x.copy_sign(y)
+    # Sign bit set but coefficient is 0
+    testing.assert_true(result.sign)
+    testing.assert_true(result.is_zero())
+
+
+# ===----------------------------------------------------------------------=== #
+# adjusted()
+# ===----------------------------------------------------------------------=== #
+
+
+fn test_adjusted_basic() raises:
+    """Basic adjusted exponent values."""
+    testing.assert_equal(BigDecimal("123.45").adjusted(), 2)
+    testing.assert_equal(BigDecimal("0.00123").adjusted(), -3)
+    testing.assert_equal(BigDecimal("100").adjusted(), 2)
+    testing.assert_equal(BigDecimal("1").adjusted(), 0)
+    testing.assert_equal(BigDecimal("10").adjusted(), 1)
+
+
+fn test_adjusted_zero() raises:
+    """Zero has adjusted exponent 0."""
+    testing.assert_equal(BigDecimal("0").adjusted(), 0)
+
+
+fn test_adjusted_scientific() raises:
+    """Scientific notation inputs."""
+    testing.assert_equal(BigDecimal("1E+5").adjusted(), 5)
+    testing.assert_equal(BigDecimal("1E-5").adjusted(), -5)
+    testing.assert_equal(BigDecimal("1.23E+10").adjusted(), 10)
 
 
 fn main() raises:


### PR DESCRIPTION
Related to Issue #175 .

This PR aligns `BigDecimal`’s API more closely with Python’s `decimal.Decimal` by renaming the scientific-notation exponent helper to `adjusted()` and adding sign-copying convenience methods, then updates internal call sites and documentation/tests accordingly.

**Changes:**
- Rename `BigDecimal.exponent()` to `BigDecimal.adjusted()` and update call sites in exponential math routines. Note that `0.00` now returns 0 rather than 2.
- Add `copy_abs()`, `copy_negate()`, and `copy_sign()` to `BigDecimal`.
- Add/extend tests and update the API roadmap to reflect the new/renamed methods.