### PR TITLE
[mojo] Update the codebase to Mojo v0.26.2

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -170,6 +170,8 @@ jobs:
           echo "$HOME/.pixi/bin" >> $GITHUB_PATH
       - name: pixi install
         run: pixi install
+      - name: Fetch argmojo
+        run: pixi run fetch
       - name: Build CLI binary
         run: pixi run buildcli
       - name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ magic.lock
 tempCodeRunnerFile.mojo
 temp.md
 temp*.mojo
+temp/
 kgen.trace.json*
 # macOS environments
 .DS_Store

--- a/benches/bigdecimal/bench.mojo
+++ b/benches/bigdecimal/bench.mojo
@@ -9,7 +9,7 @@ from bench_bigdecimal_root import main as bench_root
 from bench_bigdecimal_round import main as bench_round
 
 
-fn main() raises:
+def main() raises:
     while True:
         print(
             """

--- a/benches/bigdecimal/bench_bigdecimal_add.mojo
+++ b/benches/bigdecimal/bench_bigdecimal_add.mojo
@@ -10,9 +10,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -23,8 +23,8 @@ fn run_case(
     mut sf: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("a: " + bc.a[:80], log_file)
-    log_print("b: " + bc.b[:80], log_file)
+    log_print("a: " + bc.a[byte=:80], log_file)
+    log_print("b: " + bc.b[byte=:80], log_file)
 
     var m_a = BigDecimal(bc.a)
     var m_b = BigDecimal(bc.b)
@@ -41,20 +41,20 @@ fn run_case(
         # Correctness check: exact string match with Python
         if rm_str != rp_str:
             log_print("*** WARNING: String mismatch detected! ***", log_file)
-            log_print("Decimo result:   " + rm_str[:100], log_file)
-            log_print("Python result:     " + rp_str[:100], log_file)
+            log_print("Decimo result:   " + rm_str[byte=:100], log_file)
+            log_print("Python result:     " + rp_str[byte=:100], log_file)
 
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m_a + m_b
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa + pb
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/bigdecimal/bench_bigdecimal_add.mojo
+++ b/benches/bigdecimal/bench_bigdecimal_add.mojo
@@ -15,7 +15,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     pydecimal: PythonObject,
@@ -67,7 +67,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_bigdecimal_add")
     print_header("Decimo BigDecimal Addition Benchmark", log_file)
 

--- a/benches/bigdecimal/bench_bigdecimal_divide.mojo
+++ b/benches/bigdecimal/bench_bigdecimal_divide.mojo
@@ -21,7 +21,7 @@ comptime ITERATIONS_LARGE = 3
 comptime LARGE_CASE_THRESHOLD = 50  # Cases index >= this use fewer iterations
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     precision: Int,
@@ -74,7 +74,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_bigdecimal_divide")
     print_header("Decimo BigDecimal Division Benchmark", log_file)
 

--- a/benches/bigdecimal/bench_bigdecimal_divide.mojo
+++ b/benches/bigdecimal/bench_bigdecimal_divide.mojo
@@ -12,9 +12,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 comptime ITERATIONS = 100
 comptime ITERATIONS_LARGE = 3
@@ -30,8 +30,8 @@ fn run_case(
     mut sf: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("a: " + bc.a[:80], log_file)
-    log_print("b: " + bc.b[:80], log_file)
+    log_print("a: " + bc.a[byte=:80], log_file)
+    log_print("b: " + bc.b[byte=:80], log_file)
 
     var m_a = BigDecimal(bc.a)
     var m_b = BigDecimal(bc.b)
@@ -48,20 +48,20 @@ fn run_case(
         # Correctness check: exact string match with Python
         if rm_str != rp_str:
             log_print("*** WARNING: String mismatch detected! ***", log_file)
-            log_print("Decimo result:   " + rm_str[:100], log_file)
-            log_print("Python result:     " + rp_str[:100], log_file)
+            log_print("Decimo result:   " + rm_str[byte=:100], log_file)
+            log_print("Python result:     " + rp_str[byte=:100], log_file)
 
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = true_divide_general(m_a, m_b, precision)
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa / pb
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/bigdecimal/bench_bigdecimal_exp.mojo
+++ b/benches/bigdecimal/bench_bigdecimal_exp.mojo
@@ -17,9 +17,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -31,7 +31,7 @@ fn run_case(
     mut sf: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("a: " + bc.a[:80], log_file)
+    log_print("a: " + bc.a[byte=:80], log_file)
 
     var m_a = BigDecimal(bc.a)
     var pa = pydecimal.Decimal(bc.a)
@@ -46,20 +46,20 @@ fn run_case(
         # Correctness check: exact string match with Python
         if rm_str != rp_str:
             log_print("*** WARNING: String mismatch detected! ***", log_file)
-            log_print("Decimo result:   " + rm_str[:100], log_file)
-            log_print("Python result:     " + rp_str[:100], log_file)
+            log_print("Decimo result:   " + rm_str[byte=:100], log_file)
+            log_print("Python result:     " + rp_str[byte=:100], log_file)
 
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m_a.exp(precision)
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa.exp()
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/bigdecimal/bench_bigdecimal_exp.mojo
+++ b/benches/bigdecimal/bench_bigdecimal_exp.mojo
@@ -22,7 +22,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     precision: Int,
@@ -72,7 +72,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_bigdecimal_exp")
     print_header(
         "Decimo BigDecimal Exponential (exp) Multi-Precision Benchmark",

--- a/benches/bigdecimal/bench_bigdecimal_ln.mojo
+++ b/benches/bigdecimal/bench_bigdecimal_ln.mojo
@@ -17,9 +17,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -31,7 +31,7 @@ fn run_case(
     mut sf: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("a: " + bc.a[:80], log_file)
+    log_print("a: " + bc.a[byte=:80], log_file)
 
     var m_a = BigDecimal(bc.a)
     var pa = pydecimal.Decimal(bc.a)
@@ -46,20 +46,20 @@ fn run_case(
         # Correctness check: exact string match with Python
         if rm_str != rp_str:
             log_print("*** WARNING: String mismatch detected! ***", log_file)
-            log_print("Decimo result:   " + rm_str[:100], log_file)
-            log_print("Python result:     " + rp_str[:100], log_file)
+            log_print("Decimo result:   " + rm_str[byte=:100], log_file)
+            log_print("Python result:     " + rp_str[byte=:100], log_file)
 
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m_a.ln(precision)
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa.ln()
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/bigdecimal/bench_bigdecimal_ln.mojo
+++ b/benches/bigdecimal/bench_bigdecimal_ln.mojo
@@ -22,7 +22,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     precision: Int,
@@ -72,7 +72,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_bigdecimal_ln")
     print_header(
         "Decimo BigDecimal Logarithm (ln) Multi-Precision Benchmark", log_file

--- a/benches/bigdecimal/bench_bigdecimal_multiply.mojo
+++ b/benches/bigdecimal/bench_bigdecimal_multiply.mojo
@@ -15,7 +15,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     pydecimal: PythonObject,
@@ -67,7 +67,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_bigdecimal_multiply")
     print_header("Decimo BigDecimal Multiplication Benchmark", log_file)
 

--- a/benches/bigdecimal/bench_bigdecimal_multiply.mojo
+++ b/benches/bigdecimal/bench_bigdecimal_multiply.mojo
@@ -10,9 +10,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -23,8 +23,8 @@ fn run_case(
     mut sf: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("a: " + bc.a[:80], log_file)
-    log_print("b: " + bc.b[:80], log_file)
+    log_print("a: " + bc.a[byte=:80], log_file)
+    log_print("b: " + bc.b[byte=:80], log_file)
 
     var m_a = BigDecimal(bc.a)
     var m_b = BigDecimal(bc.b)
@@ -41,20 +41,20 @@ fn run_case(
         # Correctness check: exact string match with Python
         if rm_str != rp_str:
             log_print("*** WARNING: String mismatch detected! ***", log_file)
-            log_print("Decimo result:   " + rm_str[:100], log_file)
-            log_print("Python result:     " + rp_str[:100], log_file)
+            log_print("Decimo result:   " + rm_str[byte=:100], log_file)
+            log_print("Python result:     " + rp_str[byte=:100], log_file)
 
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m_a * m_b
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa * pb
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/bigdecimal/bench_bigdecimal_root.mojo
+++ b/benches/bigdecimal/bench_bigdecimal_root.mojo
@@ -17,9 +17,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -31,8 +31,8 @@ fn run_case(
     mut sf: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("a: " + bc.a[:80], log_file)
-    log_print("b (root index): " + bc.b[:80], log_file)
+    log_print("a: " + bc.a[byte=:80], log_file)
+    log_print("b (root index): " + bc.b[byte=:80], log_file)
 
     var m_a = BigDecimal(bc.a)
     var m_n = BigDecimal(bc.b)
@@ -50,20 +50,20 @@ fn run_case(
         # Correctness check: exact string match with Python
         if rm_str != rp_str:
             log_print("*** WARNING: String mismatch detected! ***", log_file)
-            log_print("Decimo result:   " + rm_str[:100], log_file)
-            log_print("Python result:     " + rp_str[:100], log_file)
+            log_print("Decimo result:   " + rm_str[byte=:100], log_file)
+            log_print("Python result:     " + rp_str[byte=:100], log_file)
 
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m_a.root(m_n, precision)
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa.__pow__(py_reciprocal)
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/bigdecimal/bench_bigdecimal_root.mojo
+++ b/benches/bigdecimal/bench_bigdecimal_root.mojo
@@ -22,7 +22,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     precision: Int,
@@ -76,7 +76,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_bigdecimal_root")
     print_header(
         "Decimo BigDecimal Root (nth root) Multi-Precision Benchmark",

--- a/benches/bigdecimal/bench_bigdecimal_round.mojo
+++ b/benches/bigdecimal/bench_bigdecimal_round.mojo
@@ -16,7 +16,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn parse_rounding_mode(mode_str: String) raises -> RoundingMode:
+def parse_rounding_mode(mode_str: String) raises -> RoundingMode:
     """Parse a rounding mode string to RoundingMode enum."""
     if mode_str == "ROUND_DOWN":
         return RoundingMode.ROUND_DOWN
@@ -30,7 +30,7 @@ fn parse_rounding_mode(mode_str: String) raises -> RoundingMode:
         raise Error("Unknown rounding mode: " + mode_str)
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     pydecimal: PythonObject,
@@ -103,7 +103,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_bigdecimal_round")
     print_header("Decimo BigDecimal Rounding Benchmark", log_file)
 

--- a/benches/bigdecimal/bench_bigdecimal_round.mojo
+++ b/benches/bigdecimal/bench_bigdecimal_round.mojo
@@ -11,9 +11,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn parse_rounding_mode(mode_str: String) raises -> RoundingMode:
@@ -38,7 +38,7 @@ fn run_case(
     mut sf: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("a: " + bc.a[:80], log_file)
+    log_print("a: " + bc.a[byte=:80], log_file)
     log_print("b: " + bc.b, log_file)
 
     # Parse b field: "ndigits|ROUNDING_MODE"
@@ -77,20 +77,20 @@ fn run_case(
         # Correctness check: exact string match with Python
         if rm_str != rp_str:
             log_print("*** WARNING: String mismatch detected! ***", log_file)
-            log_print("Decimo result:   " + rm_str[:100], log_file)
-            log_print("Python result:     " + rp_str[:100], log_file)
+            log_print("Decimo result:   " + rm_str[byte=:100], log_file)
+            log_print("Python result:     " + rp_str[byte=:100], log_file)
 
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m_a.round(ndigits, mode)
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa.__round__(ndigits)
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/bigdecimal/bench_bigdecimal_sqrt.mojo
+++ b/benches/bigdecimal/bench_bigdecimal_sqrt.mojo
@@ -12,9 +12,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -26,7 +26,7 @@ fn run_case(
     mut sf: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("a: " + bc.a[:80], log_file)
+    log_print("a: " + bc.a[byte=:80], log_file)
 
     var m_a = BigDecimal(bc.a)
     var pa = pydecimal.Decimal(bc.a)
@@ -41,20 +41,20 @@ fn run_case(
         # Correctness check: exact string match with Python
         if rm_str != rp_str:
             log_print("*** WARNING: String mismatch detected! ***", log_file)
-            log_print("Decimo result:   " + rm_str[:100], log_file)
-            log_print("Python result:     " + rp_str[:100], log_file)
+            log_print("Decimo result:   " + rm_str[byte=:100], log_file)
+            log_print("Python result:     " + rp_str[byte=:100], log_file)
 
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m_a.sqrt(precision=precision)
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa.sqrt()
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/bigdecimal/bench_bigdecimal_sqrt.mojo
+++ b/benches/bigdecimal/bench_bigdecimal_sqrt.mojo
@@ -17,7 +17,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     precision: Int,
@@ -67,7 +67,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_bigdecimal_sqrt")
     print_header("Decimo BigDecimal Square Root Benchmark", log_file)
 

--- a/benches/bigdecimal/bench_bigdecimal_subtract.mojo
+++ b/benches/bigdecimal/bench_bigdecimal_subtract.mojo
@@ -10,9 +10,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -23,8 +23,8 @@ fn run_case(
     mut sf: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("a: " + bc.a[:80], log_file)
-    log_print("b: " + bc.b[:80], log_file)
+    log_print("a: " + bc.a[byte=:80], log_file)
+    log_print("b: " + bc.b[byte=:80], log_file)
 
     var m_a = BigDecimal(bc.a)
     var m_b = BigDecimal(bc.b)
@@ -41,20 +41,20 @@ fn run_case(
         # Correctness check: exact string match with Python
         if rm_str != rp_str:
             log_print("*** WARNING: String mismatch detected! ***", log_file)
-            log_print("Decimo result:   " + rm_str[:100], log_file)
-            log_print("Python result:     " + rp_str[:100], log_file)
+            log_print("Decimo result:   " + rm_str[byte=:100], log_file)
+            log_print("Python result:     " + rp_str[byte=:100], log_file)
 
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m_a - m_b
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa - pb
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/bigdecimal/bench_bigdecimal_subtract.mojo
+++ b/benches/bigdecimal/bench_bigdecimal_subtract.mojo
@@ -15,7 +15,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     pydecimal: PythonObject,
@@ -67,7 +67,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_bigdecimal_subtract")
     print_header("Decimo BigDecimal Subtraction Benchmark", log_file)
 

--- a/benches/bigint/bench.mojo
+++ b/benches/bigint/bench.mojo
@@ -11,7 +11,7 @@ from bench_to_string import main as bench_to_string
 from bench_shift import main as bench_shift
 
 
-fn main() raises:
+def main() raises:
     while True:
         print(
             """

--- a/benches/bigint/bench_add.mojo
+++ b/benches/bigint/bench_add.mojo
@@ -18,7 +18,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     log_file: PythonObject,
@@ -87,7 +87,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var pysys = Python.import_module("sys")
     pysys.set_int_max_str_digits(10000000)
 

--- a/benches/bigint/bench_add.mojo
+++ b/benches/bigint/bench_add.mojo
@@ -13,9 +13,9 @@ from decimo.tests import (
     print_header,
     print_summary_dual,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -26,8 +26,8 @@ fn run_case(
     mut sf_bigint: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("a: " + bc.a[:80], log_file)
-    log_print("b: " + bc.b[:80], log_file)
+    log_print("a: " + bc.a[byte=:80], log_file)
+    log_print("b: " + bc.b[byte=:80], log_file)
 
     var m1a = BigInt10(bc.a)
     var m1b = BigInt10(bc.b)
@@ -49,28 +49,28 @@ fn run_case(
         # Correctness check: string match
         if r1_str != rp_str or r2_str != rp_str:
             log_print("*** WARNING: String mismatch detected! ***", log_file)
-            log_print("BigInt10 result: " + r1_str[:120], log_file)
-            log_print("BigInt result:  " + r2_str[:120], log_file)
-            log_print("Python result:   " + rp_str[:120], log_file)
+            log_print("BigInt10 result: " + r1_str[byte=:120], log_file)
+            log_print("BigInt result:  " + r2_str[byte=:120], log_file)
+            log_print("Python result:   " + rp_str[byte=:120], log_file)
 
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m1a + m1b
-        var t1 = (perf_counter_ns() - t0) / iterations
+        var t1 = (perf_counter_ns() - t0) / UInt(iterations)
         if t1 == 0:
             t1 = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m2a + m2b
-        var t2 = (perf_counter_ns() - t0) / iterations
+        var t2 = (perf_counter_ns() - t0) / UInt(iterations)
         if t2 == 0:
             t2 = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa + pb
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s1 = Float64(tp) / Float64(t1)
         var s2 = Float64(tp) / Float64(t2)

--- a/benches/bigint/bench_floor_divide.mojo
+++ b/benches/bigint/bench_floor_divide.mojo
@@ -13,9 +13,9 @@ from decimo.tests import (
     print_header,
     print_summary_dual,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -26,8 +26,8 @@ fn run_case(
     mut sf_bigint: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("a: " + bc.a[:80], log_file)
-    log_print("b: " + bc.b[:80], log_file)
+    log_print("a: " + bc.a[byte=:80], log_file)
+    log_print("b: " + bc.b[byte=:80], log_file)
 
     var m1a = BigInt10(bc.a)
     var m1b = BigInt10(bc.b)
@@ -49,28 +49,28 @@ fn run_case(
         # Correctness check: string match
         if r1_str != rp_str or r2_str != rp_str:
             log_print("*** WARNING: String mismatch detected! ***", log_file)
-            log_print("BigInt10 result: " + r1_str[:80], log_file)
-            log_print("BigInt result:  " + r2_str[:80], log_file)
-            log_print("Python result:   " + rp_str[:80], log_file)
+            log_print("BigInt10 result: " + r1_str[byte=:80], log_file)
+            log_print("BigInt result:  " + r2_str[byte=:80], log_file)
+            log_print("Python result:   " + rp_str[byte=:80], log_file)
 
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = decimo.bigint10.arithmetics.floor_divide(m1a, m1b)
-        var t1 = (perf_counter_ns() - t0) / iterations
+        var t1 = (perf_counter_ns() - t0) / UInt(iterations)
         if t1 == 0:
             t1 = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = decimo.bigint.arithmetics.floor_divide(m2a, m2b)
-        var t2 = (perf_counter_ns() - t0) / iterations
+        var t2 = (perf_counter_ns() - t0) / UInt(iterations)
         if t2 == 0:
             t2 = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa // pb
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s1 = Float64(tp) / Float64(t1)
         var s2 = Float64(tp) / Float64(t2)

--- a/benches/bigint/bench_floor_divide.mojo
+++ b/benches/bigint/bench_floor_divide.mojo
@@ -18,7 +18,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     log_file: PythonObject,
@@ -87,7 +87,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var pysys = Python.import_module("sys")
     pysys.set_int_max_str_digits(10000000)
 

--- a/benches/bigint/bench_from_string.mojo
+++ b/benches/bigint/bench_from_string.mojo
@@ -11,9 +11,9 @@ from decimo.tests import (
     print_header,
     print_summary_dual,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -24,7 +24,9 @@ fn run_case(
     mut sf_bigint: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("a: " + bc.a[:80] + (" ..." if len(bc.a) > 80 else ""), log_file)
+    log_print(
+        "a: " + bc.a[byte=:80] + (" ..." if len(bc.a) > 80 else ""), log_file
+    )
     log_print("digits:          " + String(len(bc.a)), log_file)
 
     var py = Python.import_module("builtins")
@@ -33,21 +35,21 @@ fn run_case(
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = BigInt10(bc.a)
-        var t1 = (perf_counter_ns() - t0) / iterations
+        var t1 = (perf_counter_ns() - t0) / UInt(iterations)
         if t1 == 0:
             t1 = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = BigInt(bc.a)
-        var t2 = (perf_counter_ns() - t0) / iterations
+        var t2 = (perf_counter_ns() - t0) / UInt(iterations)
         if t2 == 0:
             t2 = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = py.int(bc.a)
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s1 = Float64(tp) / Float64(t1)
         var s2 = Float64(tp) / Float64(t2)

--- a/benches/bigint/bench_from_string.mojo
+++ b/benches/bigint/bench_from_string.mojo
@@ -16,7 +16,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     log_file: PythonObject,
@@ -66,7 +66,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var pysys = Python.import_module("sys")
     pysys.set_int_max_str_digits(10000000)
 

--- a/benches/bigint/bench_multiply.mojo
+++ b/benches/bigint/bench_multiply.mojo
@@ -13,9 +13,9 @@ from decimo.tests import (
     print_header,
     print_summary_dual,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -26,8 +26,8 @@ fn run_case(
     mut sf_bigint: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("a: " + bc.a[:80], log_file)
-    log_print("b: " + bc.b[:80], log_file)
+    log_print("a: " + bc.a[byte=:80], log_file)
+    log_print("b: " + bc.b[byte=:80], log_file)
 
     var m1a = BigInt10(bc.a)
     var m1b = BigInt10(bc.b)
@@ -49,28 +49,28 @@ fn run_case(
         # Correctness check: string match
         if r1_str != rp_str or r2_str != rp_str:
             log_print("*** WARNING: String mismatch detected! ***", log_file)
-            log_print("BigInt10 result: " + r1_str[:80], log_file)
-            log_print("BigInt result:  " + r2_str[:80], log_file)
-            log_print("Python result:   " + rp_str[:80], log_file)
+            log_print("BigInt10 result: " + r1_str[byte=:80], log_file)
+            log_print("BigInt result:  " + r2_str[byte=:80], log_file)
+            log_print("Python result:   " + rp_str[byte=:80], log_file)
 
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m1a * m1b
-        var t1 = (perf_counter_ns() - t0) / iterations
+        var t1 = (perf_counter_ns() - t0) / UInt(iterations)
         if t1 == 0:
             t1 = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m2a * m2b
-        var t2 = (perf_counter_ns() - t0) / iterations
+        var t2 = (perf_counter_ns() - t0) / UInt(iterations)
         if t2 == 0:
             t2 = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa * pb
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s1 = Float64(tp) / Float64(t1)
         var s2 = Float64(tp) / Float64(t2)

--- a/benches/bigint/bench_multiply.mojo
+++ b/benches/bigint/bench_multiply.mojo
@@ -18,7 +18,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     log_file: PythonObject,
@@ -87,7 +87,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var pysys = Python.import_module("sys")
     pysys.set_int_max_str_digits(10000000)
 

--- a/benches/bigint/bench_power.mojo
+++ b/benches/bigint/bench_power.mojo
@@ -12,9 +12,9 @@ from decimo.tests import (
     print_header,
     print_summary_dual,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -25,8 +25,8 @@ fn run_case(
     mut sf_bigint: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("base: " + bc.a[:80], log_file)
-    log_print("exp:  " + bc.b[:80], log_file)
+    log_print("base: " + bc.a[byte=:80], log_file)
+    log_print("exp:  " + bc.b[byte=:80], log_file)
 
     var m1_base = BigInt10(bc.a)
     var base = BigInt(bc.a)
@@ -47,28 +47,28 @@ fn run_case(
         # Correctness check: string match
         if r1_str != rp_str or r2_str != rp_str:
             log_print("*** WARNING: String mismatch detected! ***", log_file)
-            log_print("BigInt10 result: " + r1_str[:80], log_file)
-            log_print("BigInt result:  " + r2_str[:80], log_file)
-            log_print("Python result:   " + rp_str[:80], log_file)
+            log_print("BigInt10 result: " + r1_str[byte=:80], log_file)
+            log_print("BigInt result:  " + r2_str[byte=:80], log_file)
+            log_print("Python result:   " + rp_str[byte=:80], log_file)
 
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m1_base.power(exp_int)
-        var t1 = (perf_counter_ns() - t0) / iterations
+        var t1 = (perf_counter_ns() - t0) / UInt(iterations)
         if t1 == 0:
             t1 = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = base**exp_int
-        var t2 = (perf_counter_ns() - t0) / iterations
+        var t2 = (perf_counter_ns() - t0) / UInt(iterations)
         if t2 == 0:
             t2 = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa**pb
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s1 = Float64(tp) / Float64(t1)
         var s2 = Float64(tp) / Float64(t2)

--- a/benches/bigint/bench_power.mojo
+++ b/benches/bigint/bench_power.mojo
@@ -17,7 +17,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     log_file: PythonObject,
@@ -85,7 +85,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var pysys = Python.import_module("sys")
     pysys.set_int_max_str_digits(10000000)
 

--- a/benches/bigint/bench_shift.mojo
+++ b/benches/bigint/bench_shift.mojo
@@ -11,9 +11,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -23,7 +23,9 @@ fn run_case(
     mut sf: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("a: " + bc.a[:80] + (" ..." if len(bc.a) > 80 else ""), log_file)
+    log_print(
+        "a: " + bc.a[byte=:80] + (" ..." if len(bc.a) > 80 else ""), log_file
+    )
     log_print("shift: " + bc.b, log_file)
 
     var m2a = BigInt(bc.a)
@@ -42,20 +44,20 @@ fn run_case(
         # Correctness check: string match
         if r2_str != rp_str:
             log_print("*** WARNING: String mismatch detected! ***", log_file)
-            log_print("BigInt result:  " + r2_str[:80], log_file)
-            log_print("Python result:   " + rp_str[:80], log_file)
+            log_print("BigInt result:  " + r2_str[byte=:80], log_file)
+            log_print("Python result:   " + rp_str[byte=:80], log_file)
 
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m2a << shift
-        var t2 = (perf_counter_ns() - t0) / iterations
+        var t2 = (perf_counter_ns() - t0) / UInt(iterations)
         if t2 == 0:
             t2 = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa << pb
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s2 = Float64(tp) / Float64(t2)
         sf.append(s2)

--- a/benches/bigint/bench_shift.mojo
+++ b/benches/bigint/bench_shift.mojo
@@ -16,7 +16,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     log_file: PythonObject,
@@ -70,7 +70,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var pysys = Python.import_module("sys")
     pysys.set_int_max_str_digits(10000000)
 

--- a/benches/bigint/bench_sqrt.mojo
+++ b/benches/bigint/bench_sqrt.mojo
@@ -13,9 +13,9 @@ from decimo.tests import (
     print_header,
     print_summary_dual,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -26,7 +26,9 @@ fn run_case(
     mut sf_bigint: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("a: " + bc.a[:80] + (" ..." if len(bc.a) > 80 else ""), log_file)
+    log_print(
+        "a: " + bc.a[byte=:80] + (" ..." if len(bc.a) > 80 else ""), log_file
+    )
 
     var m1a = BigUInt(bc.a)
     var m2a = BigInt(bc.a)
@@ -46,28 +48,28 @@ fn run_case(
         # Correctness check: string match
         if r1_str != rp_str or r2_str != rp_str:
             log_print("*** WARNING: String mismatch detected! ***", log_file)
-            log_print("BigUInt result:  " + r1_str[:80], log_file)
-            log_print("BigInt result:  " + r2_str[:80], log_file)
-            log_print("Python result:   " + rp_str[:80], log_file)
+            log_print("BigUInt result:  " + r1_str[byte=:80], log_file)
+            log_print("BigInt result:  " + r2_str[byte=:80], log_file)
+            log_print("Python result:   " + rp_str[byte=:80], log_file)
 
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m1a.sqrt()
-        var t1 = (perf_counter_ns() - t0) / iterations
+        var t1 = (perf_counter_ns() - t0) / UInt(iterations)
         if t1 == 0:
             t1 = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m2a.sqrt()
-        var t2 = (perf_counter_ns() - t0) / iterations
+        var t2 = (perf_counter_ns() - t0) / UInt(iterations)
         if t2 == 0:
             t2 = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = math_mod.isqrt(pa)
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s1 = Float64(tp) / Float64(t1)
         var s2 = Float64(tp) / Float64(t2)

--- a/benches/bigint/bench_sqrt.mojo
+++ b/benches/bigint/bench_sqrt.mojo
@@ -18,7 +18,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     log_file: PythonObject,
@@ -86,7 +86,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var pysys = Python.import_module("sys")
     pysys.set_int_max_str_digits(10000000)
 

--- a/benches/bigint/bench_to_string.mojo
+++ b/benches/bigint/bench_to_string.mojo
@@ -16,7 +16,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     log_file: PythonObject,
@@ -72,7 +72,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var pysys = Python.import_module("sys")
     pysys.set_int_max_str_digits(10000000)
 

--- a/benches/bigint/bench_to_string.mojo
+++ b/benches/bigint/bench_to_string.mojo
@@ -11,9 +11,9 @@ from decimo.tests import (
     print_header,
     print_summary_dual,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -41,21 +41,21 @@ fn run_case(
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = String(m1)
-        var t1 = (perf_counter_ns() - t0) / iterations
+        var t1 = (perf_counter_ns() - t0) / UInt(iterations)
         if t1 == 0:
             t1 = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = String(m2)
-        var t2 = (perf_counter_ns() - t0) / iterations
+        var t2 = (perf_counter_ns() - t0) / UInt(iterations)
         if t2 == 0:
             t2 = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = py.str(pa)
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s1 = Float64(tp) / Float64(t1)
         var s2 = Float64(tp) / Float64(t2)

--- a/benches/bigint/bench_truncate_divide.mojo
+++ b/benches/bigint/bench_truncate_divide.mojo
@@ -13,9 +13,9 @@ from decimo.tests import (
     print_header,
     print_summary_dual,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -26,8 +26,8 @@ fn run_case(
     mut sf_bigint: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("a: " + bc.a[:80], log_file)
-    log_print("b: " + bc.b[:80], log_file)
+    log_print("a: " + bc.a[byte=:80], log_file)
+    log_print("b: " + bc.b[byte=:80], log_file)
 
     var m1a = BigInt10(bc.a)
     var m1b = BigInt10(bc.b)
@@ -49,28 +49,28 @@ fn run_case(
         # Correctness check: string match
         if r1_str != rp_str or r2_str != rp_str:
             log_print("*** WARNING: String mismatch detected! ***", log_file)
-            log_print("BigInt10 result: " + r1_str[:120], log_file)
-            log_print("BigInt result:  " + r2_str[:120], log_file)
-            log_print("Python result:   " + rp_str[:120], log_file)
+            log_print("BigInt10 result: " + r1_str[byte=:120], log_file)
+            log_print("BigInt result:  " + r2_str[byte=:120], log_file)
+            log_print("Python result:   " + rp_str[byte=:120], log_file)
 
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m1a.truncate_divide(m1b)
-        var t1 = (perf_counter_ns() - t0) / iterations
+        var t1 = (perf_counter_ns() - t0) / UInt(iterations)
         if t1 == 0:
             t1 = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m2a.truncate_divide(m2b)
-        var t2 = (perf_counter_ns() - t0) / iterations
+        var t2 = (perf_counter_ns() - t0) / UInt(iterations)
         if t2 == 0:
             t2 = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa // pb
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s1 = Float64(tp) / Float64(t1)
         var s2 = Float64(tp) / Float64(t2)

--- a/benches/bigint/bench_truncate_divide.mojo
+++ b/benches/bigint/bench_truncate_divide.mojo
@@ -18,7 +18,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     log_file: PythonObject,
@@ -87,7 +87,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var pysys = Python.import_module("sys")
     pysys.set_int_max_str_digits(10000000)
 

--- a/benches/biguint/bench.mojo
+++ b/benches/biguint/bench.mojo
@@ -9,7 +9,7 @@ from bench_biguint_divide_complexity import main as bench_div_complexity
 from bench_biguint_multiply_complexity import main as bench_mul_complexity
 
 
-fn main() raises:
+def main() raises:
     while True:
         print(
             """

--- a/benches/biguint/bench_biguint_add.mojo
+++ b/benches/biguint/bench_biguint_add.mojo
@@ -16,7 +16,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     log_file: PythonObject,
@@ -68,7 +68,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var pysys = Python.import_module("sys")
     pysys.set_int_max_str_digits(10000000)
 

--- a/benches/biguint/bench_biguint_add.mojo
+++ b/benches/biguint/bench_biguint_add.mojo
@@ -11,9 +11,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -23,8 +23,8 @@ fn run_case(
     mut sf: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("a: " + bc.a[:80], log_file)
-    log_print("b: " + bc.b[:80], log_file)
+    log_print("a: " + bc.a[byte=:80], log_file)
+    log_print("b: " + bc.b[byte=:80], log_file)
 
     var m_a = BigUInt(bc.a)
     var m_b = BigUInt(bc.b)
@@ -42,20 +42,20 @@ fn run_case(
         # Correctness check: string match
         if rm_str != rp_str:
             log_print("*** WARNING: String mismatch detected! ***", log_file)
-            log_print("BigUInt result:  " + rm_str[:120], log_file)
-            log_print("Python result:   " + rp_str[:120], log_file)
+            log_print("BigUInt result:  " + rm_str[byte=:120], log_file)
+            log_print("Python result:   " + rp_str[byte=:120], log_file)
 
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m_a + m_b
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa + pb
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/biguint/bench_biguint_divide_complexity.mojo
+++ b/benches/biguint/bench_biguint_divide_complexity.mojo
@@ -12,7 +12,7 @@ from std.python import Python, PythonObject
 from std.collections import List
 
 
-fn create_test_biguint(num_words: Int) raises -> BigUInt:
+def create_test_biguint(num_words: Int) raises -> BigUInt:
     """Creates a BigUInt with the specified number of words filled with test
     values."""
     var words = List[UInt32](capacity=num_words)
@@ -24,7 +24,7 @@ fn create_test_biguint(num_words: Int) raises -> BigUInt:
     return BigUInt(words=words^)
 
 
-fn benchmark_divide_at_size(
+def benchmark_divide_at_size(
     dividend_words: Int,
     divisor_words: Int,
     iterations: Int,
@@ -72,7 +72,7 @@ fn benchmark_divide_at_size(
     return avg
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_divide_complexity")
     print_header("Decimo BigUInt Division Time Complexity Benchmark", log_file)
 

--- a/benches/biguint/bench_biguint_divide_complexity.mojo
+++ b/benches/biguint/bench_biguint_divide_complexity.mojo
@@ -4,12 +4,12 @@ Tests word sizes from 32 to 2^18 words (powers of 2).
 Cases are generated programmatically — no TOML data file.
 """
 
-from time import perf_counter_ns
+from std.time import perf_counter_ns
 from decimo import BigUInt
 from decimo.biguint.arithmetics import floor_divide
 from decimo.tests import open_log_file, log_print, print_header
-from python import Python, PythonObject
-from collections import List
+from std.python import Python, PythonObject
+from std.collections import List
 
 
 fn create_test_biguint(num_words: Int) raises -> BigUInt:

--- a/benches/biguint/bench_biguint_from_string.mojo
+++ b/benches/biguint/bench_biguint_from_string.mojo
@@ -11,9 +11,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -23,7 +23,7 @@ fn run_case(
     mut sf: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("a: " + bc.a[:80], log_file)
+    log_print("a: " + bc.a[byte=:80], log_file)
 
     var py = Python.import_module("builtins")
 
@@ -37,20 +37,20 @@ fn run_case(
         # Correctness check: string match
         if rm_str != rp_str:
             log_print("*** WARNING: String mismatch detected! ***", log_file)
-            log_print("BigUInt result:  " + rm_str[:120], log_file)
-            log_print("Python result:   " + rp_str[:120], log_file)
+            log_print("BigUInt result:  " + rm_str[byte=:120], log_file)
+            log_print("Python result:   " + rp_str[byte=:120], log_file)
 
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = BigUInt(bc.a)
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = py.int(bc.a)
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/biguint/bench_biguint_from_string.mojo
+++ b/benches/biguint/bench_biguint_from_string.mojo
@@ -16,7 +16,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     log_file: PythonObject,
@@ -63,7 +63,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var pysys = Python.import_module("sys")
     pysys.set_int_max_str_digits(10000000)
 

--- a/benches/biguint/bench_biguint_multiply.mojo
+++ b/benches/biguint/bench_biguint_multiply.mojo
@@ -11,9 +11,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -23,8 +23,8 @@ fn run_case(
     mut sf: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("a: " + bc.a[:80], log_file)
-    log_print("b: " + bc.b[:80], log_file)
+    log_print("a: " + bc.a[byte=:80], log_file)
+    log_print("b: " + bc.b[byte=:80], log_file)
 
     var m_a = BigUInt(bc.a)
     var m_b = BigUInt(bc.b)
@@ -42,20 +42,20 @@ fn run_case(
         # Correctness check: string match
         if rm_str != rp_str:
             log_print("*** WARNING: String mismatch detected! ***", log_file)
-            log_print("BigUInt result:  " + rm_str[:120], log_file)
-            log_print("Python result:   " + rp_str[:120], log_file)
+            log_print("BigUInt result:  " + rm_str[byte=:120], log_file)
+            log_print("Python result:   " + rp_str[byte=:120], log_file)
 
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m_a * m_b
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa * pb
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/biguint/bench_biguint_multiply.mojo
+++ b/benches/biguint/bench_biguint_multiply.mojo
@@ -16,7 +16,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     log_file: PythonObject,
@@ -68,7 +68,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var pysys = Python.import_module("sys")
     pysys.set_int_max_str_digits(10000000)
 

--- a/benches/biguint/bench_biguint_multiply_complexity.mojo
+++ b/benches/biguint/bench_biguint_multiply_complexity.mojo
@@ -12,7 +12,7 @@ from std.python import Python, PythonObject
 from std.collections import List
 
 
-fn create_test_biguint(num_words: Int) raises -> BigUInt:
+def create_test_biguint(num_words: Int) raises -> BigUInt:
     """Creates a BigUInt with the specified number of words filled with test
     values."""
     var words = List[UInt32](capacity=num_words)
@@ -24,7 +24,7 @@ fn create_test_biguint(num_words: Int) raises -> BigUInt:
     return BigUInt(words=words^)
 
 
-fn benchmark_multiply_at_size(
+def benchmark_multiply_at_size(
     num_words: Int, iterations: Int, log_file: PythonObject
 ) raises -> Float64:
     """Benchmarks multiplication for a specific word size."""
@@ -60,7 +60,7 @@ fn benchmark_multiply_at_size(
     return avg
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_multiply_complexity")
     print_header(
         "Decimo BigUInt Multiplication Time Complexity Benchmark", log_file

--- a/benches/biguint/bench_biguint_multiply_complexity.mojo
+++ b/benches/biguint/bench_biguint_multiply_complexity.mojo
@@ -4,12 +4,12 @@ Tests word sizes from 8 to 262144 words (powers of 2).
 Cases are generated programmatically — no TOML data file.
 """
 
-from time import perf_counter_ns
+from std.time import perf_counter_ns
 from decimo import BigUInt
 from decimo.biguint.arithmetics import multiply
 from decimo.tests import open_log_file, log_print, print_header
-from python import Python, PythonObject
-from collections import List
+from std.python import Python, PythonObject
+from std.collections import List
 
 
 fn create_test_biguint(num_words: Int) raises -> BigUInt:

--- a/benches/biguint/bench_biguint_sqrt.mojo
+++ b/benches/biguint/bench_biguint_sqrt.mojo
@@ -16,7 +16,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     log_file: PythonObject,
@@ -66,7 +66,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var pysys = Python.import_module("sys")
     pysys.set_int_max_str_digits(10000000)
 

--- a/benches/biguint/bench_biguint_sqrt.mojo
+++ b/benches/biguint/bench_biguint_sqrt.mojo
@@ -11,9 +11,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -23,7 +23,7 @@ fn run_case(
     mut sf: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("a: " + bc.a[:80], log_file)
+    log_print("a: " + bc.a[byte=:80], log_file)
 
     var m_a = BigUInt(bc.a)
     var py = Python.import_module("builtins")
@@ -40,20 +40,20 @@ fn run_case(
         # Correctness check: string match
         if rm_str != rp_str:
             log_print("*** WARNING: String mismatch detected! ***", log_file)
-            log_print("BigUInt result:  " + rm_str[:120], log_file)
-            log_print("Python result:   " + rp_str[:120], log_file)
+            log_print("BigUInt result:  " + rm_str[byte=:120], log_file)
+            log_print("Python result:   " + rp_str[byte=:120], log_file)
 
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = String(decimo.biguint.exponential.sqrt(m_a))
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = py.str(math.isqrt(pa))
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/biguint/bench_biguint_subtraction.mojo
+++ b/benches/biguint/bench_biguint_subtraction.mojo
@@ -16,7 +16,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     log_file: PythonObject,
@@ -68,7 +68,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var pysys = Python.import_module("sys")
     pysys.set_int_max_str_digits(10000000)
 

--- a/benches/biguint/bench_biguint_subtraction.mojo
+++ b/benches/biguint/bench_biguint_subtraction.mojo
@@ -11,9 +11,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -23,8 +23,8 @@ fn run_case(
     mut sf: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("a: " + bc.a[:80], log_file)
-    log_print("b: " + bc.b[:80], log_file)
+    log_print("a: " + bc.a[byte=:80], log_file)
+    log_print("b: " + bc.b[byte=:80], log_file)
 
     var m_a = BigUInt(bc.a)
     var m_b = BigUInt(bc.b)
@@ -42,20 +42,20 @@ fn run_case(
         # Correctness check: string match
         if rm_str != rp_str:
             log_print("*** WARNING: String mismatch detected! ***", log_file)
-            log_print("BigUInt result:  " + rm_str[:120], log_file)
-            log_print("Python result:   " + rp_str[:120], log_file)
+            log_print("BigUInt result:  " + rm_str[byte=:120], log_file)
+            log_print("Python result:   " + rp_str[byte=:120], log_file)
 
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m_a - m_b
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa - pb
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/biguint/bench_biguint_truncate_divide.mojo
+++ b/benches/biguint/bench_biguint_truncate_divide.mojo
@@ -16,7 +16,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     log_file: PythonObject,
@@ -68,7 +68,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var pysys = Python.import_module("sys")
     pysys.set_int_max_str_digits(10000000)
 

--- a/benches/biguint/bench_biguint_truncate_divide.mojo
+++ b/benches/biguint/bench_biguint_truncate_divide.mojo
@@ -11,9 +11,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -23,8 +23,8 @@ fn run_case(
     mut sf: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("a: " + bc.a[:80], log_file)
-    log_print("b: " + bc.b[:80], log_file)
+    log_print("a: " + bc.a[byte=:80], log_file)
+    log_print("b: " + bc.b[byte=:80], log_file)
 
     var m_a = BigUInt(bc.a)
     var m_b = BigUInt(bc.b)
@@ -42,20 +42,20 @@ fn run_case(
         # Correctness check: string match
         if rm_str != rp_str:
             log_print("*** WARNING: String mismatch detected! ***", log_file)
-            log_print("BigUInt result:  " + rm_str[:120], log_file)
-            log_print("Python result:   " + rp_str[:120], log_file)
+            log_print("BigUInt result:  " + rm_str[byte=:120], log_file)
+            log_print("Python result:   " + rp_str[byte=:120], log_file)
 
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m_a // m_b
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa // pb
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/biguint/bench_scale_up_by_power_of_10.mojo
+++ b/benches/biguint/bench_scale_up_by_power_of_10.mojo
@@ -15,7 +15,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     log_file: PythonObject,
@@ -37,7 +37,7 @@ fn run_case(
     log_print("BigUInt:         " + String(tm) + " ns/iter", log_file)
 
 
-fn main() raises:
+def main() raises:
     var toml_path = "bench_data/scale_up_by_power_of_10.toml"
     var log_file = open_log_file("benchmark_biguint_scale_up")
     print_header("Decimo BigUInt scale_up_by_power_of_10 Benchmark", log_file)

--- a/benches/biguint/bench_scale_up_by_power_of_10.mojo
+++ b/benches/biguint/bench_scale_up_by_power_of_10.mojo
@@ -10,9 +10,9 @@ from decimo.tests import (
     log_print,
     print_header,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -22,7 +22,7 @@ fn run_case(
     mut times: List[Float64],
 ) raises:
     log_print("\nBenchmark:       " + bc.name, log_file)
-    log_print("a: " + bc.a[:80], log_file)
+    log_print("a: " + bc.a[byte=:80], log_file)
     log_print("power: " + bc.b, log_file)
 
     var m_a = BigUInt(bc.a)
@@ -31,7 +31,7 @@ fn run_case(
     var t0 = perf_counter_ns()
     for _ in range(iterations):
         _ = decimo.biguint.arithmetics.multiply_by_power_of_ten(m_a, power)
-    var tm = (perf_counter_ns() - t0) / iterations
+    var tm = (perf_counter_ns() - t0) / UInt(iterations)
     times.append(Float64(tm))
 
     log_print("BigUInt:         " + String(tm) + " ns/iter", log_file)

--- a/benches/decimal128/bench.mojo
+++ b/benches/decimal128/bench.mojo
@@ -20,7 +20,7 @@ from bench_quantize import main as bench_quantize
 from bench_round import main as bench_round
 
 
-fn main() raises:
+def main() raises:
     while True:
         print(
             """

--- a/benches/decimal128/bench_add.mojo
+++ b/benches/decimal128/bench_add.mojo
@@ -14,7 +14,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     pydecimal: PythonObject,
@@ -60,7 +60,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_add")
     print_header("Decimo Decimal128 Addition Benchmark", log_file)
 

--- a/benches/decimal128/bench_add.mojo
+++ b/benches/decimal128/bench_add.mojo
@@ -9,9 +9,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -40,14 +40,14 @@ fn run_case(
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m_a + m_b
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa + pb
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/decimal128/bench_comparison.mojo
+++ b/benches/decimal128/bench_comparison.mojo
@@ -13,9 +13,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn main() raises:
@@ -77,7 +77,7 @@ fn main() raises:
             elif op == "!=":
                 for _ in range(iterations):
                     _ = m_a != m_b
-            var tm = (perf_counter_ns() - t0) / iterations
+            var tm = (perf_counter_ns() - t0) / UInt(iterations)
             if tm == 0:
                 tm = 1
 
@@ -101,7 +101,7 @@ fn main() raises:
             elif op == "!=":
                 for _ in range(iterations):
                     _ = pa != pb
-            var tp = (perf_counter_ns() - t0) / iterations
+            var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
             var s = Float64(tp) / Float64(tm)
             sf.append(s)

--- a/benches/decimal128/bench_comparison.mojo
+++ b/benches/decimal128/bench_comparison.mojo
@@ -18,7 +18,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_comparison")
     print_header("Decimo Decimal128 Comparison Benchmark", log_file)
 

--- a/benches/decimal128/bench_divide.mojo
+++ b/benches/decimal128/bench_divide.mojo
@@ -9,9 +9,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -40,14 +40,14 @@ fn run_case(
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m_a / m_b
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa / pb
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/decimal128/bench_divide.mojo
+++ b/benches/decimal128/bench_divide.mojo
@@ -14,7 +14,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     pydecimal: PythonObject,
@@ -60,7 +60,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_divide")
     print_header("Decimo Decimal128 Division Benchmark", log_file)
 

--- a/benches/decimal128/bench_exp.mojo
+++ b/benches/decimal128/bench_exp.mojo
@@ -9,9 +9,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -37,14 +37,14 @@ fn run_case(
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m_a.exp()
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa.exp()
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/decimal128/bench_exp.mojo
+++ b/benches/decimal128/bench_exp.mojo
@@ -14,7 +14,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     pydecimal: PythonObject,
@@ -57,7 +57,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_exp")
     print_header("Decimo Decimal128 Exponential Benchmark", log_file)
 

--- a/benches/decimal128/bench_from_float.mojo
+++ b/benches/decimal128/bench_from_float.mojo
@@ -14,7 +14,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     pydecimal: PythonObject,
@@ -58,7 +58,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_from_float")
     print_header("Decimo Decimal128 From-Float Benchmark", log_file)
 

--- a/benches/decimal128/bench_from_float.mojo
+++ b/benches/decimal128/bench_from_float.mojo
@@ -9,9 +9,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -38,14 +38,14 @@ fn run_case(
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = Decimal128(fval)
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pydecimal.Decimal(py_float)
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/decimal128/bench_from_int.mojo
+++ b/benches/decimal128/bench_from_int.mojo
@@ -9,9 +9,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -38,14 +38,14 @@ fn run_case(
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = Decimal128(int_val)
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pydecimal.Decimal(py_int)
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/decimal128/bench_from_int.mojo
+++ b/benches/decimal128/bench_from_int.mojo
@@ -14,7 +14,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     pydecimal: PythonObject,
@@ -58,7 +58,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_from_int")
     print_header("Decimo Decimal128 From-Int Benchmark", log_file)
 

--- a/benches/decimal128/bench_from_string.mojo
+++ b/benches/decimal128/bench_from_string.mojo
@@ -9,9 +9,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -36,14 +36,14 @@ fn run_case(
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = Decimal128(str_val)
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pydecimal.Decimal(str_val)
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/decimal128/bench_from_string.mojo
+++ b/benches/decimal128/bench_from_string.mojo
@@ -14,7 +14,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     pydecimal: PythonObject,
@@ -56,7 +56,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_from_string")
     print_header("Decimo Decimal128 From-String Benchmark", log_file)
 

--- a/benches/decimal128/bench_ln.mojo
+++ b/benches/decimal128/bench_ln.mojo
@@ -9,9 +9,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -37,14 +37,14 @@ fn run_case(
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m_a.ln()
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa.ln()
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/decimal128/bench_ln.mojo
+++ b/benches/decimal128/bench_ln.mojo
@@ -14,7 +14,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     pydecimal: PythonObject,
@@ -57,7 +57,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_ln")
     print_header("Decimo Decimal128 Natural Logarithm Benchmark", log_file)
 

--- a/benches/decimal128/bench_log10.mojo
+++ b/benches/decimal128/bench_log10.mojo
@@ -14,7 +14,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     pydecimal: PythonObject,
@@ -57,7 +57,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_log10")
     print_header("Decimo Decimal128 log10 Benchmark", log_file)
 

--- a/benches/decimal128/bench_log10.mojo
+++ b/benches/decimal128/bench_log10.mojo
@@ -9,9 +9,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -37,14 +37,14 @@ fn run_case(
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m_a.log10()
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa.log10()
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/decimal128/bench_modulo.mojo
+++ b/benches/decimal128/bench_modulo.mojo
@@ -14,7 +14,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     pydecimal: PythonObject,
@@ -60,7 +60,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_modulo")
     print_header("Decimo Decimal128 Modulo Benchmark", log_file)
 

--- a/benches/decimal128/bench_modulo.mojo
+++ b/benches/decimal128/bench_modulo.mojo
@@ -9,9 +9,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -40,14 +40,14 @@ fn run_case(
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m_a % m_b
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa % pb
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/decimal128/bench_multiply.mojo
+++ b/benches/decimal128/bench_multiply.mojo
@@ -9,9 +9,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -40,14 +40,14 @@ fn run_case(
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m_a * m_b
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa * pb
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/decimal128/bench_multiply.mojo
+++ b/benches/decimal128/bench_multiply.mojo
@@ -14,7 +14,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     pydecimal: PythonObject,
@@ -60,7 +60,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_multiply")
     print_header("Decimo Decimal128 Multiplication Benchmark", log_file)
 

--- a/benches/decimal128/bench_power.mojo
+++ b/benches/decimal128/bench_power.mojo
@@ -9,9 +9,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -40,14 +40,14 @@ fn run_case(
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = dm.decimal128.exponential.power(m_a, m_b)
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa**pb
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/decimal128/bench_power.mojo
+++ b/benches/decimal128/bench_power.mojo
@@ -14,7 +14,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     pydecimal: PythonObject,
@@ -60,7 +60,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_power")
     print_header("Decimo Decimal128 Power Benchmark", log_file)
 

--- a/benches/decimal128/bench_quantize.mojo
+++ b/benches/decimal128/bench_quantize.mojo
@@ -13,9 +13,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn get_mojo_rounding(mode_str: String) -> RoundingMode:
@@ -95,14 +95,14 @@ fn main() raises:
             var t0 = perf_counter_ns()
             for _ in range(iterations):
                 _ = m_a.quantize(m_quant, mojo_rm)
-            var tm = (perf_counter_ns() - t0) / iterations
+            var tm = (perf_counter_ns() - t0) / UInt(iterations)
             if tm == 0:
                 tm = 1
 
             t0 = perf_counter_ns()
             for _ in range(iterations):
                 _ = pa.quantize(py_quant, rounding=py_rm)
-            var tp = (perf_counter_ns() - t0) / iterations
+            var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
             var s = Float64(tp) / Float64(tm)
             sf.append(s)

--- a/benches/decimal128/bench_quantize.mojo
+++ b/benches/decimal128/bench_quantize.mojo
@@ -18,7 +18,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn get_mojo_rounding(mode_str: String) -> RoundingMode:
+def get_mojo_rounding(mode_str: String) -> RoundingMode:
     """Map a TOML rounding string to a Mojo RoundingMode enum value."""
     if mode_str == "ROUND_HALF_UP":
         return RoundingMode.ROUND_HALF_UP
@@ -30,7 +30,7 @@ fn get_mojo_rounding(mode_str: String) -> RoundingMode:
         return RoundingMode.ROUND_HALF_EVEN
 
 
-fn get_py_rounding(
+def get_py_rounding(
     mode_str: String, pydecimal: PythonObject
 ) raises -> PythonObject:
     """Map a TOML rounding string to a Python decimal rounding constant."""
@@ -44,7 +44,7 @@ fn get_py_rounding(
         return pydecimal.ROUND_HALF_EVEN
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_quantize")
     print_header("Decimo Decimal128 Quantize Benchmark", log_file)
 

--- a/benches/decimal128/bench_root.mojo
+++ b/benches/decimal128/bench_root.mojo
@@ -14,7 +14,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     pydecimal: PythonObject,
@@ -79,7 +79,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_root")
     print_header("Decimo Decimal128 Root Benchmark", log_file)
 

--- a/benches/decimal128/bench_root.mojo
+++ b/benches/decimal128/bench_root.mojo
@@ -9,9 +9,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -53,7 +53,7 @@ fn run_case(
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = dm.decimal128.exponential.root(m_a, nth_root)
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
@@ -66,7 +66,7 @@ fn run_case(
         else:
             for _ in range(iterations):
                 _ = py_val**py_frac
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/decimal128/bench_round.mojo
+++ b/benches/decimal128/bench_round.mojo
@@ -9,9 +9,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -41,14 +41,14 @@ fn run_case(
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = round(m_a, ndigits)
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = py_builtins.round(pa, ndigits)
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/decimal128/bench_round.mojo
+++ b/benches/decimal128/bench_round.mojo
@@ -14,7 +14,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     pydecimal: PythonObject,
@@ -61,7 +61,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_round")
     print_header("Decimo Decimal128 Round Benchmark", log_file)
 

--- a/benches/decimal128/bench_sqrt.mojo
+++ b/benches/decimal128/bench_sqrt.mojo
@@ -9,9 +9,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -37,14 +37,14 @@ fn run_case(
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m_a.sqrt()
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa.sqrt()
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/decimal128/bench_sqrt.mojo
+++ b/benches/decimal128/bench_sqrt.mojo
@@ -14,7 +14,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     pydecimal: PythonObject,
@@ -57,7 +57,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_sqrt")
     print_header("Decimo Decimal128 Square Root Benchmark", log_file)
 

--- a/benches/decimal128/bench_subtract.mojo
+++ b/benches/decimal128/bench_subtract.mojo
@@ -14,7 +14,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     pydecimal: PythonObject,
@@ -60,7 +60,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_subtract")
     print_header("Decimo Decimal128 Subtraction Benchmark", log_file)
 

--- a/benches/decimal128/bench_subtract.mojo
+++ b/benches/decimal128/bench_subtract.mojo
@@ -9,9 +9,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -40,14 +40,14 @@ fn run_case(
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m_a - m_b
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa - pb
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/benches/decimal128/bench_truncate_divide.mojo
+++ b/benches/decimal128/bench_truncate_divide.mojo
@@ -14,7 +14,7 @@ from std.time import perf_counter_ns
 from std.collections import List
 
 
-fn run_case(
+def run_case(
     bc: BenchCase,
     iterations: Int,
     pydecimal: PythonObject,
@@ -60,7 +60,7 @@ fn run_case(
         log_print("Skipping this case", log_file)
 
 
-fn main() raises:
+def main() raises:
     var log_file = open_log_file("benchmark_truncate_divide")
     print_header("Decimo Decimal128 Floor Division Benchmark", log_file)
 

--- a/benches/decimal128/bench_truncate_divide.mojo
+++ b/benches/decimal128/bench_truncate_divide.mojo
@@ -9,9 +9,9 @@ from decimo.tests import (
     print_header,
     print_summary,
 )
-from python import Python, PythonObject
-from time import perf_counter_ns
-from collections import List
+from std.python import Python, PythonObject
+from std.time import perf_counter_ns
+from std.collections import List
 
 
 fn run_case(
@@ -40,14 +40,14 @@ fn run_case(
         var t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = m_a // m_b
-        var tm = (perf_counter_ns() - t0) / iterations
+        var tm = (perf_counter_ns() - t0) / UInt(iterations)
         if tm == 0:
             tm = 1
 
         t0 = perf_counter_ns()
         for _ in range(iterations):
             _ = pa // pb
-        var tp = (perf_counter_ns() - t0) / iterations
+        var tp = (perf_counter_ns() - t0) / UInt(iterations)
 
         var s = Float64(tp) / Float64(tm)
         sf.append(s)

--- a/docs/examples_on_bigdecimal.mojo
+++ b/docs/examples_on_bigdecimal.mojo
@@ -1,7 +1,7 @@
 from decimo.prelude import *
 
 
-fn main() raises:
+def main() raises:
     var b = Decimal(
         "1234.56789"
     )  # Decimal is a Python-like alias for BigDecimal

--- a/docs/examples_on_bigint.mojo
+++ b/docs/examples_on_bigint.mojo
@@ -1,7 +1,7 @@
 from decimo.prelude import *
 
 
-fn main() raises:
+def main() raises:
     # === Construction ===
     var a = BInt("12345678901234567890")  # From string
     var b = BInt(12345)  # From integer

--- a/docs/examples_on_decimal128.mojo
+++ b/docs/examples_on_decimal128.mojo
@@ -1,7 +1,7 @@
 from decimo.prelude import *
 
 
-fn main() raises:
+def main() raises:
     # === Construction ===
     var a = Dec128("123.45")  # From string
     var b = Dec128(123)  # From integer

--- a/pixi.lock
+++ b/pixi.lock
@@ -2,8 +2,8 @@ version: 6
 environments:
   default:
     channels:
-    - url: https://conda.modular.com/max-nightly/
     - url: https://conda.modular.com/max/
+    - url: https://conda.modular.com/max-nightly/
     - url: https://repo.prefix.dev/modular-community/
     - url: https://conda.anaconda.org/conda-forge/
     options:
@@ -12,7 +12,6 @@ environments:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-      - conda: https://repo.prefix.dev/modular-community/linux-64/argmojo-0.1.0-hb0f4dca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.3.0-py313h18e8e13_0.conda
@@ -21,7 +20,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py313hf46b229_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cmarkgfm-2024.11.20-py313h07c4f96_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
@@ -32,43 +31,41 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/id-1.6.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhcf101f3_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.4.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jeepney-0.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.7.0-pyha804496_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.4-h6548e54_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.2-hf4e2dac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.21-h280c20c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.1.0-release.conda
+      - conda: https://conda.modular.com/max/noarch/mblack-26.2.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-0.26.1.0-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-0.26.1.0-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-0.26.1.0-release.conda
+      - conda: https://conda.modular.com/max/linux-64/mojo-0.26.2.0-release.conda
+      - conda: https://conda.modular.com/max/linux-64/mojo-compiler-0.26.2.0-release.conda
+      - conda: https://conda.modular.com/max/noarch/mojo-python-0.26.2.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.8.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
@@ -77,7 +74,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
@@ -94,7 +91,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.3-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.2-h40fa522_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.7-h7805a7d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.4.1-py313h78bf25f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
@@ -105,12 +102,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h387f397_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h41580af_10.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-      - conda: https://repo.prefix.dev/modular-community/osx-arm64/argmojo-0.1.0-h60d57d3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/backports.zstd-1.3.0-py313h48bb75e_0.conda
@@ -119,7 +115,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.0.0-py313h224173a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cmarkgfm-2024.11.20-py313hcdf3177_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
@@ -128,33 +124,33 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.2-h38cb7af_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/id-1.6.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhcf101f3_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.4.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.7.0-pyh534df25_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.0-h55c6f16_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.1-h55c6f16_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.4-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.2-h8088a28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.51.2-h1ae2325_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.21-h1a92334_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.52.0-h1ae2325_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.1.0-release.conda
+      - conda: https://conda.modular.com/max/noarch/mblack-26.2.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-0.26.1.0-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-0.26.1.0-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-0.26.1.0-release.conda
+      - conda: https://conda.modular.com/max/osx-arm64/mojo-0.26.2.0-release.conda
+      - conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-0.26.2.0-release.conda
+      - conda: https://conda.modular.com/max/noarch/mojo-python-0.26.2.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.8.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
@@ -162,7 +158,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.1-hd24854e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
@@ -179,7 +175,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.3-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.15.2-h279115b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.15.7-hc5c3a1d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
@@ -189,7 +185,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h888dc83_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h4818236_10.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
 packages:
@@ -216,22 +212,6 @@ packages:
   license_family: MIT
   size: 8191
   timestamp: 1744137672556
-- conda: https://repo.prefix.dev/modular-community/linux-64/argmojo-0.1.0-hb0f4dca_0.conda
-  sha256: d8079bdcc2ed18af5df87b08e9de07bc6815b0999e721f2b1f18d404b0556a36
-  md5: 371575b6d132a0b34da84cdacb3558e7
-  depends:
-  - mojo-compiler 0.26.1.*
-  license: Apache-2.0
-  size: 1246432
-  timestamp: 1772049474332
-- conda: https://repo.prefix.dev/modular-community/osx-arm64/argmojo-0.1.0-h60d57d3_0.conda
-  sha256: 9f7453f4b4cc393f95782719cba7cb4361d6a9a83fab471d33566d280c879c7c
-  md5: 6d72608b39e7d4a83594ffbac14a87d1
-  depends:
-  - mojo-compiler 0.26.1.*
-  license: Apache-2.0
-  size: 1245438
-  timestamp: 1772049389471
 - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
   sha256: e1c3dc8b5aa6e12145423fed262b4754d70fec601339896b9ccf483178f690a6
   md5: 767d508c1a67e02ae8f50e44cacfadb2
@@ -369,15 +349,15 @@ packages:
   license_family: MIT
   size: 291376
   timestamp: 1761203583358
-- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
-  sha256: b32f8362e885f1b8417bac2b3da4db7323faa12d5db62b7fd6691c02d60d6f59
-  md5: a22d1fd9bf98827e280a02875d9a007a
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.6-pyhd8ed1ab_0.conda
+  sha256: d86dfd428b2e3c364fa90e07437c8405d635aa4ef54b25ab51d9c712be4112a5
+  md5: 49ee13eb9b8f44d63879c69b8a40a74b
   depends:
   - python >=3.10
   license: MIT
   license_family: MIT
-  size: 50965
-  timestamp: 1760437331772
+  size: 58510
+  timestamp: 1773660086450
 - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
   sha256: 38cfe1ee75b21a8361c8824f5544c3866f303af1762693a178266d7f198e8715
   md5: ea8a6c3256897cc31263de9f455e25d9
@@ -501,26 +481,26 @@ packages:
   license_family: MIT
   size: 17397
   timestamp: 1737618427549
-- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
-  sha256: 142a722072fa96cf16ff98eaaf641f54ab84744af81754c292cb81e0881c0329
-  md5: 186a18e3ba246eccfc7cff00cd19a870
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+  sha256: fbf86c4a59c2ed05bbffb2ba25c7ed94f6185ec30ecb691615d42342baa1a16a
+  md5: c80d8a3b84358cb967fa81e7075fbc8a
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
   license: MIT
   license_family: MIT
-  size: 12728445
-  timestamp: 1767969922681
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.2-h38cb7af_0.conda
-  sha256: d4cefbca587429d1192509edc52c88de52bc96c2447771ddc1f8bee928aed5ef
-  md5: 1e93aca311da0210e660d2247812fa02
+  size: 12723451
+  timestamp: 1773822285671
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
+  sha256: 3a7907a17e9937d3a46dfd41cffaf815abad59a569440d1e25177c15fd0684e5
+  md5: f1182c91c0de31a7abd40cedf6a5ebef
   depends:
   - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 12358010
-  timestamp: 1767970350308
+  size: 12361647
+  timestamp: 1773822915649
 - conda: https://conda.anaconda.org/conda-forge/noarch/id-1.6.1-pyhcf101f3_0.conda
   sha256: 54c80a4ca6e6a19b4bb89c829f757d0de00362a3bfa4647517d2ebd519717f0f
   md5: 563a022fc58cf7a200c35cb3fee07a6b
@@ -541,17 +521,17 @@ packages:
   license_family: BSD
   size: 50721
   timestamp: 1760286526795
-- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
-  sha256: c18ab120a0613ada4391b15981d86ff777b5690ca461ea7e9e49531e8f374745
-  md5: 63ccfdc3a3ce25b027b8767eb722fca8
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
+  sha256: 82ab2a0d91ca1e7e63ab6a4939356667ef683905dea631bc2121aa534d347b16
+  md5: 080594bf4493e6bae2607e65390c520a
   depends:
-  - python >=3.9
+  - python >=3.10
   - zipp >=3.20
   - python
   license: Apache-2.0
   license_family: APACHE
-  size: 34641
-  timestamp: 1747934053147
+  size: 34387
+  timestamp: 1773931568510
 - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
   sha256: acc1d991837c0afb67c75b77fdc72b4bf022aac71fedd8b9ea45918ac9b08a80
   md5: c85c76dc67d75619a92f51dfbce06992
@@ -575,17 +555,17 @@ packages:
   license_family: MIT
   size: 14831
   timestamp: 1767294269456
-- conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.0-pyhcf101f3_0.conda
-  sha256: 04c9f919dcc9edd18f748c47d809479812429af27c43c5562a861df22d5bda6a
-  md5: f34ec3aa0ea911a038d973d97603faf3
+- conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.1-pyhcf101f3_0.conda
+  sha256: 49c3e2e9aa4930734badfcbb31543406ed1b5531cb833f595cf57baf628dea7d
+  md5: 5ed60de12f1673398943262371667f79
   depends:
   - python >=3.10
   - backports.tarfile
   - python
   license: MIT
   license_family: MIT
-  size: 15566
-  timestamp: 1768299702258
+  size: 15368
+  timestamp: 1773131463776
 - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.4.0-pyhcf101f3_1.conda
   sha256: 6a91447b3bb4d7ae94cc0d77ed12617796629aee11111efe7ea43cbd0e113bda
   md5: aa83cc08626bf6b613a3103942be8951
@@ -678,33 +658,34 @@ packages:
   license: LGPL-2.1-or-later
   size: 134088
   timestamp: 1754905959823
-- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
-  sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
-  md5: 3f43953b7d3fb3aaa1d0d0723d91e368
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
+  sha256: 3e307628ca3527448dd1cb14ad7bb9d04d1d28c7d4c5f97ba196ae984571dd25
+  md5: fb53fb07ce46a575c5d004bbc96032c2
   depends:
-  - keyutils >=1.6.1,<2.0a0
-  - libedit >=3.1.20191231,<3.2.0a0
-  - libedit >=3.1.20191231,<4.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - openssl >=3.3.1,<4.0a0
+  - __glibc >=2.17,<3.0.a0
+  - keyutils >=1.6.3,<2.0a0
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - openssl >=3.5.5,<4.0a0
   license: MIT
   license_family: MIT
-  size: 1370023
-  timestamp: 1719463201255
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
-  sha256: 4442f957c3c77d69d9da3521268cad5d54c9033f1a73f99cde0a3658937b159b
-  md5: c6dc8a0fdec13a0565936655c33069a1
+  size: 1386730
+  timestamp: 1769769569681
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
+  sha256: c0a0bf028fe7f3defcdcaa464e536cf1b202d07451e18ad83fdd169d15bef6ed
+  md5: e446e1822f4da8e5080a9de93474184d
   depends:
   - __osx >=11.0
-  - libcxx >=16
-  - libedit >=3.1.20191231,<3.2.0a0
-  - libedit >=3.1.20191231,<4.0a0
-  - openssl >=3.3.1,<4.0a0
+  - libcxx >=19
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - openssl >=3.5.5,<4.0a0
   license: MIT
   license_family: MIT
-  size: 1155530
-  timestamp: 1719463474401
+  size: 1160828
+  timestamp: 1769770119811
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
   sha256: 565941ac1f8b0d2f2e8f02827cbca648f4d18cd461afc31f15604cd291b5c5f3
   md5: 12bd9a3f089ee6c9266a37dab82afabd
@@ -717,15 +698,15 @@ packages:
   license_family: GPL
   size: 725507
   timestamp: 1770267139900
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.0-h55c6f16_1.conda
-  sha256: ce1049fa6fda9cf08ff1c50fb39573b5b0ea6958375d8ea7ccd8456ab81a0bcb
-  md5: e9c56daea841013e7774b5cd46f41564
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.1-h55c6f16_0.conda
+  sha256: 3c8142cdd3109c250a926c492ec45bc954697b288e5d1154ada95272ffa21be8
+  md5: 7a290d944bc0c481a55baf33fa289deb
   depends:
   - __osx >=11.0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 568910
-  timestamp: 1772001095642
+  size: 570281
+  timestamp: 1773203613980
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
   sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
   md5: c277e0a4d549b03ac1e9d6cbbe3d017b
@@ -804,15 +785,6 @@ packages:
   license_family: GPL
   size: 1041788
   timestamp: 1771378212382
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
-  sha256: e318a711400f536c81123e753d4c797a821021fb38970cebfb3f454126016893
-  md5: d5e96b1ed75ca01906b3d2469b4ce493
-  depends:
-  - libgcc 15.2.0 he0feb66_18
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 27526
-  timestamp: 1771378224552
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.4-h6548e54_1.conda
   sha256: a27e44168a1240b15659888ce0d9b938ed4bdb49e9ea68a7c1ff27bcea8b55ce
   md5: bb26456332b07f68bf3b7622ed71c0da
@@ -886,43 +858,44 @@ packages:
   license_family: BSD
   size: 73690
   timestamp: 1769482560514
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
-  sha256: 0105bd108f19ea8e6a78d2d994a6d4a8db16d19a41212070d2d1d48a63c34161
-  md5: a587892d3c13b6621a6091be690dbca2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.21-h280c20c_3.conda
+  sha256: 64e5c80cbce4680a2d25179949739a6def695d72c40ca28f010711764e372d97
+  md5: 7af961ef4aa2c1136e11dd43ded245ab
   depends:
-  - libgcc-ng >=12
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   license: ISC
-  size: 205978
-  timestamp: 1716828628198
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
-  sha256: fade8223e1e1004367d7101dd17261003b60aa576df6d7802191f8972f7470b1
-  md5: a7ce36e284c5faaf93c220dfc39e3abd
+  size: 277661
+  timestamp: 1772479381288
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.21-h1a92334_3.conda
+  sha256: df603472ea1ebd8e7d4fb71e4360fe48d10b11c240df51c129de1da2ff9e8227
+  md5: 7cc5247987e6d115134ebab15186bc13
   depends:
   - __osx >=11.0
   license: ISC
-  size: 164972
-  timestamp: 1716828607917
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.2-hf4e2dac_0.conda
-  sha256: 04596fcee262a870e4b7c9807224680ff48d4d0cc0dac076a602503d3dc6d217
-  md5: da5be73701eecd0e8454423fd6ffcf30
+  size: 248039
+  timestamp: 1772479570912
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
+  sha256: d716847b7deca293d2e49ed1c8ab9e4b9e04b9d780aea49a97c26925b28a7993
+  md5: fd893f6a3002a635b5e50ceb9dd2c0f4
   depends:
   - __glibc >=2.17,<3.0.a0
   - icu >=78.2,<79.0a0
   - libgcc >=14
   - libzlib >=1.3.1,<2.0a0
   license: blessing
-  size: 942808
-  timestamp: 1768147973361
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.51.2-h1ae2325_0.conda
-  sha256: 6e9b9f269732cbc4698c7984aa5b9682c168e2a8d1e0406e1ff10091ca046167
-  md5: 4b0bf313c53c3e89692f020fb55d5f2c
+  size: 951405
+  timestamp: 1772818874251
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.52.0-h1ae2325_0.conda
+  sha256: beb0fd5594d6d7c7cd42c992b6bb4d66cbb39d6c94a8234f15956da99a04306c
+  md5: f6233a3fddc35a2ec9f617f79d6f3d71
   depends:
   - __osx >=11.0
   - icu >=78.2,<79.0a0
   - libzlib >=1.3.1,<2.0a0
   license: blessing
-  size: 909777
-  timestamp: 1768148320535
+  size: 918420
+  timestamp: 1772819478684
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
   sha256: 78668020064fdaa27e9ab65cd2997e2c837b564ab26ce3bf0e58a2ce1a525c6e
   md5: 1b08cd684f34175e4514474793d44bcb
@@ -935,15 +908,6 @@ packages:
   license_family: GPL
   size: 5852330
   timestamp: 1771378262446
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
-  sha256: 3c902ffd673cb3c6ddde624cdb80f870b6c835f8bf28384b0016e7d444dd0145
-  md5: 6235adb93d064ecdf3d44faee6f468de
-  depends:
-  - libstdcxx 15.2.0 h934c35e_18
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 27575
-  timestamp: 1771378314494
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
   sha256: 1a7539cfa7df00714e8943e18de0b06cceef6778e420a5ee3a2a145773758aee
   md5: db409b7c1720428638e7c0d509d3e1b5
@@ -987,9 +951,10 @@ packages:
   license_family: MIT
   size: 64736
   timestamp: 1754951288511
-- conda: https://conda.modular.com/max-nightly/noarch/mblack-26.1.0-release.conda
+- conda: https://conda.modular.com/max/noarch/mblack-26.2.0-release.conda
   noarch: python
-  sha256: 6ccec52fe7354f44be93a41a122d2214ecdb030e6362afe8e7876eab35472e62
+  sha256: 3c2fceb89cefca899dcd7c8f26a6202acacb2a073e4cb2ef365514a465d01dcd
+  md5: dd13667299b9b66b8b314dc8d95b54a3
   depends:
   - python >=3.10
   - click >=8.0.0
@@ -998,10 +963,9 @@ packages:
   - pathspec >=0.9.0
   - platformdirs >=2
   - tomli >=1.1.0
-  - python
-  license: MIT
-  size: 135743
-  timestamp: 1769478151312
+  license: LicenseRef-Modular-Proprietary
+  size: 133798
+  timestamp: 1773780198354
 - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
   sha256: 78c1bbe1723449c52b7a9df1af2ee5f005209f67e40b6e1d3c7619127c43b1c7
   md5: 592132998493b3ff25fd7479396e8351
@@ -1011,48 +975,53 @@ packages:
   license_family: MIT
   size: 14465
   timestamp: 1733255681319
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-0.26.1.0-release.conda
-  sha256: e945e8fbff0fdd2064ea193b26fb4ba95ab782367cfd2a2c4522350066434494
+- conda: https://conda.modular.com/max/linux-64/mojo-0.26.2.0-release.conda
+  sha256: 4d7047466c13d92b1c8eb19c6d203a8503afbd2b1ad63eb5289a8f4bbf4d2945
+  md5: 61318988733a695066b39704f6e08bd2
   depends:
   - python >=3.10
-  - mojo-compiler ==0.26.1.0 release
-  - mblack ==26.1.0 release
+  - mojo-compiler ==0.26.2.0
+  - mblack ==26.2.0
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 89061870
-  timestamp: 1769478151312
-- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-0.26.1.0-release.conda
-  sha256: ba205a5bb4fafc47abee5db87fd58dee091b104d20651363f3dc1e6ca60e1d21
+  size: 89753715
+  timestamp: 1773797215278
+- conda: https://conda.modular.com/max/osx-arm64/mojo-0.26.2.0-release.conda
+  sha256: e35b8d34564b30189c5a985990466b4283f9e1d897baf23fe9ddbcbc9283459c
+  md5: 12e4d8397c451b7c8a55ff5a759ce00b
   depends:
   - python >=3.10
-  - mojo-compiler ==0.26.1.0 release
-  - mblack ==26.1.0 release
+  - mojo-compiler ==0.26.2.0
+  - mblack ==26.2.0
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 75217574
-  timestamp: 1769480882531
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-0.26.1.0-release.conda
-  sha256: aad6cf9e55824ada1147acaee8b37c68ef1973b208a4a4182f7ac85bc20e690c
+  size: 81534498
+  timestamp: 1773797099755
+- conda: https://conda.modular.com/max/linux-64/mojo-compiler-0.26.2.0-release.conda
+  sha256: e53f30d72a65e6b0a67745e6988f978d8f6ecc14531420631c9719eb9c7b9c2b
+  md5: e3a673daa0ddf3ca6af297daee4ceab5
   depends:
-  - mojo-python ==0.26.1.0 release
+  - mojo-python ==0.26.2.0
   license: LicenseRef-Modular-Proprietary
-  size: 85722183
-  timestamp: 1769478151311
-- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-0.26.1.0-release.conda
-  sha256: 335323a29c632adaf75958366a93352082f2e6a8bee43353269e86eefa86a2cf
+  size: 89091679
+  timestamp: 1773797216619
+- conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-0.26.2.0-release.conda
+  sha256: e82cb7ce1a756876a233d364d5397adca5ad7e20fff5204c1c7e93aefe4549b5
+  md5: 96e3ec50a2ea4abdb9fc4f3f89dc874b
   depends:
-  - mojo-python ==0.26.1.0 release
+  - mojo-python ==0.26.2.0
   license: LicenseRef-Modular-Proprietary
-  size: 65952232
-  timestamp: 1769480882531
-- conda: https://conda.modular.com/max-nightly/noarch/mojo-python-0.26.1.0-release.conda
+  size: 67499721
+  timestamp: 1773797103208
+- conda: https://conda.modular.com/max/noarch/mojo-python-0.26.2.0-release.conda
   noarch: python
-  sha256: 9bccbc9045984961426038832c8657198f8ef238d95e00d9bdcff2dd139b7fdf
+  sha256: 2d9e350cfe7a0ae5d96dea13c082b09f21aac8ac4caa3e5def6b075930348fa1
+  md5: 67a4fc0d47e84d3a91c4f12cc912c7ac
   depends:
-  - python
+  - python >=3.10
   license: LicenseRef-Modular-Proprietary
-  size: 24169
-  timestamp: 1769478151311
+  size: 22936
+  timestamp: 1773780198161
 - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.8.0-pyhcf101f3_1.conda
   sha256: 449609f0d250607a300754474350a3b61faf45da183d3071e9720e453c765b8a
   md5: 32f78e9d06e8593bc4bbf1338da06f5f
@@ -1172,16 +1141,16 @@ packages:
   license_family: BSD
   size: 1222481
   timestamp: 1763655398280
-- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
-  sha256: 7f263219cecf0ba6d74c751efa60c4676ce823157ca90aa43ebba5ac615ca0fa
-  md5: 4fefefb892ce9cc1539405bec2f1a6cd
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
+  sha256: 0289f0a38337ee201d984f8f31f11f6ef076cfbbfd0ab9181d12d9d1d099bf46
+  md5: 82c1787f2a65c0155ef9652466ee98d6
   depends:
   - python >=3.10
   - python
   license: MIT
   license_family: MIT
-  size: 25643
-  timestamp: 1771233827084
+  size: 25646
+  timestamp: 1773199142345
 - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
   sha256: 79db7928d13fab2d892592223d7570f5061c192f27b9febd1a418427b719acc6
   md5: 12c566707c80111f9799308d9e265aef
@@ -1429,33 +1398,31 @@ packages:
   license_family: MIT
   size: 208472
   timestamp: 1771572730357
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.2-h40fa522_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.7-h7805a7d_1.conda
   noarch: python
-  sha256: e0403324ac0de06f51c76ae2a4671255d48551a813d1f1dc03bd4db7364604f0
-  md5: 8dec25bd8a94496202f6f3c9085f2ad3
+  sha256: 2985cfff61368323db477c2a0d7f100a57f6cb34aafec51ae96b6fc409d9090f
+  md5: f5678c1a929d9efe3c2397675ae90a3c
   depends:
   - python
-  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   constrains:
   - __glibc >=2.17
   license: MIT
-  license_family: MIT
-  size: 9284016
-  timestamp: 1771570005837
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.15.2-h279115b_0.conda
+  size: 9220190
+  timestamp: 1774012576023
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.15.7-hc5c3a1d_1.conda
   noarch: python
-  sha256: 80f93811d26e58bf5a635d1034cba8497223c2bf9efa2a67776a18903e40944a
-  md5: a52cf978daa5290b1414d3bba6b6ea0b
+  sha256: b8e869469607bf00dc80ad920bffe96adc9b21d22e940ffeff71a664d35ef9b7
+  md5: c8590d44f44c1406844b1e10795153e5
   depends:
   - python
   - __osx >=11.0
   constrains:
   - __osx >=11.0
   license: MIT
-  license_family: MIT
-  size: 8415205
-  timestamp: 1771570140500
+  size: 8432798
+  timestamp: 1774012820989
 - conda: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.4.1-py313h78bf25f_0.conda
   sha256: 43ea89b53cbede879e57ac9dd20153c5cd2bb9575228e7faf5a8764aa6c201b7
   md5: 013a7d73eaef154f0dc5e415ffa8ff87
@@ -1594,32 +1561,31 @@ packages:
   license_family: MIT
   size: 103172
   timestamp: 1767817860341
-- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h387f397_9.conda
-  sha256: 47cfe31255b91b4a6fa0e9dbaf26baa60ac97e033402dbc8b90ba5fee5ffe184
-  md5: 8035e5b54c08429354d5d64027041cad
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h41580af_10.conda
+  sha256: 325d370b28e2b9cc1f765c5b4cdb394c91a5d958fbd15da1a14607a28fee09f6
+  md5: 755b096086851e1193f3b10347415d7c
   depends:
-  - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libsodium >=1.0.20,<1.0.21.0a0
-  - krb5 >=1.21.3,<1.22.0a0
+  - libstdcxx >=14
+  - krb5 >=1.22.2,<1.23.0a0
+  - libsodium >=1.0.21,<1.0.22.0a0
   license: MPL-2.0
   license_family: MOZILLA
-  size: 310648
-  timestamp: 1757370847287
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h888dc83_9.conda
-  sha256: b6f9c130646e5971f6cad708e1eee278f5c7eea3ca97ec2fdd36e7abb764a7b8
-  md5: 26f39dfe38a2a65437c29d69906a0f68
+  size: 311150
+  timestamp: 1772476812121
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h4818236_10.conda
+  sha256: 2705360c72d4db8de34291493379ffd13b09fd594d0af20c9eefa8a3f060d868
+  md5: e85dcd3bde2b10081cdcaeae15797506
   depends:
   - __osx >=11.0
   - libcxx >=19
-  - libsodium >=1.0.20,<1.0.21.0a0
-  - krb5 >=1.21.3,<1.22.0a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libsodium >=1.0.21,<1.0.22.0a0
   license: MPL-2.0
   license_family: MOZILLA
-  size: 244772
-  timestamp: 1757371008525
+  size: 245246
+  timestamp: 1772476886668
 - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
   sha256: b4533f7d9efc976511a73ef7d4a2473406d7f4c750884be8e8620b0ce70f4dae
   md5: 30cd29cb87d819caead4d55184c1d115

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 authors = ["ZHU Yuhao (朱宇浩) <dr.yuhao.zhu@outlook.com>"]
-channels = ["https://conda.modular.com/max-nightly", "https://conda.modular.com/max", "https://repo.prefix.dev/modular-community", "conda-forge"]
+channels = ["https://conda.modular.com/max", "https://conda.modular.com/max-nightly", "https://repo.prefix.dev/modular-community", "conda-forge"]
 description = "An arbitrary-precision decimal and integer library for Mojo"
 license = "Apache-2.0"
 name = "decimo"
@@ -9,12 +9,12 @@ readme = "README.md"
 version = "0.8.0"
 
 [dependencies]
-argmojo = ">=0.1.0,<0.2" # CLI argument parsing for the Decimo calculator
-mojo = "==0.26.1" # Mojo language compiler and runtime
-python = ">=3.13,<3.14" # For Python bindings and tests
-python-build = ">=1.4.0,<2" # Build PyPI wheel (`pixi run wheel`)
-ruff = ">=0.9,<1" # Python code formatter
-twine = ">=6.2.0,<7" # Upload wheel to PyPI (`twine upload dist/*`)
+# argmojo = ">=0.4.0" # CLI argument parsing for the Decimo calculator (TODO: waiting for argmojo 0.2.0 compatible with mojo 0.26.2)
+mojo = ">=0.26.2.0,<0.26.3" # Mojo language compiler and runtime
+python = ">=3.13" # For Python bindings and tests
+python-build = ">=0.2.0" # Build PyPI wheel (`pixi run wheel`)
+ruff = ">=0.15.0" # Python code formatter
+twine = ">=6.2.0" # Upload wheel to PyPI (`twine upload dist/*`)
 
 [tasks]
 # format the code

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 version = "0.8.0"
 
 [dependencies]
-# argmojo = ">=0.4.0" # CLI argument parsing for the Decimo calculator (TODO: waiting for argmojo 0.2.0 compatible with mojo 0.26.2)
+# argmojo = ">=0.4.0" # CLI argument parsing for the Decimo calculator (TODO: waiting for argmojo 0.4.0 compatible with mojo 0.26.2)
 mojo = ">=0.26.2.0,<0.26.3" # Mojo language compiler and runtime
 python = ">=3.13" # For Python bindings and tests
 python-build = ">=0.2.0" # Build PyPI wheel (`pixi run wheel`)
@@ -68,9 +68,14 @@ dec_debug = """clear && pixi run package && cd benches/decimal128 \
 && pixi run mojo run -I ../ -D ASSERT=all bench.mojo && cd ../.. \
 && pixi run clean"""
 
+# Fetch argmojo source code for CLI calculator
+fetch = """git clone https://github.com/forfudan/argmojo.git temp/argmojo 2>/dev/null || true \
+&& cd temp/argmojo && git checkout 24ca712fa291ec6a82dc9317f6ba5d0484d1fb47 2>/dev/null"""
+
 # cli calculator
 bcli = "clear && pixi run buildcli"
-buildcli = "pixi run mojo build -I src -I src/cli -o decimo src/cli/main.mojo"
+buildcli = """pixi run mojo package temp/argmojo/src/argmojo -o temp/argmojo.mojopkg \
+&& pixi run mojo build -I src -I src/cli -I temp -o decimo src/cli/main.mojo"""
 tcli = "clear && pixi run testcli"
 testcli = "bash tests/test_cli.sh"
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -26,7 +26,7 @@ format = """pixi run mojo format ./src \
 &&pixi run ruff format ./python"""
 
 # doc
-doc = """clear && pixi run mojo doc \
+doc = """pixi run mojo doc \
 --diagnose-missing-doc-strings --validate-doc-strings src/decimo"""
 
 # compile the package
@@ -87,3 +87,15 @@ testpy = "pixi run buildpy && pixi run python python/tests/test_decimo.py"
 tpy = "clear && pixi run testpy"
 # build PyPI wheel (placeholder, no .so included)
 wheel = "cd python && pixi run python -m build --wheel"
+
+# All task
+all = """pixi run format \
+&&pixi run package \
+&&pixi run doc \
+&&pixi run test \
+&&pixi run fetch \
+&&pixi run buildcli \
+&&pixi run testcli \
+&&pixi run buildpy \
+&&pixi run testpy \
+&&pixi run clean"""

--- a/python/decimo_module.mojo
+++ b/python/decimo_module.mojo
@@ -9,9 +9,9 @@
 # https://docs.modular.com/mojo/manual/python/mojo-from-python
 # ===----------------------------------------------------------------------=== #
 
-from python import PythonObject
-from python.bindings import PythonModuleBuilder
-from os import abort
+from std.python import PythonObject
+from std.python.bindings import PythonModuleBuilder
+from std.os import abort
 
 from decimo import BigDecimal
 
@@ -75,13 +75,13 @@ fn bigdecimal_py_init(
 fn bigdecimal_to_string(py_self: PythonObject) raises -> PythonObject:
     """Return the decimal as a plain string, e.g. '3.14'."""
     var ptr = py_self.downcast_value_ptr[BigDecimal]()
-    return PythonObject(ptr[].__str__())
+    return PythonObject(String(ptr[]))
 
 
 fn bigdecimal_to_repr(py_self: PythonObject) raises -> PythonObject:
     """Return the repr string, e.g. 'Decimal(\"3.14\")'."""
     var ptr = py_self.downcast_value_ptr[BigDecimal]()
-    return PythonObject('Decimal("' + ptr[].__str__() + '")')
+    return PythonObject('Decimal("' + String(ptr[]) + '")')
 
 
 fn bigdecimal_add(

--- a/python/decimo_module.mojo
+++ b/python/decimo_module.mojo
@@ -22,7 +22,7 @@ from decimo import BigDecimal
 
 
 @export
-fn PyInit__decimo() -> PythonObject:
+def PyInit__decimo() -> PythonObject:
     try:
         var m = PythonModuleBuilder("_decimo")
         _ = (
@@ -50,7 +50,7 @@ fn PyInit__decimo() -> PythonObject:
 # ===----------------------------------------------------------------------=== #
 
 
-fn bigdecimal_py_init(
+def bigdecimal_py_init(
     out self: BigDecimal, args: PythonObject, kwargs: PythonObject
 ) raises:
     """Construct a BigDecimal from a single argument (string, int, or float).
@@ -72,19 +72,19 @@ fn bigdecimal_py_init(
     self = BigDecimal(s)
 
 
-fn bigdecimal_to_string(py_self: PythonObject) raises -> PythonObject:
+def bigdecimal_to_string(py_self: PythonObject) raises -> PythonObject:
     """Return the decimal as a plain string, e.g. '3.14'."""
     var ptr = py_self.downcast_value_ptr[BigDecimal]()
     return PythonObject(String(ptr[]))
 
 
-fn bigdecimal_to_repr(py_self: PythonObject) raises -> PythonObject:
+def bigdecimal_to_repr(py_self: PythonObject) raises -> PythonObject:
     """Return the repr string, e.g. 'Decimal(\"3.14\")'."""
     var ptr = py_self.downcast_value_ptr[BigDecimal]()
     return PythonObject('Decimal("' + String(ptr[]) + '")')
 
 
-fn bigdecimal_add(
+def bigdecimal_add(
     py_self: PythonObject, other: PythonObject
 ) raises -> PythonObject:
     """Return self + other."""
@@ -94,7 +94,7 @@ fn bigdecimal_add(
     return PythonObject(alloc=result^)
 
 
-fn bigdecimal_sub(
+def bigdecimal_sub(
     py_self: PythonObject, other: PythonObject
 ) raises -> PythonObject:
     """Return self - other."""
@@ -104,7 +104,7 @@ fn bigdecimal_sub(
     return PythonObject(alloc=result^)
 
 
-fn bigdecimal_mul(
+def bigdecimal_mul(
     py_self: PythonObject, other: PythonObject
 ) raises -> PythonObject:
     """Return self * other."""
@@ -114,7 +114,7 @@ fn bigdecimal_mul(
     return PythonObject(alloc=result^)
 
 
-fn bigdecimal_div(
+def bigdecimal_div(
     py_self: PythonObject, other: PythonObject
 ) raises -> PythonObject:
     """Return self / other."""
@@ -124,21 +124,21 @@ fn bigdecimal_div(
     return PythonObject(alloc=result^)
 
 
-fn bigdecimal_neg(py_self: PythonObject) raises -> PythonObject:
+def bigdecimal_neg(py_self: PythonObject) raises -> PythonObject:
     """Return -self."""
     var ptr = py_self.downcast_value_ptr[BigDecimal]()
     var result = -(ptr[])
     return PythonObject(alloc=result^)
 
 
-fn bigdecimal_abs(py_self: PythonObject) raises -> PythonObject:
+def bigdecimal_abs(py_self: PythonObject) raises -> PythonObject:
     """Return abs(self)."""
     var ptr = py_self.downcast_value_ptr[BigDecimal]()
     var result = abs(ptr[])
     return PythonObject(alloc=result^)
 
 
-fn bigdecimal_eq(
+def bigdecimal_eq(
     py_self: PythonObject, other: PythonObject
 ) raises -> PythonObject:
     """Return self == other."""
@@ -147,7 +147,7 @@ fn bigdecimal_eq(
     return PythonObject(self_ptr[] == other_ptr[])
 
 
-fn bigdecimal_lt(
+def bigdecimal_lt(
     py_self: PythonObject, other: PythonObject
 ) raises -> PythonObject:
     """Return self < other."""
@@ -156,7 +156,7 @@ fn bigdecimal_lt(
     return PythonObject(self_ptr[] < other_ptr[])
 
 
-fn bigdecimal_le(
+def bigdecimal_le(
     py_self: PythonObject, other: PythonObject
 ) raises -> PythonObject:
     """Return self <= other."""

--- a/src/cli/calculator/display.mojo
+++ b/src/cli/calculator/display.mojo
@@ -29,7 +29,7 @@ in an expression.  Modelled after ArgMojo's colour system.
 ```
 """
 
-from sys import stderr
+from std.sys import stderr
 
 # ── ANSI colour codes ────────────────────────────────────────────────────────
 

--- a/src/cli/calculator/display.mojo
+++ b/src/cli/calculator/display.mojo
@@ -56,7 +56,7 @@ comptime CARET_COLOR = GREEN
 # ── Public API ───────────────────────────────────────────────────────────────
 
 
-fn print_error(message: String):
+def print_error(message: String):
     """Print a coloured error message to stderr.
 
     Format:  ``Error: <message>``
@@ -69,7 +69,7 @@ fn print_error(message: String):
     )
 
 
-fn print_error(message: String, expr: String, position: Int):
+def print_error(message: String, expr: String, position: Int):
     """Print a coloured error message with a caret pointing at
     the offending position in `expr`.
 
@@ -92,7 +92,7 @@ fn print_error(message: String, expr: String, position: Int):
     _write_caret(expr, position)
 
 
-fn print_warning(message: String):
+def print_warning(message: String):
     """Print a coloured warning message to stderr.
 
     Format:  ``Warning: <message>``
@@ -104,7 +104,7 @@ fn print_warning(message: String):
     )
 
 
-fn print_warning(message: String, expr: String, position: Int):
+def print_warning(message: String, expr: String, position: Int):
     """Print a coloured warning message with a caret indicator."""
     _write_stderr(
         BOLD + WARNING_COLOR + "Warning" + RESET + BOLD + ": " + RESET + message
@@ -112,7 +112,7 @@ fn print_warning(message: String, expr: String, position: Int):
     _write_caret(expr, position)
 
 
-fn print_hint(message: String):
+def print_hint(message: String):
     """Print a coloured hint message to stderr.
 
     Format:  ``Hint: <message>``
@@ -127,12 +127,12 @@ fn print_hint(message: String):
 # ── Internal helpers ─────────────────────────────────────────────────────────
 
 
-fn _write_stderr(msg: String):
+def _write_stderr(msg: String):
     """Write a line to stderr."""
     print(msg, file=stderr)
 
 
-fn _write_caret(expr: String, position: Int):
+def _write_caret(expr: String, position: Int):
     """Print the expression line and a green caret (^) under the
     given column position to stderr.
 

--- a/src/cli/calculator/evaluator.mojo
+++ b/src/cli/calculator/evaluator.mojo
@@ -44,7 +44,7 @@ from .tokenizer import tokenize
 # ===----------------------------------------------------------------------=== #
 
 
-fn _call_func(
+def _call_func(
     name: String, mut stack: List[BDec], precision: Int, position: Int
 ) raises:
     """Pop argument(s) from `stack`, call the named Decimo function,
@@ -168,7 +168,7 @@ fn _call_func(
 # ===----------------------------------------------------------------------=== #
 
 
-fn evaluate_rpn(rpn: List[Token], precision: Int) raises -> BDec:
+def evaluate_rpn(rpn: List[Token], precision: Int) raises -> BDec:
     """Evaluate an RPN token list using BigDecimal arithmetic.
 
     Internally uses `working_precision = precision + GUARD_DIGITS` for all
@@ -305,7 +305,7 @@ fn evaluate_rpn(rpn: List[Token], precision: Int) raises -> BDec:
     return stack.pop()
 
 
-fn final_round(
+def final_round(
     value: BDec,
     precision: Int,
     rounding_mode: RoundingMode = RoundingMode.half_even(),
@@ -323,7 +323,7 @@ fn final_round(
     return result^
 
 
-fn evaluate(
+def evaluate(
     expr: String,
     precision: Int = 50,
     rounding_mode: RoundingMode = RoundingMode.half_even(),

--- a/src/cli/calculator/parser.mojo
+++ b/src/cli/calculator/parser.mojo
@@ -37,7 +37,7 @@ from .tokenizer import (
 )
 
 
-fn parse_to_rpn(tokens: List[Token]) raises -> List[Token]:
+def parse_to_rpn(tokens: List[Token]) raises -> List[Token]:
     """Convert infix tokens to Reverse Polish Notation using
     Dijkstra's shunting-yard algorithm.
 

--- a/src/cli/calculator/tokenizer.mojo
+++ b/src/cli/calculator/tokenizer.mojo
@@ -58,15 +58,15 @@ struct Token(Copyable, ImplicitlyCopyable, Movable):
         self.value = value
         self.position = position
 
-    fn __copyinit__(out self, other: Self):
-        self.kind = other.kind
-        self.value = other.value
-        self.position = other.position
+    fn __init__(out self, *, copy: Self):
+        self.kind = copy.kind
+        self.value = copy.value
+        self.position = copy.position
 
-    fn __moveinit__(out self, deinit other: Self):
-        self.kind = other.kind
-        self.value = other.value^
-        self.position = other.position
+    fn __init__(out self, *, deinit take: Self):
+        self.kind = take.kind
+        self.value = take.value^
+        self.position = take.position
 
     fn is_operator(self) -> Bool:
         """Returns True if this token is a binary or unary operator."""
@@ -173,7 +173,7 @@ fn tokenize(expr: String) raises -> List[Token]:
             column position included in the message).
     """
     var tokens = List[Token]()
-    var expr_bytes = expr.as_string_slice().as_bytes()
+    var expr_bytes = StringSlice(expr).as_bytes()
     var n = len(expr_bytes)
     var ptr = expr_bytes.unsafe_ptr()
     var i = 0

--- a/src/cli/calculator/tokenizer.mojo
+++ b/src/cli/calculator/tokenizer.mojo
@@ -53,22 +53,22 @@ struct Token(Copyable, ImplicitlyCopyable, Movable):
     starts.  Used to produce clear diagnostics such as
     ``Error at position 5: unexpected '*'``."""
 
-    fn __init__(out self, kind: Int, value: String = "", position: Int = 0):
+    def __init__(out self, kind: Int, value: String = "", position: Int = 0):
         self.kind = kind
         self.value = value
         self.position = position
 
-    fn __init__(out self, *, copy: Self):
+    def __init__(out self, *, copy: Self):
         self.kind = copy.kind
         self.value = copy.value
         self.position = copy.position
 
-    fn __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         self.kind = take.kind
         self.value = take.value^
         self.position = take.position
 
-    fn is_operator(self) -> Bool:
+    def is_operator(self) -> Bool:
         """Returns True if this token is a binary or unary operator."""
         return (
             self.kind == TOKEN_PLUS
@@ -79,7 +79,7 @@ struct Token(Copyable, ImplicitlyCopyable, Movable):
             or self.kind == TOKEN_UNARY_MINUS
         )
 
-    fn precedence(self) -> Int:
+    def precedence(self) -> Int:
         """Returns the precedence level (higher binds tighter).
 
         | Precedence | Operators | Associativity |
@@ -99,7 +99,7 @@ struct Token(Copyable, ImplicitlyCopyable, Movable):
             return 4
         return 0
 
-    fn is_left_associative(self) -> Bool:
+    def is_left_associative(self) -> Bool:
         """Returns True if this operator is left-associative."""
         if self.kind == TOKEN_UNARY_MINUS or self.kind == TOKEN_CARET:
             return False
@@ -122,7 +122,7 @@ struct Token(Copyable, ImplicitlyCopyable, Movable):
 # Known function names and built-in constants.
 
 
-fn _is_known_function(name: String) -> Bool:
+def _is_known_function(name: String) -> Bool:
     """Returns True if `name` is a recognized function."""
     return (
         name == "sqrt"
@@ -141,22 +141,22 @@ fn _is_known_function(name: String) -> Bool:
     )
 
 
-fn _is_known_constant(name: String) -> Bool:
+def _is_known_constant(name: String) -> Bool:
     """Returns True if `name` is a recognized constant."""
     return name == "pi" or name == "e"
 
 
-fn _is_alpha_or_underscore(c: UInt8) -> Bool:
+def _is_alpha_or_underscore(c: UInt8) -> Bool:
     """Returns True if c is a-z, A-Z, or '_'."""
     return (c >= 65 and c <= 90) or (c >= 97 and c <= 122) or c == 95
 
 
-fn _is_alnum_or_underscore(c: UInt8) -> Bool:
+def _is_alnum_or_underscore(c: UInt8) -> Bool:
     """Returns True if c is a-z, A-Z, 0-9, or '_'."""
     return _is_alpha_or_underscore(c) or (c >= 48 and c <= 57)
 
 
-fn tokenize(expr: String) raises -> List[Token]:
+def tokenize(expr: String) raises -> List[Token]:
     """Converts an expression string into a list of tokens.
 
     Handles: numbers (integer and decimal), operators (+, -, *, /, ^),

--- a/src/cli/main.mojo
+++ b/src/cli/main.mojo
@@ -9,7 +9,7 @@
 #   ./decimo "100 * 12 - 23/17" -p 50
 # ===----------------------------------------------------------------------=== #
 
-from sys import exit
+from std.sys import exit
 
 from argmojo import Arg, Command
 from decimo.rounding_mode import RoundingMode
@@ -196,8 +196,10 @@ fn _display_calc_error(error_msg: String, expr: String):
 
         if colon_pos > after_prefix:
             # Extract position number and description.
-            var pos_str = String(error_msg[after_prefix:colon_pos])
-            var description = String(error_msg[colon_pos + 2 :])  # skip ": "
+            var pos_str = String(error_msg[byte=after_prefix:colon_pos])
+            var description = String(
+                error_msg[byte = colon_pos + 2 :]
+            )  # skip ": "
 
             try:
                 var pos = Int(pos_str)

--- a/src/cli/main.mojo
+++ b/src/cli/main.mojo
@@ -19,7 +19,7 @@ from calculator.evaluator import evaluate_rpn, final_round
 from calculator.display import print_error
 
 
-fn main():
+def main():
     try:
         _run()
     except e:
@@ -30,7 +30,7 @@ fn main():
         exit(1)
 
 
-fn _run() raises:
+def _run() raises:
     var cmd = Command(
         "decimo",
         (
@@ -166,7 +166,7 @@ fn _run() raises:
         exit(1)
 
 
-fn _display_calc_error(error_msg: String, expr: String):
+def _display_calc_error(error_msg: String, expr: String):
     """Parse a calculator error message and display it with colours
     and a caret indicator.
 
@@ -209,7 +209,7 @@ fn _display_calc_error(error_msg: String, expr: String):
     print_error(error_msg)
 
 
-fn _pad_to_precision(plain: String, precision: Int) -> String:
+def _pad_to_precision(plain: String, precision: Int) -> String:
     """Pad (or add) trailing zeros so the fractional part has exactly
     `precision` digits.
     """
@@ -233,7 +233,7 @@ fn _pad_to_precision(plain: String, precision: Int) -> String:
     return plain + "0" * (precision - frac_len)
 
 
-fn _parse_rounding_mode(name: String) -> RoundingMode:
+def _parse_rounding_mode(name: String) -> RoundingMode:
     """Convert a CLI rounding-mode name (hyphenated) to a RoundingMode value."""
     if name == "half-even":
         return RoundingMode.half_even()

--- a/src/cli/main.mojo
+++ b/src/cli/main.mojo
@@ -46,7 +46,7 @@ fn _run() raises:
     )
 
     # Positional: the math expression
-    cmd.add_arg(
+    cmd.add_argument(
         Arg(
             "expr",
             help=(
@@ -58,41 +58,41 @@ fn _run() raises:
     )
 
     # Named option: number of significant digits
-    cmd.add_arg(
+    cmd.add_argument(
         Arg("precision", help="Number of significant digits (default: 50)")
-        .long("precision")
-        .short("p")
-        .default("50")
+        .long["precision"]()
+        .short["p"]()
+        .default["50"]()
     )
 
     # Output formatting flags
     # Mutually exclusive: scientific, engineering
-    cmd.add_arg(
+    cmd.add_argument(
         Arg("scientific", help="Output in scientific notation (e.g. 1.23E+10)")
-        .long("scientific")
-        .short("s")
+        .long["scientific"]()
+        .short["s"]()
         .flag()
     )
-    cmd.add_arg(
+    cmd.add_argument(
         Arg(
             "engineering",
             help="Output in engineering notation (exponent multiple of 3)",
         )
-        .long("engineering")
-        .short("e")
+        .long["engineering"]()
+        .short["e"]()
         .flag()
     )
     cmd.mutually_exclusive(["scientific", "engineering"])
-    cmd.add_arg(
+    cmd.add_argument(
         Arg(
             "pad",
             help="Pad trailing zeros to the specified precision",
         )
-        .long("pad")
-        .short("P")
+        .long["pad"]()
+        .short["P"]()
         .flag()
     )
-    cmd.add_arg(
+    cmd.add_argument(
         Arg(
             "delimiter",
             help=(
@@ -100,30 +100,27 @@ fn _run() raises:
                 " (e.g. '_' gives 1_234.567_89)"
             ),
         )
-        .long("delimiter")
-        .short("d")
-        .default("")
+        .long["delimiter"]()
+        .short["d"]()
+        .default[""]()
     )
 
     # Rounding mode for the final result
-    var rounding_choices: List[String] = [
-        "half-even",
-        "half-up",
-        "half-down",
-        "up",
-        "down",
-        "ceiling",
-        "floor",
-    ]
-    cmd.add_arg(
+    cmd.add_argument(
         Arg(
             "rounding-mode",
             help="Rounding mode for the final result (default: half-even)",
         )
-        .long("rounding-mode")
-        .short("r")
-        .choices(rounding_choices^)
-        .default("half-even")
+        .long["rounding-mode"]()
+        .short["r"]()
+        .choice["half-even"]()
+        .choice["half-up"]()
+        .choice["half-down"]()
+        .choice["up"]()
+        .choice["down"]()
+        .choice["ceiling"]()
+        .choice["floor"]()
+        .default["half-even"]()
     )
 
     var result = cmd.parse()

--- a/src/decimo/bigdecimal/arithmetics.mojo
+++ b/src/decimo/bigdecimal/arithmetics.mojo
@@ -18,7 +18,7 @@
 Implements functions for mathematical operations on BigDecimal objects.
 """
 
-import math
+from std import math
 
 from decimo.rounding_mode import RoundingMode
 

--- a/src/decimo/bigdecimal/arithmetics.mojo
+++ b/src/decimo/bigdecimal/arithmetics.mojo
@@ -32,7 +32,7 @@ from decimo.rounding_mode import RoundingMode
 # ===----------------------------------------------------------------------=== #
 
 
-fn add(x1: BigDecimal, x2: BigDecimal) raises -> BigDecimal:
+def add(x1: BigDecimal, x2: BigDecimal) raises -> BigDecimal:
     """Returns the sum of two numbers.
 
     Args:
@@ -91,7 +91,7 @@ fn add(x1: BigDecimal, x2: BigDecimal) raises -> BigDecimal:
         )
 
 
-fn subtract(x1: BigDecimal, x2: BigDecimal) raises -> BigDecimal:
+def subtract(x1: BigDecimal, x2: BigDecimal) raises -> BigDecimal:
     """Returns the difference of two numbers.
 
     Args:
@@ -153,7 +153,7 @@ fn subtract(x1: BigDecimal, x2: BigDecimal) raises -> BigDecimal:
         )
 
 
-fn multiply(x1: BigDecimal, x2: BigDecimal) -> BigDecimal:
+def multiply(x1: BigDecimal, x2: BigDecimal) -> BigDecimal:
     """Returns the product of two numbers.
 
     Args:
@@ -184,7 +184,7 @@ fn multiply(x1: BigDecimal, x2: BigDecimal) -> BigDecimal:
     )
 
 
-fn multiply_inplace(mut x1: BigDecimal, x2: BigDecimal):
+def multiply_inplace(mut x1: BigDecimal, x2: BigDecimal):
     """Multiplies x1 by x2 in place, avoiding full BigDecimal construction.
 
     This computes the product and moves the result words into x1,
@@ -205,7 +205,7 @@ fn multiply_inplace(mut x1: BigDecimal, x2: BigDecimal):
     x1.sign = x1.sign != x2.sign
 
 
-fn add_inplace(mut x1: BigDecimal, x2: BigDecimal) raises:
+def add_inplace(mut x1: BigDecimal, x2: BigDecimal) raises:
     """Adds x2 to x1 in place.
 
     This avoids constructing a new BigDecimal for the result.
@@ -275,7 +275,7 @@ fn add_inplace(mut x1: BigDecimal, x2: BigDecimal) raises:
             x1.sign = False
 
 
-fn subtract_inplace(mut x1: BigDecimal, x2: BigDecimal) raises:
+def subtract_inplace(mut x1: BigDecimal, x2: BigDecimal) raises:
     """Subtracts x2 from x1 in place.
 
     This avoids constructing a new BigDecimal for the result.
@@ -293,7 +293,7 @@ fn subtract_inplace(mut x1: BigDecimal, x2: BigDecimal) raises:
     add_inplace(x1, neg_x2)
 
 
-fn true_divide(
+def true_divide(
     x: BigDecimal, y: BigDecimal, precision: Int
 ) raises -> BigDecimal:
     """Returns the quotient of two numbers with specified precision.
@@ -334,7 +334,7 @@ fn true_divide(
     return true_divide_general(x, y, precision)
 
 
-fn true_divide_fast(
+def true_divide_fast(
     x: BigDecimal, y: BigDecimal, minimum_precision: Int
 ) raises -> BigDecimal:
     """Returns the quotient of two numbers.
@@ -413,7 +413,7 @@ fn true_divide_fast(
     )
 
 
-fn _true_divide_fast_truncated(
+def _true_divide_fast_truncated(
     x: BigDecimal,
     y: BigDecimal,
     minimum_precision: Int,
@@ -464,7 +464,7 @@ fn _true_divide_fast_truncated(
     )
 
 
-fn true_divide_general(
+def true_divide_general(
     x: BigDecimal, y: BigDecimal, precision: Int
 ) raises -> BigDecimal:
     """Returns the quotient of two numbers with the specified precision.
@@ -571,7 +571,7 @@ fn true_divide_general(
     return result^
 
 
-fn _true_divide_general_truncated(
+def _true_divide_general_truncated(
     x: BigDecimal,
     y: BigDecimal,
     precision: Int,
@@ -669,7 +669,7 @@ fn _true_divide_general_truncated(
     return result^
 
 
-fn true_divide_inexact(
+def true_divide_inexact(
     x1: BigDecimal, x2: BigDecimal, number_of_significant_digits: Int
 ) raises -> BigDecimal:
     """Returns the quotient of two numbers with number of significant digits.
@@ -751,7 +751,7 @@ fn true_divide_inexact(
     )
 
 
-fn _true_divide_inexact_truncated(
+def _true_divide_inexact_truncated(
     x1: BigDecimal,
     x2: BigDecimal,
     number_of_significant_digits: Int,
@@ -811,7 +811,7 @@ fn _true_divide_inexact_truncated(
     )
 
 
-fn true_divide_inexact_by_uint32(
+def true_divide_inexact_by_uint32(
     x1: BigDecimal, y: UInt32, number_of_significant_digits: Int
 ) raises -> BigDecimal:
     """Returns the quotient of a BigDecimal divided by a small UInt32 integer.
@@ -886,7 +886,7 @@ fn true_divide_inexact_by_uint32(
     )
 
 
-fn truncate_divide(x1: BigDecimal, x2: BigDecimal) raises -> BigDecimal:
+def truncate_divide(x1: BigDecimal, x2: BigDecimal) raises -> BigDecimal:
     """Returns the quotient of two numbers truncated to zeros.
 
     Args:
@@ -927,7 +927,7 @@ fn truncate_divide(x1: BigDecimal, x2: BigDecimal) raises -> BigDecimal:
         return BigDecimal(quotient^, 0, x1.sign != x2.sign)
 
 
-fn truncate_modulo(
+def truncate_modulo(
     x1: BigDecimal, x2: BigDecimal, precision: Int
 ) raises -> BigDecimal:
     """Returns the trucated modulo of two numbers.

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -100,53 +100,53 @@ struct BigDecimal(
     # Constructors and life time dunder methods
     # ===------------------------------------------------------------------=== #
 
-    fn __init__(out self):
+    def __init__(out self):
         """Initializes to zero by default."""
         self.coefficient = BigUInt()
         self.scale = 0
         self.sign = False
 
     @implicit
-    fn __init__(out self, coefficient: BigUInt):
+    def __init__(out self, coefficient: BigUInt):
         """Constructs a BigDecimal from a BigUInt object."""
         self.coefficient = coefficient.copy()
         self.scale = 0
         self.sign = False
 
-    fn __init__(out self, coefficient: BigUInt, scale: Int, sign: Bool):
+    def __init__(out self, coefficient: BigUInt, scale: Int, sign: Bool):
         """Constructs a BigDecimal from its components."""
         self.coefficient = coefficient.copy()
         self.scale = scale
         self.sign = sign
 
     @implicit
-    fn __init__(out self, value: BigInt10):
+    def __init__(out self, value: BigInt10):
         """Constructs a BigDecimal from a big integer."""
         self.coefficient = value.magnitude.copy()
         self.scale = 0
         self.sign = value.sign
 
-    fn __init__(out self, value: String) raises:
+    def __init__(out self, value: String) raises:
         """Constructs a BigDecimal from a string representation."""
         # The string is normalized with `deciomojo.str.parse_numeric_string()`.
         self = Self.from_string(value)
 
     @implicit
-    fn __init__(out self, value: Int):
+    def __init__(out self, value: Int):
         """Constructs a BigDecimal from an `Int` object.
         See `from_int()` for more information.
         """
         self = Self.from_int(value)
 
     @implicit
-    fn __init__(out self, value: UInt):
+    def __init__(out self, value: UInt):
         """Constructs a BigDecimal from an `UInt` object.
         See `from_uint()` for more information.
         """
         self = Self.from_uint(value)
 
     @implicit
-    fn __init__[dtype: DType, //](out self, value: SIMD[dtype, 1]):
+    def __init__[dtype: DType, //](out self, value: SIMD[dtype, 1]):
         """Constructs a BigDecimal from an integral scalar.
         This includes all SIMD integral types, such as Int8, Int16, UInt32, etc.
 
@@ -166,7 +166,7 @@ struct BigDecimal(
 
         self = Self.from_integral_scalar(value)
 
-    fn __init__(out self, *, py: PythonObject) raises:
+    def __init__(out self, *, py: PythonObject) raises:
         """Constructs a BigDecimal from a Python Decimal object."""
         self = Self.from_python_decimal(py)
 
@@ -178,7 +178,7 @@ struct BigDecimal(
     # ===------------------------------------------------------------------=== #
 
     @staticmethod
-    fn from_raw_components(
+    def from_raw_components(
         var words: List[UInt32], scale: Int = 0, sign: Bool = False
     ) -> Self:
         """**UNSAFE** Creates a BigDecimal from its raw components.
@@ -202,7 +202,7 @@ struct BigDecimal(
         return Self(coefficient=coefficient^, scale=scale, sign=sign)
 
     @staticmethod
-    fn from_raw_components(
+    def from_raw_components(
         word: UInt32, scale: Int = 0, sign: Bool = False
     ) -> Self:
         """**UNSAFE** Creates a BigDecimal from its raw components.
@@ -211,7 +211,7 @@ struct BigDecimal(
         return Self(BigUInt(raw_words=[word]), scale, sign)
 
     @staticmethod
-    fn from_int(value: Int) -> Self:
+    def from_int(value: Int) -> Self:
         """Creates a BigDecimal from an integer."""
         if value == 0:
             return Self(coefficient=BigUInt.zero(), scale=0, sign=False)
@@ -246,7 +246,7 @@ struct BigDecimal(
 
     # TODO: This method is no longer needed as UInt is now an alias for SIMD.
     @staticmethod
-    fn from_uint(value: UInt) -> Self:
+    def from_uint(value: UInt) -> Self:
         """Creates a BigDecimal from an unsigned integer."""
         return Self(
             coefficient=BigUInt.from_unsigned_integral_scalar(value),
@@ -255,7 +255,7 @@ struct BigDecimal(
         )
 
     @staticmethod
-    fn from_integral_scalar[dtype: DType, //](value: SIMD[dtype, 1]) -> Self:
+    def from_integral_scalar[dtype: DType, //](value: SIMD[dtype, 1]) -> Self:
         """Initializes a BigDecimal from an integral scalar.
         This includes all SIMD integral types, such as Int8, Int16, UInt32, etc.
 
@@ -278,7 +278,7 @@ struct BigDecimal(
         )
 
     @staticmethod
-    fn from_float[dtype: DType, //](value: Scalar[dtype]) raises -> Self:
+    def from_float[dtype: DType, //](value: Scalar[dtype]) raises -> Self:
         """Initializes a BigDecimal from a floating-point scalar.
 
         Args:
@@ -312,7 +312,7 @@ struct BigDecimal(
             )
 
     @staticmethod
-    fn from_string(value: String) raises -> Self:
+    def from_string(value: String) raises -> Self:
         """Initializes a BigDecimal from a string representation.
         The string is normalized with `deciomojo.str.parse_numeric_string()`.
 
@@ -354,7 +354,7 @@ struct BigDecimal(
         return Self(coefficient=coefficient^, scale=scale, sign=sign)
 
     @staticmethod
-    fn from_python_decimal(value: PythonObject) raises -> Self:
+    def from_python_decimal(value: PythonObject) raises -> Self:
         """Initializes a BigDecimal from a Python Decimal object.
         Only finite Decimal values are supported for conversion.
 
@@ -373,7 +373,7 @@ struct BigDecimal(
         from std.python import Python
         from decimo.prelude import *
 
-        fn main() raises:
+        def main() raises:
             var decimal = Python.import_module("decimal")
             var py_dec = decimal.Decimal("123.456")
             var mojo_dec = BigDecimal.from_python_decimal(py_dec)
@@ -491,11 +491,11 @@ struct BigDecimal(
     # __float__()
     # ===------------------------------------------------------------------=== #
 
-    fn __int__(self) raises -> Int:
+    def __int__(self) raises -> Int:
         """Converts the BigDecimal to an integer."""
         return Int(self.to_string())
 
-    fn __float__(self) raises -> Float64:
+    def __float__(self) raises -> Float64:
         """Converts the BigDecimal to a floating-point number."""
         return Float64(self.to_string())
 
@@ -503,7 +503,7 @@ struct BigDecimal(
     # Type-transfer or output methods that are not dunders
     # ===------------------------------------------------------------------=== #
 
-    fn to_string(
+    def to_string(
         self,
         scientific: Bool = False,
         engineering: Bool = False,
@@ -698,17 +698,17 @@ struct BigDecimal(
 
         return result^
 
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """Writes the BigDecimal to a writer.
         This implement the `write` method of the `Writer` trait.
         """
         writer.write(self.to_string())
 
-    fn write_repr_to[W: Writer](self, mut writer: W):
+    def write_repr_to[W: Writer](self, mut writer: W):
         """Writes the debug representation to a writer."""
         writer.write('BigDecimal("', self.to_string(), '")')
 
-    fn to_scientific_string(self) -> String:
+    def to_scientific_string(self) -> String:
         """Returns the number in scientific notation (trailing zeros stripped).
 
         Convenience alias for `to_string(scientific=True)`.
@@ -722,7 +722,7 @@ struct BigDecimal(
         """
         return self.to_string(scientific=True)
 
-    fn to_eng_string(self) -> String:
+    def to_eng_string(self) -> String:
         """Returns the number in engineering notation (exponent is a multiple
         of 3, trailing zeros stripped).
 
@@ -737,7 +737,7 @@ struct BigDecimal(
         """
         return self.to_string(engineering=True)
 
-    fn to_string_with_separators(self, separator: String = "_") -> String:
+    def to_string_with_separators(self, separator: String = "_") -> String:
         """Returns a string with digit-group separators inserted every 3 digits.
 
         Groups both the integer and fractional parts.  Convenience alias for
@@ -763,7 +763,7 @@ struct BigDecimal(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __abs__(self) -> Self:
+    def __abs__(self) -> Self:
         """Returns the absolute value of this number.
         See `absolute()` for more information.
         """
@@ -774,7 +774,7 @@ struct BigDecimal(
         )
 
     @always_inline
-    fn __neg__(self) -> Self:
+    def __neg__(self) -> Self:
         """Returns the negation of this number.
         See `negative()` for more information.
         """
@@ -785,7 +785,7 @@ struct BigDecimal(
         )
 
     @always_inline
-    fn __bool__(self) -> Bool:
+    def __bool__(self) -> Bool:
         """Returns True if the number is nonzero.
 
         This enables `if x:` syntax, consistent with Python's `decimal.Decimal`.
@@ -793,7 +793,7 @@ struct BigDecimal(
         return not self.coefficient.is_zero()
 
     @always_inline
-    fn __pos__(self) -> Self:
+    def __pos__(self) -> Self:
         """Returns the number unchanged (unary plus).
 
         This enables `+x` syntax, consistent with Python's `decimal.Decimal`.
@@ -808,32 +808,32 @@ struct BigDecimal(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __add__(self, other: Self) raises -> Self:
+    def __add__(self, other: Self) raises -> Self:
         return decimo.bigdecimal.arithmetics.add(self, other)
 
     @always_inline
-    fn __sub__(self, other: Self) raises -> Self:
+    def __sub__(self, other: Self) raises -> Self:
         return decimo.bigdecimal.arithmetics.subtract(self, other)
 
     @always_inline
-    fn __mul__(self, other: Self) -> Self:
+    def __mul__(self, other: Self) -> Self:
         return decimo.bigdecimal.arithmetics.multiply(self, other)
 
     @always_inline
-    fn __truediv__(self, other: Self) raises -> Self:
+    def __truediv__(self, other: Self) raises -> Self:
         return decimo.bigdecimal.arithmetics.true_divide(
             self, other, precision=PRECISION
         )
 
     @always_inline
-    fn __floordiv__(self, other: Self) raises -> Self:
+    def __floordiv__(self, other: Self) raises -> Self:
         """Returns the result of floor division.
         See `arithmetics.truncate_divide()` for more information.
         """
         return decimo.bigdecimal.arithmetics.truncate_divide(self, other)
 
     @always_inline
-    fn __mod__(self, other: Self) raises -> Self:
+    def __mod__(self, other: Self) raises -> Self:
         """Returns the result of modulo operation.
         See `arithmetics.truncate_modulo()` for more information.
         """
@@ -842,13 +842,13 @@ struct BigDecimal(
         )
 
     @always_inline
-    fn __pow__(self, exponent: Self) raises -> Self:
+    def __pow__(self, exponent: Self) raises -> Self:
         """Returns the result of exponentiation."""
         return decimo.bigdecimal.exponential.power(
             self, exponent, precision=PRECISION
         )
 
-    fn __divmod__(self, other: Self) raises -> Tuple[Self, Self]:
+    def __divmod__(self, other: Self) raises -> Tuple[Self, Self]:
         """Returns `(self // other, self % other)`.
 
         This enables `divmod(a, b)` syntax, consistent with Python's
@@ -868,7 +868,7 @@ struct BigDecimal(
         )
         return (quotient^, remainder^)
 
-    fn __rdivmod__(self, other: Self) raises -> Tuple[Self, Self]:
+    def __rdivmod__(self, other: Self) raises -> Tuple[Self, Self]:
         """Returns `divmod(other, self)` for right-side divmod."""
         var quotient = decimo.bigdecimal.arithmetics.truncate_divide(
             other, self
@@ -886,35 +886,35 @@ struct BigDecimal(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __radd__(self, other: Self) raises -> Self:
+    def __radd__(self, other: Self) raises -> Self:
         return decimo.bigdecimal.arithmetics.add(self, other)
 
     @always_inline
-    fn __rsub__(self, other: Self) raises -> Self:
+    def __rsub__(self, other: Self) raises -> Self:
         return decimo.bigdecimal.arithmetics.subtract(other, self)
 
     @always_inline
-    fn __rmul__(self, other: Self) raises -> Self:
+    def __rmul__(self, other: Self) raises -> Self:
         return decimo.bigdecimal.arithmetics.multiply(self, other)
 
     @always_inline
-    fn __rfloordiv__(self, other: Self) raises -> Self:
+    def __rfloordiv__(self, other: Self) raises -> Self:
         return decimo.bigdecimal.arithmetics.truncate_divide(other, self)
 
     @always_inline
-    fn __rmod__(self, other: Self) raises -> Self:
+    def __rmod__(self, other: Self) raises -> Self:
         return decimo.bigdecimal.arithmetics.truncate_modulo(
             other, self, precision=PRECISION
         )
 
     @always_inline
-    fn __rpow__(self, base: Self) raises -> Self:
+    def __rpow__(self, base: Self) raises -> Self:
         return decimo.bigdecimal.exponential.power(
             base, self, precision=PRECISION
         )
 
     @always_inline
-    fn __rtruediv__(self, other: Self) raises -> Self:
+    def __rtruediv__(self, other: Self) raises -> Self:
         return decimo.bigdecimal.arithmetics.true_divide(
             other, self, precision=PRECISION
         )
@@ -927,29 +927,29 @@ struct BigDecimal(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __iadd__(mut self, other: Self) raises:
+    def __iadd__(mut self, other: Self) raises:
         decimo.bigdecimal.arithmetics.add_inplace(self, other)
 
     @always_inline
-    fn __isub__(mut self, other: Self) raises:
+    def __isub__(mut self, other: Self) raises:
         decimo.bigdecimal.arithmetics.subtract_inplace(self, other)
 
     @always_inline
-    fn __imul__(mut self, other: Self) raises:
+    def __imul__(mut self, other: Self) raises:
         decimo.bigdecimal.arithmetics.multiply_inplace(self, other)
 
     @always_inline
-    fn __itruediv__(mut self, other: Self) raises:
+    def __itruediv__(mut self, other: Self) raises:
         self = decimo.bigdecimal.arithmetics.true_divide(
             self, other, precision=PRECISION
         )
 
     @always_inline
-    fn __ifloordiv__(mut self, other: Self) raises:
+    def __ifloordiv__(mut self, other: Self) raises:
         self = decimo.bigdecimal.arithmetics.truncate_divide(self, other)
 
     @always_inline
-    fn __imod__(mut self, other: Self) raises:
+    def __imod__(mut self, other: Self) raises:
         self = decimo.bigdecimal.arithmetics.truncate_modulo(
             self, other, precision=PRECISION
         )
@@ -960,32 +960,32 @@ struct BigDecimal(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __gt__(self, other: Self) -> Bool:
+    def __gt__(self, other: Self) -> Bool:
         """Returns whether self is greater than other."""
         return decimo.bigdecimal.comparison.compare(self, other) > 0
 
     @always_inline
-    fn __ge__(self, other: Self) -> Bool:
+    def __ge__(self, other: Self) -> Bool:
         """Returns whether self is greater than or equal to other."""
         return decimo.bigdecimal.comparison.compare(self, other) >= 0
 
     @always_inline
-    fn __lt__(self, other: Self) -> Bool:
+    def __lt__(self, other: Self) -> Bool:
         """Returns whether self is less than other."""
         return decimo.bigdecimal.comparison.compare(self, other) < 0
 
     @always_inline
-    fn __le__(self, other: Self) -> Bool:
+    def __le__(self, other: Self) -> Bool:
         """Returns whether self is less than or equal to other."""
         return decimo.bigdecimal.comparison.compare(self, other) <= 0
 
     @always_inline
-    fn __eq__(self, other: Self) -> Bool:
+    def __eq__(self, other: Self) -> Bool:
         """Returns whether self equals other."""
         return decimo.bigdecimal.comparison.compare(self, other) == 0
 
     @always_inline
-    fn __ne__(self, other: Self) -> Bool:
+    def __ne__(self, other: Self) -> Bool:
         """Returns whether self does not equal other."""
         return decimo.bigdecimal.comparison.compare(self, other) != 0
 
@@ -994,7 +994,7 @@ struct BigDecimal(
     # round
     # ===------------------------------------------------------------------=== #
 
-    fn __round__(self, ndigits: Int) -> Self:
+    def __round__(self, ndigits: Int) -> Self:
         """Rounds the number to the specified number of decimal places.
         If `ndigits` is not given, rounds to 0 decimal places.
         If rounding causes errors, returns the value itself.
@@ -1008,7 +1008,7 @@ struct BigDecimal(
         except e:
             return self.copy()
 
-    fn __round__(self) -> Self:
+    def __round__(self) -> Self:
         """Rounds the number to the specified number of decimal places.
         If `ndigits` is not given, rounds to 0 decimal places.
         If rounding causes errors, returns the value itself.
@@ -1024,7 +1024,7 @@ struct BigDecimal(
     # Other dunders
     # ===------------------------------------------------------------------=== #
 
-    fn __ceil__(self) raises -> Self:
+    def __ceil__(self) raises -> Self:
         """Returns the smallest integer value >= self.
 
         Equivalent to `math.ceil()` in Python. Returns a BigDecimal with
@@ -1041,7 +1041,7 @@ struct BigDecimal(
             return truncated + Self(1)
         return truncated^
 
-    fn __floor__(self) raises -> Self:
+    def __floor__(self) raises -> Self:
         """Returns the largest integer value <= self.
 
         Equivalent to `math.floor()` in Python. Returns a BigDecimal with
@@ -1058,7 +1058,7 @@ struct BigDecimal(
             return truncated - Self(1)
         return truncated^
 
-    fn __trunc__(self) raises -> Self:
+    def __trunc__(self) raises -> Self:
         """Returns self truncated toward zero (removes fractional part).
 
         Equivalent to `math.trunc()` in Python. Returns a BigDecimal
@@ -1077,14 +1077,14 @@ struct BigDecimal(
     # === Comparisons === #
 
     @always_inline
-    fn compare(self, other: Self) raises -> Int8:
+    def compare(self, other: Self) raises -> Int8:
         """Compares two BigDecimal numbers.
         See `comparison.compare()` for more information.
         """
         return decimo.bigdecimal.comparison.compare(self, other)
 
     @always_inline
-    fn compare_absolute(self, other: Self) raises -> Int8:
+    def compare_absolute(self, other: Self) raises -> Int8:
         """Compares two BigDecimal numbers by absolute value.
         See `comparison.compare_absolute()` for more information.
         """
@@ -1093,12 +1093,12 @@ struct BigDecimal(
     # === Extrema === #
 
     @always_inline
-    fn max(self, other: Self) raises -> Self:
+    def max(self, other: Self) raises -> Self:
         """Returns the maximum of two BigDecimal numbers."""
         return decimo.bigdecimal.comparison.max(self, other)
 
     @always_inline
-    fn min(self, other: Self) raises -> Self:
+    def min(self, other: Self) raises -> Self:
         """Returns the minimum of two BigDecimal numbers."""
         return decimo.bigdecimal.comparison.min(self, other)
 
@@ -1106,13 +1106,13 @@ struct BigDecimal(
 
     @always_inline
     @staticmethod
-    fn pi(precision: Int) raises -> Self:
+    def pi(precision: Int) raises -> Self:
         """Returns the mathematical constant pi to the specified precision."""
         return decimo.bigdecimal.constants.pi(precision=precision)
 
     @always_inline
     @staticmethod
-    fn e(precision: Int) raises -> Self:
+    def e(precision: Int) raises -> Self:
         """Returns the mathematical constant e to the specified precision."""
         return decimo.bigdecimal.exponential.exp(
             x=Self(BigUInt.one()), precision=precision
@@ -1121,17 +1121,17 @@ struct BigDecimal(
     # === Exponentional operations === #
 
     @always_inline
-    fn exp(self, precision: Int = PRECISION) raises -> Self:
+    def exp(self, precision: Int = PRECISION) raises -> Self:
         """Returns the exponential of the BigDecimal number."""
         return decimo.bigdecimal.exponential.exp(self, precision)
 
     @always_inline
-    fn ln(self, precision: Int = PRECISION) raises -> Self:
+    def ln(self, precision: Int = PRECISION) raises -> Self:
         """Returns the natural logarithm of the BigDecimal number."""
         return decimo.bigdecimal.exponential.ln(self, precision)
 
     @always_inline
-    fn ln(
+    def ln(
         self,
         precision: Int,
         mut cache: decimo.bigdecimal.exponential.MathCache,
@@ -1140,33 +1140,33 @@ struct BigDecimal(
         return decimo.bigdecimal.exponential.ln(self, precision, cache)
 
     @always_inline
-    fn log(self, base: Self, precision: Int = PRECISION) raises -> Self:
+    def log(self, base: Self, precision: Int = PRECISION) raises -> Self:
         """Returns the logarithm of the BigDecimal number with the given base.
         """
         return decimo.bigdecimal.exponential.log(self, base, precision)
 
     @always_inline
-    fn log10(self, precision: Int = PRECISION) raises -> Self:
+    def log10(self, precision: Int = PRECISION) raises -> Self:
         """Returns the base-10 logarithm of the BigDecimal number."""
         return decimo.bigdecimal.exponential.log10(self, precision)
 
     @always_inline
-    fn root(self, root: Self, precision: Int = PRECISION) raises -> Self:
+    def root(self, root: Self, precision: Int = PRECISION) raises -> Self:
         """Returns the root of the BigDecimal number."""
         return decimo.bigdecimal.exponential.root(self, root, precision)
 
     @always_inline
-    fn sqrt(self, precision: Int = PRECISION) raises -> Self:
+    def sqrt(self, precision: Int = PRECISION) raises -> Self:
         """Returns the square root of the BigDecimal number."""
         return decimo.bigdecimal.exponential.sqrt(self, precision)
 
     @always_inline
-    fn cbrt(self, precision: Int = PRECISION) raises -> Self:
+    def cbrt(self, precision: Int = PRECISION) raises -> Self:
         """Returns the cube root of the BigDecimal number."""
         return decimo.bigdecimal.exponential.cbrt(self, precision)
 
     @always_inline
-    fn power(self, exponent: Self, precision: Int = PRECISION) raises -> Self:
+    def power(self, exponent: Self, precision: Int = PRECISION) raises -> Self:
         """Returns the result of exponentiation with the given precision.
         See `exponential.power()` for more information.
         """
@@ -1174,44 +1174,44 @@ struct BigDecimal(
 
     # === Trigonometric operations === #
     @always_inline
-    fn sin(self, precision: Int = PRECISION) raises -> Self:
+    def sin(self, precision: Int = PRECISION) raises -> Self:
         """Returns the sine of the BigDecimal number."""
         return decimo.bigdecimal.trigonometric.sin(self, precision)
 
     @always_inline
-    fn cos(self, precision: Int = PRECISION) raises -> Self:
+    def cos(self, precision: Int = PRECISION) raises -> Self:
         """Returns the cosine of the BigDecimal number."""
         return decimo.bigdecimal.trigonometric.cos(self, precision)
 
     @always_inline
-    fn tan(self, precision: Int = PRECISION) raises -> Self:
+    def tan(self, precision: Int = PRECISION) raises -> Self:
         """Returns the tangent of the BigDecimal number."""
         return decimo.bigdecimal.trigonometric.tan(self, precision)
 
     @always_inline
-    fn cot(self, precision: Int = PRECISION) raises -> Self:
+    def cot(self, precision: Int = PRECISION) raises -> Self:
         """Returns the cotangent of the BigDecimal number."""
         return decimo.bigdecimal.trigonometric.cot(self, precision)
 
     @always_inline
-    fn csc(self, precision: Int = PRECISION) raises -> Self:
+    def csc(self, precision: Int = PRECISION) raises -> Self:
         """Returns the cosecant of the BigDecimal number."""
         return decimo.bigdecimal.trigonometric.csc(self, precision)
 
     @always_inline
-    fn sec(self, precision: Int = PRECISION) raises -> Self:
+    def sec(self, precision: Int = PRECISION) raises -> Self:
         """Returns the secant of the BigDecimal number."""
         return decimo.bigdecimal.trigonometric.sec(self, precision)
 
     @always_inline
-    fn arctan(self, precision: Int = PRECISION) raises -> Self:
+    def arctan(self, precision: Int = PRECISION) raises -> Self:
         """Returns the arctangent of the BigDecimal number."""
         return decimo.bigdecimal.trigonometric.arctan(self, precision)
 
     # === Arithmetic operations === #
 
     @always_inline
-    fn true_divide(
+    def true_divide(
         self, other: Self, precision: Int = PRECISION
     ) raises -> Self:
         """Returns the result of true division of two BigDecimal numbers.
@@ -1220,7 +1220,7 @@ struct BigDecimal(
         return decimo.bigdecimal.arithmetics.true_divide(self, other, precision)
 
     @always_inline
-    fn true_divide_inexact(
+    def true_divide_inexact(
         self, other: Self, number_of_significant_digits: Int
     ) raises -> Self:
         """Returns the result of true division with inexact precision.
@@ -1231,7 +1231,7 @@ struct BigDecimal(
         )
 
     @always_inline
-    fn true_divide_inexact_by_uint32(
+    def true_divide_inexact_by_uint32(
         self, y: UInt32, number_of_significant_digits: Int
     ) raises -> Self:
         """Returns the result of division by a small UInt32 integer.
@@ -1242,7 +1242,7 @@ struct BigDecimal(
         )
 
     @always_inline
-    fn truncate_divide(self, other: Self) raises -> Self:
+    def truncate_divide(self, other: Self) raises -> Self:
         """Returns the result of truncating division of two BigDecimal numbers.
         See `arithmetics.truncate_divide()` for more information.
         """
@@ -1251,7 +1251,7 @@ struct BigDecimal(
     # === Rounding operations === #
 
     @always_inline
-    fn round(
+    def round(
         self,
         ndigits: Int,
         rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,
@@ -1279,7 +1279,7 @@ struct BigDecimal(
         return decimo.bigdecimal.rounding.round(self, ndigits, rounding_mode)
 
     @always_inline
-    fn round_to_precision(
+    def round_to_precision(
         mut self,
         precision: Int,
         rounding_mode: RoundingMode,
@@ -1305,7 +1305,7 @@ struct BigDecimal(
         )
 
     @always_inline
-    fn quantize(
+    def quantize(
         self,
         exp: Self,
         rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,
@@ -1354,7 +1354,7 @@ struct BigDecimal(
         """
         return decimo.bigdecimal.rounding.quantize(self, exp, rounding_mode)
 
-    fn fma(self, a: Self, b: Self) raises -> Self:
+    def fma(self, a: Self, b: Self) raises -> Self:
         """Fused multiply-add: returns `self * a + b` with no intermediate
         rounding.
 
@@ -1386,7 +1386,7 @@ struct BigDecimal(
     # Other methods
     # ===------------------------------------------------------------------=== #
 
-    fn adjusted(self) -> Int:
+    def adjusted(self) -> Int:
         """Returns the adjusted exponent.
 
         This is the exponent of the number when written with a single leading
@@ -1411,7 +1411,7 @@ struct BigDecimal(
             return 0
         return self.coefficient.number_of_digits() - 1 - self.scale
 
-    fn as_tuple(self) -> Tuple[Bool, List[UInt8], Int]:
+    def as_tuple(self) -> Tuple[Bool, List[UInt8], Int]:
         """Returns a 3-tuple `(sign, digits, exponent)`.
 
         The components are:
@@ -1459,7 +1459,7 @@ struct BigDecimal(
         return (self.sign, digits^, -self.scale)
 
     @always_inline
-    fn copy_abs(self) -> Self:
+    def copy_abs(self) -> Self:
         """Returns a copy with the sign set to positive.
 
         Equivalent to `abs(self)`. Matches Python's
@@ -1468,7 +1468,7 @@ struct BigDecimal(
         return self.__abs__()
 
     @always_inline
-    fn copy_negate(self) -> Self:
+    def copy_negate(self) -> Self:
         """Returns a copy with the sign inverted.
 
         Equivalent to `-self`. Matches Python's
@@ -1477,7 +1477,7 @@ struct BigDecimal(
         return self.__neg__()
 
     @always_inline
-    fn copy_sign(self, other: Self) -> Self:
+    def copy_sign(self, other: Self) -> Self:
         """Returns a copy of `self` with the sign of `other`.
 
         Matches Python's `decimal.Decimal.copy_sign(other)`.
@@ -1492,7 +1492,7 @@ struct BigDecimal(
         )
 
     @always_inline
-    fn same_quantum(self, other: Self) -> Bool:
+    def same_quantum(self, other: Self) -> Bool:
         """Returns True if both operands have the same scale (exponent).
 
         Matches Python's `decimal.Decimal.same_quantum(other)`.  Two numbers
@@ -1513,7 +1513,7 @@ struct BigDecimal(
         return self.scale == other.scale
 
     @always_inline
-    fn scaleb(self, n: Int) -> Self:
+    def scaleb(self, n: Int) -> Self:
         """Multiplies the value by 10^n by adjusting the scale.
 
         Matches Python's `decimal.Decimal.scaleb(other)`.  The name
@@ -1541,7 +1541,7 @@ struct BigDecimal(
         result.scale -= n
         return result^
 
-    fn extend_precision(self, precision_diff: Int) -> Self:
+    def extend_precision(self, precision_diff: Int) -> Self:
         """Returns a number with additional decimal places (trailing zeros).
         This multiplies the coefficient by 10^precision_diff and increases
         the scale accordingly, preserving the numeric value.
@@ -1585,7 +1585,7 @@ struct BigDecimal(
             self.sign,
         )
 
-    fn extend_precision_inplace(mut self, precision_diff: Int):
+    def extend_precision_inplace(mut self, precision_diff: Int):
         """Add additional decimal places (trailing zeros) in-place.
         This multiplies the coefficient by 10^precision_diff and increases
         the scale accordingly, preserving the numeric value.
@@ -1622,7 +1622,7 @@ struct BigDecimal(
         )
         self.scale += precision_diff
 
-    fn internal_representation(self) -> String:
+    def internal_representation(self) -> String:
         """Returns the internal representation of the BigDecimal as a String."""
         # Collect all labels to find max width
         var fixed_labels = List[String]()
@@ -1689,11 +1689,11 @@ struct BigDecimal(
         result += sep_line
         return result^
 
-    fn print_internal_representation(self):
+    def print_internal_representation(self):
         """Prints the internal representation of the BigDecimal."""
         print(self.internal_representation())
 
-    fn print_representation_as_components(self):
+    def print_representation_as_components(self):
         """Prints the representation of the BigDecimal as components."""
         print(
             (
@@ -1717,7 +1717,7 @@ struct BigDecimal(
             sep="",
         )
 
-    fn is_integer(self) -> Bool:
+    def is_integer(self) -> Bool:
         """Returns True if this number represents an integer value."""
         var number_of_trailing_zeros = self.number_of_trailing_zeros()
         if number_of_trailing_zeros >= self.scale:
@@ -1726,16 +1726,16 @@ struct BigDecimal(
             return False
 
     @always_inline
-    fn is_negative(self) -> Bool:
+    def is_negative(self) -> Bool:
         """Returns True if this number represents a negative value."""
         return self.sign
 
     @always_inline
-    fn is_positive(self) -> Bool:
+    def is_positive(self) -> Bool:
         """Returns True if this number represents a strictly positive value."""
         return not self.sign and not self.coefficient.is_zero()
 
-    fn is_odd(self) raises -> Bool:
+    def is_odd(self) raises -> Bool:
         """Returns True if this number represents an odd value."""
         if self.scale < 0:
             return False
@@ -1746,7 +1746,7 @@ struct BigDecimal(
         else:
             return True
 
-    fn is_one(self) raises -> Bool:
+    def is_one(self) raises -> Bool:
         """Returns True if this number represents one."""
         if self.sign:
             return False
@@ -1762,11 +1762,11 @@ struct BigDecimal(
         return True
 
     @always_inline
-    fn is_zero(self) -> Bool:
+    def is_zero(self) -> Bool:
         """Returns True if this number represents zero."""
         return self.coefficient.is_zero()
 
-    fn normalize(self) raises -> Self:
+    def normalize(self) raises -> Self:
         """Removes trailing zeros from coefficient while adjusting scale.
 
         For example,
@@ -1820,7 +1820,7 @@ struct BigDecimal(
             self.sign,
         )
 
-    fn number_of_trailing_zeros(self) -> Int:
+    def number_of_trailing_zeros(self) -> Int:
         """Returns the number of trailing zeros in the coefficient."""
         if self.coefficient.is_zero():
             return 0
@@ -1839,7 +1839,7 @@ struct BigDecimal(
 
         return number_of_zero_words * 9 + number_of_trailing_zeros
 
-    fn number_of_digits(self) -> Int:
+    def number_of_digits(self) -> Int:
         """Returns the total number of digits in the coefficient.
 
         This counts all digits stored in the coefficient, including any
@@ -1863,7 +1863,7 @@ struct BigDecimal(
 # ===----------------------------------------------------------------------=== #
 
 
-fn _insert_digit_separators(s: String, delimiter: String) -> String:
+def _insert_digit_separators(s: String, delimiter: String) -> String:
     """Insert ``delimiter`` every 3 digits in both the integer and
     fractional parts of a numeric string.
 

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -23,14 +23,15 @@ operation dunders, and other dunders that implement traits, as well as
 mathematical methods that do not implement a trait.
 """
 
-from memory import UnsafePointer
-from python import PythonObject
-import testing
+from std.memory import UnsafePointer
+from std.python import PythonObject
+from std import testing
 
 from decimo.errors import DecimoError
 from decimo.rounding_mode import RoundingMode
 from decimo.bigdecimal.rounding import round_to_precision
 from decimo.bigint10.bigint10 import BigInt10
+import decimo.str
 
 comptime BDec = BigDecimal
 """An arbitrary-precision decimal, similar to Python's `decimal.Decimal`."""
@@ -51,9 +52,7 @@ struct BigDecimal(
     FloatableRaising,
     IntableRaising,
     Movable,
-    Representable,
     Roundable,
-    Stringable,
     Writable,
 ):
     """An arbitrary-precision decimal, similar to Python's `decimal.Decimal`.
@@ -154,19 +153,16 @@ struct BigDecimal(
         Constraints:
             The dtype of the scalar must be integral.
         """
-        constrained[
-            dtype.is_integral(),
-            (
-                "\n***********************************************************\n"
-                "BigDecimal does not allow floating-point numbers as input to"
-                " avoid unintentional loss of precision. If you want to create"
-                " a BigDecimal from a floating-point number, please consider"
-                " wrapping it with quotation marks or using the"
-                " `BigDecimal.from_float()` (or `BDec.from_float()`) method"
-                " instead."
-                "\n***********************************************************"
-            ),
-        ]()
+        comptime assert dtype.is_integral(), (
+            "\n***********************************************************\n"
+            "BigDecimal does not allow floating-point numbers as input to"
+            " avoid unintentional loss of precision. If you want to create"
+            " a BigDecimal from a floating-point number, please consider"
+            " wrapping it with quotation marks or using the"
+            " `BigDecimal.from_float()` (or `BDec.from_float()`) method"
+            " instead."
+            "\n***********************************************************"
+        )
 
         self = Self.from_integral_scalar(value)
 
@@ -270,7 +266,7 @@ struct BigDecimal(
             The BigDecimal representation of the Scalar value.
         """
 
-        constrained[dtype.is_integral(), "dtype must be integral."]()
+        comptime assert dtype.is_integral(), "dtype must be integral."
 
         if value == 0:
             return Self(coefficient=BigUInt.zero(), scale=0, sign=False)
@@ -297,9 +293,9 @@ struct BigDecimal(
         with full precision before converting to BigDecimal.
         """
 
-        constrained[
-            dtype.is_floating_point(), "dtype must be floating-point."
-        ]()
+        comptime assert (
+            dtype.is_floating_point()
+        ), "dtype must be floating-point."
 
         if value == 0:
             return Self(coefficient=BigUInt.zero(), scale=0, sign=False)
@@ -374,7 +370,7 @@ struct BigDecimal(
 
         Examples:
         ```mojo
-        from python import Python
+        from std.python import Python
         from decimo.prelude import *
 
         fn main() raises:
@@ -497,23 +493,31 @@ struct BigDecimal(
     # __float__()
     # ===------------------------------------------------------------------=== #
 
+    # TODO: Deprecate this.
+    # Stringable -> Writable (write_to())
     fn __str__(self) -> String:
         """Returns string representation of the BigDecimal.
         See `to_string()` for more information.
         """
         return self.to_string()
 
+    # TODO: Deprecate this.
+    # Representable -> Writable (write_repr_to())
     fn __repr__(self) -> String:
         """Returns a string representation of the BigDecimal."""
         return 'BigDecimal("' + self.__str__() + '")'
 
+    fn write_repr_to[W: Writer](self, mut writer: W):
+        """Writes the debug representation to a writer."""
+        writer.write('BigDecimal("', self.__str__(), '")')
+
     fn __int__(self) raises -> Int:
         """Converts the BigDecimal to an integer."""
-        return Int(String(self))
+        return Int(self.__str__())
 
     fn __float__(self) raises -> Float64:
         """Converts the BigDecimal to a floating-point number."""
-        return Float64(String(self))
+        return Float64(self.__str__())
 
     # ===------------------------------------------------------------------=== #
     # Type-transfer or output methods that are not dunders
@@ -611,7 +615,7 @@ struct BigDecimal(
 
             # Strip trailing zeros (artifacts of working precision)
             var coef = coefficient_string
-            var cb = coef.as_string_slice().as_bytes()
+            var cb = StringSlice(coef).as_bytes()
             var clen = len(cb)
             var cptr = cb.unsafe_ptr()
             while clen > 1 and cptr[clen - 1] == 48:  # '0'
@@ -631,9 +635,9 @@ struct BigDecimal(
             if len(coef) <= lead_digits:
                 result += coef
             else:
-                result += coef[:lead_digits]
+                result += coef[byte=:lead_digits]
                 result += "."
-                result += coef[lead_digits:]
+                result += coef[byte=lead_digits:]
 
             # Append exponent (omit the 'E' suffix when eng_exp == 0)
             if eng_exp != 0:
@@ -652,7 +656,7 @@ struct BigDecimal(
             # preserve all digits so that __str__ stays round-trip safe.
             var coef = coefficient_string
             if scientific:
-                var cb = coef.as_string_slice().as_bytes()
+                var cb = StringSlice(coef).as_bytes()
                 var clen = len(cb)
                 var cptr = cb.unsafe_ptr()
                 while clen > 1 and cptr[clen - 1] == 48:  # ord('0')
@@ -665,7 +669,7 @@ struct BigDecimal(
             result += coef[byte=0]
             if len(coef) > 1:
                 result += "."
-                result += coef[1:]
+                result += coef[byte=1:]
             result += "E"
             if exponent > 0:
                 result += "+"
@@ -692,9 +696,9 @@ struct BigDecimal(
             else:
                 # Decimal point falls within the digit string.
                 # Example: coefficient "123456", scale 3 -> "123.456"
-                result += coefficient_string[:leftdigits]
+                result += coefficient_string[byte=:leftdigits]
                 result += "."
-                result += coefficient_string[leftdigits:]
+                result += coefficient_string[byte=leftdigits:]
 
         # Insert digit-group separators if requested
         if delimiter:
@@ -706,10 +710,10 @@ struct BigDecimal(
             var end = line_width
             var lines = List[String](capacity=len(result) // line_width + 1)
             while end < len(result):
-                lines.append(String(result[start:end]))
+                lines.append(String(result[byte=start:end]))
                 start = end
                 end += line_width
-            lines.append(String(result[start:]))
+            lines.append(String(result[byte=start:]))
             result = String("\n").join(lines^)
 
         return result^
@@ -722,7 +726,7 @@ struct BigDecimal(
         """Writes the BigDecimal to a writer.
         This implement the `write` method of the `Writer` trait.
         """
-        writer.write(String(self))
+        writer.write(self.__str__())
 
     fn to_scientific_string(self) -> String:
         """Returns the number in scientific notation (trailing zeros stripped).
@@ -1466,7 +1470,7 @@ struct BigDecimal(
         instead of a `Tuple[int]` for better performance in Mojo.
         """
         var coef_str = self.coefficient.to_string()
-        var cb = coef_str.as_string_slice().as_bytes()
+        var cb = StringSlice(coef_str).as_bytes()
         var n = len(cb)
         var ptr = cb.unsafe_ptr()
         var digits = List[UInt8](capacity=n)
@@ -1696,7 +1700,10 @@ struct BigDecimal(
             var label = "word " + String(i) + ":"
             result += label + String(" ") * (col - len(label))
             result += (
-                String(self.coefficient.words[i]).rjust(9, fillchar="0") + "\n"
+                decimo.str.rjust(
+                    String(self.coefficient.words[i]), 9, fillchar="0"
+                )
+                + "\n"
             )
 
         result += sep_line
@@ -1893,7 +1900,7 @@ fn _insert_digit_separators(s: String, delimiter: String) -> String:
     if not delimiter:
         return s
 
-    var sb = s.as_string_slice().as_bytes()
+    var sb = StringSlice(s).as_bytes()
     var n = len(sb)
     var ptr = sb.unsafe_ptr()
 
@@ -1918,11 +1925,11 @@ fn _insert_digit_separators(s: String, delimiter: String) -> String:
 
     # Determine integer-part and fractional-part ranges within `s`
     var int_end = dot_pos if dot_pos >= 0 else e_pos
-    var int_part = String(s[start:int_end])
+    var int_part = String(s[byte=start:int_end])
 
     var frac_part = String("")
     if dot_pos >= 0:
-        frac_part = String(s[dot_pos + 1 : e_pos])
+        frac_part = String(s[byte = dot_pos + 1 : e_pos])
 
     # --- Group integer part (right-to-left every 3 digits) ---
     var int_len = len(int_part)
@@ -1931,10 +1938,10 @@ fn _insert_digit_separators(s: String, delimiter: String) -> String:
         var end_i = int_len
         var start_i = end_i - 3
         while start_i > 0:
-            blocks.append(String(int_part[start_i:end_i]))
+            blocks.append(String(int_part[byte=start_i:end_i]))
             end_i = start_i
             start_i = end_i - 3
-        blocks.append(String(int_part[0:end_i]))
+        blocks.append(String(int_part[byte=0:end_i]))
         blocks.reverse()
         int_part = delimiter.join(blocks)
 
@@ -1944,17 +1951,17 @@ fn _insert_digit_separators(s: String, delimiter: String) -> String:
         var blocks = List[String](capacity=frac_len // 3 + 1)
         var i = 0
         while i + 3 < frac_len:
-            blocks.append(String(frac_part[i : i + 3]))
+            blocks.append(String(frac_part[byte = i : i + 3]))
             i += 3
-        blocks.append(String(frac_part[i:]))
+        blocks.append(String(frac_part[byte=i:]))
         frac_part = delimiter.join(blocks)
 
     # --- Rebuild ---
-    var result = String(s[:start])  # sign (if any)
+    var result = String(s[byte=:start])  # sign (if any)
     result += int_part
     if dot_pos >= 0:
         result += "."
         result += frac_part
     if e_pos < n:
-        result += String(s[e_pos:])  # exponent suffix
+        result += String(s[byte=e_pos:])  # exponent suffix
     return result^

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -487,37 +487,17 @@ struct BigDecimal(
 
     # ===------------------------------------------------------------------=== #
     # Output dunders, type-transfer dunders
-    # __str__()
-    # __repr__()
     # __int__()
     # __float__()
     # ===------------------------------------------------------------------=== #
 
-    # TODO: Deprecate this.
-    # Stringable -> Writable (write_to())
-    fn __str__(self) -> String:
-        """Returns string representation of the BigDecimal.
-        See `to_string()` for more information.
-        """
-        return self.to_string()
-
-    # TODO: Deprecate this.
-    # Representable -> Writable (write_repr_to())
-    fn __repr__(self) -> String:
-        """Returns a string representation of the BigDecimal."""
-        return 'BigDecimal("' + self.__str__() + '")'
-
-    fn write_repr_to[W: Writer](self, mut writer: W):
-        """Writes the debug representation to a writer."""
-        writer.write('BigDecimal("', self.__str__(), '")')
-
     fn __int__(self) raises -> Int:
         """Converts the BigDecimal to an integer."""
-        return Int(self.__str__())
+        return Int(self.to_string())
 
     fn __float__(self) raises -> Float64:
         """Converts the BigDecimal to a floating-point number."""
-        return Float64(self.__str__())
+        return Float64(self.to_string())
 
     # ===------------------------------------------------------------------=== #
     # Type-transfer or output methods that are not dunders
@@ -718,15 +698,15 @@ struct BigDecimal(
 
         return result^
 
-    # ===------------------------------------------------------------------=== #
-    # Type-transfer or output methods that are not dunders
-    # ===------------------------------------------------------------------=== #
-
     fn write_to[W: Writer](self, mut writer: W):
         """Writes the BigDecimal to a writer.
         This implement the `write` method of the `Writer` trait.
         """
-        writer.write(self.__str__())
+        writer.write(self.to_string())
+
+    fn write_repr_to[W: Writer](self, mut writer: W):
+        """Writes the debug representation to a writer."""
+        writer.write('BigDecimal("', self.to_string(), '")')
 
     fn to_scientific_string(self) -> String:
         """Returns the number in scientific notation (trailing zeros stripped).

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -46,7 +46,6 @@ This will be configurable in future when Mojo supports global variables.
 
 struct BigDecimal(
     Absable,
-    AnyType,
     Comparable,
     Copyable,
     FloatableRaising,

--- a/src/decimo/bigdecimal/comparison.mojo
+++ b/src/decimo/bigdecimal/comparison.mojo
@@ -21,7 +21,7 @@ Implements functions for comparison operations on BigDecimal objects.
 from decimo.bigdecimal.bigdecimal import BigDecimal
 
 
-fn compare_absolute(x1: BigDecimal, x2: BigDecimal) -> Int8:
+def compare_absolute(x1: BigDecimal, x2: BigDecimal) -> Int8:
     """Compares the absolute values of two numbers.
 
     Args:
@@ -71,7 +71,7 @@ fn compare_absolute(x1: BigDecimal, x2: BigDecimal) -> Int8:
         return scaled_x1.compare(x2.coefficient)
 
 
-fn compare(x1: BigDecimal, x2: BigDecimal) -> Int8:
+def compare(x1: BigDecimal, x2: BigDecimal) -> Int8:
     """Compares two BigDecimal numbers.
 
     Args:
@@ -110,44 +110,44 @@ fn compare(x1: BigDecimal, x2: BigDecimal) -> Int8:
         return abs_comparison
 
 
-fn equal(x1: BigDecimal, x2: BigDecimal) -> Bool:
+def equal(x1: BigDecimal, x2: BigDecimal) -> Bool:
     """Returns whether x1 equals x2."""
     return compare(x1, x2) == 0
 
 
-fn not_equal(x1: BigDecimal, x2: BigDecimal) -> Bool:
+def not_equal(x1: BigDecimal, x2: BigDecimal) -> Bool:
     """Returns whether x1 does not equal x2."""
     return compare(x1, x2) != 0
 
 
-fn less(x1: BigDecimal, x2: BigDecimal) -> Bool:
+def less(x1: BigDecimal, x2: BigDecimal) -> Bool:
     """Returns whether x1 is less than x2."""
     return compare(x1, x2) < 0
 
 
-fn less_equal(x1: BigDecimal, x2: BigDecimal) -> Bool:
+def less_equal(x1: BigDecimal, x2: BigDecimal) -> Bool:
     """Returns whether x1 is less than or equal to x2."""
     return compare(x1, x2) <= 0
 
 
-fn greater(x1: BigDecimal, x2: BigDecimal) -> Bool:
+def greater(x1: BigDecimal, x2: BigDecimal) -> Bool:
     """Returns whether x1 is greater than x2."""
     return compare(x1, x2) > 0
 
 
-fn greater_equal(x1: BigDecimal, x2: BigDecimal) -> Bool:
+def greater_equal(x1: BigDecimal, x2: BigDecimal) -> Bool:
     """Returns whether x1 is greater than or equal to x2."""
     return compare(x1, x2) >= 0
 
 
-fn max(x1: BigDecimal, x2: BigDecimal) -> BigDecimal:
+def max(x1: BigDecimal, x2: BigDecimal) -> BigDecimal:
     """Returns the maximum of x1 and x2."""
     if compare(x1, x2) >= 0:
         return x1.copy()
     return x2.copy()
 
 
-fn min(x1: BigDecimal, x2: BigDecimal) -> BigDecimal:
+def min(x1: BigDecimal, x2: BigDecimal) -> BigDecimal:
     """Returns the minimum of x1 and x2."""
     if compare(x1, x2) <= 0:
         return x1.copy()

--- a/src/decimo/bigdecimal/comparison.mojo
+++ b/src/decimo/bigdecimal/comparison.mojo
@@ -90,15 +90,15 @@ fn compare(x1: BigDecimal, x2: BigDecimal) -> Int8:
 
     # If one is zero, handle specially
     if x1.coefficient.is_zero():
-        return 1 if x2.sign else -1  # 0 > negative, 0 < positive
+        return Int8(1) if x2.sign else Int8(-1)  # 0 > negative, 0 < positive
     if x2.coefficient.is_zero():
-        return -1 if x1.sign else 1  # negative < 0, positive > 0
+        return Int8(-1) if x1.sign else Int8(1)  # negative < 0, positive > 0
 
     # If signs differ, the positive one is greater
     if not x1.sign and x2.sign:  # x1 is positive, x2 is negative
-        return 1
+        return Int8(1)
     if x1.sign and not x2.sign:  # x1 is negative, x2 is positive
-        return -1
+        return Int8(-1)
 
     # Same sign - compare absolute values
     var abs_comparison = compare_absolute(x1, x2)

--- a/src/decimo/bigdecimal/constants.mojo
+++ b/src/decimo/bigdecimal/constants.mojo
@@ -153,7 +153,7 @@ comptime PI_1024 = BigDecimal(
 # Everytime when user calls pi(precision),
 # we check whether the precision is higher than the current precision.
 # If yes, then we save it into the global scope as cached value.
-fn pi(precision: Int) raises -> BigDecimal:
+def pi(precision: Int) raises -> BigDecimal:
     """Calculates π using the fastest available algorithm."""
 
     if precision < 0:
@@ -181,12 +181,12 @@ struct Rational:
     var p: BigInt10  # numerator
     var q: BigInt10  # denominator
 
-    fn __init__(out self, p: BigInt10, q: BigInt10):
+    def __init__(out self, p: BigInt10, q: BigInt10):
         self.p = p.copy()
         self.q = q.copy()
 
 
-fn pi_chudnovsky_binary_split(precision: Int) raises -> BigDecimal:
+def pi_chudnovsky_binary_split(precision: Int) raises -> BigDecimal:
     """Calculates π using Chudnovsky algorithm with binary splitting.
 
     Notes:
@@ -227,7 +227,7 @@ fn pi_chudnovsky_binary_split(precision: Int) raises -> BigDecimal:
     return result^
 
 
-fn chudnovsky_split(a: Int, b: Int, precision: Int) raises -> Rational:
+def chudnovsky_split(a: Int, b: Int, precision: Int) raises -> Rational:
     """Conducts binary splitting for Chudnovsky series from term a to b-1."""
 
     var bint_1 = BigInt10(1)
@@ -272,7 +272,7 @@ fn chudnovsky_split(a: Int, b: Int, precision: Int) raises -> Rational:
     return Rational(combined_p^, combined_q^)
 
 
-fn compute_m_k_rational(k: Int) raises -> Rational:
+def compute_m_k_rational(k: Int) raises -> Rational:
     """Computes M(k) = (6k)! / ((3k)! * (k!)³) as exact rational."""
 
     var bint_1 = BigInt10(1)
@@ -295,7 +295,7 @@ fn compute_m_k_rational(k: Int) raises -> Rational:
     return Rational(numerator, denominator)
 
 
-fn pi_machin(precision: Int) raises -> BigDecimal:
+def pi_machin(precision: Int) raises -> BigDecimal:
     """Fallback π calculation using Machin's formula."""
 
     var working_precision = precision + 9

--- a/src/decimo/bigdecimal/constants.mojo
+++ b/src/decimo/bigdecimal/constants.mojo
@@ -17,8 +17,6 @@
 # Implements functions for calculating common constants.
 """
 
-import math as builtin_math
-
 from decimo.bigdecimal.bigdecimal import BigDecimal
 from decimo.bigint10.bigint10 import BigInt10
 from decimo.rounding_mode import RoundingMode

--- a/src/decimo/bigdecimal/exponential.mojo
+++ b/src/decimo/bigdecimal/exponential.mojo
@@ -16,7 +16,7 @@
 
 """Implements exponential functions for the BigDecimal type."""
 
-import math
+from std import math
 
 from decimo.bigdecimal.bigdecimal import BigDecimal
 from decimo.rounding_mode import RoundingMode
@@ -1882,7 +1882,7 @@ fn exp_taylor_series(
     # print("DEBUG: exp_taylor_series")
     # print("DEBUG: x =", x)
 
-    var max_number_of_terms = Int(minimum_precision * 2.5) + 1
+    var max_number_of_terms = Int(Float64(minimum_precision) * 2.5) + 1
     var result = BigDecimal(BigUInt.one(), 0, False)
     var term = BigDecimal(BigUInt.one(), 0, False)
     var n: UInt32 = 1
@@ -2205,7 +2205,7 @@ fn ln_series_expansion(
     comptime _TAYLOR_ATANH_DIGIT_RATIO = 10
     if z_digits <= working_precision // _TAYLOR_ATANH_DIGIT_RATIO:
         # ---- Taylor path (optimal for small/simple z) ----
-        var max_terms = Int(working_precision * 2.5) + 1
+        var max_terms = Int(Float64(working_precision) * 2.5) + 1
         var result = BigDecimal(BigUInt.zero(), working_precision, False)
         var term = z.copy()
         var k: UInt32 = 1
@@ -2275,7 +2275,7 @@ fn ln_series_expansion(
     var result = term.copy()
 
     # Convergence: u² ≤ 1/9, so ~1.05*p terms suffice (vs 3.3*p Taylor)
-    var max_terms = Int(working_precision * 1.2) + 10
+    var max_terms = Int(Float64(working_precision) * 1.2) + 10
 
     for k in range(1, max_terms):
         var old_denom = UInt32(2 * k - 1)
@@ -2356,7 +2356,7 @@ fn compute_ln2(working_precision: Int) raises -> BigDecimal:
         )
         return result^
 
-    var max_terms = Int(working_precision * 2.5) + 1
+    var max_terms = Int(Float64(working_precision) * 2.5) + 1
 
     var number_of_words = working_precision // 9 + 1
     var words = List[UInt32](capacity=number_of_words)

--- a/src/decimo/bigdecimal/exponential.mojo
+++ b/src/decimo/bigdecimal/exponential.mojo
@@ -96,7 +96,7 @@ struct MathCache:
     var _ln10_precision: Int
     """Precision (in significant digits) at which _ln10 was computed."""
 
-    fn __init__(out self):
+    def __init__(out self):
         """Initializes an empty MathCache with no cached values."""
         self._ln2 = BigDecimal(BigUInt.zero(), 0, False)
         self._ln1d25 = BigDecimal(BigUInt.zero(), 0, False)
@@ -105,7 +105,7 @@ struct MathCache:
         self._ln1d25_precision = 0
         self._ln10_precision = 0
 
-    fn get_ln2(mut self, precision: Int) raises -> BigDecimal:
+    def get_ln2(mut self, precision: Int) raises -> BigDecimal:
         """Returns ln(2) computed to at least the specified precision.
 
         If the cached value has sufficient precision, it is returned (rounded
@@ -131,7 +131,7 @@ struct MathCache:
         self._ln2_precision = precision
         return self._ln2.copy()
 
-    fn get_ln1d25(mut self, precision: Int) raises -> BigDecimal:
+    def get_ln1d25(mut self, precision: Int) raises -> BigDecimal:
         """Returns ln(1.25) computed to at least the specified precision.
 
         If the cached value has sufficient precision, it is returned (rounded
@@ -157,7 +157,7 @@ struct MathCache:
         self._ln1d25_precision = precision
         return self._ln1d25.copy()
 
-    fn get_ln10(mut self, precision: Int) raises -> BigDecimal:
+    def get_ln10(mut self, precision: Int) raises -> BigDecimal:
         """Returns ln(10) computed to at least the specified precision.
 
         If the cached value has sufficient precision, it is returned (rounded
@@ -206,7 +206,7 @@ struct MathCache:
 # ===----------------------------------------------------------------------=== #
 
 
-fn power(
+def power(
     base: BigDecimal, exponent: BigDecimal, precision: Int = 28
 ) raises -> BigDecimal:
     """Raises a BigDecimal base to an arbitrary BigDecimal exponent power.
@@ -292,7 +292,7 @@ fn power(
     return exp_result^
 
 
-fn integer_power(
+def integer_power(
     base: BigDecimal, exponent: BigDecimal, precision: Int
 ) raises -> BigDecimal:
     """Raises a base to integer exponents using binary exponentiation.
@@ -367,7 +367,7 @@ fn integer_power(
     return result^
 
 
-fn _strip_trailing_fractional_zeros(mut number: BigDecimal):
+def _strip_trailing_fractional_zeros(mut number: BigDecimal):
     """Strip trailing zeros that are after the decimal point only.
 
     Unlike normalize(), this preserves integer trailing zeros. For example,
@@ -406,7 +406,7 @@ fn _strip_trailing_fractional_zeros(mut number: BigDecimal):
     number.scale -= n_strip
 
 
-fn root(x: BigDecimal, n: BigDecimal, precision: Int) raises -> BigDecimal:
+def root(x: BigDecimal, n: BigDecimal, precision: Int) raises -> BigDecimal:
     """Calculate the nth root of a BigDecimal number.
 
     Args:
@@ -522,7 +522,7 @@ fn root(x: BigDecimal, n: BigDecimal, precision: Int) raises -> BigDecimal:
     return result^
 
 
-fn integer_root(
+def integer_root(
     x: BigDecimal, n: BigDecimal, precision: Int
 ) raises -> BigDecimal:
     """Calculate the nth integer root of a BigDecimal number using Newton's
@@ -765,7 +765,7 @@ fn integer_root(
     return r^
 
 
-fn _integer_root_via_exp_ln(
+def _integer_root_via_exp_ln(
     x: BigDecimal, n: BigDecimal, precision: Int, result_sign: Bool
 ) raises -> BigDecimal:
     """Fallback: compute integer root via exp(ln(|x|)/n).
@@ -800,7 +800,7 @@ fn _integer_root_via_exp_ln(
     return result^
 
 
-fn is_integer_reciprocal_and_return(
+def is_integer_reciprocal_and_return(
     n: BigDecimal,
 ) raises -> Tuple[Bool, BigDecimal]:
     """Check if 1/n (n != 1) represents an odd integer and return the result.
@@ -819,7 +819,7 @@ fn is_integer_reciprocal_and_return(
     return Tuple(m.is_integer(), m^)
 
 
-fn is_odd_reciprocal(n: BigDecimal) raises -> Bool:
+def is_odd_reciprocal(n: BigDecimal) raises -> Bool:
     """Check if 1/n (n != 1) represents an odd integer.
 
     Args:
@@ -851,7 +851,7 @@ fn is_odd_reciprocal(n: BigDecimal) raises -> Bool:
         return False
 
 
-fn _gcd(var a: Int, var b: Int) -> Int:
+def _gcd(var a: Int, var b: Int) -> Int:
     """Compute the greatest common divisor of two integers.
 
     Handles negative inputs by taking absolute values first.
@@ -865,7 +865,7 @@ fn _gcd(var a: Int, var b: Int) -> Int:
     return a
 
 
-fn _rational_root_decomposition(
+def _rational_root_decomposition(
     n: BigDecimal,
 ) raises -> Tuple[Bool, Int, Int]:
     """Try to decompose a positive fractional n into a/b in lowest terms.
@@ -974,7 +974,7 @@ fn _rational_root_decomposition(
 # ===----------------------------------------------------------------------=== #
 
 
-fn sqrt(x: BigDecimal, precision: Int) raises -> BigDecimal:
+def sqrt(x: BigDecimal, precision: Int) raises -> BigDecimal:
     """Calculate the square root of a BigDecimal number.
 
     This is the public API for square root. It delegates to `sqrt_exact()`,
@@ -999,7 +999,7 @@ fn sqrt(x: BigDecimal, precision: Int) raises -> BigDecimal:
     return sqrt_exact(x, precision)
 
 
-fn fast_isqrt(c: BigUInt, working_digits: Int) raises -> BigUInt:
+def fast_isqrt(c: BigUInt, working_digits: Int) raises -> BigUInt:
     """Compute isqrt(c) using reciprocal sqrt with precision doubling for speed,
     then verify/correct with exact integer Newton iterations.
 
@@ -1149,7 +1149,7 @@ fn fast_isqrt(c: BigUInt, working_digits: Int) raises -> BigUInt:
     return n^
 
 
-fn sqrt_exact(x: BigDecimal, precision: Int) raises -> BigDecimal:
+def sqrt_exact(x: BigDecimal, precision: Int) raises -> BigDecimal:
     """Calculate the square root of a BigDecimal number using CPython's
     exact integer algorithm.
 
@@ -1287,7 +1287,7 @@ fn sqrt_exact(x: BigDecimal, precision: Int) raises -> BigDecimal:
     return result^
 
 
-fn sqrt_reciprocal(x: BigDecimal, precision: Int) raises -> BigDecimal:
+def sqrt_reciprocal(x: BigDecimal, precision: Int) raises -> BigDecimal:
     """Calculate the square root of a BigDecimal number using reciprocal square
     root iteration.
 
@@ -1460,7 +1460,7 @@ fn sqrt_reciprocal(x: BigDecimal, precision: Int) raises -> BigDecimal:
     return result^
 
 
-fn sqrt_newton(x: BigDecimal, precision: Int) raises -> BigDecimal:
+def sqrt_newton(x: BigDecimal, precision: Int) raises -> BigDecimal:
     """Calculates the square root of a BigDecimal number using Newton's method.
 
     Args:
@@ -1556,7 +1556,7 @@ fn sqrt_newton(x: BigDecimal, precision: Int) raises -> BigDecimal:
     return result^
 
 
-fn sqrt_decimal_approach(x: BigDecimal, precision: Int) raises -> BigDecimal:
+def sqrt_decimal_approach(x: BigDecimal, precision: Int) raises -> BigDecimal:
     """Calculate the square root of a BigDecimal number.
 
     Args:
@@ -1711,7 +1711,7 @@ fn sqrt_decimal_approach(x: BigDecimal, precision: Int) raises -> BigDecimal:
     return guess^
 
 
-fn cbrt(x: BigDecimal, precision: Int) raises -> BigDecimal:
+def cbrt(x: BigDecimal, precision: Int) raises -> BigDecimal:
     """Calculate the cube root of a BigDecimal number.
 
     Args:
@@ -1738,7 +1738,7 @@ fn cbrt(x: BigDecimal, precision: Int) raises -> BigDecimal:
 # ===----------------------------------------------------------------------=== #
 
 
-fn exp(x: BigDecimal, precision: Int) raises -> BigDecimal:
+def exp(x: BigDecimal, precision: Int) raises -> BigDecimal:
     """Calculate the natural exponential of x (e^x) to the specified precision.
 
     Args:
@@ -1857,7 +1857,7 @@ fn exp(x: BigDecimal, precision: Int) raises -> BigDecimal:
     return result^
 
 
-fn exp_taylor_series(
+def exp_taylor_series(
     x: BigDecimal, minimum_precision: Int
 ) raises -> BigDecimal:
     """Calculate exp(x) using Taylor series for |x| <= 1.
@@ -1928,7 +1928,7 @@ fn exp_taylor_series(
 # ===----------------------------------------------------------------------=== #
 
 
-fn ln(x: BigDecimal, precision: Int) raises -> BigDecimal:
+def ln(x: BigDecimal, precision: Int) raises -> BigDecimal:
     """Calculate the natural logarithm of x to the specified precision.
 
     This is the non-cached version. For repeated calls, use the overload that
@@ -1948,7 +1948,9 @@ fn ln(x: BigDecimal, precision: Int) raises -> BigDecimal:
     return ln(x, precision, cache)
 
 
-fn ln(x: BigDecimal, precision: Int, mut cache: MathCache) raises -> BigDecimal:
+def ln(
+    x: BigDecimal, precision: Int, mut cache: MathCache
+) raises -> BigDecimal:
     """Calculate the natural logarithm of x to the specified precision.
 
     This overload accepts a `MathCache` to reuse cached values of ln(2) and
@@ -2043,7 +2045,7 @@ fn ln(x: BigDecimal, precision: Int, mut cache: MathCache) raises -> BigDecimal:
     return result^
 
 
-fn log(x: BigDecimal, base: BigDecimal, precision: Int) raises -> BigDecimal:
+def log(x: BigDecimal, base: BigDecimal, precision: Int) raises -> BigDecimal:
     """Calculates the logarithm of x with respect to an arbitrary base.
 
     Args:
@@ -2108,7 +2110,7 @@ fn log(x: BigDecimal, base: BigDecimal, precision: Int) raises -> BigDecimal:
     return result^
 
 
-fn log10(x: BigDecimal, precision: Int) raises -> BigDecimal:
+def log10(x: BigDecimal, precision: Int) raises -> BigDecimal:
     """Calculates the base-10 logarithm of a BigDecimal value.
 
     Args:
@@ -2155,7 +2157,7 @@ fn log10(x: BigDecimal, precision: Int) raises -> BigDecimal:
     return result^
 
 
-fn ln_series_expansion(
+def ln_series_expansion(
     z: BigDecimal, working_precision: Int
 ) raises -> BigDecimal:
     """Calculate ln(1+z) using a hybrid Taylor / atanh series.
@@ -2306,7 +2308,7 @@ fn ln_series_expansion(
     return result^
 
 
-fn compute_ln2(working_precision: Int) raises -> BigDecimal:
+def compute_ln2(working_precision: Int) raises -> BigDecimal:
     """Compute ln(2) to the specified working precision.
 
     Args:
@@ -2402,7 +2404,7 @@ fn compute_ln2(working_precision: Int) raises -> BigDecimal:
     return result^
 
 
-fn compute_ln1d25(precision: Int) raises -> BigDecimal:
+def compute_ln1d25(precision: Int) raises -> BigDecimal:
     """Compute ln(1.25) to the specified precision.
 
     Args:

--- a/src/decimo/bigdecimal/rounding.mojo
+++ b/src/decimo/bigdecimal/rounding.mojo
@@ -26,7 +26,7 @@ from decimo.rounding_mode import RoundingMode
 # ===------------------------------------------------------------------------===#
 
 
-fn round(
+def round(
     number: BigDecimal,
     ndigits: Int,
     rounding_mode: RoundingMode,
@@ -105,7 +105,7 @@ fn round(
         )
 
 
-fn round_to_precision(
+def round_to_precision(
     mut number: BigDecimal,
     precision: Int,
     rounding_mode: RoundingMode,
@@ -167,7 +167,7 @@ fn round_to_precision(
         number.scale -= 1
 
 
-fn quantize(
+def quantize(
     value: BigDecimal,
     exp: BigDecimal,
     rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,

--- a/src/decimo/bigdecimal/trigonometric.mojo
+++ b/src/decimo/bigdecimal/trigonometric.mojo
@@ -18,7 +18,7 @@
 # Trigonometric functions for BigDecimal
 # ===----------------------------------------------------------------------=== #
 
-import time
+from std import time
 
 from decimo.bigdecimal.bigdecimal import BigDecimal
 from decimo.rounding_mode import RoundingMode

--- a/src/decimo/bigdecimal/trigonometric.mojo
+++ b/src/decimo/bigdecimal/trigonometric.mojo
@@ -31,7 +31,7 @@ import decimo.bigdecimal.exponential
 # ===----------------------------------------------------------------------=== #
 
 
-fn sin(x: BigDecimal, precision: Int) raises -> BigDecimal:
+def sin(x: BigDecimal, precision: Int) raises -> BigDecimal:
     """Calculates sine (sin) of the number.
 
     Args:
@@ -149,7 +149,7 @@ fn sin(x: BigDecimal, precision: Int) raises -> BigDecimal:
     return result^
 
 
-fn sin_taylor_series(
+def sin_taylor_series(
     x: BigDecimal, minimum_precision: Int
 ) raises -> BigDecimal:
     """Calculates sine of a number with Taylor series.
@@ -210,7 +210,7 @@ fn sin_taylor_series(
     return result^
 
 
-fn cos(x: BigDecimal, precision: Int) raises -> BigDecimal:
+def cos(x: BigDecimal, precision: Int) raises -> BigDecimal:
     """Calculates cosine (cos) of the number.
 
     Args:
@@ -237,7 +237,7 @@ fn cos(x: BigDecimal, precision: Int) raises -> BigDecimal:
     return result^
 
 
-fn cos_taylor_series(
+def cos_taylor_series(
     x: BigDecimal, minimum_precision: Int
 ) raises -> BigDecimal:
     """Calculates cosine using Taylor series.
@@ -300,7 +300,7 @@ fn cos_taylor_series(
     return result^
 
 
-fn tan(x: BigDecimal, precision: Int) raises -> BigDecimal:
+def tan(x: BigDecimal, precision: Int) raises -> BigDecimal:
     """Calculates tangent (tan) of the number.
 
     Args:
@@ -317,7 +317,7 @@ fn tan(x: BigDecimal, precision: Int) raises -> BigDecimal:
     return tan_cot(x, precision, is_tan=True)
 
 
-fn cot(x: BigDecimal, precision: Int) raises -> BigDecimal:
+def cot(x: BigDecimal, precision: Int) raises -> BigDecimal:
     """Calculates cotangent (cot) of the number.
 
     Args:
@@ -334,7 +334,7 @@ fn cot(x: BigDecimal, precision: Int) raises -> BigDecimal:
     return tan_cot(x, precision, is_tan=False)
 
 
-fn tan_cot(x: BigDecimal, precision: Int, is_tan: Bool) raises -> BigDecimal:
+def tan_cot(x: BigDecimal, precision: Int, is_tan: Bool) raises -> BigDecimal:
     """Calculates tangent (tan) or cotangent (cot) of the number.
 
     Args:
@@ -414,7 +414,7 @@ fn tan_cot(x: BigDecimal, precision: Int, is_tan: Bool) raises -> BigDecimal:
     return result^
 
 
-fn csc(x: BigDecimal, precision: Int) raises -> BigDecimal:
+def csc(x: BigDecimal, precision: Int) raises -> BigDecimal:
     """Calculates cosecant (csc) of the number.
 
     Args:
@@ -439,7 +439,7 @@ fn csc(x: BigDecimal, precision: Int) raises -> BigDecimal:
     return BigDecimal(BigUInt.one()).true_divide(sin_x, precision=precision)
 
 
-fn sec(x: BigDecimal, precision: Int) raises -> BigDecimal:
+def sec(x: BigDecimal, precision: Int) raises -> BigDecimal:
     """Calculates secant (sec) of the number.
 
     Args:
@@ -469,7 +469,7 @@ fn sec(x: BigDecimal, precision: Int) raises -> BigDecimal:
 # ===----------------------------------------------------------------------=== #
 
 
-fn arctan(x: BigDecimal, precision: Int) raises -> BigDecimal:
+def arctan(x: BigDecimal, precision: Int) raises -> BigDecimal:
     """Calculates arctangent (arctan) of the number.
 
     Notes:
@@ -539,7 +539,7 @@ fn arctan(x: BigDecimal, precision: Int) raises -> BigDecimal:
     return result^
 
 
-fn arctan_taylor_series(
+def arctan_taylor_series(
     x: BigDecimal, minimum_precision: Int
 ) raises -> BigDecimal:
     """Calculates arctangent (arctan) of a number with Taylor series.

--- a/src/decimo/bigint/arithmetics.mojo
+++ b/src/decimo/bigint/arithmetics.mojo
@@ -58,7 +58,7 @@ comptime CUTOFF_BURNIKEL_ZIEGLER: Int = 64
 # ===----------------------------------------------------------------------=== #
 
 
-fn _add_magnitudes(a: List[UInt32], b: List[UInt32]) -> List[UInt32]:
+def _add_magnitudes(a: List[UInt32], b: List[UInt32]) -> List[UInt32]:
     """Adds two unsigned magnitudes represented as little-endian UInt32 words.
 
     Uses UInt64 accumulation to handle carries naturally via bit shift.
@@ -90,7 +90,7 @@ fn _add_magnitudes(a: List[UInt32], b: List[UInt32]) -> List[UInt32]:
     return result^
 
 
-fn _add_magnitudes_into(
+def _add_magnitudes_into(
     mut result: List[UInt32],
     read a: List[UInt32],
     a_start: Int,
@@ -129,7 +129,7 @@ fn _add_magnitudes_into(
         result[len_max] = UInt32(carry)
 
 
-fn _subtract_magnitudes(a: List[UInt32], b: List[UInt32]) -> List[UInt32]:
+def _subtract_magnitudes(a: List[UInt32], b: List[UInt32]) -> List[UInt32]:
     """Subtracts magnitude b from magnitude a, assuming |a| >= |b|.
 
     The caller MUST ensure |a| >= |b|; otherwise the result is undefined.
@@ -165,7 +165,7 @@ fn _subtract_magnitudes(a: List[UInt32], b: List[UInt32]) -> List[UInt32]:
     return result^
 
 
-fn _multiply_magnitudes(a: List[UInt32], b: List[UInt32]) -> List[UInt32]:
+def _multiply_magnitudes(a: List[UInt32], b: List[UInt32]) -> List[UInt32]:
     """Multiplies two unsigned magnitudes, dispatching to the best algorithm.
 
     Uses Karatsuba O(n^1.585) for large operands, schoolbook O(n*m) for small.
@@ -207,7 +207,7 @@ fn _multiply_magnitudes(a: List[UInt32], b: List[UInt32]) -> List[UInt32]:
         return _multiply_magnitudes_karatsuba(a, 0, len_a, b, 0, len_b)
 
 
-fn _multiply_magnitude_by_word(
+def _multiply_magnitude_by_word(
     read a: List[UInt32], a_start: Int, a_end: Int, w: UInt32
 ) -> List[UInt32]:
     """Multiplies a magnitude slice by a single UInt32 word.
@@ -254,7 +254,7 @@ fn _multiply_magnitude_by_word(
     return result^
 
 
-fn _multiply_magnitudes_school(
+def _multiply_magnitudes_school(
     read a: List[UInt32],
     a_start: Int,
     a_end: Int,
@@ -314,7 +314,7 @@ fn _multiply_magnitudes_school(
     return result^
 
 
-fn _multiply_magnitudes_karatsuba(
+def _multiply_magnitudes_karatsuba(
     read a: List[UInt32],
     a_start: Int,
     a_end: Int,
@@ -466,7 +466,7 @@ fn _multiply_magnitudes_karatsuba(
 # ===----------------------------------------------------------------------=== #
 
 
-fn _add_slices(
+def _add_slices(
     read a: List[UInt32],
     a_start: Int,
     a_end: Int,
@@ -517,7 +517,7 @@ fn _add_slices(
     return result^
 
 
-fn _add_magnitudes_inplace(mut a: List[UInt32], read b: List[UInt32]):
+def _add_magnitudes_inplace(mut a: List[UInt32], read b: List[UInt32]):
     """Adds magnitude b into a in-place: a += b.
 
     Grows a if needed to accommodate the sum.
@@ -559,7 +559,7 @@ fn _add_magnitudes_inplace(mut a: List[UInt32], read b: List[UInt32]):
             a.shrink(len(a) - 1)
 
 
-fn _add_at_offset_inplace(
+def _add_at_offset_inplace(
     mut a: List[UInt32], read b: List[UInt32], offset: Int
 ):
     """Adds magnitude b into a at a word offset: a[offset:] += b.
@@ -589,7 +589,7 @@ fn _add_at_offset_inplace(
         j += 1
 
 
-fn _subtract_magnitudes_inplace(mut a: List[UInt32], read b: List[UInt32]):
+def _subtract_magnitudes_inplace(mut a: List[UInt32], read b: List[UInt32]):
     """Subtracts magnitude b from a in-place: a -= b.
 
     Assumes a >= b. Used by Karatsuba where this is guaranteed by construction.
@@ -620,7 +620,7 @@ fn _subtract_magnitudes_inplace(mut a: List[UInt32], read b: List[UInt32]):
         a.shrink(len(a) - 1)
 
 
-fn _shift_left_words_inplace(mut a: List[UInt32], n: Int):
+def _shift_left_words_inplace(mut a: List[UInt32], n: Int):
     """Shifts a magnitude left by n whole words in-place (multiply by B^n).
 
     This is equivalent to prepending n zero words. In base-2^32, B^n shift
@@ -651,7 +651,7 @@ fn _shift_left_words_inplace(mut a: List[UInt32], n: Int):
     memset_zero(ptr=a._data, count=n)
 
 
-fn _divmod_single_word(
+def _divmod_single_word(
     a: List[UInt32], d: UInt32
 ) -> Tuple[List[UInt32], UInt32]:
     """Divides a magnitude by a single UInt32 word.
@@ -684,7 +684,7 @@ fn _divmod_single_word(
     return (quotient^, UInt32(remainder))
 
 
-fn _divmod_magnitudes(
+def _divmod_magnitudes(
     a: List[UInt32], b: List[UInt32]
 ) raises -> Tuple[List[UInt32], List[UInt32]]:
     """Divides magnitude a by magnitude b, returning (quotient, remainder).
@@ -841,7 +841,7 @@ fn _divmod_magnitudes(
     return (quotient^, remainder^)
 
 
-fn _compare_word_lists(a: List[UInt32], b: List[UInt32]) -> Int8:
+def _compare_word_lists(a: List[UInt32], b: List[UInt32]) -> Int8:
     """Compares two unsigned magnitude word lists.
 
     Args:
@@ -861,7 +861,7 @@ fn _compare_word_lists(a: List[UInt32], b: List[UInt32]) -> Int8:
     return 0
 
 
-fn _count_leading_zeros(word: UInt32) -> Int:
+def _count_leading_zeros(word: UInt32) -> Int:
     """Counts the number of leading zero bits in a UInt32 word.
 
     Args:
@@ -891,7 +891,7 @@ fn _count_leading_zeros(word: UInt32) -> Int:
     return count
 
 
-fn _shift_left_words(a: List[UInt32], shift: Int) -> List[UInt32]:
+def _shift_left_words(a: List[UInt32], shift: Int) -> List[UInt32]:
     """Shifts a magnitude left by `shift` bits (0 <= shift < 32).
 
     Args:
@@ -920,7 +920,7 @@ fn _shift_left_words(a: List[UInt32], shift: Int) -> List[UInt32]:
     return result^
 
 
-fn _shift_right_words(
+def _shift_right_words(
     a: List[UInt32], shift: Int, num_words: Int
 ) -> List[UInt32]:
     """Shifts the first `num_words` of a magnitude right by `shift` bits.
@@ -973,7 +973,7 @@ fn _shift_right_words(
 # ===----------------------------------------------------------------------=== #
 
 
-fn _get_words_slice(a: List[UInt32], start: Int, end: Int) -> List[UInt32]:
+def _get_words_slice(a: List[UInt32], start: Int, end: Int) -> List[UInt32]:
     """Extracts a sub-range of words from a magnitude as a new list.
 
     Returns words[start:end], stripping leading zeros. If the range is
@@ -1001,7 +1001,7 @@ fn _get_words_slice(a: List[UInt32], start: Int, end: Int) -> List[UInt32]:
     return result^
 
 
-fn _is_zero_in_range(a: List[UInt32], start: Int, end: Int) -> Bool:
+def _is_zero_in_range(a: List[UInt32], start: Int, end: Int) -> Bool:
     """Checks if all words in a[start:end] are zero.
 
     Args:
@@ -1019,7 +1019,7 @@ fn _is_zero_in_range(a: List[UInt32], start: Int, end: Int) -> Bool:
     return True
 
 
-fn _add_from_slice_inplace(
+def _add_from_slice_inplace(
     mut a: List[UInt32], read b: List[UInt32], b_start: Int, b_end: Int
 ):
     """Adds b[b_start:b_end] into a in-place: a += b[b_start:b_end].
@@ -1066,7 +1066,7 @@ fn _add_from_slice_inplace(
             a.shrink(len(a) - 1)
 
 
-fn _multiply_magnitudes_slices(
+def _multiply_magnitudes_slices(
     read a: List[UInt32],
     a_start: Int,
     a_end: Int,
@@ -1102,7 +1102,7 @@ fn _multiply_magnitudes_slices(
     return _multiply_magnitudes_karatsuba(a, a_start, a_end, b, b_start, b_end)
 
 
-fn _decrement_inplace(mut a: List[UInt32]):
+def _decrement_inplace(mut a: List[UInt32]):
     """Subtracts 1 from a magnitude in-place. Assumes a > 0."""
     for i in range(len(a)):
         if a[i] > 0:
@@ -1111,7 +1111,7 @@ fn _decrement_inplace(mut a: List[UInt32]):
         a[i] = UInt32(0xFFFF_FFFF)
 
 
-fn _divmod_knuth_d_from_slices(
+def _divmod_knuth_d_from_slices(
     read a: List[UInt32],
     a_start: Int,
     a_end: Int,
@@ -1282,7 +1282,7 @@ fn _divmod_knuth_d_from_slices(
     return (quotient^, u^)
 
 
-fn _divmod_burnikel_ziegler(
+def _divmod_burnikel_ziegler(
     a: List[UInt32], b: List[UInt32]
 ) raises -> Tuple[List[UInt32], List[UInt32]]:
     """Divides magnitude a by magnitude b using Burnikel-Ziegler algorithm.
@@ -1409,7 +1409,7 @@ fn _divmod_burnikel_ziegler(
     return (quotient^, remainder^)
 
 
-fn _bz_two_by_one_slices(
+def _bz_two_by_one_slices(
     a: List[UInt32],
     b: List[UInt32],
     a_start: Int,
@@ -1479,7 +1479,7 @@ fn _bz_two_by_one_slices(
     return (q1^, s^)
 
 
-fn _bz_three_by_two_slices(
+def _bz_three_by_two_slices(
     a: List[UInt32],
     b: List[UInt32],
     a_start: Int,
@@ -1563,7 +1563,7 @@ fn _bz_three_by_two_slices(
 # ===----------------------------------------------------------------------=== #
 
 
-fn add(x1: BigInt, x2: BigInt) -> BigInt:
+def add(x1: BigInt, x2: BigInt) -> BigInt:
     """Returns the sum of two BigInt numbers.
 
     Args:
@@ -1588,7 +1588,7 @@ fn add(x1: BigInt, x2: BigInt) -> BigInt:
     return BigInt(raw_words=result_words^, sign=x1.sign)
 
 
-fn subtract(x1: BigInt, x2: BigInt) -> BigInt:
+def subtract(x1: BigInt, x2: BigInt) -> BigInt:
     """Returns the difference of two BigInt numbers.
 
     Args:
@@ -1625,7 +1625,7 @@ fn subtract(x1: BigInt, x2: BigInt) -> BigInt:
         return BigInt(raw_words=result_words^, sign=not x1.sign)
 
 
-fn negative(x: BigInt) -> BigInt:
+def negative(x: BigInt) -> BigInt:
     """Returns the negative of a BigInt number.
 
     Args:
@@ -1641,7 +1641,7 @@ fn negative(x: BigInt) -> BigInt:
     return result^
 
 
-fn absolute(x: BigInt) -> BigInt:
+def absolute(x: BigInt) -> BigInt:
     """Returns the absolute value of a BigInt number.
 
     Args:
@@ -1656,7 +1656,7 @@ fn absolute(x: BigInt) -> BigInt:
         return x.copy()
 
 
-fn multiply(x1: BigInt, x2: BigInt) -> BigInt:
+def multiply(x1: BigInt, x2: BigInt) -> BigInt:
     """Returns the product of two BigInt numbers.
 
     Uses schoolbook multiplication O(n*m) with UInt64 intermediate products.
@@ -1682,7 +1682,7 @@ fn multiply(x1: BigInt, x2: BigInt) -> BigInt:
 # ===----------------------------------------------------------------------=== #
 
 
-fn _compare_magnitudes_words(
+def _compare_magnitudes_words(
     read a: List[UInt32], read b: List[UInt32]
 ) -> Int8:
     """Compares the magnitudes of two word lists.
@@ -1700,7 +1700,7 @@ fn _compare_magnitudes_words(
     return 0
 
 
-fn add_inplace(mut x: BigInt, read other: BigInt):
+def add_inplace(mut x: BigInt, read other: BigInt):
     """Performs x += other by mutating x.words directly.
 
     Avoids allocating a new BigInt. Uses the existing _add_magnitudes_inplace
@@ -1743,7 +1743,7 @@ fn add_inplace(mut x: BigInt, read other: BigInt):
             x.sign = other.sign
 
 
-fn add_inplace_int(mut x: BigInt, value: Int):
+def add_inplace_int(mut x: BigInt, value: Int):
     """Performs x += value (Int) by mutating x.words directly.
 
     Optimized for adding a small integer: avoids constructing a full BigInt.
@@ -1816,7 +1816,7 @@ fn add_inplace_int(mut x: BigInt, value: Int):
             x.sign = other_sign
 
 
-fn subtract_inplace(mut x: BigInt, read other: BigInt):
+def subtract_inplace(mut x: BigInt, read other: BigInt):
     """Performs x -= other by mutating x.words directly.
 
     Avoids allocating a new BigInt. Leverages the relationship:
@@ -1863,7 +1863,7 @@ fn subtract_inplace(mut x: BigInt, read other: BigInt):
             x.sign = effective_other_sign
 
 
-fn multiply_inplace(mut x: BigInt, read other: BigInt):
+def multiply_inplace(mut x: BigInt, read other: BigInt):
     """Performs x *= other by computing the product and moving the result
     into x.words.
 
@@ -1890,7 +1890,7 @@ fn multiply_inplace(mut x: BigInt, read other: BigInt):
     x.sign = x.sign != other.sign
 
 
-fn left_shift_inplace(mut x: BigInt, shift: Int):
+def left_shift_inplace(mut x: BigInt, shift: Int):
     """Performs x <<= shift by mutating x.words directly.
 
     Avoids allocating a new BigInt. Shifts left by `shift` bits
@@ -1935,7 +1935,7 @@ fn left_shift_inplace(mut x: BigInt, shift: Int):
     x.words = new_words^
 
 
-fn right_shift_inplace(mut x: BigInt, shift: Int):
+def right_shift_inplace(mut x: BigInt, shift: Int):
     """Performs x >>= shift by mutating x.words directly.
 
     For negative numbers, performs arithmetic right shift (rounds toward
@@ -2026,7 +2026,7 @@ fn right_shift_inplace(mut x: BigInt, shift: Int):
     x._normalize()
 
 
-fn floor_divide_inplace(mut x: BigInt, read other: BigInt) raises:
+def floor_divide_inplace(mut x: BigInt, read other: BigInt) raises:
     """Performs x //= other by computing the quotient and moving the result
     into x.words.
 
@@ -2073,7 +2073,7 @@ fn floor_divide_inplace(mut x: BigInt, read other: BigInt) raises:
     x._normalize()
 
 
-fn floor_modulo_inplace(mut x: BigInt, read other: BigInt) raises:
+def floor_modulo_inplace(mut x: BigInt, read other: BigInt) raises:
     """Performs x %= other by computing the remainder and moving the result
     into x.words.
 
@@ -2111,7 +2111,7 @@ fn floor_modulo_inplace(mut x: BigInt, read other: BigInt) raises:
     x._normalize()
 
 
-fn floor_divide(x1: BigInt, x2: BigInt) raises -> BigInt:
+def floor_divide(x1: BigInt, x2: BigInt) raises -> BigInt:
     """Returns the quotient of two BigInt numbers, rounding toward negative
     infinity.
 
@@ -2163,7 +2163,7 @@ fn floor_divide(x1: BigInt, x2: BigInt) raises -> BigInt:
             return BigInt(raw_words=q_plus_one^, sign=True)
 
 
-fn truncate_divide(x1: BigInt, x2: BigInt) raises -> BigInt:
+def truncate_divide(x1: BigInt, x2: BigInt) raises -> BigInt:
     """Returns the quotient of two BigInt numbers, truncating toward zero.
 
     The result satisfies: x1 = truncate_divide(x1, x2) * x2 + truncate_modulo(x1, x2).
@@ -2194,7 +2194,7 @@ fn truncate_divide(x1: BigInt, x2: BigInt) raises -> BigInt:
     return BigInt(raw_words=q_words^, sign=sign)
 
 
-fn floor_modulo(x1: BigInt, x2: BigInt) raises -> BigInt:
+def floor_modulo(x1: BigInt, x2: BigInt) raises -> BigInt:
     """Returns the floor modulo (remainder) of two BigInt numbers.
 
     The result has the same sign as the divisor and satisfies:
@@ -2234,7 +2234,7 @@ fn floor_modulo(x1: BigInt, x2: BigInt) raises -> BigInt:
         return BigInt(raw_words=adjusted^, sign=x2.sign)
 
 
-fn truncate_modulo(x1: BigInt, x2: BigInt) raises -> BigInt:
+def truncate_modulo(x1: BigInt, x2: BigInt) raises -> BigInt:
     """Returns the truncate modulo (remainder) of two BigInt numbers.
 
     The result has the same sign as the dividend and satisfies:
@@ -2268,7 +2268,7 @@ fn truncate_modulo(x1: BigInt, x2: BigInt) raises -> BigInt:
     return BigInt(raw_words=r_words^, sign=x1.sign)
 
 
-fn floor_divmod(x1: BigInt, x2: BigInt) raises -> Tuple[BigInt, BigInt]:
+def floor_divmod(x1: BigInt, x2: BigInt) raises -> Tuple[BigInt, BigInt]:
     """Returns both the floor quotient and floor remainder.
 
     The result satisfies: x1 = q * x2 + r, where r has same sign as x2.
@@ -2320,7 +2320,7 @@ fn floor_divmod(x1: BigInt, x2: BigInt) raises -> Tuple[BigInt, BigInt]:
             )
 
 
-fn power(base: BigInt, exponent: Int) raises -> BigInt:
+def power(base: BigInt, exponent: Int) raises -> BigInt:
     """Raises a BigInt to the power of a non-negative integer exponent.
 
     Uses binary exponentiation (exponentiation by squaring) for O(log n)
@@ -2403,7 +2403,7 @@ fn power(base: BigInt, exponent: Int) raises -> BigInt:
     return BigInt(raw_words=result_words^, sign=result_sign)
 
 
-fn left_shift(x: BigInt, shift: Int) -> BigInt:
+def left_shift(x: BigInt, shift: Int) -> BigInt:
     """Shifts a BigInt left by `shift` bits (multiply by 2^shift).
 
     This is an efficient operation for base-2^32 representation since it
@@ -2450,7 +2450,7 @@ fn left_shift(x: BigInt, shift: Int) -> BigInt:
     return BigInt(raw_words=result^, sign=x.sign)
 
 
-fn right_shift(x: BigInt, shift: Int) -> BigInt:
+def right_shift(x: BigInt, shift: Int) -> BigInt:
     """Shifts a BigInt right by `shift` bits (floor divide by 2^shift).
 
     For negative numbers, this performs an arithmetic right shift (rounds

--- a/src/decimo/bigint/arithmetics.mojo
+++ b/src/decimo/bigint/arithmetics.mojo
@@ -33,7 +33,7 @@ Algorithms:
   (< CUTOFF_BURNIKEL_ZIEGLER words). Single-word fast path for UInt32 divisors.
 """
 
-from memory import memcpy, memset_zero
+from std.memory import memcpy, memset_zero
 
 from decimo.bigint.bigint import BigInt
 from decimo.bigint.comparison import compare_magnitudes
@@ -854,10 +854,10 @@ fn _compare_word_lists(a: List[UInt32], b: List[UInt32]) -> Int8:
     var len_a = len(a)
     var len_b = len(b)
     if len_a != len_b:
-        return 1 if len_a > len_b else -1
+        return Int8(1) if len_a > len_b else Int8(-1)
     for i in range(len_a - 1, -1, -1):
         if a[i] != b[i]:
-            return 1 if a[i] > b[i] else -1
+            return Int8(1) if a[i] > b[i] else Int8(-1)
     return 0
 
 
@@ -911,9 +911,9 @@ fn _shift_left_words(a: List[UInt32], shift: Int) -> List[UInt32]:
     var result = List[UInt32](capacity=n + 1)
     var carry: UInt32 = 0
     for i in range(n):
-        var shifted = UInt64(a[i]) << shift
-        result.append(UInt32(shifted & 0xFFFF_FFFF) | carry)
-        carry = UInt32(shifted >> 32)
+        var shifted = UInt64(a[i]) << UInt64(shift)
+        result.append(UInt32(shifted & UInt64(0xFFFF_FFFF)) | carry)
+        carry = UInt32(shifted >> UInt64(32))
     if carry > 0:
         result.append(carry)
 
@@ -948,10 +948,12 @@ fn _shift_right_words(
     var n = min(num_words, len(a))
     var result = List[UInt32](capacity=n)
     for i in range(n):
-        var lo = UInt64(a[i]) >> shift
+        var lo = UInt64(a[i]) >> UInt64(shift)
         var hi: UInt64 = 0
         if i + 1 < n:
-            hi = (UInt64(a[i + 1]) << (32 - shift)) & 0xFFFF_FFFF
+            hi = (UInt64(a[i + 1]) << (UInt64(32) - UInt64(shift))) & UInt64(
+                0xFFFF_FFFF
+            )
         result.append(UInt32(lo | hi))
 
     # Strip leading zeros
@@ -1691,10 +1693,10 @@ fn _compare_magnitudes_words(
     var n_a = len(a)
     var n_b = len(b)
     if n_a != n_b:
-        return 1 if n_a > n_b else -1
+        return Int8(1) if n_a > n_b else Int8(-1)
     for i in range(n_a - 1, -1, -1):
         if a[i] != b[i]:
-            return 1 if a[i] > b[i] else -1
+            return Int8(1) if a[i] > b[i] else Int8(-1)
     return 0
 
 
@@ -1924,9 +1926,9 @@ fn left_shift_inplace(mut x: BigInt, shift: Int):
     else:
         var carry: UInt32 = 0
         for i in range(n):
-            var shifted = UInt64(x.words[i]) << bit_shift
-            new_words.append(UInt32(shifted & 0xFFFF_FFFF) | carry)
-            carry = UInt32(shifted >> 32)
+            var shifted = UInt64(x.words[i]) << UInt64(bit_shift)
+            new_words.append(UInt32(shifted & UInt64(0xFFFF_FFFF)) | carry)
+            carry = UInt32(shifted >> UInt64(32))
         if carry > 0:
             new_words.append(carry)
 
@@ -1989,12 +1991,13 @@ fn right_shift_inplace(mut x: BigInt, shift: Int):
             x.words[i] = x.words[i + word_shift]
     else:
         for i in range(new_len):
-            var lo = UInt64(x.words[i + word_shift]) >> bit_shift
+            var lo = UInt64(x.words[i + word_shift]) >> UInt64(bit_shift)
             var hi: UInt64 = 0
             if i + word_shift + 1 < n:
                 hi = (
-                    UInt64(x.words[i + word_shift + 1]) << (32 - bit_shift)
-                ) & 0xFFFF_FFFF
+                    UInt64(x.words[i + word_shift + 1])
+                    << (UInt64(32) - UInt64(bit_shift))
+                ) & UInt64(0xFFFF_FFFF)
             x.words[i] = UInt32(lo | hi)
 
     # Truncate to new length in a single shrink call
@@ -2438,9 +2441,9 @@ fn left_shift(x: BigInt, shift: Int) -> BigInt:
     else:
         var carry: UInt32 = 0
         for i in range(n):
-            var shifted = UInt64(x.words[i]) << bit_shift
-            result.append(UInt32(shifted & 0xFFFF_FFFF) | carry)
-            carry = UInt32(shifted >> 32)
+            var shifted = UInt64(x.words[i]) << UInt64(bit_shift)
+            result.append(UInt32(shifted & UInt64(0xFFFF_FFFF)) | carry)
+            carry = UInt32(shifted >> UInt64(32))
         if carry > 0:
             result.append(carry)
 
@@ -2486,10 +2489,12 @@ fn right_shift(x: BigInt, shift: Int) -> BigInt:
             result.append(x.words[i])
     else:
         for i in range(word_shift, n):
-            var lo = UInt64(x.words[i]) >> bit_shift
+            var lo = UInt64(x.words[i]) >> UInt64(bit_shift)
             var hi: UInt64 = 0
             if i + 1 < n:
-                hi = (UInt64(x.words[i + 1]) << (32 - bit_shift)) & 0xFFFF_FFFF
+                hi = (
+                    UInt64(x.words[i + 1]) << (UInt64(32) - UInt64(bit_shift))
+                ) & UInt64(0xFFFF_FFFF)
             result.append(UInt32(lo | hi))
 
     # Strip leading zeros

--- a/src/decimo/bigint/bigint.mojo
+++ b/src/decimo/bigint/bigint.mojo
@@ -106,19 +106,19 @@ struct BigInt(
 
     @always_inline
     @staticmethod
-    fn zero() -> Self:
+    def zero() -> Self:
         """Returns a BigInt with value 0."""
         return Self()
 
     @always_inline
     @staticmethod
-    fn one() -> Self:
+    def one() -> Self:
         """Returns a BigInt with value 1."""
         return Self(raw_words=[UInt32(1)], sign=False)
 
     @always_inline
     @staticmethod
-    fn negative_one() -> Self:
+    def negative_one() -> Self:
         """Returns a BigInt with value -1."""
         return Self(raw_words=[UInt32(1)], sign=True)
 
@@ -126,12 +126,12 @@ struct BigInt(
     # Constructors and life time dunder methods
     # ===------------------------------------------------------------------=== #
 
-    fn __init__(out self):
+    def __init__(out self):
         """Initializes a BigInt with value 0."""
         self.words = [UInt32(0)]
         self.sign = False
 
-    fn __init__(out self, *, uninitialized_capacity: Int):
+    def __init__(out self, *, uninitialized_capacity: Int):
         """Creates an uninitialized BigInt with a given word capacity.
         The words list is empty; caller must append words before use.
 
@@ -141,7 +141,7 @@ struct BigInt(
         self.words = List[UInt32](capacity=uninitialized_capacity)
         self.sign = False
 
-    fn __init__(out self, *, var raw_words: List[UInt32], sign: Bool):
+    def __init__(out self, *, var raw_words: List[UInt32], sign: Bool):
         """Initializes a BigInt from a list of raw words without
         validation. The caller must ensure words are in valid little-endian
         form with no unnecessary leading zeros.
@@ -162,7 +162,7 @@ struct BigInt(
             self.sign = sign
 
     @implicit
-    fn __init__(out self, value: Int):
+    def __init__(out self, value: Int):
         """Initializes a BigInt from an Int.
 
         Args:
@@ -170,7 +170,7 @@ struct BigInt(
         """
         self = Self.from_int(value)
 
-    fn __init__(out self, value: String) raises:
+    def __init__(out self, value: String) raises:
         """Initializes a BigInt from a decimal string representation.
 
         Args:
@@ -179,7 +179,7 @@ struct BigInt(
         self = Self.from_string(value)
 
     @implicit
-    fn __init__(out self, value: Scalar):
+    def __init__(out self, value: Scalar):
         """Constructs a BigInt from an integral scalar.
         This includes all SIMD integral types, such as Int8, Int16, UInt32, etc.
 
@@ -193,7 +193,7 @@ struct BigInt(
     # ===------------------------------------------------------------------=== #
 
     @staticmethod
-    fn from_int(value: Int) -> Self:
+    def from_int(value: Int) -> Self:
         """Creates a BigInt from a Mojo Int.
 
         Args:
@@ -230,7 +230,7 @@ struct BigInt(
         return Self(raw_words=words^, sign=sign)
 
     @staticmethod
-    fn from_uint64(value: UInt64) -> Self:
+    def from_uint64(value: UInt64) -> Self:
         """Creates a BigInt from a UInt64.
 
         Args:
@@ -252,7 +252,7 @@ struct BigInt(
         return Self(raw_words=words^, sign=False)
 
     @staticmethod
-    fn from_uint128(value: UInt128) -> Self:
+    def from_uint128(value: UInt128) -> Self:
         """Creates a BigInt from a UInt128.
 
         Args:
@@ -273,7 +273,7 @@ struct BigInt(
         return Self(raw_words=words^, sign=False)
 
     @staticmethod
-    fn from_integral_scalar[dtype: DType, //](value: SIMD[dtype, 1]) -> Self:
+    def from_integral_scalar[dtype: DType, //](value: SIMD[dtype, 1]) -> Self:
         """Initializes a BigInt from an integral scalar.
         This includes all SIMD integral types, such as Int8, Int16, UInt32, etc.
 
@@ -317,7 +317,7 @@ struct BigInt(
         return Self(raw_words=words^, sign=sign)
 
     @staticmethod
-    fn from_string(value: String) raises -> Self:
+    def from_string(value: String) raises -> Self:
         """Creates a BigInt from a string representation.
         The string is normalized with `decimo.str.parse_numeric_string()`.
 
@@ -409,7 +409,7 @@ struct BigInt(
         return result^
 
     @staticmethod
-    fn from_bigint10(value: BigInt10) -> Self:
+    def from_bigint10(value: BigInt10) -> Self:
         """Converts a base-10^9 BigInt10 to a base-2^32 BigInt.
 
         Args:
@@ -458,13 +458,13 @@ struct BigInt(
     # Output dunders, type-transfer dunders
     # ===------------------------------------------------------------------=== #
 
-    fn __int__(self) raises -> Int:
+    def __int__(self) raises -> Int:
         """Returns the number as Int.
         See `to_int()` for more information.
         """
         return self.to_int()
 
-    fn __float__(self) raises -> Float64:
+    def __float__(self) raises -> Float64:
         """Converts the BigInt to a floating-point number.
 
         Matches Python's `float(n)` for `int` objects.
@@ -476,11 +476,11 @@ struct BigInt(
         """
         return Float64(self.to_string())
 
-    fn write_repr_to[W: Writer](self, mut writer: W):
+    def write_repr_to[W: Writer](self, mut writer: W):
         """Writes the debug representation to a writer."""
         writer.write('BigInt("', self.to_string(), '")')
 
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """Writes the decimal string representation to a writer."""
         writer.write(self.to_string())
 
@@ -488,7 +488,7 @@ struct BigInt(
     # Type-transfer or output methods that are not dunders
     # ===------------------------------------------------------------------=== #
 
-    fn to_int(self) raises -> Int:
+    def to_int(self) raises -> Int:
         """Returns the number as Int.
 
         Returns:
@@ -523,7 +523,7 @@ struct BigInt(
                 )
             return Int(magnitude)
 
-    fn to_bigint10(self) -> BigInt10:
+    def to_bigint10(self) -> BigInt10:
         """Converts the BigInt to a base-10^9 BigInt10.
 
         Returns:
@@ -551,7 +551,7 @@ struct BigInt(
 
         return BigInt10(raw_words=decimal_words^, sign=self.sign)
 
-    fn to_string(self, line_width: Int = 0) -> String:
+    def to_string(self, line_width: Int = 0) -> String:
         """Returns the decimal string representation of the BigInt.
 
         Uses divide-and-conquer base conversion for large numbers (O(M(n)·log n))
@@ -604,14 +604,14 @@ struct BigInt(
 
         return result^
 
-    fn to_decimal_string(self, line_width: Int = 0) -> String:
+    def to_decimal_string(self, line_width: Int = 0) -> String:
         """Returns the decimal string representation of the BigInt.
 
         Deprecated: Use ``to_string(line_width=...)`` instead.
         """
         return self.to_string(line_width=line_width)
 
-    fn to_string_with_separators(self, separator: String = "_") -> String:
+    def to_string_with_separators(self, separator: String = "_") -> String:
         """Returns string representation of the BigInt with separators.
 
         Args:
@@ -642,7 +642,7 @@ struct BigInt(
             return String("-") + formatted
         return formatted^
 
-    fn to_hex_string(self) -> String:
+    def to_hex_string(self) -> String:
         """Returns a hexadecimal string representation of the BigInt.
 
         Returns:
@@ -674,7 +674,7 @@ struct BigInt(
 
         return result
 
-    fn to_binary_string(self) -> String:
+    def to_binary_string(self) -> String:
         """Returns a binary string representation of the BigInt.
 
         Returns:
@@ -710,18 +710,18 @@ struct BigInt(
     # Unary arithmetic dunders
     # ===------------------------------------------------------------------=== #
 
-    fn __neg__(self) -> Self:
+    def __neg__(self) -> Self:
         """Returns the negation of the BigInt."""
         if self.is_zero():
             return Self()
         return Self(raw_words=self.words.copy(), sign=not self.sign)
 
-    fn __abs__(self) -> Self:
+    def __abs__(self) -> Self:
         """Returns the absolute value of the BigInt."""
         return Self(raw_words=self.words.copy(), sign=False)
 
     @always_inline
-    fn __bool__(self) -> Bool:
+    def __bool__(self) -> Bool:
         """Returns True if the number is nonzero.
 
         This enables `if n:` syntax, consistent with Python's `int`.
@@ -729,7 +729,7 @@ struct BigInt(
         return not self.is_zero()
 
     @always_inline
-    fn __pos__(self) -> Self:
+    def __pos__(self) -> Self:
         """Returns the number unchanged (unary plus).
 
         This enables `+n` syntax, consistent with Python's `int`.
@@ -737,7 +737,7 @@ struct BigInt(
         return Self(raw_words=self.words.copy(), sign=self.sign)
 
     @always_inline
-    fn __ceil__(self) -> Self:
+    def __ceil__(self) -> Self:
         """Returns self unchanged. Integers are already integers.
 
         This enables `math.ceil()` compatibility with Python's `int`.
@@ -745,7 +745,7 @@ struct BigInt(
         return Self(raw_words=self.words.copy(), sign=self.sign)
 
     @always_inline
-    fn __floor__(self) -> Self:
+    def __floor__(self) -> Self:
         """Returns self unchanged. Integers are already integers.
 
         This enables `math.floor()` compatibility with Python's `int`.
@@ -753,7 +753,7 @@ struct BigInt(
         return Self(raw_words=self.words.copy(), sign=self.sign)
 
     @always_inline
-    fn __trunc__(self) -> Self:
+    def __trunc__(self) -> Self:
         """Returns self unchanged. Integers are already integers.
 
         This enables `math.trunc()` compatibility with Python's `int`.
@@ -767,19 +767,19 @@ struct BigInt(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __add__(self, other: Self) -> Self:
+    def __add__(self, other: Self) -> Self:
         return decimo.bigint.arithmetics.add(self, other)
 
     @always_inline
-    fn __sub__(self, other: Self) -> Self:
+    def __sub__(self, other: Self) -> Self:
         return decimo.bigint.arithmetics.subtract(self, other)
 
     @always_inline
-    fn __mul__(self, other: Self) -> Self:
+    def __mul__(self, other: Self) -> Self:
         return decimo.bigint.arithmetics.multiply(self, other)
 
     @always_inline
-    fn __floordiv__(self, other: Self) raises -> Self:
+    def __floordiv__(self, other: Self) raises -> Self:
         try:
             return decimo.bigint.arithmetics.floor_divide(self, other)
         except e:
@@ -793,7 +793,7 @@ struct BigInt(
             )
 
     @always_inline
-    fn __mod__(self, other: Self) raises -> Self:
+    def __mod__(self, other: Self) raises -> Self:
         try:
             return decimo.bigint.arithmetics.floor_modulo(self, other)
         except e:
@@ -807,7 +807,7 @@ struct BigInt(
             )
 
     @always_inline
-    fn __divmod__(self, other: Self) raises -> Tuple[Self, Self]:
+    def __divmod__(self, other: Self) raises -> Tuple[Self, Self]:
         try:
             return decimo.bigint.arithmetics.floor_divmod(self, other)
         except e:
@@ -821,20 +821,20 @@ struct BigInt(
             )
 
     @always_inline
-    fn __pow__(self, exponent: Self) raises -> Self:
+    def __pow__(self, exponent: Self) raises -> Self:
         return self.power(exponent)
 
     @always_inline
-    fn __pow__(self, exponent: Int) raises -> Self:
+    def __pow__(self, exponent: Int) raises -> Self:
         return self.power(exponent)
 
     @always_inline
-    fn __lshift__(self, shift: Int) -> Self:
+    def __lshift__(self, shift: Int) -> Self:
         """Returns self << shift (multiply by 2^shift)."""
         return decimo.bigint.arithmetics.left_shift(self, shift)
 
     @always_inline
-    fn __rshift__(self, shift: Int) -> Self:
+    def __rshift__(self, shift: Int) -> Self:
         """Returns self >> shift (floor divide by 2^shift)."""
         return decimo.bigint.arithmetics.right_shift(self, shift)
 
@@ -843,31 +843,31 @@ struct BigInt(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __radd__(self, other: Self) -> Self:
+    def __radd__(self, other: Self) -> Self:
         return decimo.bigint.arithmetics.add(self, other)
 
     @always_inline
-    fn __rsub__(self, other: Self) -> Self:
+    def __rsub__(self, other: Self) -> Self:
         return decimo.bigint.arithmetics.subtract(other, self)
 
     @always_inline
-    fn __rmul__(self, other: Self) -> Self:
+    def __rmul__(self, other: Self) -> Self:
         return decimo.bigint.arithmetics.multiply(self, other)
 
     @always_inline
-    fn __rfloordiv__(self, other: Self) raises -> Self:
+    def __rfloordiv__(self, other: Self) raises -> Self:
         return decimo.bigint.arithmetics.floor_divide(other, self)
 
     @always_inline
-    fn __rmod__(self, other: Self) raises -> Self:
+    def __rmod__(self, other: Self) raises -> Self:
         return decimo.bigint.arithmetics.floor_modulo(other, self)
 
     @always_inline
-    fn __rdivmod__(self, other: Self) raises -> Tuple[Self, Self]:
+    def __rdivmod__(self, other: Self) raises -> Tuple[Self, Self]:
         return decimo.bigint.arithmetics.floor_divmod(other, self)
 
     @always_inline
-    fn __rpow__(self, base: Self) raises -> Self:
+    def __rpow__(self, base: Self) raises -> Self:
         return base.power(self)
 
     # ===------------------------------------------------------------------=== #
@@ -876,42 +876,42 @@ struct BigInt(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __iadd__(mut self, other: Self):
+    def __iadd__(mut self, other: Self):
         """True in-place addition: mutates self.words directly."""
         decimo.bigint.arithmetics.add_inplace(self, other)
 
     @always_inline
-    fn __iadd__(mut self, other: Int):
+    def __iadd__(mut self, other: Int):
         """True in-place addition with Int: mutates self.words directly."""
         decimo.bigint.arithmetics.add_inplace_int(self, other)
 
     @always_inline
-    fn __isub__(mut self, other: Self):
+    def __isub__(mut self, other: Self):
         """True in-place subtraction: mutates self.words directly."""
         decimo.bigint.arithmetics.subtract_inplace(self, other)
 
     @always_inline
-    fn __imul__(mut self, other: Self):
+    def __imul__(mut self, other: Self):
         """True in-place multiplication: computes product into self.words."""
         decimo.bigint.arithmetics.multiply_inplace(self, other)
 
     @always_inline
-    fn __ifloordiv__(mut self, other: Self) raises:
+    def __ifloordiv__(mut self, other: Self) raises:
         """True in-place floor division: moves quotient into self.words."""
         decimo.bigint.arithmetics.floor_divide_inplace(self, other)
 
     @always_inline
-    fn __imod__(mut self, other: Self) raises:
+    def __imod__(mut self, other: Self) raises:
         """True in-place modulo: moves remainder into self.words."""
         decimo.bigint.arithmetics.floor_modulo_inplace(self, other)
 
     @always_inline
-    fn __ilshift__(mut self, shift: Int):
+    def __ilshift__(mut self, shift: Int):
         """True in-place left shift: mutates self.words directly."""
         decimo.bigint.arithmetics.left_shift_inplace(self, shift)
 
     @always_inline
-    fn __irshift__(mut self, shift: Int):
+    def __irshift__(mut self, shift: Int):
         """True in-place right shift: mutates self.words directly."""
         decimo.bigint.arithmetics.right_shift_inplace(self, shift)
 
@@ -921,64 +921,64 @@ struct BigInt(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __gt__(self, other: Self) -> Bool:
+    def __gt__(self, other: Self) -> Bool:
         """Returns True if self > other."""
         return decimo.bigint.comparison.greater(self, other)
 
     @always_inline
-    fn __gt__(self, other: Int) -> Bool:
+    def __gt__(self, other: Int) -> Bool:
         """Returns True if self > other."""
         return decimo.bigint.comparison.greater(self, Self.from_int(other))
 
     @always_inline
-    fn __ge__(self, other: Self) -> Bool:
+    def __ge__(self, other: Self) -> Bool:
         """Returns True if self >= other."""
         return decimo.bigint.comparison.greater_equal(self, other)
 
     @always_inline
-    fn __ge__(self, other: Int) -> Bool:
+    def __ge__(self, other: Int) -> Bool:
         """Returns True if self >= other."""
         return decimo.bigint.comparison.greater_equal(
             self, Self.from_int(other)
         )
 
     @always_inline
-    fn __lt__(self, other: Self) -> Bool:
+    def __lt__(self, other: Self) -> Bool:
         """Returns True if self < other."""
         return decimo.bigint.comparison.less(self, other)
 
     @always_inline
-    fn __lt__(self, other: Int) -> Bool:
+    def __lt__(self, other: Int) -> Bool:
         """Returns True if self < other."""
         return decimo.bigint.comparison.less(self, Self.from_int(other))
 
     @always_inline
-    fn __le__(self, other: Self) -> Bool:
+    def __le__(self, other: Self) -> Bool:
         """Returns True if self <= other."""
         return decimo.bigint.comparison.less_equal(self, other)
 
     @always_inline
-    fn __le__(self, other: Int) -> Bool:
+    def __le__(self, other: Int) -> Bool:
         """Returns True if self <= other."""
         return decimo.bigint.comparison.less_equal(self, Self.from_int(other))
 
     @always_inline
-    fn __eq__(self, other: Self) -> Bool:
+    def __eq__(self, other: Self) -> Bool:
         """Returns True if self == other."""
         return decimo.bigint.comparison.equal(self, other)
 
     @always_inline
-    fn __eq__(self, other: Int) -> Bool:
+    def __eq__(self, other: Int) -> Bool:
         """Returns True if self == other."""
         return decimo.bigint.comparison.equal(self, Self.from_int(other))
 
     @always_inline
-    fn __ne__(self, other: Self) -> Bool:
+    def __ne__(self, other: Self) -> Bool:
         """Returns True if self != other."""
         return decimo.bigint.comparison.not_equal(self, other)
 
     @always_inline
-    fn __ne__(self, other: Int) -> Bool:
+    def __ne__(self, other: Int) -> Bool:
         """Returns True if self != other."""
         return decimo.bigint.comparison.not_equal(self, Self.from_int(other))
 
@@ -987,27 +987,27 @@ struct BigInt(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn truncate_divide(self, other: Self) raises -> Self:
+    def truncate_divide(self, other: Self) raises -> Self:
         """Performs a truncated division of two BigInt numbers.
         See `truncate_divide()` for more information.
         """
         return decimo.bigint.arithmetics.truncate_divide(self, other)
 
     @always_inline
-    fn floor_modulo(self, other: Self) raises -> Self:
+    def floor_modulo(self, other: Self) raises -> Self:
         """Performs a floor modulo of two BigInt numbers.
         See `floor_modulo()` for more information.
         """
         return decimo.bigint.arithmetics.floor_modulo(self, other)
 
     @always_inline
-    fn truncate_modulo(self, other: Self) raises -> Self:
+    def truncate_modulo(self, other: Self) raises -> Self:
         """Performs a truncated modulo of two BigInt numbers.
         See `truncate_modulo()` for more information.
         """
         return decimo.bigint.arithmetics.truncate_modulo(self, other)
 
-    fn power(self, exponent: Int) raises -> Self:
+    def power(self, exponent: Int) raises -> Self:
         """Raises the BigInt to the power of an integer exponent.
 
         Args:
@@ -1021,7 +1021,7 @@ struct BigInt(
         """
         return decimo.bigint.arithmetics.power(self, exponent)
 
-    fn power(self, exponent: Self) raises -> Self:
+    def power(self, exponent: Self) raises -> Self:
         """Raises the BigInt to the power of another BigInt.
 
         Args:
@@ -1042,7 +1042,7 @@ struct BigInt(
             raise Error("BigInt.power(): Exponent too large to fit in Int")
         return self.power(exp_int)
 
-    fn sqrt(self) raises -> Self:
+    def sqrt(self) raises -> Self:
         """Returns the integer square root of this BigInt.
 
         The result is the largest integer y such that y * y <= self
@@ -1056,7 +1056,7 @@ struct BigInt(
         """
         return decimo.bigint.exponential.sqrt(self)
 
-    fn isqrt(self) raises -> Self:
+    def isqrt(self) raises -> Self:
         """Returns the integer square root of this BigInt.
         It is equal to `sqrt()`.
 
@@ -1069,14 +1069,14 @@ struct BigInt(
         return decimo.bigint.exponential.sqrt(self)
 
     @always_inline
-    fn compare_magnitudes(self, other: Self) -> Int8:
+    def compare_magnitudes(self, other: Self) -> Int8:
         """Compares the magnitudes (absolute values) of two BigInt numbers.
         See `compare_magnitudes()` for more information.
         """
         return decimo.bigint.comparison.compare_magnitudes(self, other)
 
     @always_inline
-    fn compare(self, other: Self) -> Int8:
+    def compare(self, other: Self) -> Int8:
         """Compares two BigInt numbers.
         See `compare()` for more information.
         """
@@ -1087,55 +1087,55 @@ struct BigInt(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __and__(self, other: Self) -> Self:
+    def __and__(self, other: Self) -> Self:
         """Returns self & other (bitwise AND, Python two's complement semantics).
         """
         return decimo.bigint.bitwise.bitwise_and(self, other)
 
     @always_inline
-    fn __and__(self, other: Int) -> Self:
+    def __and__(self, other: Int) -> Self:
         """Returns self & other where other is an Int."""
         return decimo.bigint.bitwise.bitwise_and(self, Self(other))
 
     @always_inline
-    fn __or__(self, other: Self) -> Self:
+    def __or__(self, other: Self) -> Self:
         """Returns self | other (bitwise OR, Python two's complement semantics).
         """
         return decimo.bigint.bitwise.bitwise_or(self, other)
 
     @always_inline
-    fn __or__(self, other: Int) -> Self:
+    def __or__(self, other: Int) -> Self:
         """Returns self | other where other is an Int."""
         return decimo.bigint.bitwise.bitwise_or(self, Self(other))
 
     @always_inline
-    fn __xor__(self, other: Self) -> Self:
+    def __xor__(self, other: Self) -> Self:
         """Returns self ^ other (bitwise XOR, Python two's complement semantics).
         """
         return decimo.bigint.bitwise.bitwise_xor(self, other)
 
     @always_inline
-    fn __xor__(self, other: Int) -> Self:
+    def __xor__(self, other: Int) -> Self:
         """Returns self ^ other where other is an Int."""
         return decimo.bigint.bitwise.bitwise_xor(self, Self(other))
 
     @always_inline
-    fn __invert__(self) -> Self:
+    def __invert__(self) -> Self:
         """Returns ~self (bitwise NOT, Python two's complement semantics)."""
         return decimo.bigint.bitwise.bitwise_not(self)
 
     @always_inline
-    fn __iand__(mut self, other: Self):
+    def __iand__(mut self, other: Self):
         """True in-place bitwise AND: mutates self.words directly."""
         decimo.bigint.bitwise.bitwise_and_inplace(self, other)
 
     @always_inline
-    fn __ior__(mut self, other: Self):
+    def __ior__(mut self, other: Self):
         """True in-place bitwise OR: mutates self.words directly."""
         decimo.bigint.bitwise.bitwise_or_inplace(self, other)
 
     @always_inline
-    fn __ixor__(mut self, other: Self):
+    def __ixor__(mut self, other: Self):
         """True in-place bitwise XOR: mutates self.words directly."""
         decimo.bigint.bitwise.bitwise_xor_inplace(self, other)
 
@@ -1144,12 +1144,12 @@ struct BigInt(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn gcd(self, other: Self) -> Self:
+    def gcd(self, other: Self) -> Self:
         """Returns the greatest common divisor of self and other."""
         return decimo.bigint.number_theory.gcd(self, other)
 
     @always_inline
-    fn extended_gcd(self, other: Self) raises -> Tuple[Self, Self, Self]:
+    def extended_gcd(self, other: Self) raises -> Tuple[Self, Self, Self]:
         """Returns a tuple (g, x, y) such that g = gcd(self, other) and
         self*x + other*y = g.
 
@@ -1163,19 +1163,19 @@ struct BigInt(
         return decimo.bigint.number_theory.extended_gcd(self, other)
 
     @always_inline
-    fn lcm(self, other: Self) raises -> Self:
+    def lcm(self, other: Self) raises -> Self:
         """Returns the least common multiple of self and other."""
         return decimo.bigint.number_theory.lcm(self, other)
 
     @always_inline
-    fn mod_pow(self, exponent: Self, modulus: Self) raises -> Self:
+    def mod_pow(self, exponent: Self, modulus: Self) raises -> Self:
         """Returns (self ** exponent) % modulus efficiently using modular
         exponentiation.
         """
         return decimo.bigint.number_theory.mod_pow(self, exponent, modulus)
 
     @always_inline
-    fn mod_pow(self, exponent: Int, modulus: Self) raises -> Self:
+    def mod_pow(self, exponent: Int, modulus: Self) raises -> Self:
         """Returns (self ** exponent) % modulus efficiently using modular
         exponentiation.
         """
@@ -1184,7 +1184,7 @@ struct BigInt(
         )
 
     @always_inline
-    fn mod_inverse(self, modulus: Self) raises -> Self:
+    def mod_inverse(self, modulus: Self) raises -> Self:
         """Returns the modular inverse of self modulo modulus, i.e. a number x
         such that (self * x) % modulus == 1.
         """
@@ -1195,7 +1195,7 @@ struct BigInt(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn is_zero(self) -> Bool:
+    def is_zero(self) -> Bool:
         """Returns True if the value is zero."""
         if len(self.words) == 1 and self.words[0] == 0:
             return True
@@ -1205,24 +1205,24 @@ struct BigInt(
         return True
 
     @always_inline
-    fn is_negative(self) -> Bool:
+    def is_negative(self) -> Bool:
         """Returns True if the value is strictly negative."""
         return self.sign and not self.is_zero()
 
     @always_inline
-    fn is_positive(self) -> Bool:
+    def is_positive(self) -> Bool:
         """Returns True if the value is strictly positive."""
         return not self.sign and not self.is_zero()
 
-    fn is_one(self) -> Bool:
+    def is_one(self) -> Bool:
         """Returns True if the value is exactly 1."""
         return not self.sign and len(self.words) == 1 and self.words[0] == 1
 
-    fn is_one_or_minus_one(self) -> Bool:
+    def is_one_or_minus_one(self) -> Bool:
         """Returns True if the value is 1 or -1."""
         return len(self.words) == 1 and self.words[0] == 1
 
-    fn bit_length(self) -> Int:
+    def bit_length(self) -> Int:
         """Returns the number of bits needed to represent the magnitude,
         excluding leading zeros.
 
@@ -1244,7 +1244,7 @@ struct BigInt(
 
         return (n_words - 1) * 32 + bits_in_msw
 
-    fn bit_count(self) -> Int:
+    def bit_count(self) -> Int:
         """Returns the number of ones in the binary representation of the
         absolute value (population count).
 
@@ -1270,11 +1270,11 @@ struct BigInt(
                 count += 1
         return count
 
-    fn number_of_words(self) -> Int:
+    def number_of_words(self) -> Int:
         """Returns the number of words in the magnitude."""
         return len(self.words)
 
-    fn number_of_digits(self) -> Int:
+    def number_of_digits(self) -> Int:
         """Returns the number of decimal digits in the magnitude.
 
         Notes:
@@ -1290,14 +1290,14 @@ struct BigInt(
     # Internal utility methods
     # ===------------------------------------------------------------------=== #
 
-    fn copy(self) -> Self:
+    def copy(self) -> Self:
         """Returns a deep copy of this BigInt."""
         var new_words = List[UInt32](capacity=len(self.words))
         for word in self.words:
             new_words.append(word)
         return Self(raw_words=new_words^, sign=self.sign)
 
-    fn _normalize(mut self):
+    def _normalize(mut self):
         """Strips leading zero words and normalizes -0 to +0."""
         while len(self.words) > 1 and self.words[-1] == 0:
             self.words.shrink(len(self.words) - 1)
@@ -1306,7 +1306,7 @@ struct BigInt(
         if self.is_zero():
             self.sign = False
 
-    fn internal_representation(self) -> String:
+    def internal_representation(self) -> String:
         """Returns the internal representation details as a String."""
         # Collect all labels to find max width
         var fixed_labels = List[String]()
@@ -1375,7 +1375,7 @@ struct BigInt(
         result += sep_line
         return result^
 
-    fn print_internal_representation(self):
+    def print_internal_representation(self):
         """Prints the internal representation details."""
         print(self.internal_representation())
 
@@ -1386,7 +1386,7 @@ struct BigInt(
 # ===----------------------------------------------------------------------=== #
 
 
-fn _multiply_inplace_by_uint32(mut x: BigInt, y: UInt32):
+def _multiply_inplace_by_uint32(mut x: BigInt, y: UInt32):
     """Multiplies a BigInt magnitude by a UInt32 scalar in-place.
 
     This is used internally by from_string() during base conversion.
@@ -1412,7 +1412,7 @@ fn _multiply_inplace_by_uint32(mut x: BigInt, y: UInt32):
         x.words.append(UInt32(carry))
 
 
-fn _add_inplace_by_uint32(mut x: BigInt, y: UInt32):
+def _add_inplace_by_uint32(mut x: BigInt, y: UInt32):
     """Adds a UInt32 value to a BigInt magnitude in-place.
 
     This is used internally by from_string() during base conversion.
@@ -1436,7 +1436,7 @@ fn _add_inplace_by_uint32(mut x: BigInt, y: UInt32):
         x.words.append(UInt32(carry))
 
 
-fn _multiply_add_inplace(mut x: BigInt, mul: UInt32, add: UInt32):
+def _multiply_add_inplace(mut x: BigInt, mul: UInt32, add: UInt32):
     """Computes x = x * mul + add in a single pass over the word array.
 
     Fuses the multiply-by-scalar and add-scalar operations into one O(n) pass
@@ -1488,7 +1488,7 @@ comptime _DC_FROM_STR_ENTRY_THRESHOLD = 10000
 comptime _DC_FROM_STR_BASE_THRESHOLD = 256
 
 
-fn _from_decimal_digits_simple(
+def _from_decimal_digits_simple(
     digits: List[UInt8], start: Int, end: Int
 ) -> BigInt:
     """Converts a range of digit values to a BigInt using the simple
@@ -1595,7 +1595,7 @@ fn _from_decimal_digits_simple(
     return result^
 
 
-fn _from_decimal_digits_dc(
+def _from_decimal_digits_dc(
     digits: List[UInt8], start: Int, end: Int
 ) raises -> BigInt:
     """Converts a range of digit values to a BigInt using
@@ -1648,7 +1648,7 @@ fn _from_decimal_digits_dc(
     return _dc_from_str_recursive(digits, start, end, power_table, top_level)
 
 
-fn _dc_from_str_recursive(
+def _dc_from_str_recursive(
     digits: List[UInt8],
     start: Int,
     end: Int,
@@ -1740,7 +1740,7 @@ comptime _DC_TO_STR_BASE_THRESHOLD = 64
 comptime _DECIMAL_CHUNK_BASE: UInt64 = 1_000_000_000
 
 
-fn _magnitude_to_decimal_simple(words: List[UInt32], eff_words: Int) -> String:
+def _magnitude_to_decimal_simple(words: List[UInt32], eff_words: Int) -> String:
     """Converts a magnitude (unsigned word list) to a decimal string using
     the simple O(n²) method of repeated division by 10^9.
 
@@ -1831,7 +1831,7 @@ fn _magnitude_to_decimal_simple(words: List[UInt32], eff_words: Int) -> String:
     return String(unsafe_from_utf8=buf^)
 
 
-fn _magnitude_to_decimal_dc(
+def _magnitude_to_decimal_dc(
     words: List[UInt32], eff_words: Int
 ) raises -> String:
     """Converts a magnitude to a decimal string using divide-and-conquer
@@ -1897,7 +1897,7 @@ fn _magnitude_to_decimal_dc(
     return _dc_to_str_recursive(n, power_table, num_powers - 1)
 
 
-fn _dc_to_str_recursive(
+def _dc_to_str_recursive(
     n: BigInt,
     power_table: List[BigInt],
     max_level: Int,

--- a/src/decimo/bigint/bigint.mojo
+++ b/src/decimo/bigint/bigint.mojo
@@ -474,15 +474,7 @@ struct BigInt(
         Returns:
             The value as a Float64.
         """
-        return Float64(self.__str__())
-
-    fn __str__(self) -> String:
-        """Returns a decimal string representation of the BigInt."""
-        return self.to_string()
-
-    fn __repr__(self) -> String:
-        """Returns a debug representation of the BigInt."""
-        return 'BigInt("' + self.to_string() + '")'
+        return Float64(self.to_string())
 
     fn write_repr_to[W: Writer](self, mut writer: W):
         """Writes the debug representation to a writer."""

--- a/src/decimo/bigint/bigint.mojo
+++ b/src/decimo/bigint/bigint.mojo
@@ -27,7 +27,7 @@ for the Decimo library. It uses base-2^32 representation with UInt32 words
 in little-endian order, and a separate sign bit.
 """
 
-from memory import UnsafePointer, memcpy
+from std.memory import UnsafePointer, memcpy
 
 import decimo.bigint.arithmetics
 import decimo.bigint.bitwise
@@ -51,8 +51,6 @@ struct BigInt(
     FloatableRaising,
     IntableRaising,
     Movable,
-    Representable,
-    Stringable,
     Writable,
 ):
     """An arbitrary-precision signed integer, similar to Python's `int`.
@@ -289,7 +287,7 @@ struct BigInt(
             The BigInt representation of the Scalar value.
         """
 
-        constrained[dtype.is_integral(), "dtype must be integral."]()
+        comptime assert dtype.is_integral(), "dtype must be integral."
 
         if value == 0:
             return Self()
@@ -297,8 +295,7 @@ struct BigInt(
         var sign: Bool
         var magnitude: UInt64
 
-        @parameter
-        if dtype.is_unsigned():
+        comptime if dtype.is_unsigned():
             sign = False
             magnitude = UInt64(value)
         else:
@@ -477,7 +474,7 @@ struct BigInt(
         Returns:
             The value as a Float64.
         """
-        return Float64(String(self))
+        return Float64(self.__str__())
 
     fn __str__(self) -> String:
         """Returns a decimal string representation of the BigInt."""
@@ -486,6 +483,10 @@ struct BigInt(
     fn __repr__(self) -> String:
         """Returns a debug representation of the BigInt."""
         return 'BigInt("' + self.to_string() + '")'
+
+    fn write_repr_to[W: Writer](self, mut writer: W):
+        """Writes the debug representation to a writer."""
+        writer.write('BigInt("', self.to_string(), '")')
 
     fn write_to[W: Writer](self, mut writer: W):
         """Writes the decimal string representation to a writer."""
@@ -603,10 +604,10 @@ struct BigInt(
             var end = line_width
             var lines = List[String](capacity=len(result) // line_width + 1)
             while end < len(result):
-                lines.append(String(result[start:end]))
+                lines.append(String(result[byte=start:end]))
                 start = end
                 end += line_width
-            lines.append(String(result[start:]))
+            lines.append(String(result[byte=start:]))
             result = String("\n").join(lines^)
 
         return result^
@@ -633,15 +634,15 @@ struct BigInt(
         if self.sign:
             start_idx = 1  # Skip the minus sign
 
-        var digits_part = String(result[start_idx:])
+        var digits_part = String(result[byte=start_idx:])
         var end = len(digits_part)
         var start = end - 3
         var blocks = List[String](capacity=len(digits_part) // 3 + 1)
         while start > 0:
-            blocks.append(String(digits_part[start:end]))
+            blocks.append(String(digits_part[byte=start:end]))
             end = start
             start = end - 3
-        blocks.append(String(digits_part[0:end]))
+        blocks.append(String(digits_part[byte=0:end]))
         blocks.reverse()
         var formatted = separator.join(blocks)
 
@@ -668,10 +669,10 @@ struct BigInt(
             var word = self.words[i]
             if first_word:
                 if word != 0:
-                    result += hex(word)[2:]
+                    result += hex(word)[byte=2:]
                     first_word = False
             else:
-                var h = hex(word)[2:]
+                var h = hex(word)[byte=2:]
                 for _ in range(8 - len(h)):
                     result += "0"
                 result += h
@@ -700,10 +701,10 @@ struct BigInt(
             var word = self.words[i]
             if first_word:
                 if word != 0:
-                    result += bin(word)[2:]
+                    result += bin(word)[byte=2:]
                     first_word = False
             else:
-                var b = bin(word)[2:]
+                var b = bin(word)[byte=2:]
                 for _ in range(32 - len(b)):
                     result += "0"
                 result += b
@@ -1357,13 +1358,14 @@ struct BigInt(
             if not first_hex_line:
                 result += String(" ") * col
             result += (
-                String(hex_str[hex_start : hex_start + value_width]) + "\n"
+                String(hex_str[byte = hex_start : hex_start + value_width])
+                + "\n"
             )
             hex_start += value_width
             first_hex_line = False
         if not first_hex_line:
             result += String(" ") * col
-        result += String(hex_str[hex_start:]) + "\n"
+        result += String(hex_str[byte=hex_start:]) + "\n"
 
         # sign line
         result += "sign:" + String(" ") * (col - len("sign:"))
@@ -1373,7 +1375,9 @@ struct BigInt(
         for i in range(len(self.words)):
             var label = "word " + String(i) + ":"
             result += label + String(" ") * (col - len(label))
-            result += "0x" + hex(self.words[i])[2:].rjust(8, fillchar="0")
+            result += "0x" + decimo.str.rjust(
+                String(hex(self.words[i])[byte=2:]), 8, fillchar="0"
+            )
             result += "  (" + String(self.words[i]) + ")\n"
 
         result += sep_line

--- a/src/decimo/bigint/bitwise.mojo
+++ b/src/decimo/bigint/bitwise.mojo
@@ -53,22 +53,18 @@ fn _binary_bitwise_op[op: StringLiteral](a: BigInt, b: BigInt) -> BigInt:
     # Determine result sign from operation on sign-extension bits
     var result_negative: Bool
 
-    @parameter
-    if op == "and":
+    comptime if op == "and":
         result_negative = a.sign and b.sign
     elif op == "or":
         result_negative = a.sign or b.sign
     elif op == "xor":
         result_negative = a.sign != b.sign
     else:
-        constrained[False, "op must be 'and', 'or', or 'xor'"]()
-        result_negative = False  # unreachable
+        comptime assert False, "op must be 'and', 'or', or 'xor'"
 
     # Fast path: both non-negative
     if not a.sign and not b.sign:
-
-        @parameter
-        if op == "and":
+        comptime if op == "and":
             # AND with zeros → zeros, so result is at most min_len words
             var min_len = min(len(a.words), len(b.words))
             var result_words = List[UInt32](capacity=min_len)
@@ -136,8 +132,7 @@ fn _binary_bitwise_op[op: StringLiteral](a: BigInt, b: BigInt) -> BigInt:
         var wa = a_fill if i >= len(a_tc) else a_tc[i]
         var wb = b_fill if i >= len(b_tc) else b_tc[i]
 
-        @parameter
-        if op == "and":
+        comptime if op == "and":
             result_tc.append(wa & wb)
         elif op == "or":
             result_tc.append(wa | wb)
@@ -199,22 +194,18 @@ fn _binary_bitwise_op_inplace[op: StringLiteral](mut a: BigInt, read b: BigInt):
     # Determine result sign from operation on sign-extension bits
     var result_negative: Bool
 
-    @parameter
-    if op == "and":
+    comptime if op == "and":
         result_negative = a.sign and b.sign
     elif op == "or":
         result_negative = a.sign or b.sign
     elif op == "xor":
         result_negative = a.sign != b.sign
     else:
-        constrained[False, "op must be 'and', 'or', or 'xor'"]()
-        result_negative = False  # unreachable
+        comptime assert False, "op must be 'and', 'or', or 'xor'"
 
     # Fast path: both non-negative
     if not a.sign and not b.sign:
-
-        @parameter
-        if op == "and":
+        comptime if op == "and":
             var min_len = min(len(a.words), len(b.words))
             # We can modify a.words in-place for AND (result <= min_len)
             for i in range(min_len):
@@ -285,8 +276,7 @@ fn _binary_bitwise_op_inplace[op: StringLiteral](mut a: BigInt, read b: BigInt):
         var wa = a_fill if i >= len(a_tc) else a_tc[i]
         var wb = b_fill if i >= len(b_tc) else b_tc[i]
 
-        @parameter
-        if op == "and":
+        comptime if op == "and":
             result_tc.append(wa & wb)
         elif op == "or":
             result_tc.append(wa | wb)

--- a/src/decimo/bigint/bitwise.mojo
+++ b/src/decimo/bigint/bitwise.mojo
@@ -35,7 +35,7 @@ from decimo.bigint.bigint import BigInt
 # ===----------------------------------------------------------------------=== #
 
 
-fn _binary_bitwise_op[op: StringLiteral](a: BigInt, b: BigInt) -> BigInt:
+def _binary_bitwise_op[op: StringLiteral](a: BigInt, b: BigInt) -> BigInt:
     """Performs a word-by-word binary bitwise operation on two BigInt values.
 
     The operation is determined by the `op` parameter:
@@ -175,7 +175,9 @@ fn _binary_bitwise_op[op: StringLiteral](a: BigInt, b: BigInt) -> BigInt:
 # ===----------------------------------------------------------------------=== #
 
 
-fn _binary_bitwise_op_inplace[op: StringLiteral](mut a: BigInt, read b: BigInt):
+def _binary_bitwise_op_inplace[
+    op: StringLiteral
+](mut a: BigInt, read b: BigInt):
     """Performs a word-by-word binary bitwise operation on `a` in-place.
 
     Computes the result word list and moves it into a.words, avoiding
@@ -324,22 +326,22 @@ fn _binary_bitwise_op_inplace[op: StringLiteral](mut a: BigInt, read b: BigInt):
 # ===----------------------------------------------------------------------=== #
 
 
-fn bitwise_and(a: BigInt, b: BigInt) -> BigInt:
+def bitwise_and(a: BigInt, b: BigInt) -> BigInt:
     """Returns a & b using Python-compatible two's complement semantics."""
     return _binary_bitwise_op["and"](a, b)
 
 
-fn bitwise_or(a: BigInt, b: BigInt) -> BigInt:
+def bitwise_or(a: BigInt, b: BigInt) -> BigInt:
     """Returns a | b using Python-compatible two's complement semantics."""
     return _binary_bitwise_op["or"](a, b)
 
 
-fn bitwise_xor(a: BigInt, b: BigInt) -> BigInt:
+def bitwise_xor(a: BigInt, b: BigInt) -> BigInt:
     """Returns a ^ b using Python-compatible two's complement semantics."""
     return _binary_bitwise_op["xor"](a, b)
 
 
-fn bitwise_not(x: BigInt) -> BigInt:
+def bitwise_not(x: BigInt) -> BigInt:
     """Returns ~x using Python-compatible two's complement semantics.
 
     ~x = -(x + 1)
@@ -381,19 +383,19 @@ fn bitwise_not(x: BigInt) -> BigInt:
 # ===----------------------------------------------------------------------=== #
 
 
-fn bitwise_and_inplace(mut a: BigInt, read b: BigInt):
+def bitwise_and_inplace(mut a: BigInt, read b: BigInt):
     """Performs a &= b in-place using Python-compatible two's complement
     semantics."""
     _binary_bitwise_op_inplace["and"](a, b)
 
 
-fn bitwise_or_inplace(mut a: BigInt, read b: BigInt):
+def bitwise_or_inplace(mut a: BigInt, read b: BigInt):
     """Performs a |= b in-place using Python-compatible two's complement
     semantics."""
     _binary_bitwise_op_inplace["or"](a, b)
 
 
-fn bitwise_xor_inplace(mut a: BigInt, read b: BigInt):
+def bitwise_xor_inplace(mut a: BigInt, read b: BigInt):
     """Performs a ^= b in-place using Python-compatible two's complement
     semantics."""
     _binary_bitwise_op_inplace["xor"](a, b)

--- a/src/decimo/bigint/comparison.mojo
+++ b/src/decimo/bigint/comparison.mojo
@@ -43,12 +43,12 @@ fn compare_magnitudes(x1: BigInt, x2: BigInt) -> Int8:
 
     # More words means larger magnitude
     if n1 != n2:
-        return 1 if n1 > n2 else -1
+        return Int8(1) if n1 > n2 else Int8(-1)
 
     # Same number of words: compare from most-significant to least-significant
     for i in range(n1 - 1, -1, -1):
         if x1.words[i] != x2.words[i]:
-            return 1 if x1.words[i] > x2.words[i] else -1
+            return Int8(1) if x1.words[i] > x2.words[i] else Int8(-1)
 
     return 0
 
@@ -72,7 +72,7 @@ fn compare(x1: BigInt, x2: BigInt) -> Int8:
 
     # Different signs: negative < positive
     if x1.sign != x2.sign:
-        return -1 if x1.sign else 1
+        return Int8(-1) if x1.sign else Int8(1)
 
     # Same signs: compare magnitudes
     var magnitude_comparison = compare_magnitudes(x1, x2)

--- a/src/decimo/bigint/comparison.mojo
+++ b/src/decimo/bigint/comparison.mojo
@@ -21,7 +21,7 @@ Implements functions for comparison operations on BigInt objects.
 from decimo.bigint.bigint import BigInt
 
 
-fn compare_magnitudes(x1: BigInt, x2: BigInt) -> Int8:
+def compare_magnitudes(x1: BigInt, x2: BigInt) -> Int8:
     """Compares the magnitudes (absolute values) of two BigInt numbers.
 
     The comparison is performed on the unsigned word arrays in base-2^32:
@@ -53,7 +53,7 @@ fn compare_magnitudes(x1: BigInt, x2: BigInt) -> Int8:
     return 0
 
 
-fn compare(x1: BigInt, x2: BigInt) -> Int8:
+def compare(x1: BigInt, x2: BigInt) -> Int8:
     """Compares two BigInt objects and returns the result.
 
     Args:
@@ -81,7 +81,7 @@ fn compare(x1: BigInt, x2: BigInt) -> Int8:
     return magnitude_comparison if not x1.sign else -magnitude_comparison
 
 
-fn greater(x1: BigInt, x2: BigInt) -> Bool:
+def greater(x1: BigInt, x2: BigInt) -> Bool:
     """Checks if the first number is greater than the second.
 
     Args:
@@ -94,7 +94,7 @@ fn greater(x1: BigInt, x2: BigInt) -> Bool:
     return compare(x1, x2) > 0
 
 
-fn greater_equal(x1: BigInt, x2: BigInt) -> Bool:
+def greater_equal(x1: BigInt, x2: BigInt) -> Bool:
     """Checks if the first number is greater than or equal to the second.
 
     Args:
@@ -107,7 +107,7 @@ fn greater_equal(x1: BigInt, x2: BigInt) -> Bool:
     return compare(x1, x2) >= 0
 
 
-fn less(x1: BigInt, x2: BigInt) -> Bool:
+def less(x1: BigInt, x2: BigInt) -> Bool:
     """Checks if the first number is less than the second.
 
     Args:
@@ -120,7 +120,7 @@ fn less(x1: BigInt, x2: BigInt) -> Bool:
     return compare(x1, x2) < 0
 
 
-fn less_equal(x1: BigInt, x2: BigInt) -> Bool:
+def less_equal(x1: BigInt, x2: BigInt) -> Bool:
     """Checks if the first number is less than or equal to the second.
 
     Args:
@@ -133,7 +133,7 @@ fn less_equal(x1: BigInt, x2: BigInt) -> Bool:
     return compare(x1, x2) <= 0
 
 
-fn equal(x1: BigInt, x2: BigInt) -> Bool:
+def equal(x1: BigInt, x2: BigInt) -> Bool:
     """Checks if two numbers are equal.
 
     Args:
@@ -146,7 +146,7 @@ fn equal(x1: BigInt, x2: BigInt) -> Bool:
     return compare(x1, x2) == 0
 
 
-fn not_equal(x1: BigInt, x2: BigInt) -> Bool:
+def not_equal(x1: BigInt, x2: BigInt) -> Bool:
     """Checks if two numbers are not equal.
 
     Args:

--- a/src/decimo/bigint/exponential.mojo
+++ b/src/decimo/bigint/exponential.mojo
@@ -21,7 +21,7 @@ algorithm with a UInt64 fast path for early iterations, leveraging BigInt's
 base-2^32 representation for efficient bit-level operations.
 """
 
-import math
+from std import math
 
 from decimo.bigint.bigint import BigInt
 import decimo.bigint.arithmetics
@@ -60,11 +60,11 @@ fn _extract_uint64_from_words(words: List[UInt32], bit_shift: Int) -> UInt64:
         return result
 
     # bi > 0: need up to 3 consecutive words to cover 64 bits at alignment
-    var result = UInt64(words[wi]) >> bi
+    var result = UInt64(words[wi]) >> UInt64(bi)
     if wi + 1 < n:
-        result |= UInt64(words[wi + 1]) << (32 - bi)
+        result |= UInt64(words[wi + 1]) << UInt64(32 - bi)
     if wi + 2 < n:
-        result |= UInt64(words[wi + 2]) << (64 - bi)
+        result |= UInt64(words[wi + 2]) << UInt64(64 - bi)
     return result
 
 
@@ -117,20 +117,20 @@ fn _extract_uint128_from_words(words: List[UInt32], bit_shift: Int) -> UInt128:
         # Aligned: read exactly 4 words
         var result = UInt128(0)
         for k in range(min(4, n - wi)):
-            result |= UInt128(words[wi + k]) << (k * 32)
+            result |= UInt128(words[wi + k]) << UInt128(k * 32)
         return result
 
     # Unaligned: need bits [bi..bi+127] from words[wi..wi+4]
     # Build result by placing each word's contribution at the correct position
-    var result = UInt128(words[wi]) >> bi
+    var result = UInt128(words[wi]) >> UInt128(bi)
     if wi + 1 < n:
-        result |= UInt128(words[wi + 1]) << (32 - bi)
+        result |= UInt128(words[wi + 1]) << UInt128(32 - bi)
     if wi + 2 < n:
-        result |= UInt128(words[wi + 2]) << (64 - bi)
+        result |= UInt128(words[wi + 2]) << UInt128(64 - bi)
     if wi + 3 < n:
-        result |= UInt128(words[wi + 3]) << (96 - bi)
+        result |= UInt128(words[wi + 3]) << UInt128(96 - bi)
     if wi + 4 < n:
-        result |= UInt128(words[wi + 4]) << (128 - bi)
+        result |= UInt128(words[wi + 4]) << UInt128(128 - bi)
     return result
 
 
@@ -191,7 +191,7 @@ fn _left_shift_magnitude_bits(a: List[UInt32], shift: Int) -> List[UInt32]:
     else:
         var carry: UInt32 = 0
         for i in range(n):
-            var shifted = UInt64(a[i]) << bit_shift
+            var shifted = UInt64(a[i]) << UInt64(bit_shift)
             result.append(UInt32(shifted & 0xFFFF_FFFF) | carry)
             carry = UInt32(shifted >> 32)
         if carry > 0:
@@ -229,10 +229,12 @@ fn _right_shift_magnitude_bits(a: List[UInt32], shift: Int) -> List[UInt32]:
             result.append(a[i])
     else:
         for i in range(word_shift, n):
-            var lo = UInt64(a[i]) >> bit_shift
+            var lo = UInt64(a[i]) >> UInt64(bit_shift)
             var hi: UInt64 = 0
             if i + 1 < n:
-                hi = (UInt64(a[i + 1]) << (32 - bit_shift)) & 0xFFFF_FFFF
+                hi = (UInt64(a[i + 1]) << UInt64(32 - bit_shift)) & UInt64(
+                    0xFFFF_FFFF
+                )
             result.append(UInt32(lo | hi))
 
     # Strip leading zeros
@@ -380,7 +382,7 @@ fn _sqrt_precision_doubling_fast(x: BigInt) raises -> BigInt:
 
         # Save old a for division, then shift a
         var old_a = a_val
-        a_val <<= shift_a
+        a_val <<= UInt64(shift_a)
 
         # Extract n_shifted directly from x.words as UInt64 — O(1), no alloc
         var n_val = _extract_uint64_from_words(x.words, shift_n)
@@ -420,7 +422,7 @@ fn _sqrt_precision_doubling_fast(x: BigInt) raises -> BigInt:
         var shift_n = 2 * c - e - d + 1
 
         var old_a128 = a128
-        a128 <<= shift_a
+        a128 <<= UInt128(shift_a)
 
         # Extract n_shifted as UInt128 from x.words (O(1))
         var n128 = _extract_uint128_from_words(x.words, shift_n)

--- a/src/decimo/bigint/exponential.mojo
+++ b/src/decimo/bigint/exponential.mojo
@@ -33,7 +33,7 @@ from decimo.errors import DecimoError
 # ===----------------------------------------------------------------------=== #
 
 
-fn _extract_uint64_from_words(words: List[UInt32], bit_shift: Int) -> UInt64:
+def _extract_uint64_from_words(words: List[UInt32], bit_shift: Int) -> UInt64:
     """Extracts up to 64 bits from a magnitude at a given bit offset.
 
     Computes floor(value(words) >> bit_shift) mod 2^64, reading only the
@@ -68,7 +68,7 @@ fn _extract_uint64_from_words(words: List[UInt32], bit_shift: Int) -> UInt64:
     return result
 
 
-fn _uint64_to_words(val: UInt64) -> List[UInt32]:
+def _uint64_to_words(val: UInt64) -> List[UInt32]:
     """Converts a UInt64 value to a magnitude word list.
 
     Args:
@@ -93,7 +93,7 @@ fn _uint64_to_words(val: UInt64) -> List[UInt32]:
     return result^
 
 
-fn _extract_uint128_from_words(words: List[UInt32], bit_shift: Int) -> UInt128:
+def _extract_uint128_from_words(words: List[UInt32], bit_shift: Int) -> UInt128:
     """Extracts up to 128 bits from a magnitude at a given bit offset.
 
     Similar to _extract_uint64_from_words but returns UInt128.
@@ -134,7 +134,7 @@ fn _extract_uint128_from_words(words: List[UInt32], bit_shift: Int) -> UInt128:
     return result
 
 
-fn _uint128_to_words(val: UInt128) -> List[UInt32]:
+def _uint128_to_words(val: UInt128) -> List[UInt32]:
     """Converts a UInt128 value to a magnitude word list.
 
     Args:
@@ -156,7 +156,7 @@ fn _uint128_to_words(val: UInt128) -> List[UInt32]:
     return result^
 
 
-fn _left_shift_magnitude_bits(a: List[UInt32], shift: Int) -> List[UInt32]:
+def _left_shift_magnitude_bits(a: List[UInt32], shift: Int) -> List[UInt32]:
     """Shifts a magnitude left by an arbitrary number of bits.
 
     Handles both whole-word and sub-word shifts in a single pass.
@@ -200,7 +200,7 @@ fn _left_shift_magnitude_bits(a: List[UInt32], shift: Int) -> List[UInt32]:
     return result^
 
 
-fn _right_shift_magnitude_bits(a: List[UInt32], shift: Int) -> List[UInt32]:
+def _right_shift_magnitude_bits(a: List[UInt32], shift: Int) -> List[UInt32]:
     """Shifts a magnitude right by an arbitrary number of bits.
 
     Efficiently skips lower words that would be entirely shifted out,
@@ -251,7 +251,7 @@ fn _right_shift_magnitude_bits(a: List[UInt32], shift: Int) -> List[UInt32]:
 # ===----------------------------------------------------------------------=== #
 
 
-fn sqrt(x: BigInt) raises -> BigInt:
+def sqrt(x: BigInt) raises -> BigInt:
     """Calculates the integer square root of a BigInt.
 
     Args:
@@ -321,7 +321,7 @@ fn sqrt(x: BigInt) raises -> BigInt:
     return _sqrt_precision_doubling_fast(x)
 
 
-fn _sqrt_precision_doubling_fast(x: BigInt) raises -> BigInt:
+def _sqrt_precision_doubling_fast(x: BigInt) raises -> BigInt:
     """Optimized precision-doubling integer sqrt with UInt64 fast path.
 
     Args:
@@ -487,7 +487,7 @@ fn _sqrt_precision_doubling_fast(x: BigInt) raises -> BigInt:
     return BigInt(raw_words=a_words^, sign=False)
 
 
-fn isqrt(x: BigInt) raises -> BigInt:
+def isqrt(x: BigInt) raises -> BigInt:
     """Calculates the integer square root of a BigInt.
     Equivalent to `sqrt()`.
 

--- a/src/decimo/bigint/number_theory.mojo
+++ b/src/decimo/bigint/number_theory.mojo
@@ -42,7 +42,7 @@ from decimo.errors import DecimoError
 # ===----------------------------------------------------------------------=== #
 
 
-fn _count_trailing_zeros(words: List[UInt32]) -> Int:
+def _count_trailing_zeros(words: List[UInt32]) -> Int:
     """Counts the number of trailing zero bits in a magnitude word list.
 
     Words are stored little-endian, so trailing zero bits correspond to
@@ -76,7 +76,7 @@ fn _count_trailing_zeros(words: List[UInt32]) -> Int:
 # ===----------------------------------------------------------------------=== #
 
 
-fn gcd(a: BigInt, b: BigInt) -> BigInt:
+def gcd(a: BigInt, b: BigInt) -> BigInt:
     """Computes the greatest common divisor of two integers.
 
     Uses the binary GCD (Stein's) algorithm, which is efficient for the
@@ -141,7 +141,7 @@ fn gcd(a: BigInt, b: BigInt) -> BigInt:
 # ===----------------------------------------------------------------------=== #
 
 
-fn extended_gcd(a: BigInt, b: BigInt) raises -> Tuple[BigInt, BigInt, BigInt]:
+def extended_gcd(a: BigInt, b: BigInt) raises -> Tuple[BigInt, BigInt, BigInt]:
     """Computes the extended greatest common divisor.
 
     Returns (g, x, y) such that a * x + b * y = g, where g = gcd(a, b) >= 0.
@@ -200,7 +200,7 @@ fn extended_gcd(a: BigInt, b: BigInt) raises -> Tuple[BigInt, BigInt, BigInt]:
 # ===----------------------------------------------------------------------=== #
 
 
-fn lcm(a: BigInt, b: BigInt) raises -> BigInt:
+def lcm(a: BigInt, b: BigInt) raises -> BigInt:
     """Computes the least common multiple of two integers.
 
     Follows Python semantics:
@@ -227,7 +227,7 @@ fn lcm(a: BigInt, b: BigInt) raises -> BigInt:
 # ===----------------------------------------------------------------------=== #
 
 
-fn mod_pow(base: BigInt, exponent: BigInt, modulus: BigInt) raises -> BigInt:
+def mod_pow(base: BigInt, exponent: BigInt, modulus: BigInt) raises -> BigInt:
     """Computes (base ** exponent) mod modulus efficiently.
 
     Uses right-to-left binary exponentiation with modular reduction at
@@ -293,7 +293,7 @@ fn mod_pow(base: BigInt, exponent: BigInt, modulus: BigInt) raises -> BigInt:
     return result^
 
 
-fn mod_pow(base: BigInt, exponent: Int, modulus: BigInt) raises -> BigInt:
+def mod_pow(base: BigInt, exponent: Int, modulus: BigInt) raises -> BigInt:
     """Convenience overload accepting an Int exponent.
 
     Args:
@@ -312,7 +312,7 @@ fn mod_pow(base: BigInt, exponent: Int, modulus: BigInt) raises -> BigInt:
 # ===----------------------------------------------------------------------=== #
 
 
-fn mod_inverse(a: BigInt, modulus: BigInt) raises -> BigInt:
+def mod_inverse(a: BigInt, modulus: BigInt) raises -> BigInt:
     """Computes the modular multiplicative inverse of a modulo modulus.
 
     Returns x in [0, modulus) such that (a * x) ≡ 1 (mod modulus).

--- a/src/decimo/bigint10/arithmetics.mojo
+++ b/src/decimo/bigint10/arithmetics.mojo
@@ -24,7 +24,7 @@ from decimo.errors import DecimoError
 from decimo.rounding_mode import RoundingMode
 
 
-fn add(x1: BigInt10, x2: BigInt10) -> BigInt10:
+def add(x1: BigInt10, x2: BigInt10) -> BigInt10:
     """Returns the sum of two BigInts.
 
     Args:
@@ -58,7 +58,7 @@ fn add(x1: BigInt10, x2: BigInt10) -> BigInt10:
     return BigInt10(magnitude^, sign=x1.sign)
 
 
-fn add_inplace(mut x1: BigInt10, x2: BigInt10) -> None:
+def add_inplace(mut x1: BigInt10, x2: BigInt10) -> None:
     """Increments a BigInt10 number by another BigInt10 number in place.
 
     Args:
@@ -78,7 +78,7 @@ fn add_inplace(mut x1: BigInt10, x2: BigInt10) -> None:
     return
 
 
-fn subtract(x1: BigInt10, x2: BigInt10) -> BigInt10:
+def subtract(x1: BigInt10, x2: BigInt10) -> BigInt10:
     """Returns the difference of two numbers.
 
     Args:
@@ -134,7 +134,7 @@ fn subtract(x1: BigInt10, x2: BigInt10) -> BigInt10:
     return BigInt10(magnitude^, sign=sign)
 
 
-fn negative(x: BigInt10) -> BigInt10:
+def negative(x: BigInt10) -> BigInt10:
     """Returns the negative of a BigInt10 number.
 
     Args:
@@ -159,7 +159,7 @@ fn negative(x: BigInt10) -> BigInt10:
     return result^
 
 
-fn absolute(x: BigInt10) -> BigInt10:
+def absolute(x: BigInt10) -> BigInt10:
     """Returns the absolute value of a BigInt10 number.
 
     Args:
@@ -174,7 +174,7 @@ fn absolute(x: BigInt10) -> BigInt10:
         return x.copy()
 
 
-fn multiply(x1: BigInt10, x2: BigInt10) -> BigInt10:
+def multiply(x1: BigInt10, x2: BigInt10) -> BigInt10:
     """Returns the product of two BigInt10 numbers.
 
     Args:
@@ -195,7 +195,7 @@ fn multiply(x1: BigInt10, x2: BigInt10) -> BigInt10:
     return BigInt10(result_magnitude^, sign=x1.sign != x2.sign)
 
 
-fn floor_divide(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
+def floor_divide(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
     """Returns the quotient of two numbers, rounding toward negative infinity.
     The modulo has the same sign as the divisor and satisfies:
     x1 = floor_divide(x1, x2) * x2 + floor_divide(x1, x2).
@@ -253,7 +253,7 @@ fn floor_divide(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
         return BigInt10(magnitude^, sign=True)
 
 
-fn truncate_divide(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
+def truncate_divide(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
     """Returns the quotient of two BigInt10 numbers, truncating toward zero.
     The modulo has the same sign as the divisor and satisfies:
     x1 = truncate_divide(x1, x2) * x2 + truncate_modulo(x1, x2).
@@ -285,7 +285,7 @@ fn truncate_divide(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
     return BigInt10(magnitude^, sign=x1.sign != x2.sign)
 
 
-fn floor_modulo(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
+def floor_modulo(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
     """Returns the remainder of two numbers, truncating toward negative infinity.
     The remainder has the same sign as the divisor and satisfies:
     x1 = floor_divide(x1, x2) * x2 + floor_modulo(x1, x2).
@@ -339,7 +339,7 @@ fn floor_modulo(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
         return BigInt10(magnitude^, sign=x2.sign)
 
 
-fn truncate_modulo(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
+def truncate_modulo(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
     """Returns the remainder of two numbers, truncating toward zero.
     The remainder has the same sign as the dividend and satisfies:
     x1 = truncate_divide(x1, x2) * x2 + truncate_modulo(x1, x2).

--- a/src/decimo/bigint10/bigint10.mojo
+++ b/src/decimo/bigint10/bigint10.mojo
@@ -23,8 +23,8 @@ operation dunders, and other dunders that implement traits, as well as
 mathematical methods that do not implement a trait.
 """
 
-from memory import UnsafePointer
-from python import PythonObject
+from std.memory import UnsafePointer
+from std.python import PythonObject
 
 import decimo.bigint10.arithmetics
 import decimo.bigint10.comparison
@@ -41,8 +41,6 @@ struct BigInt10(
     Copyable,
     IntableRaising,
     Movable,
-    Representable,
-    Stringable,
     Writable,
 ):
     """Represents a base-10 arbitrary-precision signed integer.
@@ -296,7 +294,7 @@ struct BigInt10(
             The BigInt10 representation of the Scalar value.
         """
 
-        constrained[dtype.is_integral(), "dtype must be integral."]()
+        comptime assert dtype.is_integral(), "dtype must be integral."
 
         if value == 0:
             return Self()
@@ -345,7 +343,7 @@ struct BigInt10(
 
         Examples:
         ```mojo
-        from python import Python
+        from std.python import Python
         from decimo.bigint10.bigint10 import BigInt10
 
         fn main() raises:
@@ -397,6 +395,10 @@ struct BigInt10(
         """Returns a string representation of the BigInt10."""
         return 'BigInt10("' + self.__str__() + '")'
 
+    fn write_repr_to[W: Writer](self, mut writer: W):
+        """Writes the debug representation to a writer."""
+        writer.write('BigInt10("', self.__str__(), '")')
+
     # ===------------------------------------------------------------------=== #
     # Type-transfer or output methods that are not dunders
     # ===------------------------------------------------------------------=== #
@@ -405,7 +407,7 @@ struct BigInt10(
         """Writes the BigInt10 to a writer.
         This implement the `write` method of the `Writer` trait.
         """
-        writer.write(String(self))
+        writer.write(self.__str__())
 
     fn to_int(self) raises -> Int:
         """Returns the number as Int.
@@ -471,10 +473,10 @@ struct BigInt10(
             var end = line_width
             var lines = List[String](capacity=len(result) // line_width + 1)
             while end < len(result):
-                lines.append(String(result[start:end]))
+                lines.append(String(result[byte=start:end]))
                 start = end
                 end += line_width
-            lines.append(String(result[start:]))
+            lines.append(String(result[byte=start:]))
             result = String("\n").join(lines^)
 
         return result^
@@ -494,10 +496,10 @@ struct BigInt10(
         var start = end - 3
         var blocks = List[String](capacity=len(result) // 3 + 1)
         while start > 0:
-            blocks.append(String(result[start:end]))
+            blocks.append(String(result[byte=start:end]))
             end = start
             start = end - 3
-        blocks.append(String(result[0:end]))
+        blocks.append(String(result[byte=0:end]))
         blocks.reverse()
         result = separator.join(blocks)
 
@@ -838,7 +840,10 @@ struct BigInt10(
             var label = "word " + String(i) + ":"
             result += label + String(" ") * (col - len(label))
             result += (
-                String(self.magnitude.words[i]).rjust(9, fillchar="0") + "\n"
+                decimo.str.rjust(
+                    String(self.magnitude.words[i]), 9, fillchar="0"
+                )
+                + "\n"
             )
 
         result += sep_line

--- a/src/decimo/bigint10/bigint10.mojo
+++ b/src/decimo/bigint10/bigint10.mojo
@@ -69,18 +69,18 @@ struct BigInt10(
     # __init__(out self, value: String) raises
     # ===------------------------------------------------------------------=== #
 
-    fn __init__(out self):
+    def __init__(out self):
         """Initializes a BigInt10 with value 0."""
         self.magnitude = BigUInt()
         self.sign = False
 
     @implicit
-    fn __init__(out self, magnitude: BigUInt):
+    def __init__(out self, magnitude: BigUInt):
         """Constructs a BigInt10 from a BigUInt object."""
         self.magnitude = magnitude.copy()
         self.sign = False
 
-    fn __init__(out self, magnitude: BigUInt, sign: Bool):
+    def __init__(out self, magnitude: BigUInt, sign: Bool):
         """Initializes a BigInt10 from a BigUInt and a sign.
 
         Args:
@@ -90,7 +90,7 @@ struct BigInt10(
         self.magnitude = magnitude.copy()
         self.sign = sign
 
-    fn __init__(out self, var words: List[UInt32], sign: Bool) raises:
+    def __init__(out self, var words: List[UInt32], sign: Bool) raises:
         """Initializes a BigInt10 from a list of UInt32 words and a sign.
         The BigInt10 constructed in this way is guaranteed to be valid.
         If the list is empty, the BigInt10 is initialized with value 0.
@@ -120,7 +120,7 @@ struct BigInt10(
                 )
             )
 
-    fn __init__(out self, *, var raw_words: List[UInt32], sign: Bool):
+    def __init__(out self, *, var raw_words: List[UInt32], sign: Bool):
         """Initializes a BigInt10 from a list of raw words.
 
         Args:
@@ -142,7 +142,7 @@ struct BigInt10(
         self.magnitude = BigUInt(raw_words=raw_words^)
         self.sign = sign
 
-    fn __init__(out self, value: String) raises:
+    def __init__(out self, value: String) raises:
         """Initializes a BigInt10 from a string representation.
         See `from_string()` for more information.
         """
@@ -154,14 +154,14 @@ struct BigInt10(
     # TODO: If Mojo makes Int type an alias of SIMD[DType.index, 1],
     # we can remove this method.
     @implicit
-    fn __init__(out self, value: Int):
+    def __init__(out self, value: Int):
         """Initializes a BigInt10 from an `Int` object.
         See `from_int()` for more information.
         """
         self = Self.from_int(value)
 
     @implicit
-    fn __init__(out self, value: Scalar):
+    def __init__(out self, value: Scalar):
         """Constructs a BigInt10 from an integral scalar.
         This includes all SIMD integral types, such as Int8, Int16, UInt32, etc.
 
@@ -170,7 +170,7 @@ struct BigInt10(
         """
         self = Self.from_integral_scalar(value)
 
-    fn __init__(out self, *, py: PythonObject) raises:
+    def __init__(out self, *, py: PythonObject) raises:
         """Constructs a BigInt10 from a Python int object."""
         self = Self.from_python_int(py)
 
@@ -183,7 +183,7 @@ struct BigInt10(
     # ===------------------------------------------------------------------=== #
 
     @staticmethod
-    fn from_list(var words: List[UInt32], sign: Bool) raises -> Self:
+    def from_list(var words: List[UInt32], sign: Bool) raises -> Self:
         """Initializes a BigInt10 from a list of UInt32 words safely.
         If the list is empty, the BigInt10 is initialized with value 0.
         If there are leading zero words, they are removed.
@@ -217,7 +217,7 @@ struct BigInt10(
             )
 
     @staticmethod
-    fn from_words(*words: UInt32, sign: Bool) raises -> Self:
+    def from_words(*words: UInt32, sign: Bool) raises -> Self:
         """Initializes a BigInt10 from raw words.
 
         Args:
@@ -246,7 +246,7 @@ struct BigInt10(
         return Self(BigUInt(raw_words=list_of_words^), sign)
 
     @staticmethod
-    fn from_int(value: Int) -> Self:
+    def from_int(value: Int) -> Self:
         """Creates a BigInt10 from an integer."""
         if value == 0:
             return Self()
@@ -280,7 +280,7 @@ struct BigInt10(
         return Self(BigUInt(raw_words=words^), sign)
 
     @staticmethod
-    fn from_integral_scalar[dtype: DType, //](value: SIMD[dtype, 1]) -> Self:
+    def from_integral_scalar[dtype: DType, //](value: SIMD[dtype, 1]) -> Self:
         """Initializes a BigInt10 from an integral scalar.
         This includes all SIMD integral types, such as Int8, Int16, UInt32, etc.
 
@@ -305,7 +305,7 @@ struct BigInt10(
         )
 
     @staticmethod
-    fn from_string(value: String) raises -> Self:
+    def from_string(value: String) raises -> Self:
         """Initializes a BigInt10 from a string representation.
         The string is normalized with `deciomojo.str.parse_numeric_string()`.
 
@@ -328,7 +328,7 @@ struct BigInt10(
         return Self(magnitude=magnitude^, sign=sign)
 
     @staticmethod
-    fn from_python_int(value: PythonObject) raises -> Self:
+    def from_python_int(value: PythonObject) raises -> Self:
         """Initializes a BigInt10 from a Python integer object.
 
         Args:
@@ -346,7 +346,7 @@ struct BigInt10(
         from std.python import Python
         from decimo.bigint10.bigint10 import BigInt10
 
-        fn main() raises:
+        def main() raises:
             var py = Python.import_module("builtins")
             var py_int = py.int("123456789012345678901234567890")
             var mojo_bigint = BigInt10.from_python_int(py_int)
@@ -379,13 +379,13 @@ struct BigInt10(
     # Output dunders, type-transfer dunders
     # ===------------------------------------------------------------------=== #
 
-    fn __int__(self) raises -> Int:
+    def __int__(self) raises -> Int:
         """Returns the number as Int.
         See `to_int()` for more information.
         """
         return self.to_int()
 
-    fn write_repr_to[W: Writer](self, mut writer: W):
+    def write_repr_to[W: Writer](self, mut writer: W):
         """Writes the debug representation to a writer."""
         writer.write('BigInt10("', self.to_string(), '")')
 
@@ -393,13 +393,13 @@ struct BigInt10(
     # Type-transfer or output methods that are not dunders
     # ===------------------------------------------------------------------=== #
 
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """Writes the BigInt10 to a writer.
         This implement the `write` method of the `Writer` trait.
         """
         writer.write(self.to_string())
 
-    fn to_int(self) raises -> Int:
+    def to_int(self) raises -> Int:
         """Returns the number as Int.
 
         Returns:
@@ -438,7 +438,7 @@ struct BigInt10(
             )
         return Int(value)
 
-    fn to_string(self, line_width: Int = 0) -> String:
+    def to_string(self, line_width: Int = 0) -> String:
         """Returns string representation of the BigInt10.
 
         Args:
@@ -471,7 +471,7 @@ struct BigInt10(
 
         return result^
 
-    fn to_string_with_separators(self, separator: String = "_") -> String:
+    def to_string_with_separators(self, separator: String = "_") -> String:
         """Returns string representation of the BigInt10 with separators.
 
         Args:
@@ -501,14 +501,14 @@ struct BigInt10(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __abs__(self) -> Self:
+    def __abs__(self) -> Self:
         """Returns the absolute value of this number.
         See `absolute()` for more information.
         """
         return decimo.bigint10.arithmetics.absolute(self)
 
     @always_inline
-    fn __neg__(self) -> Self:
+    def __neg__(self) -> Self:
         """Returns the negation of this number.
         See `negative()` for more information.
         """
@@ -521,19 +521,19 @@ struct BigInt10(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __add__(self, other: Self) -> Self:
+    def __add__(self, other: Self) -> Self:
         return decimo.bigint10.arithmetics.add(self, other)
 
     @always_inline
-    fn __sub__(self, other: Self) -> Self:
+    def __sub__(self, other: Self) -> Self:
         return decimo.bigint10.arithmetics.subtract(self, other)
 
     @always_inline
-    fn __mul__(self, other: Self) -> Self:
+    def __mul__(self, other: Self) -> Self:
         return decimo.bigint10.arithmetics.multiply(self, other)
 
     @always_inline
-    fn __floordiv__(self, other: Self) raises -> Self:
+    def __floordiv__(self, other: Self) raises -> Self:
         try:
             return decimo.bigint10.arithmetics.floor_divide(self, other)
         except e:
@@ -547,7 +547,7 @@ struct BigInt10(
             )
 
     @always_inline
-    fn __mod__(self, other: Self) raises -> Self:
+    def __mod__(self, other: Self) raises -> Self:
         try:
             return decimo.bigint10.arithmetics.floor_modulo(self, other)
         except e:
@@ -561,7 +561,7 @@ struct BigInt10(
             )
 
     @always_inline
-    fn __pow__(self, exponent: Self) raises -> Self:
+    def __pow__(self, exponent: Self) raises -> Self:
         return self.power(exponent)
 
     # ===------------------------------------------------------------------=== #
@@ -571,27 +571,27 @@ struct BigInt10(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __radd__(self, other: Self) -> Self:
+    def __radd__(self, other: Self) -> Self:
         return decimo.bigint10.arithmetics.add(self, other)
 
     @always_inline
-    fn __rsub__(self, other: Self) -> Self:
+    def __rsub__(self, other: Self) -> Self:
         return decimo.bigint10.arithmetics.subtract(other, self)
 
     @always_inline
-    fn __rmul__(self, other: Self) -> Self:
+    def __rmul__(self, other: Self) -> Self:
         return decimo.bigint10.arithmetics.multiply(self, other)
 
     @always_inline
-    fn __rfloordiv__(self, other: Self) raises -> Self:
+    def __rfloordiv__(self, other: Self) raises -> Self:
         return decimo.bigint10.arithmetics.floor_divide(other, self)
 
     @always_inline
-    fn __rmod__(self, other: Self) raises -> Self:
+    def __rmod__(self, other: Self) raises -> Self:
         return decimo.bigint10.arithmetics.floor_modulo(other, self)
 
     @always_inline
-    fn __rpow__(self, base: Self) raises -> Self:
+    def __rpow__(self, base: Self) raises -> Self:
         return base.power(self)
 
     # ===------------------------------------------------------------------=== #
@@ -602,11 +602,11 @@ struct BigInt10(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __iadd__(mut self, other: Self):
+    def __iadd__(mut self, other: Self):
         decimo.bigint10.arithmetics.add_inplace(self, other)
 
     @always_inline
-    fn __iadd__(mut self, other: Int):
+    def __iadd__(mut self, other: Int):
         # Optimize the case `i += 1`
         if (self >= 0) and (other >= 0) and (other <= 999_999_999):
             decimo.biguint.arithmetics.add_inplace_by_uint32(
@@ -616,19 +616,19 @@ struct BigInt10(
             decimo.bigint10.arithmetics.add_inplace(self, Self(other))
 
     @always_inline
-    fn __isub__(mut self, other: Self):
+    def __isub__(mut self, other: Self):
         self = decimo.bigint10.arithmetics.subtract(self, other)
 
     @always_inline
-    fn __imul__(mut self, other: Self):
+    def __imul__(mut self, other: Self):
         self = decimo.bigint10.arithmetics.multiply(self, other)
 
     @always_inline
-    fn __ifloordiv__(mut self, other: Self) raises:
+    def __ifloordiv__(mut self, other: Self) raises:
         self = decimo.bigint10.arithmetics.floor_divide(self, other)
 
     @always_inline
-    fn __imod__(mut self, other: Self) raises:
+    def __imod__(mut self, other: Self) raises:
         self = decimo.bigint10.arithmetics.floor_modulo(self, other)
 
     # ===------------------------------------------------------------------=== #
@@ -637,64 +637,64 @@ struct BigInt10(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __gt__(self, other: Self) -> Bool:
+    def __gt__(self, other: Self) -> Bool:
         """Returns True if self > other."""
         return decimo.bigint10.comparison.greater(self, other)
 
     @always_inline
-    fn __gt__(self, other: Int) -> Bool:
+    def __gt__(self, other: Int) -> Bool:
         """Returns True if self > other."""
         return decimo.bigint10.comparison.greater(self, Self.from_int(other))
 
     @always_inline
-    fn __ge__(self, other: Self) -> Bool:
+    def __ge__(self, other: Self) -> Bool:
         """Returns True if self >= other."""
         return decimo.bigint10.comparison.greater_equal(self, other)
 
     @always_inline
-    fn __ge__(self, other: Int) -> Bool:
+    def __ge__(self, other: Int) -> Bool:
         """Returns True if self >= other."""
         return decimo.bigint10.comparison.greater_equal(
             self, Self.from_int(other)
         )
 
     @always_inline
-    fn __lt__(self, other: Self) -> Bool:
+    def __lt__(self, other: Self) -> Bool:
         """Returns True if self < other."""
         return decimo.bigint10.comparison.less(self, other)
 
     @always_inline
-    fn __lt__(self, other: Int) -> Bool:
+    def __lt__(self, other: Int) -> Bool:
         """Returns True if self < other."""
         return decimo.bigint10.comparison.less(self, Self.from_int(other))
 
     @always_inline
-    fn __le__(self, other: Self) -> Bool:
+    def __le__(self, other: Self) -> Bool:
         """Returns True if self <= other."""
         return decimo.bigint10.comparison.less_equal(self, other)
 
     @always_inline
-    fn __le__(self, other: Int) -> Bool:
+    def __le__(self, other: Int) -> Bool:
         """Returns True if self <= other."""
         return decimo.bigint10.comparison.less_equal(self, Self.from_int(other))
 
     @always_inline
-    fn __eq__(self, other: Self) -> Bool:
+    def __eq__(self, other: Self) -> Bool:
         """Returns True if self == other."""
         return decimo.bigint10.comparison.equal(self, other)
 
     @always_inline
-    fn __eq__(self, other: Int) -> Bool:
+    def __eq__(self, other: Int) -> Bool:
         """Returns True if self == other."""
         return decimo.bigint10.comparison.equal(self, Self.from_int(other))
 
     @always_inline
-    fn __ne__(self, other: Self) -> Bool:
+    def __ne__(self, other: Self) -> Bool:
         """Returns True if self != other."""
         return decimo.bigint10.comparison.not_equal(self, other)
 
     @always_inline
-    fn __ne__(self, other: Int) -> Bool:
+    def __ne__(self, other: Int) -> Bool:
         """Returns True if self != other."""
         return decimo.bigint10.comparison.not_equal(self, Self.from_int(other))
 
@@ -702,7 +702,7 @@ struct BigInt10(
     # Other dunders
     # ===------------------------------------------------------------------=== #
 
-    fn __merge_with__[other_type: type_of(BigDecimal)](self) -> BigDecimal:
+    def __merge_with__[other_type: type_of(BigDecimal)](self) -> BigDecimal:
         "Merges this BigInt10 with a BigDecimal into a BigDecimal."
         return BigDecimal(self)
 
@@ -711,34 +711,34 @@ struct BigInt10(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn floor_divide(self, other: Self) raises -> Self:
+    def floor_divide(self, other: Self) raises -> Self:
         """Performs a floor division of two BigInts.
         See `floor_divide()` for more information.
         """
         return decimo.bigint10.arithmetics.floor_divide(self, other)
 
     @always_inline
-    fn truncate_divide(self, other: Self) raises -> Self:
+    def truncate_divide(self, other: Self) raises -> Self:
         """Performs a truncated division of two BigInts.
         See `truncate_divide()` for more information.
         """
         return decimo.bigint10.arithmetics.truncate_divide(self, other)
 
     @always_inline
-    fn floor_modulo(self, other: Self) raises -> Self:
+    def floor_modulo(self, other: Self) raises -> Self:
         """Performs a floor modulo of two BigInts.
         See `floor_modulo()` for more information.
         """
         return decimo.bigint10.arithmetics.floor_modulo(self, other)
 
     @always_inline
-    fn truncate_modulo(self, other: Self) raises -> Self:
+    def truncate_modulo(self, other: Self) raises -> Self:
         """Performs a truncated modulo of two BigInts.
         See `truncate_modulo()` for more information.
         """
         return decimo.bigint10.arithmetics.truncate_modulo(self, other)
 
-    fn power(self, exponent: Int) raises -> Self:
+    def power(self, exponent: Int) raises -> Self:
         """Raises the BigInt10 to the power of an integer exponent.
         See `power()` for more information.
         """
@@ -748,7 +748,7 @@ struct BigInt10(
             sign = exponent % 2 == 1
         return Self(magnitude^, sign)
 
-    fn power(self, exponent: Self) raises -> Self:
+    def power(self, exponent: Self) raises -> Self:
         """Raises the BigInt10 to the power of another BigInt10.
         See `power()` for more information.
         """
@@ -758,14 +758,14 @@ struct BigInt10(
         return self.power(exponent_as_int)
 
     @always_inline
-    fn compare_magnitudes(self, other: Self) -> Int8:
+    def compare_magnitudes(self, other: Self) -> Int8:
         """Compares the magnitudes of two BigInts.
         See `compare_magnitudes()` for more information.
         """
         return decimo.bigint10.comparison.compare_magnitudes(self, other)
 
     @always_inline
-    fn compare(self, other: Self) -> Int8:
+    def compare(self, other: Self) -> Int8:
         """Compares two BigInts.
         See `compare()` for more information.
         """
@@ -776,22 +776,22 @@ struct BigInt10(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn is_zero(self) -> Bool:
+    def is_zero(self) -> Bool:
         """Returns True if this BigInt10 represents zero."""
         return self.magnitude.is_zero()
 
     @always_inline
-    fn is_one_or_minus_one(self) -> Bool:
+    def is_one_or_minus_one(self) -> Bool:
         """Returns True if this BigInt10 represents one or negative one."""
         return self.magnitude.is_one()
 
     @always_inline
-    fn is_negative(self) -> Bool:
+    def is_negative(self) -> Bool:
         """Returns True if this BigInt10 is negative."""
         return self.sign
 
     @always_inline
-    fn number_of_words(self) -> Int:
+    def number_of_words(self) -> Int:
         """Returns the number of words in the BigInt10."""
         return len(self.magnitude.words)
 
@@ -799,7 +799,7 @@ struct BigInt10(
     # Internal methods
     # ===------------------------------------------------------------------=== #
 
-    fn internal_representation(self) raises -> String:
+    def internal_representation(self) raises -> String:
         """Returns the internal representation details as a String."""
         # Collect all labels to find max width
         var max_label_len = len("number:")
@@ -839,6 +839,6 @@ struct BigInt10(
         result += sep_line
         return result^
 
-    fn print_internal_representation(self) raises:
+    def print_internal_representation(self) raises:
         """Prints the internal representation details of a BigInt10."""
         print(self.internal_representation())

--- a/src/decimo/bigint10/bigint10.mojo
+++ b/src/decimo/bigint10/bigint10.mojo
@@ -36,7 +36,6 @@ import decimo.str
 
 struct BigInt10(
     Absable,
-    AnyType,
     Comparable,
     Copyable,
     IntableRaising,

--- a/src/decimo/bigint10/bigint10.mojo
+++ b/src/decimo/bigint10/bigint10.mojo
@@ -385,19 +385,9 @@ struct BigInt10(
         """
         return self.to_int()
 
-    fn __str__(self) -> String:
-        """Returns string representation of the BigInt10.
-        See `to_string()` for more information.
-        """
-        return self.to_string()
-
-    fn __repr__(self) -> String:
-        """Returns a string representation of the BigInt10."""
-        return 'BigInt10("' + self.__str__() + '")'
-
     fn write_repr_to[W: Writer](self, mut writer: W):
         """Writes the debug representation to a writer."""
-        writer.write('BigInt10("', self.__str__(), '")')
+        writer.write('BigInt10("', self.to_string(), '")')
 
     # ===------------------------------------------------------------------=== #
     # Type-transfer or output methods that are not dunders
@@ -407,7 +397,7 @@ struct BigInt10(
         """Writes the BigInt10 to a writer.
         This implement the `write` method of the `Writer` trait.
         """
-        writer.write(self.__str__())
+        writer.write(self.to_string())
 
     fn to_int(self) raises -> Int:
         """Returns the number as Int.

--- a/src/decimo/bigint10/comparison.mojo
+++ b/src/decimo/bigint10/comparison.mojo
@@ -56,7 +56,7 @@ fn compare(x1: BigInt10, x2: BigInt10) -> Int8:
 
     # Different signs: negative < positive
     if x1.sign != x2.sign:
-        return -1 if x1.sign else 1
+        return Int8(-1) if x1.sign else Int8(1)
 
     # Same signs: compare magnitudes
     var magnitude_comparison = compare_magnitudes(x1, x2)

--- a/src/decimo/bigint10/comparison.mojo
+++ b/src/decimo/bigint10/comparison.mojo
@@ -22,7 +22,7 @@ from decimo.bigint10.bigint10 import BigInt10
 from decimo.biguint.biguint import BigUInt
 
 
-fn compare_magnitudes(x1: BigInt10, x2: BigInt10) -> Int8:
+def compare_magnitudes(x1: BigInt10, x2: BigInt10) -> Int8:
     """Compares the magnitudes of two numbers and returns the result.
 
     Args:
@@ -38,7 +38,7 @@ fn compare_magnitudes(x1: BigInt10, x2: BigInt10) -> Int8:
     return x1.magnitude.compare(x2.magnitude)
 
 
-fn compare(x1: BigInt10, x2: BigInt10) -> Int8:
+def compare(x1: BigInt10, x2: BigInt10) -> Int8:
     """Compares two BigInt10 objects and returns the result.
 
     Args:
@@ -65,7 +65,7 @@ fn compare(x1: BigInt10, x2: BigInt10) -> Int8:
     return magnitude_comparison if not x1.sign else -magnitude_comparison
 
 
-fn greater(x1: BigInt10, x2: BigInt10) -> Bool:
+def greater(x1: BigInt10, x2: BigInt10) -> Bool:
     """Checks if the first number is greater than the second.
 
     Args:
@@ -78,7 +78,7 @@ fn greater(x1: BigInt10, x2: BigInt10) -> Bool:
     return compare(x1, x2) > 0
 
 
-fn greater_equal(x1: BigInt10, x2: BigInt10) -> Bool:
+def greater_equal(x1: BigInt10, x2: BigInt10) -> Bool:
     """Checks if the first number is greater than or equal to the second.
 
     Args:
@@ -91,7 +91,7 @@ fn greater_equal(x1: BigInt10, x2: BigInt10) -> Bool:
     return compare(x1, x2) >= 0
 
 
-fn less(x1: BigInt10, x2: BigInt10) -> Bool:
+def less(x1: BigInt10, x2: BigInt10) -> Bool:
     """Checks if the first number is less than the second.
 
     Args:
@@ -104,7 +104,7 @@ fn less(x1: BigInt10, x2: BigInt10) -> Bool:
     return compare(x1, x2) < 0
 
 
-fn less_equal(x1: BigInt10, x2: BigInt10) -> Bool:
+def less_equal(x1: BigInt10, x2: BigInt10) -> Bool:
     """Checks if the first number is less than or equal to the second.
 
     Args:
@@ -117,7 +117,7 @@ fn less_equal(x1: BigInt10, x2: BigInt10) -> Bool:
     return compare(x1, x2) <= 0
 
 
-fn equal(x1: BigInt10, x2: BigInt10) -> Bool:
+def equal(x1: BigInt10, x2: BigInt10) -> Bool:
     """Checks if two numbers are equal.
 
     Args:
@@ -130,7 +130,7 @@ fn equal(x1: BigInt10, x2: BigInt10) -> Bool:
     return compare(x1, x2) == 0
 
 
-fn not_equal(x1: BigInt10, x2: BigInt10) -> Bool:
+def not_equal(x1: BigInt10, x2: BigInt10) -> Bool:
     """Checks if two numbers are not equal.
 
     Args:

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -87,7 +87,7 @@ comptime CUTOFF_BURNIKEL_ZIEGLER = 32
 # ===----------------------------------------------------------------------=== #
 
 
-fn negative(x: BigUInt) raises -> BigUInt:
+def negative(x: BigUInt) raises -> BigUInt:
     """Returns the negative of a BigUInt number if it is zero.
 
     Args:
@@ -114,7 +114,7 @@ fn negative(x: BigUInt) raises -> BigUInt:
     return BigUInt.zero()  # Return zero
 
 
-fn absolute(x: BigUInt) -> BigUInt:
+def absolute(x: BigUInt) -> BigUInt:
     """Returns the absolute value of a BigUInt number.
 
     Args:
@@ -132,7 +132,7 @@ fn absolute(x: BigUInt) -> BigUInt:
 # ===----------------------------------------------------------------------=== #
 
 
-fn add(x: BigUInt, y: BigUInt) -> BigUInt:
+def add(x: BigUInt, y: BigUInt) -> BigUInt:
     """Returns the sum of two unsigned integers.
 
     Args:
@@ -201,7 +201,7 @@ fn add(x: BigUInt, y: BigUInt) -> BigUInt:
     return add_slices_simd(x, y, (0, len(x.words)), (0, len(y.words)))
 
 
-fn add_slices(
+def add_slices(
     x: BigUInt, y: BigUInt, bounds_x: Tuple[Int, Int], bounds_y: Tuple[Int, Int]
 ) -> BigUInt:
     """Adds two BigUInt slices using the school method.
@@ -253,7 +253,7 @@ fn add_slices(
     return add_slices_simd(x, y, bounds_x, bounds_y)
 
 
-fn add_slices_simd(
+def add_slices_simd(
     x: BigUInt, y: BigUInt, bounds_x: Tuple[Int, Int], bounds_y: Tuple[Int, Int]
 ) -> BigUInt:
     """Adds two BigUInt slices using SIMD operations.
@@ -296,7 +296,7 @@ fn add_slices_simd(
     )
 
     @parameter
-    fn vector_add[
+    def vector_add[
         simd_width: Int
     ](i: Int) unified {
         mut result, read x, read y, read bounds_x, read bounds_y
@@ -328,7 +328,7 @@ fn add_slices_simd(
         longer_start = bounds_y[0]
 
     @parameter
-    fn vector_copy_rest_from_longer[
+    def vector_copy_rest_from_longer[
         simd_width: Int
     ](i: Int) unified {
         mut result, read longer, read n_words_shorter_slice, read longer_start
@@ -350,7 +350,7 @@ fn add_slices_simd(
     return result^
 
 
-fn add_inplace(mut x: BigUInt, y: BigUInt) -> None:
+def add_inplace(mut x: BigUInt, y: BigUInt) -> None:
     """Increments a BigUInt number by another BigUInt number in place.
 
     Args:
@@ -384,7 +384,7 @@ fn add_inplace(mut x: BigUInt, y: BigUInt) -> None:
         x.words.resize(new_size=len(y.words), value=UInt32(0))
 
     @parameter
-    fn vector_add[simd_width: Int](i: Int) unified {mut x, read y}:
+    def vector_add[simd_width: Int](i: Int) unified {mut x, read y}:
         x.words.unsafe_ptr().store[width=simd_width](
             i,
             x.words.unsafe_ptr().load[width=simd_width](i)
@@ -400,7 +400,7 @@ fn add_inplace(mut x: BigUInt, y: BigUInt) -> None:
     return
 
 
-fn add_inplace_by_slice(
+def add_inplace_by_slice(
     mut x: BigUInt, y: BigUInt, bounds_y: Tuple[Int, Int]
 ) -> None:
     """Increments a BigUInt number in-place by another BigUInt slice.
@@ -435,7 +435,7 @@ fn add_inplace_by_slice(
         x.words.resize(new_size=n_words_y_slice, value=UInt32(0))
 
     @parameter
-    fn vector_add[
+    def vector_add[
         simd_width: Int
     ](i: Int) unified {mut x, read y, read bounds_y}:
         x.words.unsafe_ptr().store[width=simd_width](
@@ -452,7 +452,7 @@ fn add_inplace_by_slice(
     return
 
 
-fn add_inplace_by_uint32(mut x: BigUInt, y: UInt32) -> None:
+def add_inplace_by_uint32(mut x: BigUInt, y: UInt32) -> None:
     """Increments a BigUInt number by a UInt32 value."""
     var carry: UInt32 = y
     for i in range(len(x.words)):
@@ -473,7 +473,7 @@ fn add_inplace_by_uint32(mut x: BigUInt, y: UInt32) -> None:
 # ===----------------------------------------------------------------------=== #
 
 
-fn subtract(x: BigUInt, y: BigUInt) raises -> BigUInt:
+def subtract(x: BigUInt, y: BigUInt) raises -> BigUInt:
     """Returns the difference of two unsigned integers.
 
     Args:
@@ -497,7 +497,7 @@ fn subtract(x: BigUInt, y: BigUInt) raises -> BigUInt:
     # return subtract_school(x, y)
 
 
-fn subtract_school(x: BigUInt, y: BigUInt) raises -> BigUInt:
+def subtract_school(x: BigUInt, y: BigUInt) raises -> BigUInt:
     """Returns the difference of two unsigned integers using the school method.
 
     Args:
@@ -580,7 +580,7 @@ fn subtract_school(x: BigUInt, y: BigUInt) raises -> BigUInt:
     return result^
 
 
-fn subtract_simd(x: BigUInt, y: BigUInt) raises -> BigUInt:
+def subtract_simd(x: BigUInt, y: BigUInt) raises -> BigUInt:
     """Returns the difference of two unsigned integers using SIMD operations.
 
     Args:
@@ -648,7 +648,7 @@ fn subtract_simd(x: BigUInt, y: BigUInt) raises -> BigUInt:
     # Note that there will be potential overflow in the subtraction,
     # but we will take advantage of that.
     @parameter
-    fn vector_subtract[
+    def vector_subtract[
         simd_width: Int
     ](i: Int) unified {mut result, read x, read y}:
         result.words.unsafe_ptr().store[width=simd_width](
@@ -660,7 +660,7 @@ fn subtract_simd(x: BigUInt, y: BigUInt) raises -> BigUInt:
     vectorize[BigUInt.VECTOR_WIDTH](len(y.words), vector_subtract)
 
     @parameter
-    fn vector_copy_rest[
+    def vector_copy_rest[
         simd_width: Int
     ](i: Int) unified {mut result, read x, read y}:
         result.words.unsafe_ptr().store[width=simd_width](
@@ -678,7 +678,7 @@ fn subtract_simd(x: BigUInt, y: BigUInt) raises -> BigUInt:
     return result^
 
 
-fn subtract_inplace(mut x: BigUInt, y: BigUInt) raises -> None:
+def subtract_inplace(mut x: BigUInt, y: BigUInt) raises -> None:
     """Subtracts y from x in place."""
 
     # If the subtrahend is zero, return the minuend
@@ -716,7 +716,7 @@ fn subtract_inplace(mut x: BigUInt, y: BigUInt) raises -> None:
     # Note that len(x.words) >= len(y.words) here
     # Use SIMD operations to subtract the words in parallel.
     @parameter
-    fn vector_subtract[simd_width: Int](i: Int) unified {mut x, read y}:
+    def vector_subtract[simd_width: Int](i: Int) unified {mut x, read y}:
         x.words.unsafe_ptr().store[width=simd_width](
             i,
             x.words.unsafe_ptr().load[width=simd_width](i)
@@ -732,7 +732,7 @@ fn subtract_inplace(mut x: BigUInt, y: BigUInt) raises -> None:
     return
 
 
-fn subtract_inplace_no_check(mut x: BigUInt, y: BigUInt) -> None:
+def subtract_inplace_no_check(mut x: BigUInt, y: BigUInt) -> None:
     """Subtracts y from x in-place without checking for underflow.
 
     Notes:
@@ -753,7 +753,7 @@ fn subtract_inplace_no_check(mut x: BigUInt, y: BigUInt) -> None:
     # Note that len(x.words) >= len(y.words) under this assumption
 
     @parameter
-    fn vector_subtract[simd_width: Int](i: Int) unified {mut x, read y}:
+    def vector_subtract[simd_width: Int](i: Int) unified {mut x, read y}:
         x.words.unsafe_ptr().store[width=simd_width](
             i,
             x.words.unsafe_ptr().load[width=simd_width](i)
@@ -769,7 +769,7 @@ fn subtract_inplace_no_check(mut x: BigUInt, y: BigUInt) -> None:
     return
 
 
-fn subtract_inplace_by_uint32(mut x: BigUInt, y: UInt32) -> None:
+def subtract_inplace_by_uint32(mut x: BigUInt, y: UInt32) -> None:
     """Subtracts a UInt32 value from a BigUInt number in-place.
 
     Args:
@@ -819,7 +819,7 @@ fn subtract_inplace_by_uint32(mut x: BigUInt, y: UInt32) -> None:
 # ===----------------------------------------------------------------------=== #
 
 
-fn multiply(x: BigUInt, y: BigUInt) -> BigUInt:
+def multiply(x: BigUInt, y: BigUInt) -> BigUInt:
     """Returns the product of two BigUInt numbers.
 
     Args:
@@ -893,7 +893,7 @@ fn multiply(x: BigUInt, y: BigUInt) -> BigUInt:
         )
 
 
-fn multiply_slices(
+def multiply_slices(
     x: BigUInt,
     y: BigUInt,
     bounds_x: Tuple[Int, Int],
@@ -941,7 +941,7 @@ fn multiply_slices(
         )
 
 
-fn multiply_slices_school(
+def multiply_slices_school(
     read x: BigUInt,
     read y: BigUInt,
     bounds_x: Tuple[Int, Int],
@@ -1027,7 +1027,7 @@ fn multiply_slices_school(
     return result^
 
 
-fn multiply_slices_karatsuba(
+def multiply_slices_karatsuba(
     read x: BigUInt,
     read y: BigUInt,
     bounds_x: Tuple[Int, Int],
@@ -1208,7 +1208,7 @@ fn multiply_slices_karatsuba(
         return z2^
 
 
-fn multiply_slices_toom3(
+def multiply_slices_toom3(
     read x: BigUInt,
     read y: BigUInt,
     bounds_x: Tuple[Int, Int],
@@ -1491,7 +1491,7 @@ fn multiply_slices_toom3(
 
     # Helper: add a BigUInt value at a word offset into result
     @parameter
-    fn _add_at_offset(mut result: BigUInt, value: BigUInt, offset: Int):
+    def _add_at_offset(mut result: BigUInt, value: BigUInt, offset: Int):
         """Adds value into result starting at the given word offset."""
         if value.is_zero():
             return
@@ -1521,7 +1521,7 @@ fn multiply_slices_toom3(
     return result^
 
 
-fn multiply_inplace_by_uint32(mut x: BigUInt, y: UInt32):
+def multiply_inplace_by_uint32(mut x: BigUInt, y: UInt32):
     """Multiplies in-place a BigUInt by a UInt32 value.
 
     Args:
@@ -1548,7 +1548,7 @@ fn multiply_inplace_by_uint32(mut x: BigUInt, y: UInt32):
         x.words.append(UInt32(carry))
 
 
-fn multiply_inplace_by_uint32_le_4(mut x: BigUInt, y: UInt32):
+def multiply_inplace_by_uint32_le_4(mut x: BigUInt, y: UInt32):
     """Multiplies in-place a BigUInt by a UInt32 value which is between 0 and 4.
 
     Args:
@@ -1581,7 +1581,7 @@ fn multiply_inplace_by_uint32_le_4(mut x: BigUInt, y: UInt32):
 
     # y is 2, we can just shift the digits of each word to the left by 1
     @parameter
-    fn vector_multiply_by_2[simd_width: Int](i: Int) unified {mut x}:
+    def vector_multiply_by_2[simd_width: Int](i: Int) unified {mut x}:
         """Shifts the digits of each word to the left by 1."""
         x.words.unsafe_ptr().store[width=simd_width](
             i, x.words.unsafe_ptr().load[width=simd_width](i) << 1
@@ -1594,7 +1594,7 @@ fn multiply_inplace_by_uint32_le_4(mut x: BigUInt, y: UInt32):
 
     # y is 3, we can just multiply the digits of each word by 3
     @parameter
-    fn vector_multiply_by_3[simd_width: Int](i: Int) unified {mut x}:
+    def vector_multiply_by_3[simd_width: Int](i: Int) unified {mut x}:
         """Multiplies the digits of each word by 3."""
         x.words.unsafe_ptr().store[width=simd_width](
             i, x.words.unsafe_ptr().load[width=simd_width](i) * 3
@@ -1607,7 +1607,7 @@ fn multiply_inplace_by_uint32_le_4(mut x: BigUInt, y: UInt32):
 
     # y is 4, we can just shift the digits of each word to the left by 2
     @parameter
-    fn vector_multiply_by_4[simd_width: Int](i: Int) unified {mut x}:
+    def vector_multiply_by_4[simd_width: Int](i: Int) unified {mut x}:
         """Shifts the digits of each word to the left by 2."""
         x.words.unsafe_ptr().store[width=simd_width](
             i, x.words.unsafe_ptr().load[width=simd_width](i) << 2
@@ -1619,7 +1619,7 @@ fn multiply_inplace_by_uint32_le_4(mut x: BigUInt, y: UInt32):
         return
 
 
-fn multiply_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt:
+def multiply_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt:
     """Multiplies a BigUInt by 10^n (n >= 0).
 
     Args:
@@ -1694,7 +1694,7 @@ fn multiply_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt:
     return result^
 
 
-fn multiply_inplace_by_power_of_ten(mut x: BigUInt, n: Int):
+def multiply_inplace_by_power_of_ten(mut x: BigUInt, n: Int):
     """Multiplies a BigUInt in-place by 10^n (n >= 0).
 
     Args:
@@ -1785,7 +1785,7 @@ fn multiply_inplace_by_power_of_ten(mut x: BigUInt, n: Int):
         return
 
 
-fn multiply_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt:
+def multiply_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt:
     """Multiplies a BigUInt by (10^9)^n (n >= 0).
     This equals to adding 9n zeros (n words) to the end of the number.
 
@@ -1826,7 +1826,7 @@ fn multiply_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt:
     return res^
 
 
-fn multiply_inplace_by_power_of_billion(mut x: BigUInt, n: Int):
+def multiply_inplace_by_power_of_billion(mut x: BigUInt, n: Int):
     """Multiplies a BigUInt in-place by (10^9)^n (n >= 0).
     This equals to adding 9n zeros (n words) to the end of the number.
 
@@ -1873,7 +1873,7 @@ fn multiply_inplace_by_power_of_billion(mut x: BigUInt, n: Int):
     return
 
 
-fn exact_divide_by_2_inplace(mut x: BigUInt):
+def exact_divide_by_2_inplace(mut x: BigUInt):
     """Divides a BigUInt by 2 exactly, in-place.
 
     The caller must ensure that x is even (divisible by 2).
@@ -1889,7 +1889,7 @@ fn exact_divide_by_2_inplace(mut x: BigUInt):
     x.remove_leading_empty_words()
 
 
-fn exact_divide_by_3_inplace(mut x: BigUInt):
+def exact_divide_by_3_inplace(mut x: BigUInt):
     """Divides a BigUInt by 3 exactly, in-place.
 
     The caller must ensure that x is divisible by 3.
@@ -1913,7 +1913,7 @@ fn exact_divide_by_3_inplace(mut x: BigUInt):
 # ===----------------------------------------------------------------------=== #
 
 
-fn floor_divide(x: BigUInt, y: BigUInt) raises -> BigUInt:
+def floor_divide(x: BigUInt, y: BigUInt) raises -> BigUInt:
     """Returns the quotient of two BigUInt numbers, truncating toward zero.
 
     Args:
@@ -2038,7 +2038,7 @@ fn floor_divide(x: BigUInt, y: BigUInt) raises -> BigUInt:
 
 # TODO: Implement a `floor_divide_slices_school()` function that
 # can be used for slices of BigUInt numbers.
-fn floor_divide_school(x: BigUInt, y: BigUInt) raises -> BigUInt:
+def floor_divide_school(x: BigUInt, y: BigUInt) raises -> BigUInt:
     """**[PRIVATE]** General schoolbook division algorithm for BigInt10 numbers.
 
     Args:
@@ -2146,7 +2146,7 @@ fn floor_divide_school(x: BigUInt, y: BigUInt) raises -> BigUInt:
     return result^
 
 
-fn floor_divide_estimate_quotient(
+def floor_divide_estimate_quotient(
     dividend: BigUInt, divisor: BigUInt, index_of_word: Int
 ) -> UInt32:
     """Estimates the quotient digit using 3-by-2 division.
@@ -2227,7 +2227,7 @@ fn floor_divide_estimate_quotient(
     return min(quotient, BigUInt.BASE_MAX)
 
 
-fn floor_divide_by_uint32(x: BigUInt, y: UInt32) -> BigUInt:
+def floor_divide_by_uint32(x: BigUInt, y: UInt32) -> BigUInt:
     """**[PRIVATE]** Divides a BigUInt by a UInt32 divisor.
 
     Args:
@@ -2268,7 +2268,7 @@ fn floor_divide_by_uint32(x: BigUInt, y: UInt32) -> BigUInt:
     return result^
 
 
-fn floor_divide_inplace_by_uint32(mut x: BigUInt, y: UInt32) -> None:
+def floor_divide_inplace_by_uint32(mut x: BigUInt, y: UInt32) -> None:
     """Divides a BigUInt by a UInt32 divisor in-place.
 
     Args:
@@ -2300,7 +2300,7 @@ fn floor_divide_inplace_by_uint32(mut x: BigUInt, y: UInt32) -> None:
         carry = dividend % y_uint64
 
 
-fn floor_divide_by_uint64(x: BigUInt, y: UInt64) -> BigUInt:
+def floor_divide_by_uint64(x: BigUInt, y: UInt64) -> BigUInt:
     """Divides a BigUInt by UInt64.
 
     Args:
@@ -2339,7 +2339,7 @@ fn floor_divide_by_uint64(x: BigUInt, y: UInt64) -> BigUInt:
     return result^
 
 
-fn floor_divide_inplace_by_uint64(mut x: BigUInt, y: UInt64) -> None:
+def floor_divide_inplace_by_uint64(mut x: BigUInt, y: UInt64) -> None:
     """Divides a BigUInt by UInt64 in-place.
 
     Args:
@@ -2375,7 +2375,7 @@ fn floor_divide_inplace_by_uint64(mut x: BigUInt, y: UInt64) -> None:
     return
 
 
-fn floor_divide_by_uint128(x: BigUInt, y: UInt128) -> BigUInt:
+def floor_divide_by_uint128(x: BigUInt, y: UInt128) -> BigUInt:
     """Divides a BigUInt by UInt128.
 
     Args:
@@ -2450,7 +2450,7 @@ fn floor_divide_by_uint128(x: BigUInt, y: UInt128) -> BigUInt:
     return result^
 
 
-fn floor_divide_inplace_by_2(mut x: BigUInt) -> None:
+def floor_divide_inplace_by_2(mut x: BigUInt) -> None:
     """Divides a BigUInt by 2 in-place.
 
     Args:
@@ -2477,7 +2477,7 @@ fn floor_divide_inplace_by_2(mut x: BigUInt) -> None:
 
 
 # TODO: Implement a in-place version of this function
-fn floor_divide_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt:
+def floor_divide_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt:
     """Floor divides a BigUInt by 10^n (n>=0).
     It is equal to removing the last n digits of the number.
 
@@ -2555,7 +2555,7 @@ fn floor_divide_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt:
     return result^
 
 
-fn floor_divide_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt:
+def floor_divide_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt:
     """Floor divides a BigUInt by (10^9)^n (n>=0).
     This function is equivalent to removing the last n words of the number.
 
@@ -2619,7 +2619,7 @@ fn floor_divide_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt:
 # - avoid unnecessary memory allocations and copies
 
 
-fn floor_divide_burnikel_ziegler(
+def floor_divide_burnikel_ziegler(
     a: BigUInt, b: BigUInt, cut_off: Int
 ) raises -> BigUInt:
     """Divides BigUInt using the Burnikel-Ziegler algorithm.
@@ -2763,7 +2763,7 @@ fn floor_divide_burnikel_ziegler(
     return q^
 
 
-fn floor_divide_two_by_one(
+def floor_divide_two_by_one(
     a: BigUInt, b: BigUInt, n: Int, cut_off: Int
 ) raises -> Tuple[BigUInt, BigUInt]:
     """Divides a BigUInt by another BigUInt using a recursive approach.
@@ -2825,7 +2825,7 @@ fn floor_divide_two_by_one(
         return (q^, s^)
 
 
-fn floor_divide_three_by_two(
+def floor_divide_three_by_two(
     a2: BigUInt,
     a1: BigUInt,
     a0: BigUInt,
@@ -2891,7 +2891,7 @@ fn floor_divide_three_by_two(
 # `floor_divide_two_by_one` and `floor_divide_three_by_two` functions.
 # They record the boundaries of the slices of the dividend and divisor
 # to avoid unnecessary recursive slicing and copying of the BigUInt objects.
-fn floor_divide_slices_two_by_one(
+def floor_divide_slices_two_by_one(
     a: BigUInt,
     b: BigUInt,
     bounds_a: Tuple[Int, Int],
@@ -2992,7 +2992,7 @@ fn floor_divide_slices_two_by_one(
         return (q^, s^)
 
 
-fn floor_divide_slices_three_by_two(
+def floor_divide_slices_three_by_two(
     a: BigUInt,
     b: BigUInt,
     bounds_a: Tuple[Int, Int],
@@ -3080,7 +3080,7 @@ fn floor_divide_slices_three_by_two(
 # When then size of the divisor is less than N, we switch to the schoolbook
 # division algorithm.
 # However, these functions are still valid and can be used if needed.
-fn floor_divide_three_by_two_uint32(
+def floor_divide_three_by_two_uint32(
     a2: UInt32, a1: UInt32, a0: UInt32, b1: UInt32, b0: UInt32
 ) raises -> Tuple[UInt32, UInt32, UInt32]:
     """Divides a 3-word number by a 2-word number.
@@ -3129,7 +3129,7 @@ fn floor_divide_three_by_two_uint32(
     return (UInt32(q), r1, r0)
 
 
-fn floor_divide_four_by_two_uint32(
+def floor_divide_four_by_two_uint32(
     a3: UInt32,
     a2: UInt32,
     a1: UInt32,
@@ -3175,7 +3175,7 @@ fn floor_divide_four_by_two_uint32(
 
 
 @always_inline
-fn truncate_divide(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
+def truncate_divide(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
     """Returns the quotient of two BigUInt numbers, truncating toward zero.
     It is equal to floored division for unsigned numbers.
     See `floor_divide` for more details.
@@ -3183,7 +3183,7 @@ fn truncate_divide(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
     return floor_divide(x1, x2)
 
 
-fn ceil_divide(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
+def ceil_divide(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
     """Returns the quotient of two BigUInt numbers, rounding up.
 
     Args:
@@ -3212,7 +3212,7 @@ fn ceil_divide(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
     return quotient^
 
 
-fn floor_modulo(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
+def floor_modulo(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
     """Returns the remainder of two BigUInt numbers, truncating toward zero.
     The remainder has the same sign as the dividend and satisfies:
     x1 = floor_divide(x1, x2) * x2 + floor_modulo(x1, x2).
@@ -3294,7 +3294,7 @@ fn floor_modulo(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
 
 
 @always_inline
-fn truncate_modulo(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
+def truncate_modulo(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
     """Returns the remainder of two BigUInt numbers, truncating toward zero.
     It is equal to floored modulo for unsigned numbers.
     See `floor_modulo` for more details.
@@ -3322,7 +3322,7 @@ fn truncate_modulo(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
         )
 
 
-fn ceil_modulo(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
+def ceil_modulo(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
     """Returns the remainder of two BigUInt numbers, rounding up.
     The remainder has the same sign as the dividend and satisfies:
     x1 = ceil_divide(x1, x2) * x2 + ceil_modulo(x1, x2).
@@ -3373,7 +3373,7 @@ fn ceil_modulo(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
         return subtract(x2, remainder)
 
 
-fn floor_divide_modulo(
+def floor_divide_modulo(
     x1: BigUInt, x2: BigUInt
 ) raises -> Tuple[BigUInt, BigUInt]:
     """Returns the quotient and remainder of two numbers, truncating toward zero.
@@ -3413,7 +3413,7 @@ fn floor_divide_modulo(
 # ===----------------------------------------------------------------------=== #
 
 
-fn normalize_carries_lt_2_bases(mut x: BigUInt):
+def normalize_carries_lt_2_bases(mut x: BigUInt):
     """Normalizes the values of words into valid range by carrying over.
     The initial values of the words should be in the range [0, BASE*2).
 
@@ -3449,7 +3449,7 @@ fn normalize_carries_lt_2_bases(mut x: BigUInt):
     return
 
 
-fn normalize_carries_lt_4_bases(mut x: BigUInt):
+def normalize_carries_lt_4_bases(mut x: BigUInt):
     """Normalizes the values of words into valid range by carrying over.
     The initial values of the words should be in the range [0, BASE * 4 - 4].
 
@@ -3523,7 +3523,7 @@ fn normalize_carries_lt_4_bases(mut x: BigUInt):
     return
 
 
-fn normalize_borrows(mut x: BigUInt):
+def normalize_borrows(mut x: BigUInt):
     """Normalizes the values of words into valid range by borrowing.
     The caller should ensure that the final result is non-negative.
     The initial values of the words should be in the range:
@@ -3563,7 +3563,7 @@ fn normalize_borrows(mut x: BigUInt):
     return
 
 
-fn power_of_10(n: Int) raises -> BigUInt:
+def power_of_10(n: Int) raises -> BigUInt:
     """Calculates 10^n efficiently for non-negative n.
 
     Args:
@@ -3621,7 +3621,7 @@ fn power_of_10(n: Int) raises -> BigUInt:
 
 
 @always_inline
-fn calculate_ndigits_for_normalization(msw: UInt32) -> Int:
+def calculate_ndigits_for_normalization(msw: UInt32) -> Int:
     """Calculates the number of digits to shift left for normalization.
 
     Args:
@@ -3663,7 +3663,7 @@ fn calculate_ndigits_for_normalization(msw: UInt32) -> Int:
     return ndigits
 
 
-fn to_uint64_with_2_words(a: BigUInt, bounds_x: Tuple[Int, Int]) -> UInt64:
+def to_uint64_with_2_words(a: BigUInt, bounds_x: Tuple[Int, Int]) -> UInt64:
     """Convert two words at given index of the BigUInt to UInt64."""
     var n_words = bounds_x[1] - bounds_x[0]
     if n_words == 1:
@@ -3677,7 +3677,7 @@ fn to_uint64_with_2_words(a: BigUInt, bounds_x: Tuple[Int, Int]) -> UInt64:
         ).reduce_add()
 
 
-fn to_uint128_with_2_words(a: BigUInt, bounds_x: Tuple[Int, Int]) -> UInt128:
+def to_uint128_with_2_words(a: BigUInt, bounds_x: Tuple[Int, Int]) -> UInt128:
     """Convert two words at given index of the BigUInt to UInt128."""
     var n_words = bounds_x[1] - bounds_x[0]
     if n_words == 1:
@@ -3695,7 +3695,7 @@ fn to_uint128_with_2_words(a: BigUInt, bounds_x: Tuple[Int, Int]) -> UInt128:
         ).reduce_add()
 
 
-fn to_uint128_with_4_words(a: BigUInt, bounds_x: Tuple[Int, Int]) -> UInt128:
+def to_uint128_with_4_words(a: BigUInt, bounds_x: Tuple[Int, Int]) -> UInt128:
     """Convert four words at given index of the BigUInt to UInt128."""
     var n_words = bounds_x[1] - bounds_x[0]
     if n_words == 1:

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -18,9 +18,9 @@
 Implements basic arithmetic functions for the BigUInt type.
 """
 
-from algorithm import vectorize
-import math
-from memory import memcpy, memset_zero
+from std.algorithm import vectorize
+from std import math
+from std.memory import memcpy, memset_zero
 
 from decimo.biguint.biguint import BigUInt
 import decimo.biguint.comparison
@@ -301,10 +301,10 @@ fn add_slices_simd(
     ](i: Int) unified {
         mut result, read x, read y, read bounds_x, read bounds_y
     }:
-        result.words._data.store[width=simd_width](
+        result.words.unsafe_ptr().store[width=simd_width](
             i,
-            x.words._data.load[width=simd_width](i + bounds_x[0])
-            + y.words._data.load[width=simd_width](i + bounds_y[0]),
+            x.words.unsafe_ptr().load[width=simd_width](i + bounds_x[0])
+            + y.words.unsafe_ptr().load[width=simd_width](i + bounds_y[0]),
         )
 
     vectorize[BigUInt.VECTOR_WIDTH](
@@ -333,11 +333,11 @@ fn add_slices_simd(
     ](i: Int) unified {
         mut result, read longer, read n_words_shorter_slice, read longer_start
     }:
-        result.words._data.store[width=simd_width](
+        result.words.unsafe_ptr().store[width=simd_width](
             n_words_shorter_slice + i,
-            longer[].words._data.load[width=simd_width](
-                longer_start + n_words_shorter_slice + i
-            ),
+            longer[]
+            .words.unsafe_ptr()
+            .load[width=simd_width](longer_start + n_words_shorter_slice + i),
         )
 
     vectorize[BigUInt.VECTOR_WIDTH](
@@ -385,10 +385,10 @@ fn add_inplace(mut x: BigUInt, y: BigUInt) -> None:
 
     @parameter
     fn vector_add[simd_width: Int](i: Int) unified {mut x, read y}:
-        x.words._data.store[width=simd_width](
+        x.words.unsafe_ptr().store[width=simd_width](
             i,
-            x.words._data.load[width=simd_width](i)
-            + y.words._data.load[width=simd_width](i),
+            x.words.unsafe_ptr().load[width=simd_width](i)
+            + y.words.unsafe_ptr().load[width=simd_width](i),
         )
 
     vectorize[BigUInt.VECTOR_WIDTH](len(y.words), vector_add)
@@ -438,10 +438,10 @@ fn add_inplace_by_slice(
     fn vector_add[
         simd_width: Int
     ](i: Int) unified {mut x, read y, read bounds_y}:
-        x.words._data.store[width=simd_width](
+        x.words.unsafe_ptr().store[width=simd_width](
             i,
-            x.words._data.load[width=simd_width](i)
-            + y.words._data.load[width=simd_width](i + bounds_y[0]),
+            x.words.unsafe_ptr().load[width=simd_width](i)
+            + y.words.unsafe_ptr().load[width=simd_width](i + bounds_y[0]),
         )
 
     vectorize[BigUInt.VECTOR_WIDTH](n_words_y_slice, vector_add)
@@ -651,10 +651,10 @@ fn subtract_simd(x: BigUInt, y: BigUInt) raises -> BigUInt:
     fn vector_subtract[
         simd_width: Int
     ](i: Int) unified {mut result, read x, read y}:
-        result.words._data.store[width=simd_width](
+        result.words.unsafe_ptr().store[width=simd_width](
             i,
-            x.words._data.load[width=simd_width](i)
-            - y.words._data.load[width=simd_width](i),
+            x.words.unsafe_ptr().load[width=simd_width](i)
+            - y.words.unsafe_ptr().load[width=simd_width](i),
         )
 
     vectorize[BigUInt.VECTOR_WIDTH](len(y.words), vector_subtract)
@@ -663,9 +663,9 @@ fn subtract_simd(x: BigUInt, y: BigUInt) raises -> BigUInt:
     fn vector_copy_rest[
         simd_width: Int
     ](i: Int) unified {mut result, read x, read y}:
-        result.words._data.store[width=simd_width](
+        result.words.unsafe_ptr().store[width=simd_width](
             len(y.words) + i,
-            x.words._data.load[width=simd_width](len(y.words) + i),
+            x.words.unsafe_ptr().load[width=simd_width](len(y.words) + i),
         )
 
     vectorize[BigUInt.VECTOR_WIDTH](
@@ -717,10 +717,10 @@ fn subtract_inplace(mut x: BigUInt, y: BigUInt) raises -> None:
     # Use SIMD operations to subtract the words in parallel.
     @parameter
     fn vector_subtract[simd_width: Int](i: Int) unified {mut x, read y}:
-        x.words._data.store[width=simd_width](
+        x.words.unsafe_ptr().store[width=simd_width](
             i,
-            x.words._data.load[width=simd_width](i)
-            - y.words._data.load[width=simd_width](i),
+            x.words.unsafe_ptr().load[width=simd_width](i)
+            - y.words.unsafe_ptr().load[width=simd_width](i),
         )
 
     vectorize[BigUInt.VECTOR_WIDTH](len(y.words), vector_subtract)
@@ -754,10 +754,10 @@ fn subtract_inplace_no_check(mut x: BigUInt, y: BigUInt) -> None:
 
     @parameter
     fn vector_subtract[simd_width: Int](i: Int) unified {mut x, read y}:
-        x.words._data.store[width=simd_width](
+        x.words.unsafe_ptr().store[width=simd_width](
             i,
-            x.words._data.load[width=simd_width](i)
-            - y.words._data.load[width=simd_width](i),
+            x.words.unsafe_ptr().load[width=simd_width](i)
+            - y.words.unsafe_ptr().load[width=simd_width](i),
         )
 
     vectorize[BigUInt.VECTOR_WIDTH](len(y.words), vector_subtract)
@@ -1583,8 +1583,8 @@ fn multiply_inplace_by_uint32_le_4(mut x: BigUInt, y: UInt32):
     @parameter
     fn vector_multiply_by_2[simd_width: Int](i: Int) unified {mut x}:
         """Shifts the digits of each word to the left by 1."""
-        x.words._data.store[width=simd_width](
-            i, x.words._data.load[width=simd_width](i) << 1
+        x.words.unsafe_ptr().store[width=simd_width](
+            i, x.words.unsafe_ptr().load[width=simd_width](i) << 1
         )
 
     if y == 2:
@@ -1596,8 +1596,8 @@ fn multiply_inplace_by_uint32_le_4(mut x: BigUInt, y: UInt32):
     @parameter
     fn vector_multiply_by_3[simd_width: Int](i: Int) unified {mut x}:
         """Multiplies the digits of each word by 3."""
-        x.words._data.store[width=simd_width](
-            i, x.words._data.load[width=simd_width](i) * 3
+        x.words.unsafe_ptr().store[width=simd_width](
+            i, x.words.unsafe_ptr().load[width=simd_width](i) * 3
         )
 
     if y == 3:
@@ -1609,8 +1609,8 @@ fn multiply_inplace_by_uint32_le_4(mut x: BigUInt, y: UInt32):
     @parameter
     fn vector_multiply_by_4[simd_width: Int](i: Int) unified {mut x}:
         """Shifts the digits of each word to the left by 2."""
-        x.words._data.store[width=simd_width](
-            i, x.words._data.load[width=simd_width](i) << 2
+        x.words.unsafe_ptr().store[width=simd_width](
+            i, x.words.unsafe_ptr().load[width=simd_width](i) << 2
         )
 
     if y == 4:
@@ -2181,7 +2181,9 @@ fn floor_divide_estimate_quotient(
     if base_index + 2 < len(dividend.words):
         # We can safely load 3 words: r0, r1, r2
         numerator = (
-            dividend.words._data.load[width=4](base_index).cast[DType.uint128]()
+            dividend.words.unsafe_ptr()
+            .load[width=4](base_index)
+            .cast[DType.uint128]()
             * SIMD[DType.uint128, 4](
                 1, 1_000_000_000, 1_000_000_000_000_000_000, 0
             )
@@ -2189,7 +2191,9 @@ fn floor_divide_estimate_quotient(
     elif base_index + 1 < len(dividend.words):
         # We can safely load 2 words: r0, r1 (r2 = 0)
         numerator = (
-            dividend.words._data.load[width=2](base_index).cast[DType.uint128]()
+            dividend.words.unsafe_ptr()
+            .load[width=2](base_index)
+            .cast[DType.uint128]()
             * SIMD[DType.uint128, 2](1, 1_000_000_000)
         ).reduce_add()
     elif base_index < len(dividend.words):
@@ -2207,9 +2211,9 @@ fn floor_divide_estimate_quotient(
         "Divisor must have at least 2 words by design.",
     )
     denominator = (
-        divisor.words._data.load[width=2](len(divisor.words) - 2).cast[
-            DType.uint128
-        ]()
+        divisor.words.unsafe_ptr()
+        .load[width=2](len(divisor.words) - 2)
+        .cast[DType.uint128]()
         * SIMD[DType.uint128, 2](1, 1_000_000_000)
     ).reduce_add()
 
@@ -2322,7 +2326,7 @@ fn floor_divide_by_uint64(x: BigUInt, y: UInt64) -> BigUInt:
         var dividend = (
             carry * UInt128(1_000_000_000_000_000_000)
             + (
-                x.words._data.load[width=2](i - 1).cast[DType.uint128]()
+                x.words.unsafe_ptr().load[width=2](i - 1).cast[DType.uint128]()
                 * SIMD[DType.uint128, 2](1, 1_000_000_000)
             ).reduce_add()
         )
@@ -2358,7 +2362,7 @@ fn floor_divide_inplace_by_uint64(mut x: BigUInt, y: UInt64) -> None:
         var dividend = (
             carry * UInt128(1_000_000_000_000_000_000)
             + (
-                x.words._data.load[width=2](i - 1).cast[DType.uint128]()
+                x.words.unsafe_ptr().load[width=2](i - 1).cast[DType.uint128]()
                 * SIMD[DType.uint128, 2](1, 1_000_000_000)
             ).reduce_add()
         )
@@ -2393,9 +2397,9 @@ fn floor_divide_by_uint128(x: BigUInt, y: UInt128) -> BigUInt:
     elif len(x.words) % 4 == 2:
         carry = UInt256(
             (
-                x.words._data.load[width=2](len(x.words) - 2).cast[
-                    DType.uint64
-                ]()
+                x.words.unsafe_ptr()
+                .load[width=2](len(x.words) - 2)
+                .cast[DType.uint64]()
                 * SIMD[DType.uint64, 2](1, 1_000_000_000)
             ).reduce_add()
         )
@@ -2403,9 +2407,9 @@ fn floor_divide_by_uint128(x: BigUInt, y: UInt128) -> BigUInt:
     elif len(x.words) % 4 == 3:
         carry = UInt256(
             (
-                x.words._data.load[width=4](len(x.words) - 3).cast[
-                    DType.uint128
-                ]()
+                x.words.unsafe_ptr()
+                .load[width=4](len(x.words) - 3)
+                .cast[DType.uint128]()
                 * SIMD[DType.uint128, 4](
                     1, 1_000_000_000, 1_000_000_000_000_000_000, 0
                 )
@@ -2419,7 +2423,7 @@ fn floor_divide_by_uint128(x: BigUInt, y: UInt128) -> BigUInt:
         var dividend = (
             carry * UInt256(1_000_000_000_000_000_000_000_000_000_000_000_000)
             + (
-                x.words._data.load[width=4](i - 3).cast[DType.uint256]()
+                x.words.unsafe_ptr().load[width=4](i - 3).cast[DType.uint256]()
                 * SIMD[DType.uint256, 4](
                     1,
                     1_000_000_000,
@@ -3663,10 +3667,12 @@ fn to_uint64_with_2_words(a: BigUInt, bounds_x: Tuple[Int, Int]) -> UInt64:
     """Convert two words at given index of the BigUInt to UInt64."""
     var n_words = bounds_x[1] - bounds_x[0]
     if n_words == 1:
-        return a.words._data.load[width=1](bounds_x[0]).cast[DType.uint64]()
+        return (
+            a.words.unsafe_ptr().load[width=1](bounds_x[0]).cast[DType.uint64]()
+        )
     else:
         return (
-            a.words._data.load[width=2](bounds_x[0]).cast[DType.uint64]()
+            a.words.unsafe_ptr().load[width=2](bounds_x[0]).cast[DType.uint64]()
             * SIMD[DType.uint64, 2](1, 1_000_000_000)
         ).reduce_add()
 
@@ -3675,10 +3681,16 @@ fn to_uint128_with_2_words(a: BigUInt, bounds_x: Tuple[Int, Int]) -> UInt128:
     """Convert two words at given index of the BigUInt to UInt128."""
     var n_words = bounds_x[1] - bounds_x[0]
     if n_words == 1:
-        return a.words._data.load[width=1](bounds_x[0]).cast[DType.uint128]()
+        return (
+            a.words.unsafe_ptr()
+            .load[width=1](bounds_x[0])
+            .cast[DType.uint128]()
+        )
     else:
         return (
-            a.words._data.load[width=2](bounds_x[0]).cast[DType.uint128]()
+            a.words.unsafe_ptr()
+            .load[width=2](bounds_x[0])
+            .cast[DType.uint128]()
             * SIMD[DType.uint128, 2](1, 1_000_000_000)
         ).reduce_add()
 
@@ -3687,22 +3699,32 @@ fn to_uint128_with_4_words(a: BigUInt, bounds_x: Tuple[Int, Int]) -> UInt128:
     """Convert four words at given index of the BigUInt to UInt128."""
     var n_words = bounds_x[1] - bounds_x[0]
     if n_words == 1:
-        return a.words._data.load[width=1](bounds_x[0]).cast[DType.uint128]()
+        return (
+            a.words.unsafe_ptr()
+            .load[width=1](bounds_x[0])
+            .cast[DType.uint128]()
+        )
     elif n_words == 2:
         return (
-            a.words._data.load[width=2](bounds_x[0]).cast[DType.uint128]()
+            a.words.unsafe_ptr()
+            .load[width=2](bounds_x[0])
+            .cast[DType.uint128]()
             * SIMD[DType.uint128, 2](1, 1_000_000_000)
         ).reduce_add()
     elif n_words == 3:
         return (
-            a.words._data.load[width=4](bounds_x[0]).cast[DType.uint128]()
+            a.words.unsafe_ptr()
+            .load[width=4](bounds_x[0])
+            .cast[DType.uint128]()
             * SIMD[DType.uint128, 4](
                 1, 1_000_000_000, 1_000_000_000_000_000_000, 0
             )
         ).reduce_add()
     else:  # len(self.words) == 4
         return (
-            a.words._data.load[width=4](bounds_x[0]).cast[DType.uint128]()
+            a.words.unsafe_ptr()
+            .load[width=4](bounds_x[0])
+            .cast[DType.uint128]()
             * SIMD[DType.uint128, 4](
                 1,
                 1_000_000_000,

--- a/src/decimo/biguint/biguint.mojo
+++ b/src/decimo/biguint/biguint.mojo
@@ -23,7 +23,7 @@ operation dunders, and other dunders that implement traits, as well as
 mathematical methods that do not implement a trait.
 """
 
-from memory import UnsafePointer, memcpy, memcmp
+from std.memory import UnsafePointer, memcpy, memcmp
 
 from decimo.bigint10.bigint10 import BigInt10
 import decimo.biguint.arithmetics
@@ -41,9 +41,7 @@ import decimo.str
 comptime BUInt = BigUInt
 
 
-struct BigUInt(
-    Absable, Copyable, IntableRaising, Movable, Stringable, Writable
-):
+struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
     """Represents a base-10 arbitrary-precision unsigned integer.
 
     Notes:
@@ -508,20 +506,17 @@ struct BigUInt(
         """
 
         # Only allow unsigned integral types
-        constrained[
-            dtype.is_integral() and dtype.is_unsigned(),
-            "dtype must be unsigned integral.",
-        ]()
+        comptime assert (
+            dtype.is_integral() and dtype.is_unsigned()
+        ), "dtype must be unsigned integral."
 
         # Evaluate the conditions at compile time.
         # UInt8 and UInt16 can be directly converted to UInt32.
-        @parameter
-        if (dtype == DType.uint8) or (dtype == DType.uint16):
+        comptime if (dtype == DType.uint8) or (dtype == DType.uint16):
             return Self(raw_words=[UInt32(value)])
 
         # UInt32 is special, so we have a separate method for it.
-        @parameter
-        if dtype == DType.uint32:
+        comptime if dtype == DType.uint32:
             if value <= 999_999_999:
                 # One word is enough
                 return Self(raw_words=[UInt32(value)])
@@ -567,10 +562,9 @@ struct BigUInt(
             The BigUInt representation of the Scalar value.
         """
 
-        constrained[dtype.is_integral(), "dtype must be integral."]()
+        comptime assert dtype.is_integral(), "dtype must be integral."
 
-        @parameter
-        if (dtype == DType.uint8) or (dtype == DType.uint16):
+        comptime if (dtype == DType.uint8) or (dtype == DType.uint16):
             # For types that are smaller than word size
             # We can directly convert them to UInt32
             return Self(raw_words=[UInt32(value)])
@@ -785,6 +779,10 @@ struct BigUInt(
         """Returns a string representation of the BigUInt."""
         return 'BigUInt("' + self.__str__() + '")'
 
+    fn write_repr_to[W: Writer](self, mut writer: W):
+        """Writes the debug representation to a writer."""
+        writer.write('BigUInt("', self.__str__(), '")')
+
     # ===------------------------------------------------------------------=== #
     # Type-transfer or output methods that are not dunders
     # ===------------------------------------------------------------------=== #
@@ -793,7 +791,7 @@ struct BigUInt(
         """Writes the BigUInt to a writer.
         This implement the `write` method of the `Writer` trait.
         """
-        writer.write(String(self))
+        writer.write(self.__str__())
 
     fn to_int(self) raises -> Int:
         """Returns the number as Int.
@@ -854,15 +852,15 @@ struct BigUInt(
             )
 
         if len(self.words) == 1:
-            return self.words._data.load[width=1]().cast[DType.uint64]()
+            return self.words.unsafe_ptr().load[width=1]().cast[DType.uint64]()
         elif len(self.words) == 2:
             return (
-                self.words._data.load[width=2]().cast[DType.uint64]()
+                self.words.unsafe_ptr().load[width=2]().cast[DType.uint64]()
                 * SIMD[DType.uint64, 2](1, 1_000_000_000)
             ).reduce_add()
         else:
             return (
-                self.words._data.load[width=4]().cast[DType.uint64]()
+                self.words.unsafe_ptr().load[width=4]().cast[DType.uint64]()
                 * SIMD[DType.uint64, 4](
                     1,
                     1_000_000_000,
@@ -878,10 +876,10 @@ struct BigUInt(
             This method quickly convert BigUInt with 2 words into UInt64.
         """
         if len(self.words) == 1:
-            return self.words._data.load[width=1]().cast[DType.uint64]()
+            return self.words.unsafe_ptr().load[width=1]().cast[DType.uint64]()
         else:  # len(self.words) == 2
             return (
-                self.words._data.load[width=2]().cast[DType.uint64]()
+                self.words.unsafe_ptr().load[width=2]().cast[DType.uint64]()
                 * SIMD[DType.uint64, 2](1, 1_000_000_000)
             ).reduce_add()
 
@@ -907,22 +905,24 @@ struct BigUInt(
         var result: UInt128
 
         if len(self.words) == 1:
-            result = self.words._data.load[width=1]().cast[DType.uint128]()
+            result = (
+                self.words.unsafe_ptr().load[width=1]().cast[DType.uint128]()
+            )
         elif len(self.words) == 2:
             result = (
-                self.words._data.load[width=2]().cast[DType.uint128]()
+                self.words.unsafe_ptr().load[width=2]().cast[DType.uint128]()
                 * SIMD[DType.uint128, 2](1, 1_000_000_000)
             ).reduce_add()
         elif len(self.words) == 3:
             result = (
-                self.words._data.load[width=4]().cast[DType.uint128]()
+                self.words.unsafe_ptr().load[width=4]().cast[DType.uint128]()
                 * SIMD[DType.uint128, 4](
                     1, 1_000_000_000, 1_000_000_000_000_000_000, 0
                 )
             ).reduce_add()
         elif len(self.words) == 4:
             result = (
-                self.words._data.load[width=4]().cast[DType.uint128]()
+                self.words.unsafe_ptr().load[width=4]().cast[DType.uint128]()
                 * SIMD[DType.uint128, 4](
                     1,
                     1_000_000_000,
@@ -932,7 +932,7 @@ struct BigUInt(
             ).reduce_add()
         else:
             result = (
-                self.words._data.load[width=8]().cast[DType.uint128]()
+                self.words.unsafe_ptr().load[width=8]().cast[DType.uint128]()
                 * SIMD[DType.uint128, 8](
                     1,
                     1_000_000_000,
@@ -955,22 +955,22 @@ struct BigUInt(
         """
 
         if len(self.words) == 1:
-            return self.words._data.load[width=1]().cast[DType.uint128]()
+            return self.words.unsafe_ptr().load[width=1]().cast[DType.uint128]()
         elif len(self.words) == 2:
             return (
-                self.words._data.load[width=2]().cast[DType.uint128]()
+                self.words.unsafe_ptr().load[width=2]().cast[DType.uint128]()
                 * SIMD[DType.uint128, 2](1, 1_000_000_000)
             ).reduce_add()
         elif len(self.words) == 3:
             return (
-                self.words._data.load[width=4]().cast[DType.uint128]()
+                self.words.unsafe_ptr().load[width=4]().cast[DType.uint128]()
                 * SIMD[DType.uint128, 4](
                     1, 1_000_000_000, 1_000_000_000_000_000_000, 0
                 )
             ).reduce_add()
         else:  # len(self.words) == 4
             return (
-                self.words._data.load[width=4]().cast[DType.uint128]()
+                self.words.unsafe_ptr().load[width=4]().cast[DType.uint128]()
                 * SIMD[DType.uint128, 4](
                     1,
                     1_000_000_000,
@@ -1003,17 +1003,19 @@ struct BigUInt(
             if i == len(self.words) - 1:
                 result += String(self.words[i])
             else:
-                result += String(self.words[i]).rjust(width=9, fillchar="0")
+                result += decimo.str.rjust(
+                    String(self.words[i]), width=9, fillchar="0"
+                )
 
         if line_width > 0:
             var start = 0
             var end = line_width
             var lines = List[String](capacity=len(result) // line_width + 1)
             while end < len(result):
-                lines.append(String(result[start:end]))
+                lines.append(String(result[byte=start:end]))
                 start = end
                 end += line_width
-            lines.append(String(result[start:]))
+            lines.append(String(result[byte=start:]))
             result = String("\n").join(lines^)
 
         return result^
@@ -1033,10 +1035,10 @@ struct BigUInt(
         var start = end - 3
         var blocks = List[String](capacity=len(result) // 3 + 1)
         while start > 0:
-            blocks.append(String(result[start:end]))
+            blocks.append(String(result[byte=start:end]))
             end = start
             start = end - 3
-        blocks.append(String(result[0:end]))
+        blocks.append(String(result[byte=0:end]))
         blocks.reverse()
         result = separator.join(blocks)
 
@@ -1556,7 +1558,9 @@ struct BigUInt(
         for i in range(len(self.words)):
             var label = "word " + String(i) + ":"
             result += label + String(" ") * (col - len(label))
-            result += String(self.words[i]).rjust(9, fillchar="0") + "\n"
+            result += (
+                decimo.str.rjust(String(self.words[i]), 9, fillchar="0") + "\n"
+            )
 
         result += sep_line
         return result^
@@ -1938,7 +1942,9 @@ struct BigUInt(
                 ValueError(
                     file="src/decimo/biguint/biguint.mojo",
                     function="BigUInt.remove_trailing_digits_with_rounding()",
-                    message=("Unknown rounding mode: " + String(rounding_mode)),
+                    message=(
+                        "Unknown rounding mode: " + rounding_mode.__str__()
+                    ),
                     previous_error=None,
                 )
             )

--- a/src/decimo/biguint/biguint.mojo
+++ b/src/decimo/biguint/biguint.mojo
@@ -92,19 +92,19 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
     @always_inline
     @staticmethod
-    fn zero() -> Self:
+    def zero() -> Self:
         """Returns a BigUInt with value 0."""
         return Self()
 
     @always_inline
     @staticmethod
-    fn one() -> Self:
+    def one() -> Self:
         """Returns a BigUInt with value 1."""
         return Self(raw_words=[UInt32(1)])
 
     @staticmethod
     @always_inline
-    fn power_of_10(exponent: Int) raises -> Self:
+    def power_of_10(exponent: Int) raises -> Self:
         """Calculates 10^exponent efficiently."""
         return decimo.biguint.arithmetics.power_of_10(exponent)
 
@@ -119,11 +119,11 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
     # __init__(out self, value: String, ignore_sign: Bool = False) raises
     # ===------------------------------------------------------------------=== #
 
-    fn __init__(out self):
+    def __init__(out self):
         """Initializes to zero by default."""
         self.words = [UInt32(0)]
 
-    fn __init__(out self, *, uninitialized_capacity: Int):
+    def __init__(out self, *, uninitialized_capacity: Int):
         """Creates an uninitialized BigUInt with a given capacity.
 
         Args:
@@ -144,7 +144,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         """
         self.words = List[UInt32](capacity=uninitialized_capacity)
 
-    fn __init__(out self, *, unsafe_uninit_length: Int):
+    def __init__(out self, *, unsafe_uninit_length: Int):
         """Creates an uninitialized BigUInt with a given length.
 
         Args:
@@ -164,7 +164,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         """
         self.words = List[UInt32](unsafe_uninit_length=unsafe_uninit_length)
 
-    fn __init__(out self, var words: List[UInt32]) raises:
+    def __init__(out self, var words: List[UInt32]) raises:
         """Initializes a BigUInt from a list of UInt32 words.
         The BigUInt constructed in this way is guaranteed to be valid.
         If the list is empty, the BigUInt is initialized with value 0.
@@ -192,7 +192,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
                 )
             )
 
-    fn __init__(out self, *, var raw_words: List[UInt32]):
+    def __init__(out self, *, var raw_words: List[UInt32]):
         """Initializes a BigUInt from a list of raw words.
 
         Args:
@@ -217,7 +217,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
     # TODO: If Mojo makes Int type an alias of SIMD[DType.index, 1],
     # we can remove this method.
-    fn __init__(out self, value: Int) raises:
+    def __init__(out self, value: Int) raises:
         """Initializes a BigUInt from an Int.
         See `from_int()` for more information.
 
@@ -237,13 +237,13 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             )
 
     @implicit
-    fn __init__(out self, value: Scalar):
+    def __init__(out self, value: Scalar):
         """Initializes a BigUInt from an unsigned integral scalar.
         See `from_unsigned_integral_scalar()` for more information.
         """
         self = Self.from_unsigned_integral_scalar(value)
 
-    fn __init__(out self, value: String, *, ignore_sign: Bool = False) raises:
+    def __init__(out self, value: String, *, ignore_sign: Bool = False) raises:
         """Initializes a BigUInt from a string representation.
 
         Args:
@@ -281,7 +281,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
     # ===------------------------------------------------------------------=== #
 
     @staticmethod
-    fn from_list(var words: List[UInt32]) raises -> Self:
+    def from_list(var words: List[UInt32]) raises -> Self:
         """Initializes a BigUInt from a list of UInt32 words safely.
         If the list is empty, the BigUInt is initialized with value 0.
         If there are leading zero words, they are removed.
@@ -323,7 +323,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         return res^
 
     @staticmethod
-    fn from_list_unsafe(var words: List[UInt32]) -> Self:
+    def from_list_unsafe(var words: List[UInt32]) -> Self:
         """Initializes a BigUInt from a list of UInt32 words without checks.
         If the list is empty, the BigUInt is initialized with value 0.
         If there are leading empty words, they are removed.
@@ -342,7 +342,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         return result^
 
     @staticmethod
-    fn from_words(*words: UInt32) raises -> Self:
+    def from_words(*words: UInt32) raises -> Self:
         """Initializes a BigUInt from raw words safely.
 
         Args:
@@ -388,7 +388,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         return Self(raw_words=list_of_words^)
 
     @staticmethod
-    fn from_slice(value: Self, bounds: Tuple[Int, Int]) -> Self:
+    def from_slice(value: Self, bounds: Tuple[Int, Int]) -> Self:
         """Initializes a BigUInt from a BigUInt slice.
 
         Args:
@@ -427,7 +427,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         return result^
 
     @staticmethod
-    fn from_int(value: Int) raises -> Self:
+    def from_int(value: Int) raises -> Self:
         """Creates a BigUInt from an integer.
 
         Args:
@@ -469,13 +469,13 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         return Self(raw_words=list_of_words^)
 
     @staticmethod
-    fn from_uint32_unsafe(unsafe_value: UInt32) -> Self:
+    def from_uint32_unsafe(unsafe_value: UInt32) -> Self:
         """Creates a BigUInt from an `UInt32` object without checking the value.
         """
         return Self(raw_words=[unsafe_value])
 
     @staticmethod
-    fn from_unsigned_integral_scalar[
+    def from_unsigned_integral_scalar[
         dtype: DType, //
     ](value: SIMD[dtype, 1]) -> Self:
         """Initializes a BigUInt from an unsigned integral scalar.
@@ -545,7 +545,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         return Self(raw_words=list_of_words^)
 
     @staticmethod
-    fn from_absolute_integral_scalar[
+    def from_absolute_integral_scalar[
         dtype: DType, //
     ](value: SIMD[dtype, 1]) -> Self:
         """Initializes a BigUInt from an integral scalar and ignores the sign.
@@ -606,7 +606,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             return Self(raw_words=list_of_words^)
 
     @staticmethod
-    fn from_string(value: String, ignore_sign: Bool = False) raises -> BigUInt:
+    def from_string(value: String, ignore_sign: Bool = False) raises -> BigUInt:
         """Initializes a BigUInt from a string representation.
         The string is normalized with `deciomojo.str.parse_numeric_string()`.
 
@@ -748,7 +748,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
     # Output dunders, type-transfer dunders
     # ===------------------------------------------------------------------=== #
 
-    fn __int__(self) raises -> Int:
+    def __int__(self) raises -> Int:
         """Returns the number as Int.
 
         Returns:
@@ -769,7 +769,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
                 )
             )
 
-    fn write_repr_to[W: Writer](self, mut writer: W):
+    def write_repr_to[W: Writer](self, mut writer: W):
         """Writes the debug representation to a writer."""
         writer.write('BigUInt("', self.to_string(), '")')
 
@@ -777,13 +777,13 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
     # Type-transfer or output methods that are not dunders
     # ===------------------------------------------------------------------=== #
 
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """Writes the BigUInt to a writer.
         This implement the `write` method of the `Writer` trait.
         """
         writer.write(self.to_string())
 
-    fn to_int(self) raises -> Int:
+    def to_int(self) raises -> Int:
         """Returns the number as Int.
 
         Returns:
@@ -818,7 +818,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         return Int(value)
 
-    fn to_uint64(self) raises -> UInt64:
+    def to_uint64(self) raises -> UInt64:
         """Returns the number as UInt64.
 
         Returns:
@@ -859,7 +859,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
                 )
             ).reduce_add()
 
-    fn to_uint64_with_first_2_words(self) -> UInt64:
+    def to_uint64_with_first_2_words(self) -> UInt64:
         """Convert the first two words of the BigUInt to UInt64.
 
         Notes:
@@ -873,7 +873,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
                 * SIMD[DType.uint64, 2](1, 1_000_000_000)
             ).reduce_add()
 
-    fn to_uint128(self) -> UInt128:
+    def to_uint128(self) -> UInt128:
         """Returns the number as UInt128.
         **UNSAFE** You need to ensure that the number of words is less than 5.
 
@@ -937,7 +937,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         return result
 
-    fn to_uint128_with_first_4_words(self) -> UInt128:
+    def to_uint128_with_first_4_words(self) -> UInt128:
         """Convert the first four words of the BigUInt to UInt128.
 
         Notes:
@@ -969,7 +969,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
                 )
             ).reduce_add()
 
-    fn to_string(self, line_width: Int = 0) -> String:
+    def to_string(self, line_width: Int = 0) -> String:
         """Returns string representation of the BigUInt.
 
         Args:
@@ -1010,7 +1010,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         return result^
 
-    fn to_string_with_separators(self, separator: String = "_") -> String:
+    def to_string_with_separators(self, separator: String = "_") -> String:
         """Returns string representation of the BigUInt with separators.
 
         Args:
@@ -1044,21 +1044,21 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __abs__(self) -> Self:
+    def __abs__(self) -> Self:
         """Returns the absolute value of this number.
         See `absolute()` for more information.
         """
         return decimo.biguint.arithmetics.absolute(self)
 
     @always_inline
-    fn __neg__(self) raises -> Self:
+    def __neg__(self) raises -> Self:
         """Returns the negation of this number.
         See `negative()` for more information.
         """
         return decimo.biguint.arithmetics.negative(self)
 
     @always_inline
-    fn __rshift__(self, shift_amount: Int) -> Self:
+    def __rshift__(self, shift_amount: Int) -> Self:
         """Returns the result of floored divison by 2 to the power of `shift_amount`.
         """
         var result = self.copy()
@@ -1073,11 +1073,11 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __add__(self, other: Self) -> Self:
+    def __add__(self, other: Self) -> Self:
         return decimo.biguint.arithmetics.add(self, other)
 
     @always_inline
-    fn __sub__(self, other: Self) raises -> Self:
+    def __sub__(self, other: Self) raises -> Self:
         try:
             return decimo.biguint.arithmetics.subtract(self, other)
         except e:
@@ -1091,11 +1091,11 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             )
 
     @always_inline
-    fn __mul__(self, other: Self) -> Self:
+    def __mul__(self, other: Self) -> Self:
         return decimo.biguint.arithmetics.multiply(self, other)
 
     @always_inline
-    fn __floordiv__(self, other: Self) raises -> Self:
+    def __floordiv__(self, other: Self) raises -> Self:
         try:
             return decimo.biguint.arithmetics.floor_divide(self, other)
         except e:
@@ -1109,7 +1109,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             )
 
     @always_inline
-    fn __ceildiv__(self, other: Self) raises -> Self:
+    def __ceildiv__(self, other: Self) raises -> Self:
         """Returns the result of ceiling division."""
         try:
             return decimo.biguint.arithmetics.ceil_divide(self, other)
@@ -1124,7 +1124,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             )
 
     @always_inline
-    fn __mod__(self, other: Self) raises -> Self:
+    def __mod__(self, other: Self) raises -> Self:
         try:
             return decimo.biguint.arithmetics.floor_modulo(self, other)
         except e:
@@ -1138,7 +1138,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             )
 
     @always_inline
-    fn __divmod__(self, other: Self) raises -> Tuple[Self, Self]:
+    def __divmod__(self, other: Self) raises -> Tuple[Self, Self]:
         try:
             return decimo.biguint.arithmetics.floor_divide_modulo(self, other)
         except e:
@@ -1152,7 +1152,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             )
 
     @always_inline
-    fn __pow__(self, exponent: Self) raises -> Self:
+    def __pow__(self, exponent: Self) raises -> Self:
         try:
             return self.power(exponent)
         except e:
@@ -1166,7 +1166,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             )
 
     @always_inline
-    fn __pow__(self, exponent: Int) raises -> Self:
+    def __pow__(self, exponent: Int) raises -> Self:
         try:
             return self.power(exponent)
         except e:
@@ -1186,31 +1186,31 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __radd__(self, other: Self) raises -> Self:
+    def __radd__(self, other: Self) raises -> Self:
         return decimo.biguint.arithmetics.add(self, other)
 
     @always_inline
-    fn __rsub__(self, other: Self) raises -> Self:
+    def __rsub__(self, other: Self) raises -> Self:
         return decimo.biguint.arithmetics.subtract(other, self)
 
     @always_inline
-    fn __rmul__(self, other: Self) raises -> Self:
+    def __rmul__(self, other: Self) raises -> Self:
         return decimo.biguint.arithmetics.multiply(self, other)
 
     @always_inline
-    fn __rfloordiv__(self, other: Self) raises -> Self:
+    def __rfloordiv__(self, other: Self) raises -> Self:
         return decimo.biguint.arithmetics.floor_divide(other, self)
 
     @always_inline
-    fn __rmod__(self, other: Self) raises -> Self:
+    def __rmod__(self, other: Self) raises -> Self:
         return decimo.biguint.arithmetics.floor_modulo(other, self)
 
     @always_inline
-    fn __rdivmod__(self, other: Self) raises -> Tuple[Self, Self]:
+    def __rdivmod__(self, other: Self) raises -> Tuple[Self, Self]:
         return decimo.biguint.arithmetics.floor_divide_modulo(other, self)
 
     @always_inline
-    fn __rpow__(self, base: Self) raises -> Self:
+    def __rpow__(self, base: Self) raises -> Self:
         return base.power(self)
 
     # ===------------------------------------------------------------------=== #
@@ -1221,29 +1221,29 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __iadd__(mut self, other: Self):
+    def __iadd__(mut self, other: Self):
         """Adds `other` to `self` in place.
         See `biguint.arithmetics.add_inplace()` for more information.
         """
         decimo.biguint.arithmetics.add_inplace(self, other)
 
     @always_inline
-    fn __isub__(mut self, other: Self) raises:
+    def __isub__(mut self, other: Self) raises:
         """Subtracts `other` from `self` in place.
         See `biguint.arithmetics.subtract_inplace()` for more information.
         """
         decimo.biguint.arithmetics.subtract_inplace(self, other)
 
     @always_inline
-    fn __imul__(mut self, other: Self) raises:
+    def __imul__(mut self, other: Self) raises:
         self = decimo.biguint.arithmetics.multiply(self, other)
 
     @always_inline
-    fn __ifloordiv__(mut self, other: Self) raises:
+    def __ifloordiv__(mut self, other: Self) raises:
         self = decimo.biguint.arithmetics.floor_divide(self, other)
 
     @always_inline
-    fn __imod__(mut self, other: Self) raises:
+    def __imod__(mut self, other: Self) raises:
         self = decimo.biguint.arithmetics.floor_modulo(self, other)
 
     # ===------------------------------------------------------------------=== #
@@ -1252,32 +1252,32 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __gt__(self, other: Self) -> Bool:
+    def __gt__(self, other: Self) -> Bool:
         """Returns True if self > other."""
         return decimo.biguint.comparison.greater(self, other)
 
     @always_inline
-    fn __ge__(self, other: Self) -> Bool:
+    def __ge__(self, other: Self) -> Bool:
         """Returns True if self >= other."""
         return decimo.biguint.comparison.greater_equal(self, other)
 
     @always_inline
-    fn __lt__(self, other: Self) -> Bool:
+    def __lt__(self, other: Self) -> Bool:
         """Returns True if self < other."""
         return decimo.biguint.comparison.less(self, other)
 
     @always_inline
-    fn __le__(self, other: Self) -> Bool:
+    def __le__(self, other: Self) -> Bool:
         """Returns True if self <= other."""
         return decimo.biguint.comparison.less_equal(self, other)
 
     @always_inline
-    fn __eq__(self, other: Self) -> Bool:
+    def __eq__(self, other: Self) -> Bool:
         """Returns True if self == other."""
         return decimo.biguint.comparison.equal(self, other)
 
     @always_inline
-    fn __ne__(self, other: Self) -> Bool:
+    def __ne__(self, other: Self) -> Bool:
         """Returns True if self != other."""
         return decimo.biguint.comparison.not_equal(self, other)
 
@@ -1285,11 +1285,11 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
     # Other dunders
     # ===------------------------------------------------------------------=== #
 
-    fn __merge_with__[other_type: type_of(BigInt10)](self) -> BigInt10:
+    def __merge_with__[other_type: type_of(BigInt10)](self) -> BigInt10:
         "Merges this BigUInt with a BigInt10 into a BigInt10."
         return BigInt10(self)
 
-    fn __merge_with__[other_type: type_of(BigDecimal)](self) -> BigDecimal:
+    def __merge_with__[other_type: type_of(BigDecimal)](self) -> BigDecimal:
         "Merges this BigUInt with a BigDecimal into a BigDecimal."
         return BigDecimal(self)
 
@@ -1298,7 +1298,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn add_inplace(mut self, other: Self) raises:
+    def add_inplace(mut self, other: Self) raises:
         """Adds `other` to this number in place.
         It is equal to `self += other`.
         See `add_inplace()` for more information.
@@ -1306,7 +1306,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         decimo.biguint.arithmetics.add_inplace(self, other)
 
     @always_inline
-    fn floor_divide(self, other: Self) raises -> Self:
+    def floor_divide(self, other: Self) raises -> Self:
         """Returns the result of floor dividing this number by `other`.
         It is equal to `self // other`.
         See `floor_divide()` for more information.
@@ -1314,7 +1314,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         return decimo.biguint.arithmetics.floor_divide(self, other)
 
     @always_inline
-    fn truncate_divide(self, other: Self) raises -> Self:
+    def truncate_divide(self, other: Self) raises -> Self:
         """Returns the result of truncate dividing this number by `other`.
         It is equal to `self // other`.
         See `truncate_divide()` for more information.
@@ -1322,63 +1322,63 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         return decimo.biguint.arithmetics.truncate_divide(self, other)
 
     @always_inline
-    fn ceil_divide(self, other: Self) raises -> Self:
+    def ceil_divide(self, other: Self) raises -> Self:
         """Returns the result of ceil dividing this number by `other`.
         See `ceil_divide()` for more information.
         """
         return decimo.biguint.arithmetics.ceil_divide(self, other)
 
     @always_inline
-    fn floor_modulo(self, other: Self) raises -> Self:
+    def floor_modulo(self, other: Self) raises -> Self:
         """Returns the result of floor modulo this number by `other`.
         See `floor_modulo()` for more information.
         """
         return decimo.biguint.arithmetics.floor_modulo(self, other)
 
     @always_inline
-    fn truncate_modulo(self, other: Self) raises -> Self:
+    def truncate_modulo(self, other: Self) raises -> Self:
         """Returns the result of truncate modulo this number by `other`.
         See `truncate_modulo()` for more information.
         """
         return decimo.biguint.arithmetics.truncate_modulo(self, other)
 
     @always_inline
-    fn ceil_modulo(self, other: Self) raises -> Self:
+    def ceil_modulo(self, other: Self) raises -> Self:
         """Returns the result of ceil modulo this number by `other`.
         See `ceil_modulo()` for more information.
         """
         return decimo.biguint.arithmetics.ceil_modulo(self, other)
 
     @always_inline
-    fn divmod(self, other: Self) raises -> Tuple[Self, Self]:
+    def divmod(self, other: Self) raises -> Tuple[Self, Self]:
         """Returns the result of divmod this number by `other`.
         See `divmod()` for more information.
         """
         return decimo.biguint.arithmetics.floor_divide_modulo(self, other)
 
     @always_inline
-    fn floor_divide_inplace_by_2(mut self) raises:
+    def floor_divide_inplace_by_2(mut self) raises:
         """Divides this number by 2 in place.
         See `floor_divide_inplace_by_2()` for more information.
         """
         decimo.biguint.arithmetics.floor_divide_inplace_by_2(self)
 
     @always_inline
-    fn multiply_by_power_of_ten(self, n: Int) -> Self:
+    def multiply_by_power_of_ten(self, n: Int) -> Self:
         """Returns the result of multiplying this number by 10^n (n>=0).
         See `multiply_by_power_of_ten()` for more information.
         """
         return decimo.biguint.arithmetics.multiply_by_power_of_ten(self, n)
 
     @always_inline
-    fn multiply_inplace_by_power_of_ten(mut self, n: Int):
+    def multiply_inplace_by_power_of_ten(mut self, n: Int):
         """Multiplies this number in-place by 10^n (n>=0).
         See `multiply_inplace_by_power_of_ten()` for more information.
         """
         decimo.biguint.arithmetics.multiply_inplace_by_power_of_ten(self, n)
 
     @always_inline
-    fn floor_divide_by_power_of_ten(self, n: Int) -> Self:
+    def floor_divide_by_power_of_ten(self, n: Int) -> Self:
         """Returns the result of floored dividing this number by 10^n (n>=0).
         It is equal to removing the last n digits of the number.
         See `floor_divide_by_power_of_ten()` for more information.
@@ -1386,7 +1386,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         return decimo.biguint.arithmetics.floor_divide_by_power_of_ten(self, n)
 
     @always_inline
-    fn multiply_inplace_by_power_of_billion(mut self, n: Int):
+    def multiply_inplace_by_power_of_billion(mut self, n: Int):
         """Multiplies a BigUInt in-place by (10^9)^n if n > 0.
         This equals to adding 9n zeros (n words) to the end of the number.
 
@@ -1395,7 +1395,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         """
         decimo.biguint.arithmetics.multiply_inplace_by_power_of_billion(self, n)
 
-    fn power(self, exponent: Int) raises -> Self:
+    def power(self, exponent: Int) raises -> Self:
         """Returns the result of raising this number to the power of `exponent`.
 
         Args:
@@ -1453,7 +1453,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         return result^
 
-    fn power(self, exponent: Self) raises -> Self:
+    def power(self, exponent: Self) raises -> Self:
         """Returns the result of raising this number to the power of `exponent`.
 
         Args:
@@ -1482,7 +1482,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         var exponent_as_int = exponent.to_int()
         return self.power(exponent_as_int)
 
-    fn sqrt(self) -> Self:
+    def sqrt(self) -> Self:
         """Returns the square root of this number.
 
         Returns:
@@ -1494,7 +1494,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         """
         return decimo.biguint.exponential.sqrt(self)
 
-    fn isqrt(self) -> Self:
+    def isqrt(self) -> Self:
         """Returns the square root of this number.
         It is equal to `sqrt()`.
 
@@ -1508,7 +1508,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         return decimo.biguint.exponential.sqrt(self)
 
     @always_inline
-    fn compare(self, other: Self) -> Int8:
+    def compare(self, other: Self) -> Int8:
         """Compares the magnitudes of two BigUInts.
         See `compare()` for more information.
         """
@@ -1518,7 +1518,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
     # Other methods
     # ===------------------------------------------------------------------=== #
 
-    fn internal_representation(self) -> String:
+    def internal_representation(self) -> String:
         """Returns the internal representation details as a String."""
         # Collect all labels to find max width
         var max_label_len = len("number:")
@@ -1555,12 +1555,12 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         result += sep_line
         return result^
 
-    fn print_internal_representation(self):
+    def print_internal_representation(self):
         """Prints the internal representation details of a BigUInt."""
         print(self.internal_representation())
 
     @always_inline
-    fn is_zero(self) -> Bool:
+    def is_zero(self) -> Bool:
         """Returns True if this BigUInt represents zero."""
         # Yuhao ZHU:
         # BigUInt are desgined to have no leading zero words,
@@ -1586,7 +1586,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         # )
 
     @always_inline
-    fn is_zero_in_bounds(self, bounds: Tuple[Int, Int]) -> Bool:
+    def is_zero_in_bounds(self, bounds: Tuple[Int, Int]) -> Bool:
         """Returns True if this BigUInt slice represents zero.
 
         Args:
@@ -1602,7 +1602,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         return True
 
     @always_inline
-    fn is_one(self) -> Bool:
+    def is_one(self) -> Bool:
         """Returns True if this BigUInt represents one."""
         if self.words[0] != 1:
             # Least significant word is not 1
@@ -1620,7 +1620,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
                 return True
 
     @always_inline
-    fn is_two(self) -> Bool:
+    def is_two(self) -> Bool:
         """Returns True if this BigUInt represents two."""
         if len(self.words) != 2:
             return False
@@ -1630,7 +1630,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         return True
 
     @always_inline
-    fn is_power_of_10(x: BigUInt) -> Bool:
+    def is_power_of_10(x: BigUInt) -> Bool:
         """Check if x is a power of 10."""
         for i in range(len(x.words) - 1):
             if x.words[i] != 0:
@@ -1651,12 +1651,12 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         return False
 
     @always_inline
-    fn is_unitialized(self) -> Bool:
+    def is_unitialized(self) -> Bool:
         """Returns True if the BigUInt is uninitialized."""
         return len(self.words) == 0
 
     @always_inline
-    fn is_uint64_overflow(self) -> Bool:
+    def is_uint64_overflow(self) -> Bool:
         """Returns True if the BigUInt larger than UInt64.MAX."""
         # UInt64.MAX:     18_446_744_073_709_551_615
         # word 0:         709551615
@@ -1676,7 +1676,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         return False
 
     @always_inline
-    fn is_uint128_overflow(self) -> Bool:
+    def is_uint128_overflow(self) -> Bool:
         """Returns True if the BigUInt larger than UInt128.MAX."""
         # UInt128.MAX:    340_282_366_920_938_463_463_374_607_431_768_211_455
         # word 0:         768211455
@@ -1704,7 +1704,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         return False
 
     @always_inline
-    fn ith_digit(self, i: Int) raises -> UInt8:
+    def ith_digit(self, i: Int) raises -> UInt8:
         """Returns the ith least significant digit of the BigUInt.
         If the index is more than the number of digits, it returns 0.
 
@@ -1744,7 +1744,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         var digit = word % 10
         return UInt8(digit)
 
-    fn number_of_digits(self) -> Int:
+    def number_of_digits(self) -> Int:
         """Returns the number of digits in the BigUInt.
 
         Notes:
@@ -1762,11 +1762,11 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             last_word = last_word // 10
         return result
 
-    fn number_of_words(self) -> Int:
+    def number_of_words(self) -> Int:
         """Returns the number of words in the BigUInt."""
         return len(self.words)
 
-    fn number_of_trailing_zeros(self) -> Int:
+    def number_of_trailing_zeros(self) -> Int:
         """Returns the number of trailing zeros in the BigUInt."""
         var result: Int = 0
         for i in range(len(self.words)):
@@ -1781,7 +1781,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         return result
 
     @always_inline
-    fn remove_leading_empty_words(mut self):
+    def remove_leading_empty_words(mut self):
         """Removes the most significant empty words of a BigUInt.
 
         Notes:
@@ -1813,7 +1813,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             self.words.shrink(len(self.words) - n_empty_words)
 
     @always_inline
-    fn remove_trailing_digits_with_rounding(
+    def remove_trailing_digits_with_rounding(
         self,
         ndigits: Int,
         rounding_mode: RoundingMode,

--- a/src/decimo/biguint/biguint.mojo
+++ b/src/decimo/biguint/biguint.mojo
@@ -769,19 +769,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
                 )
             )
 
-    fn __str__(self) -> String:
-        """Returns string representation of the BigUInt.
-        See `to_string()` for more information.
-        """
-        return self.to_string()
-
-    fn __repr__(self) -> String:
-        """Returns a string representation of the BigUInt."""
-        return 'BigUInt("' + self.__str__() + '")'
-
     fn write_repr_to[W: Writer](self, mut writer: W):
         """Writes the debug representation to a writer."""
-        writer.write('BigUInt("', self.__str__(), '")')
+        writer.write('BigUInt("', self.to_string(), '")')
 
     # ===------------------------------------------------------------------=== #
     # Type-transfer or output methods that are not dunders
@@ -791,7 +781,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         """Writes the BigUInt to a writer.
         This implement the `write` method of the `Writer` trait.
         """
-        writer.write(self.__str__())
+        writer.write(self.to_string())
 
     fn to_int(self) raises -> Int:
         """Returns the number as Int.
@@ -1942,9 +1932,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
                 ValueError(
                     file="src/decimo/biguint/biguint.mojo",
                     function="BigUInt.remove_trailing_digits_with_rounding()",
-                    message=(
-                        "Unknown rounding mode: " + rounding_mode.__str__()
-                    ),
+                    message=("Unknown rounding mode: " + String(rounding_mode)),
                     previous_error=None,
                 )
             )

--- a/src/decimo/biguint/comparison.mojo
+++ b/src/decimo/biguint/comparison.mojo
@@ -21,7 +21,7 @@ Implements functions for comparison operations on BigUInt objects.
 from decimo.biguint.biguint import BigUInt
 
 
-fn compare(x1: BigUInt, x2: BigUInt) -> Int8:
+def compare(x1: BigUInt, x2: BigUInt) -> Int8:
     """Compares the values of two unsigned integers and returns the result.
 
     Args:
@@ -71,7 +71,7 @@ fn compare(x1: BigUInt, x2: BigUInt) -> Int8:
     return Int8(0)
 
 
-fn greater(x1: BigUInt, x2: BigUInt) -> Bool:
+def greater(x1: BigUInt, x2: BigUInt) -> Bool:
     """Checks if the first number is greater than the second.
 
     Args:
@@ -84,7 +84,7 @@ fn greater(x1: BigUInt, x2: BigUInt) -> Bool:
     return compare(x1, x2) > 0
 
 
-fn greater_equal(x1: BigUInt, x2: BigUInt) -> Bool:
+def greater_equal(x1: BigUInt, x2: BigUInt) -> Bool:
     """Checks if the first number is greater than or equal to the second.
 
     Args:
@@ -97,7 +97,7 @@ fn greater_equal(x1: BigUInt, x2: BigUInt) -> Bool:
     return compare(x1, x2) >= 0
 
 
-fn less(x1: BigUInt, x2: BigUInt) -> Bool:
+def less(x1: BigUInt, x2: BigUInt) -> Bool:
     """Checks if the first number is less than the second.
 
     Args:
@@ -110,7 +110,7 @@ fn less(x1: BigUInt, x2: BigUInt) -> Bool:
     return compare(x1, x2) < 0
 
 
-fn less_equal(x1: BigUInt, x2: BigUInt) -> Bool:
+def less_equal(x1: BigUInt, x2: BigUInt) -> Bool:
     """Checks if the first number is less than or equal to the second.
 
     Args:
@@ -123,7 +123,7 @@ fn less_equal(x1: BigUInt, x2: BigUInt) -> Bool:
     return compare(x1, x2) <= 0
 
 
-fn equal(x1: BigUInt, x2: BigUInt) -> Bool:
+def equal(x1: BigUInt, x2: BigUInt) -> Bool:
     """Checks if two numbers are equal.
 
     Args:
@@ -136,7 +136,7 @@ fn equal(x1: BigUInt, x2: BigUInt) -> Bool:
     return compare(x1, x2) == 0
 
 
-fn not_equal(x1: BigUInt, x2: BigUInt) -> Bool:
+def not_equal(x1: BigUInt, x2: BigUInt) -> Bool:
     """Checks if two numbers are not equal.
 
     Args:

--- a/src/decimo/biguint/exponential.mojo
+++ b/src/decimo/biguint/exponential.mojo
@@ -29,7 +29,7 @@ import decimo.biguint.arithmetics
 # ===----------------------------------------------------------------------=== #
 
 
-fn sqrt(x: BigUInt) -> BigUInt:
+def sqrt(x: BigUInt) -> BigUInt:
     """Calculates the square root of a BigUInt using Newton's method.
 
     Args:
@@ -117,7 +117,7 @@ fn sqrt(x: BigUInt) -> BigUInt:
         return guess^
 
 
-fn isqrt(x: BigUInt) -> BigUInt:
+def isqrt(x: BigUInt) -> BigUInt:
     """Calculates the integer square root of a BigUInt.
 
     Args:
@@ -130,7 +130,7 @@ fn isqrt(x: BigUInt) -> BigUInt:
     return sqrt(x)
 
 
-fn sqrt_initial_guess(x: BigUInt) -> BigUInt:
+def sqrt_initial_guess(x: BigUInt) -> BigUInt:
     """Calculates a intial guess for the square root of a BigUInt.
 
     Notes:

--- a/src/decimo/biguint/exponential.mojo
+++ b/src/decimo/biguint/exponential.mojo
@@ -16,8 +16,8 @@
 
 """Implements exponential functions for the BigUInt type."""
 
-import math
-from memory import memset_zero
+from std import math
+from std.memory import memset_zero
 
 from decimo.biguint.biguint import BigUInt
 import decimo.biguint.arithmetics
@@ -57,7 +57,7 @@ fn sqrt(x: BigUInt) -> BigUInt:
         var res = UInt32(
             math.sqrt(
                 (
-                    x.words._data.load[width=2]().cast[DType.uint64]()
+                    x.words.unsafe_ptr().load[width=2]().cast[DType.uint64]()
                     * SIMD[DType.uint64, 2](1, 1_000_000_000)
                 ).reduce_add()
             )
@@ -164,9 +164,9 @@ fn sqrt_initial_guess(x: BigUInt) -> BigUInt:
         msw_sqrt = UInt32(
             math.sqrt(
                 (
-                    x.words._data.load[width=2](len(x.words) - 2).cast[
-                        DType.uint64
-                    ]()
+                    x.words.unsafe_ptr()
+                    .load[width=2](len(x.words) - 2)
+                    .cast[DType.uint64]()
                     * SIMD[DType.uint64, 2](1, 1_000_000_000)
                 ).reduce_add()
             )

--- a/src/decimo/decimal128/arithmetics.mojo
+++ b/src/decimo/decimal128/arithmetics.mojo
@@ -40,7 +40,7 @@ import decimo.decimal128.utility
 
 
 # TODO: Like `multiply` use combined bits to determine the appropriate method
-fn add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
+def add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
     """
     Adds two Decimal128 values and returns a new Decimal128 containing the sum.
     The results will be rounded (up to even) if digits are too many.
@@ -346,7 +346,7 @@ fn add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             )
 
 
-fn subtract(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
+def subtract(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
     """
     Subtracts the x2 Decimal128 from x1 and returns a new Decimal128.
 
@@ -377,7 +377,7 @@ fn subtract(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         raise Error("Error in `subtract()`; ", e)
 
 
-fn negative(x: Decimal128) -> Decimal128:
+def negative(x: Decimal128) -> Decimal128:
     """
     Returns the negative of a Decimal128 number.
 
@@ -400,7 +400,7 @@ fn negative(x: Decimal128) -> Decimal128:
     return result
 
 
-fn absolute(x: Decimal128) -> Decimal128:
+def absolute(x: Decimal128) -> Decimal128:
     """
     Returns the absolute value of a Decimal128 number.
 
@@ -415,7 +415,7 @@ fn absolute(x: Decimal128) -> Decimal128:
     return x
 
 
-fn multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
+def multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
     """
     Multiplies two Decimal128 values and returns a new Decimal128 containing the product.
 
@@ -768,7 +768,7 @@ fn multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
     return Decimal128(low, mid, high, UInt32(final_scale), is_negative)
 
 
-fn divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
+def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
     """
     Divides x1 by x2 and returns a new Decimal128 containing the quotient.
     Uses a simpler string-based long division approach as fallback.
@@ -1227,7 +1227,7 @@ fn divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             )
 
 
-fn truncate_divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
+def truncate_divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
     """Returns the integral part of the quotient (truncating towards zero).
     The following identity always holds: x_1 == (x_1 // x_2) * x_2 + x_1 % x_2.
 
@@ -1244,7 +1244,7 @@ fn truncate_divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         raise Error("Error in `divide()`: ", e)
 
 
-fn modulo(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
+def modulo(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
     """Returns the remainder of the division of x1 by x2.
     The following identity always holds: x_1 == (x_1 // x_2) * x_2 + x_1 % x_2.
 

--- a/src/decimo/decimal128/arithmetics.mojo
+++ b/src/decimo/decimal128/arithmetics.mojo
@@ -31,8 +31,8 @@
 Implements functions for mathematical operations on Decimal128 objects.
 """
 
-import time
-import testing
+from std import time
+from std import testing
 
 from decimo.decimal128.decimal128 import Decimal128
 from decimo.rounding_mode import RoundingMode
@@ -62,7 +62,7 @@ fn add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
     # CASE: Zeros
     if x1_coef == 0 and x2_coef == 0:
-        var scale = max(x1_scale, x2_scale)
+        var scale = UInt32(max(x1_scale, x2_scale))
         return Decimal128(0, 0, 0, scale, False)
 
     elif x1_coef == 0:
@@ -86,7 +86,9 @@ fn add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             ):
                 scale -= 1
             sum_coef *= UInt128(10) ** (scale - x2_scale)
-            return Decimal128.from_uint128(sum_coef, scale, x2.is_negative())
+            return Decimal128.from_uint128(
+                sum_coef, UInt32(scale), x2.is_negative()
+            )
 
     elif x2_coef == 0:
         if x2_scale <= x1_scale:
@@ -108,7 +110,9 @@ fn add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             ):
                 scale -= 1
             sum_coef *= UInt128(10) ** (scale - x1_scale)
-            return Decimal128.from_uint128(sum_coef, scale, x1.is_negative())
+            return Decimal128.from_uint128(
+                sum_coef, UInt32(scale), x1.is_negative()
+            )
 
     # CASE: Integer addition with scale of 0 (true integers)
     elif x1_scale == 0 and x2_scale == 0:
@@ -153,15 +157,17 @@ fn add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
                 raise Error("Error in `addition()`: Decimal128 overflow")
 
             # Determine the scale for the result
-            var scale = min(
-                max(x1_scale, x2_scale),
-                Decimal128.MAX_NUM_DIGITS
-                - decimo.decimal128.utility.number_of_digits(summation),
+            var scale = UInt32(
+                min(
+                    max(x1_scale, x2_scale),
+                    Decimal128.MAX_NUM_DIGITS
+                    - decimo.decimal128.utility.number_of_digits(summation),
+                )
             )
             ## If summation > 7922816251426433759354395033
             if (summation > Decimal128.MAX_AS_UINT128 // 10) and (scale > 0):
                 scale -= 1
-            summation *= UInt128(10) ** scale
+            summation *= UInt128(10) ** UInt128(scale)
 
             return Decimal128.from_uint128(summation, scale, x1.is_negative())
 
@@ -180,15 +186,17 @@ fn add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
                 is_negative = False
 
             # Determine the scale for the result
-            var scale = min(
-                max(x1_scale, x2_scale),
-                Decimal128.MAX_NUM_DIGITS
-                - decimo.decimal128.utility.number_of_digits(diff),
+            var scale = UInt32(
+                min(
+                    max(x1_scale, x2_scale),
+                    Decimal128.MAX_NUM_DIGITS
+                    - decimo.decimal128.utility.number_of_digits(diff),
+                )
             )
             ## If summation > 7922816251426433759354395033
             if (diff > Decimal128.MAX_AS_UINT128 // 10) and (scale > 0):
                 scale -= 1
-            diff *= UInt128(10) ** scale
+            diff *= UInt128(10) ** UInt128(scale)
 
             return Decimal128.from_uint128(diff, scale, is_negative)
 
@@ -208,11 +216,15 @@ fn add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
                 summation = x2_coef - x1_coef
                 is_negative = x2.is_negative()
             else:  # x1_coef == x2_coef
-                return Decimal128.from_uint128(UInt128(0), x1_scale, False)
+                return Decimal128.from_uint128(
+                    UInt128(0), UInt32(x1_scale), False
+                )
 
         # If the summation fits in 96 bits, we can use the original scale
         if summation < Decimal128.MAX_AS_UINT128:
-            return Decimal128.from_uint128(summation, x1_scale, is_negative)
+            return Decimal128.from_uint128(
+                summation, UInt32(x1_scale), is_negative
+            )
 
         # Otherwise, it is >= 29 digits
         # we need to truncate the summation to fit in 96 bits
@@ -220,7 +232,9 @@ fn add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             var ndigits_summation = decimo.decimal128.utility.number_of_digits(
                 summation
             )
-            var ndigits_int_summation = ndigits_summation - x1_scale
+            var ndigits_int_summation = UInt32(ndigits_summation) - UInt32(
+                x1_scale
+            )
             var final_scale = Decimal128.MAX_NUM_DIGITS - ndigits_int_summation
 
             var truncated_summation = (
@@ -263,7 +277,9 @@ fn add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
                     summation = x2_coef_scaled - x1_coef_scaled
                     is_negative = x2.is_negative()
                 else:
-                    return Decimal128.from_uint128(UInt128(0), x1_scale, False)
+                    return Decimal128.from_uint128(
+                        UInt128(0), UInt32(x1_scale), False
+                    )
 
         else:  # x1_scale < x2_scale
             # Scale up x1_coef to match x2_scale
@@ -283,13 +299,15 @@ fn add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
                     summation = x2_coef_scaled - x1_coef_scaled
                     is_negative = x2.is_negative()
                 else:
-                    return Decimal128.from_uint128(UInt128(0), x2_scale, False)
+                    return Decimal128.from_uint128(
+                        UInt128(0), UInt32(x2_scale), False
+                    )
 
         # If the summation fits in 96 bits, we can use the original scale
         if summation < Decimal128.MAX_AS_UINT256:
             return Decimal128.from_uint128(
                 UInt128(summation & 0x00000000_FFFFFFFF_FFFFFFFF_FFFFFFFF),
-                max(x1_scale, x2_scale),
+                UInt32(max(x1_scale, x2_scale)),
                 is_negative,
             )
 
@@ -299,10 +317,12 @@ fn add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             var ndigits_summation = decimo.decimal128.utility.number_of_digits(
                 summation
             )
-            var ndigits_int_summation = ndigits_summation - max(
-                x1_scale, x2_scale
+            var ndigits_int_summation = UInt32(ndigits_summation) - UInt32(
+                max(x1_scale, x2_scale)
             )
-            var final_scale = Decimal128.MAX_NUM_DIGITS - ndigits_int_summation
+            var final_scale = (
+                UInt32(Decimal128.MAX_NUM_DIGITS) - ndigits_int_summation
+            )
 
             truncated_summation = (
                 decimo.decimal128.utility.round_to_keep_first_n_digits(
@@ -428,7 +448,7 @@ fn multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             0,
             0,
             0,
-            scale=min(combined_scale, Decimal128.MAX_SCALE),
+            scale=UInt32(min(combined_scale, Decimal128.MAX_SCALE)),
             sign=is_negative,
         )
 
@@ -441,11 +461,11 @@ fn multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
                 0,
                 0,
                 0,
-                Decimal128.MAX_SCALE,
+                UInt32(Decimal128.MAX_SCALE),
                 is_negative,
             )
         # Otherwise, return 1 with correct sign and scale
-        var final_scale = min(Decimal128.MAX_SCALE, combined_scale)
+        var final_scale = UInt32(min(Decimal128.MAX_SCALE, combined_scale))
         return Decimal128(1, 0, 0, final_scale, is_negative)
 
     # SPECIAL CASE: First operand has coefficient of 1
@@ -471,7 +491,7 @@ fn multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
                     prod, False, num_digits_to_keep
                 )
             )
-            var final_scale = min(Decimal128.MAX_SCALE, combined_scale)
+            var final_scale = UInt32(min(Decimal128.MAX_SCALE, combined_scale))
             return Decimal128.from_uint128(
                 truncated_prod, final_scale, is_negative
             )
@@ -499,7 +519,7 @@ fn multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
                     prod, False, num_digits_to_keep
                 )
             )
-            var final_scale = min(Decimal128.MAX_SCALE, combined_scale)
+            var final_scale = UInt32(min(Decimal128.MAX_SCALE, combined_scale))
             return Decimal128.from_uint128(
                 truncated_prod, final_scale, is_negative
             )
@@ -578,7 +598,7 @@ fn multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
                 low,
                 mid,
                 high,
-                final_scale,
+                UInt32(final_scale),
                 is_negative,
             )
 
@@ -594,7 +614,9 @@ fn multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
         # Combined scale more than max precision, no need to truncate
         if combined_scale <= Decimal128.MAX_SCALE:
-            return Decimal128.from_uint128(prod, combined_scale, is_negative)
+            return Decimal128.from_uint128(
+                prod, UInt32(combined_scale), is_negative
+            )
 
         # Combined scale no more than max precision, truncate with rounding
         else:
@@ -618,7 +640,9 @@ fn multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
                 )
                 final_scale = Decimal128.MAX_SCALE
 
-            return Decimal128.from_uint128(prod, final_scale, is_negative)
+            return Decimal128.from_uint128(
+                prod, UInt32(final_scale), is_negative
+            )
 
     # SUB-CASE: Both operands are moderate
     # The bits of the product will not exceed 128 bits
@@ -671,11 +695,13 @@ fn multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         if final_scale > Decimal128.MAX_SCALE:
             var ndigits_prod = decimo.decimal128.utility.number_of_digits(prod)
             prod = decimo.decimal128.utility.round_to_keep_first_n_digits(
-                prod, False, ndigits_prod - (final_scale - Decimal128.MAX_SCALE)
+                prod,
+                False,
+                ndigits_prod - (final_scale - Decimal128.MAX_SCALE),
             )
             final_scale = Decimal128.MAX_SCALE
 
-        return Decimal128.from_uint128(prod, final_scale, is_negative)
+        return Decimal128.from_uint128(prod, UInt32(final_scale), is_negative)
 
     # REMAINING CASES: Both operands are big
     # The bits of the product will not exceed 192 bits
@@ -739,7 +765,7 @@ fn multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
     var mid = UInt32((prod >> 32) & 0xFFFFFFFF)
     var high = UInt32((prod >> 64) & 0xFFFFFFFF)
 
-    return Decimal128(low, mid, high, final_scale, is_negative)
+    return Decimal128(low, mid, high, UInt32(final_scale), is_negative)
 
 
 fn divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
@@ -775,9 +801,9 @@ fn divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
     if x1.is_zero():
         var result = Decimal128.ZERO()
         var result_scale = max(0, x1.scale() - x2.scale())
-        result.flags = UInt32(
-            (result_scale << Decimal128.SCALE_SHIFT) & Decimal128.SCALE_MASK
-        )
+        result.flags = (
+            UInt32(result_scale) << Decimal128.SCALE_SHIFT
+        ) & Decimal128.SCALE_MASK
         return result
 
     var x1_coef = x1.coefficient()
@@ -797,12 +823,16 @@ fn divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         # SUB-CASE: divisor is 1
         # If divisor is 1, return dividend with correct sign
         if x2_scale == 0:
-            return Decimal128(x1.low, x1.mid, x1.high, x1_scale, is_negative)
+            return Decimal128(
+                x1.low, x1.mid, x1.high, UInt32(x1_scale), is_negative
+            )
 
         # SUB-CASE: divisor is of coefficient 1 with positive scale
         # diff_scale > 0, then final scale is diff_scale
         elif diff_scale > 0:
-            return Decimal128(x1.low, x1.mid, x1.high, diff_scale, is_negative)
+            return Decimal128(
+                x1.low, x1.mid, x1.high, UInt32(diff_scale), is_negative
+            )
 
         # diff_scale < 0, then times 10 ** (-diff_scale)
         else:
@@ -837,7 +867,7 @@ fn divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         # If the scales are positive, return 1 with the difference in scales
         # For example, 0.1234 / 1234 = 0.0001
         if diff_scale >= 0:
-            return Decimal128(1, 0, 0, diff_scale, is_negative)
+            return Decimal128(1, 0, 0, UInt32(diff_scale), is_negative)
 
         # SUB-CASE: The scales are negative
         # diff_scale < 0, then times 1e-diff_scale
@@ -861,7 +891,9 @@ fn divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             # High will be zero because the quotient is less than 2^48
             # For safety, we still calcuate the high word
             var quot = x1_coef // x2_coef
-            return Decimal128.from_uint128(quot, diff_scale, is_negative)
+            return Decimal128.from_uint128(
+                quot, UInt32(diff_scale), is_negative
+            )
 
         else:
             # If diff_scale < 0, return the quotient with scaling up
@@ -1029,7 +1061,9 @@ fn divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
                 )
                 scale_of_quot = Decimal128.MAX_SCALE
 
-            return Decimal128.from_uint128(quot, scale_of_quot, is_negative)
+            return Decimal128.from_uint128(
+                quot, UInt32(scale_of_quot), is_negative
+            )
 
         # Otherwise, we need to truncate the first 29 or 28 digits
         else:
@@ -1065,7 +1099,7 @@ fn divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
                 scale_of_truncated_quot = Decimal128.MAX_SCALE
 
             return Decimal128.from_uint128(
-                truncated_quot, scale_of_truncated_quot, is_negative
+                truncated_quot, UInt32(scale_of_truncated_quot), is_negative
             )
 
     # SUB-CASE: Use UInt256 to store the quotient
@@ -1139,7 +1173,9 @@ fn divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             var mid = UInt32((quot256 >> 32) & 0xFFFFFFFF)
             var high = UInt32((quot256 >> 64) & 0xFFFFFFFF)
 
-            return Decimal128(low, mid, high, scale_of_quot, is_negative)
+            return Decimal128(
+                low, mid, high, UInt32(scale_of_quot), is_negative
+            )
 
         # Otherwise, we need to truncate the first 29 or 28 digits
         else:
@@ -1187,7 +1223,7 @@ fn divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             var high = UInt32((truncated_quot >> 64) & 0xFFFFFFFF)
 
             return Decimal128(
-                low, mid, high, scale_of_truncated_quot, is_negative
+                low, mid, high, UInt32(scale_of_truncated_quot), is_negative
             )
 
 

--- a/src/decimo/decimal128/comparison.mojo
+++ b/src/decimo/decimal128/comparison.mojo
@@ -39,7 +39,7 @@
 Implements functions for comparison operations on Decimal128 objects.
 """
 
-import testing
+from std import testing
 
 from decimo.decimal128.decimal128 import Decimal128
 import decimo.decimal128.utility
@@ -66,15 +66,15 @@ fn compare(x: Decimal128, y: Decimal128) -> Int8:
 
     # If x is zero, it is less than any non-zero number
     elif x.is_zero():
-        return 1 if y.is_negative() else -1
+        return Int8(1) if y.is_negative() else Int8(-1)
 
     # If y is zero, it is less than any non-zero number
     elif y.is_zero():
-        return -1 if x.is_negative() else 1
+        return Int8(-1) if x.is_negative() else Int8(1)
 
     # If signs differ, the positive one is greater
     elif x.is_negative() != y.is_negative():
-        return -1 if x.is_negative() else 1
+        return Int8(-1) if x.is_negative() else Int8(1)
 
     # If they have the same sign, compare the absolute values
     elif x.is_negative():

--- a/src/decimo/decimal128/comparison.mojo
+++ b/src/decimo/decimal128/comparison.mojo
@@ -45,7 +45,7 @@ from decimo.decimal128.decimal128 import Decimal128
 import decimo.decimal128.utility
 
 
-fn compare(x: Decimal128, y: Decimal128) -> Int8:
+def compare(x: Decimal128, y: Decimal128) -> Int8:
     """
     Compares the values of two Decimal128 numbers and returns the result.
 
@@ -84,7 +84,7 @@ fn compare(x: Decimal128, y: Decimal128) -> Int8:
         return compare_absolute(x, y)
 
 
-fn compare_absolute(x: Decimal128, y: Decimal128) -> Int8:
+def compare_absolute(x: Decimal128, y: Decimal128) -> Int8:
     """
     Compares the absolute values of two Decimal128 numbers and returns the result.
 
@@ -157,7 +157,7 @@ fn compare_absolute(x: Decimal128, y: Decimal128) -> Int8:
                 return 0
 
 
-fn greater(a: Decimal128, b: Decimal128) -> Bool:
+def greater(a: Decimal128, b: Decimal128) -> Bool:
     """
     Returns True if a > b.
 
@@ -172,7 +172,7 @@ fn greater(a: Decimal128, b: Decimal128) -> Bool:
     return compare(a, b) == 1
 
 
-fn less(a: Decimal128, b: Decimal128) -> Bool:
+def less(a: Decimal128, b: Decimal128) -> Bool:
     """
     Returns True if a < b.
 
@@ -187,7 +187,7 @@ fn less(a: Decimal128, b: Decimal128) -> Bool:
     return compare(a, b) == -1
 
 
-fn greater_equal(a: Decimal128, b: Decimal128) -> Bool:
+def greater_equal(a: Decimal128, b: Decimal128) -> Bool:
     """
     Returns True if a >= b.
 
@@ -202,7 +202,7 @@ fn greater_equal(a: Decimal128, b: Decimal128) -> Bool:
     return compare(a, b) >= 0
 
 
-fn less_equal(a: Decimal128, b: Decimal128) -> Bool:
+def less_equal(a: Decimal128, b: Decimal128) -> Bool:
     """
     Returns True if a <= b.
 
@@ -217,7 +217,7 @@ fn less_equal(a: Decimal128, b: Decimal128) -> Bool:
     return not greater(a, b)
 
 
-fn equal(a: Decimal128, b: Decimal128) -> Bool:
+def equal(a: Decimal128, b: Decimal128) -> Bool:
     """
     Returns True if a == b.
 
@@ -232,7 +232,7 @@ fn equal(a: Decimal128, b: Decimal128) -> Bool:
     return compare(a, b) == 0
 
 
-fn not_equal(a: Decimal128, b: Decimal128) -> Bool:
+def not_equal(a: Decimal128, b: Decimal128) -> Bool:
     """
     Returns True if a != b.
 

--- a/src/decimo/decimal128/constants.mojo
+++ b/src/decimo/decimal128/constants.mojo
@@ -30,67 +30,67 @@ from decimo.decimal128.decimal128 import Decimal128
 
 
 @always_inline
-fn M0() -> Decimal128:
+def M0() -> Decimal128:
     """Returns 0 as a Decimal128."""
     return Decimal128(0x0, 0x0, 0x0, 0x0)
 
 
 @always_inline
-fn M1() -> Decimal128:
+def M1() -> Decimal128:
     """Returns 1 as a Decimal128."""
     return Decimal128(0x1, 0x0, 0x0, 0x0)
 
 
 @always_inline
-fn M2() -> Decimal128:
+def M2() -> Decimal128:
     """Returns 2 as a Decimal128."""
     return Decimal128(0x2, 0x0, 0x0, 0x0)
 
 
 @always_inline
-fn M3() -> Decimal128:
+def M3() -> Decimal128:
     """Returns 3 as a Decimal128."""
     return Decimal128(0x3, 0x0, 0x0, 0x0)
 
 
 @always_inline
-fn M4() -> Decimal128:
+def M4() -> Decimal128:
     """Returns 4 as a Decimal128."""
     return Decimal128(0x4, 0x0, 0x0, 0x0)
 
 
 @always_inline
-fn M5() -> Decimal128:
+def M5() -> Decimal128:
     """Returns 5 as a Decimal128."""
     return Decimal128(0x5, 0x0, 0x0, 0x0)
 
 
 @always_inline
-fn M6() -> Decimal128:
+def M6() -> Decimal128:
     """Returns 6 as a Decimal128."""
     return Decimal128(0x6, 0x0, 0x0, 0x0)
 
 
 @always_inline
-fn M7() -> Decimal128:
+def M7() -> Decimal128:
     """Returns 7 as a Decimal128."""
     return Decimal128(0x7, 0x0, 0x0, 0x0)
 
 
 @always_inline
-fn M8() -> Decimal128:
+def M8() -> Decimal128:
     """Returns 8 as a Decimal128."""
     return Decimal128(0x8, 0x0, 0x0, 0x0)
 
 
 @always_inline
-fn M9() -> Decimal128:
+def M9() -> Decimal128:
     """Returns 9 as a Decimal128."""
     return Decimal128(0x9, 0x0, 0x0, 0x0)
 
 
 @always_inline
-fn M10() -> Decimal128:
+def M10() -> Decimal128:
     """Returns 10 as a Decimal128."""
     return Decimal128(0xA, 0x0, 0x0, 0x0)
 
@@ -99,13 +99,13 @@ fn M10() -> Decimal128:
 
 
 @always_inline
-fn M0D5() -> Decimal128:
+def M0D5() -> Decimal128:
     """Returns 0.5 as a Decimal128."""
     return Decimal128(5, 0, 0, 0x10000)
 
 
 @always_inline
-fn M0D25() -> Decimal128:
+def M0D25() -> Decimal128:
     """Returns 0.25 as a Decimal128."""
     return Decimal128(25, 0, 0, 0x20000)
 
@@ -118,127 +118,127 @@ fn M0D25() -> Decimal128:
 
 
 @always_inline
-fn INV2() -> Decimal128:
+def INV2() -> Decimal128:
     """Returns 1/2 = 0.5."""
     return Decimal128(0x5, 0x0, 0x0, 0x10000)
 
 
 @always_inline
-fn INV10() -> Decimal128:
+def INV10() -> Decimal128:
     """Returns 1/10 = 0.1."""
     return Decimal128(0x1, 0x0, 0x0, 0x10000)
 
 
 @always_inline
-fn INV0D1() -> Decimal128:
+def INV0D1() -> Decimal128:
     """Returns 1/0.1 = 10."""
     return Decimal128(0xA, 0x0, 0x0, 0x0)
 
 
 @always_inline
-fn INV0D2() -> Decimal128:
+def INV0D2() -> Decimal128:
     """Returns 1/0.2 = 5."""
     return Decimal128(0x5, 0x0, 0x0, 0x0)
 
 
 @always_inline
-fn INV0D3() -> Decimal128:
+def INV0D3() -> Decimal128:
     """Returns 1/0.3 = 3.33333333333333333333333333333333..."""
     return Decimal128(0x35555555, 0xCF2607EE, 0x6BB4AFE4, 0x1C0000)
 
 
 @always_inline
-fn INV0D4() -> Decimal128:
+def INV0D4() -> Decimal128:
     """Returns 1/0.4 = 2.5."""
     return Decimal128(0x19, 0x0, 0x0, 0x10000)
 
 
 @always_inline
-fn INV0D5() -> Decimal128:
+def INV0D5() -> Decimal128:
     """Returns 1/0.5 = 2."""
     return Decimal128(0x2, 0x0, 0x0, 0x0)
 
 
 @always_inline
-fn INV0D6() -> Decimal128:
+def INV0D6() -> Decimal128:
     """Returns 1/0.6 = 1.66666666666666666666666666666667..."""
     return Decimal128(0x1AAAAAAB, 0x679303F7, 0x35DA57F2, 0x1C0000)
 
 
 @always_inline
-fn INV0D7() -> Decimal128:
+def INV0D7() -> Decimal128:
     """Returns 1/0.7 = 1.42857142857142857142857142857143..."""
     return Decimal128(0xCDB6DB6E, 0x3434DED3, 0x2E28DDAB, 0x1C0000)
 
 
 @always_inline
-fn INV0D8() -> Decimal128:
+def INV0D8() -> Decimal128:
     """Returns 1/0.8 = 1.25."""
     return Decimal128(0x7D, 0x0, 0x0, 0x20000)
 
 
 @always_inline
-fn INV0D9() -> Decimal128:
+def INV0D9() -> Decimal128:
     """Returns 1/0.9 = 1.11111111111111111111111111111111..."""
     return Decimal128(0x671C71C7, 0x450CAD4F, 0x23E6E54C, 0x1C0000)
 
 
 @always_inline
-fn INV1() -> Decimal128:
+def INV1() -> Decimal128:
     """Returns 1/1 = 1."""
     return Decimal128(0x1, 0x0, 0x0, 0x0)
 
 
 @always_inline
-fn INV1D1() -> Decimal128:
+def INV1D1() -> Decimal128:
     """Returns 1/1.1 = 0.90909090909090909090909090909091..."""
     return Decimal128(0x9A2E8BA3, 0x4FC48DCC, 0x1D5FD2E1, 0x1C0000)
 
 
 @always_inline
-fn INV1D2() -> Decimal128:
+def INV1D2() -> Decimal128:
     """Returns 1/1.2 = 0.83333333333333333333333333333333..."""
     return Decimal128(0x8D555555, 0x33C981FB, 0x1AED2BF9, 0x1C0000)
 
 
 @always_inline
-fn INV1D3() -> Decimal128:
+def INV1D3() -> Decimal128:
     """Returns 1/1.3 = 0.76923076923076923076923076923077..."""
     return Decimal128(0xC4EC4EC, 0x9243DA72, 0x18DAED83, 0x1C0000)
 
 
 @always_inline
-fn INV1D4() -> Decimal128:
+def INV1D4() -> Decimal128:
     """Returns 1/1.4 = 0.71428571428571428571428571428571..."""
     return Decimal128(0xE6DB6DB7, 0x9A1A6F69, 0x17146ED5, 0x1C0000)
 
 
 @always_inline
-fn INV1D5() -> Decimal128:
+def INV1D5() -> Decimal128:
     """Returns 1/1.5 = 0.66666666666666666666666666666667..."""
     return Decimal128(0xAAAAAAB, 0x296E0196, 0x158A8994, 0x1C0000)
 
 
 @always_inline
-fn INV1D6() -> Decimal128:
+def INV1D6() -> Decimal128:
     """Returns 1/1.6 = 0.625."""
     return Decimal128(0x271, 0x0, 0x0, 0x30000)
 
 
 @always_inline
-fn INV1D7() -> Decimal128:
+def INV1D7() -> Decimal128:
     """Returns 1/1.7 = 0.58823529411764705882352941176471..."""
     return Decimal128(0x45A5A5A6, 0xE8520166, 0x1301C4AF, 0x1C0000)
 
 
 @always_inline
-fn INV1D8() -> Decimal128:
+def INV1D8() -> Decimal128:
     """Returns 1/1.8 = 0.55555555555555555555555555555556..."""
     return Decimal128(0xB38E38E4, 0x228656A7, 0x11F372A6, 0x1C0000)
 
 
 @always_inline
-fn INV1D9() -> Decimal128:
+def INV1D9() -> Decimal128:
     """Returns 1/1.9 = 0.52631578947368421052631578947368..."""
     return Decimal128(0xAA1AF287, 0x2E2E6D0A, 0x11019509, 0x1C0000)
 
@@ -251,7 +251,7 @@ fn INV1D9() -> Decimal128:
 
 
 @always_inline
-fn N_DIVIDE_NEXT(n: Int) raises -> Decimal128:
+def N_DIVIDE_NEXT(n: Int) raises -> Decimal128:
     """
     Returns the pre-calculated value of n/(n+1) for n between 1 and 20.
 
@@ -336,7 +336,7 @@ fn N_DIVIDE_NEXT(n: Int) raises -> Decimal128:
 
 
 @always_inline
-fn PI() -> Decimal128:
+def PI() -> Decimal128:
     """Returns the value of pi (π) as a Decimal128."""
     return Decimal128(0x41B65F29, 0xB143885, 0x6582A536, 0x1C0000)
 
@@ -349,7 +349,7 @@ fn PI() -> Decimal128:
 
 
 @always_inline
-fn E() -> Decimal128:
+def E() -> Decimal128:
     """
     Returns the value of Euler's number (e) as a Decimal128.
 
@@ -360,109 +360,109 @@ fn E() -> Decimal128:
 
 
 @always_inline
-fn E2() -> Decimal128:
+def E2() -> Decimal128:
     """Returns the value of e^2 as a Decimal128."""
     return Decimal128(0xE4DFDCAE, 0x89F7E295, 0xEEC0D6E9, 0x1C0000)
 
 
 @always_inline
-fn E3() -> Decimal128:
+def E3() -> Decimal128:
     """Returns the value of e^3 as a Decimal128."""
     return Decimal128(0x236454F7, 0x62055A80, 0x40E65DE2, 0x1B0000)
 
 
 @always_inline
-fn E4() -> Decimal128:
+def E4() -> Decimal128:
     """Returns the value of e^4 as a Decimal128."""
     return Decimal128(0x7121EFD3, 0xFB318FB5, 0xB06A87FB, 0x1B0000)
 
 
 @always_inline
-fn E5() -> Decimal128:
+def E5() -> Decimal128:
     """Returns the value of e^5 as a Decimal128."""
     return Decimal128(0xD99BD974, 0x9F4BE5C7, 0x2FF472E3, 0x1A0000)
 
 
 @always_inline
-fn E6() -> Decimal128:
+def E6() -> Decimal128:
     """Returns the value of e^6 as a Decimal128."""
     return Decimal128(0xADB57A66, 0xBD7A423F, 0x825AD8FF, 0x1A0000)
 
 
 @always_inline
-fn E7() -> Decimal128:
+def E7() -> Decimal128:
     """Returns the value of e^7 as a Decimal128."""
     return Decimal128(0x22313FCF, 0x64D5D12F, 0x236F230A, 0x190000)
 
 
 @always_inline
-fn E8() -> Decimal128:
+def E8() -> Decimal128:
     """Returns the value of e^8 as a Decimal128."""
     return Decimal128(0x1E892E63, 0xD1BF8B5C, 0x6051E812, 0x190000)
 
 
 @always_inline
-fn E9() -> Decimal128:
+def E9() -> Decimal128:
     """Returns the value of e^9 as a Decimal128."""
     return Decimal128(0x34FAB691, 0xE7CD8DEA, 0x1A2EB6C3, 0x180000)
 
 
 @always_inline
-fn E10() -> Decimal128:
+def E10() -> Decimal128:
     """Returns the value of e^10 as a Decimal128."""
     return Decimal128(0xBA7F4F65, 0x58692B62, 0x472BDD8F, 0x180000)
 
 
 @always_inline
-fn E11() -> Decimal128:
+def E11() -> Decimal128:
     """Returns the value of e^11 as a Decimal128."""
     return Decimal128(0x8C2C6D20, 0x2A86F9E7, 0xC176BAAE, 0x180000)
 
 
 @always_inline
-fn E12() -> Decimal128:
+def E12() -> Decimal128:
     """Returns the value of e^12 as a Decimal128."""
     return Decimal128(0xE924992A, 0x31CDC314, 0x3496C2C4, 0x170000)
 
 
 @always_inline
-fn E13() -> Decimal128:
+def E13() -> Decimal128:
     """Returns the value of e^13 as a Decimal128."""
     return Decimal128(0x220130DB, 0xC386029A, 0x8EF393FB, 0x170000)
 
 
 @always_inline
-fn E14() -> Decimal128:
+def E14() -> Decimal128:
     """Returns the value of e^14 as a Decimal128."""
     return Decimal128(0x3A24795C, 0xC412DF01, 0x26DBB5A0, 0x160000)
 
 
 @always_inline
-fn E15() -> Decimal128:
+def E15() -> Decimal128:
     """Returns the value of e^15 as a Decimal128."""
     return Decimal128(0x6C1248BD, 0x90456557, 0x69A0AD8C, 0x160000)
 
 
 @always_inline
-fn E16() -> Decimal128:
+def E16() -> Decimal128:
     """Returns the value of e^16 as a Decimal128."""
     return Decimal128(0xB46A97D, 0x90655BBD, 0x1CB66B18, 0x150000)
 
 
 @always_inline
-fn E32() -> Decimal128:
+def E32() -> Decimal128:
     """Returns the value of e^32 as a Decimal128."""
     return Decimal128(0x18420EB, 0xCC2501E6, 0xFF24A138, 0xF0000)
 
 
 @always_inline
-fn E0D5() -> Decimal128:
+def E0D5() -> Decimal128:
     """Returns the value of e^0.5 = e^(1/2) as a Decimal128."""
     return Decimal128(0x8E99DD66, 0xC210E35C, 0x3545E717, 0x1C0000)
 
 
 @always_inline
-fn E0D25() -> Decimal128:
+def E0D25() -> Decimal128:
     """Returns the value of e^0.25 = e^(1/4) as a Decimal128."""
     return Decimal128(0xB43646F1, 0x2654858A, 0x297D3595, 0x1C0000)
 
@@ -476,7 +476,7 @@ fn E0D25() -> Decimal128:
 # The repr of the magic numbers can be obtained by the following code:
 #
 # ```mojo
-# fn print_repr_words(value: String, ln_value: String) raises:
+# def print_repr_words(value: String, ln_value: String) raises:
 #     """
 #     Prints the hex representation of a logarithm value.
 #     Args:
@@ -492,74 +492,74 @@ fn E0D25() -> Decimal128:
 
 
 @always_inline
-fn LN1() -> Decimal128:
+def LN1() -> Decimal128:
     """Returns ln(1) = 0."""
     return Decimal128(0x0, 0x0, 0x0, 0x0)
 
 
 @always_inline
-fn LN2() -> Decimal128:
+def LN2() -> Decimal128:
     """Returns ln(2) = 0.69314718055994530941723212145818..."""
     return Decimal128(0xAA7A65BF, 0x81F52F01, 0x1665943F, 0x1C0000)
 
 
 @always_inline
-fn LN10() -> Decimal128:
+def LN10() -> Decimal128:
     """Returns ln(10) = 2.30258509299404568401799145468436..."""
     return Decimal128(0x9FA69733, 0x1414B220, 0x4A668998, 0x1C0000)
 
 
 # Constants for values less than 1
 @always_inline
-fn LN0D1() -> Decimal128:
+def LN0D1() -> Decimal128:
     """Returns ln(0.1) = -2.30258509299404568401799145468436..."""
     return Decimal128(0x9FA69733, 0x1414B220, 0x4A668998, 0x801C0000)
 
 
 @always_inline
-fn LN0D2() -> Decimal128:
+def LN0D2() -> Decimal128:
     """Returns ln(0.2) = -1.60943791243410037460075933322619..."""
     return Decimal128(0xF52C3174, 0x921F831E, 0x3400F558, 0x801C0000)
 
 
 @always_inline
-fn LN0D3() -> Decimal128:
+def LN0D3() -> Decimal128:
     """Returns ln(0.3) = -1.20397280432593599262274621776184..."""
     return Decimal128(0x2B8E6822, 0x8258467, 0x26E70795, 0x801C0000)
 
 
 @always_inline
-fn LN0D4() -> Decimal128:
+def LN0D4() -> Decimal128:
     """Returns ln(0.4) = -0.91629073187415506518352721176801..."""
     return Decimal128(0x4AB1CBB6, 0x102A541D, 0x1D9B6119, 0x801C0000)
 
 
 @always_inline
-fn LN0D5() -> Decimal128:
+def LN0D5() -> Decimal128:
     """Returns ln(0.5) = -0.69314718055994530941723212145818..."""
     return Decimal128(0xAA7A65BF, 0x81F52F01, 0x1665943F, 0x801C0000)
 
 
 @always_inline
-fn LN0D6() -> Decimal128:
+def LN0D6() -> Decimal128:
     """Returns ln(0.6) = -0.51082562376599068320551409630366..."""
     return Decimal128(0x81140263, 0x86305565, 0x10817355, 0x801C0000)
 
 
 @always_inline
-fn LN0D7() -> Decimal128:
+def LN0D7() -> Decimal128:
     """Returns ln(0.7) = -0.35667494393873237891263871124118..."""
     return Decimal128(0x348BC5A8, 0x8B755D08, 0xB865892, 0x801C0000)
 
 
 @always_inline
-fn LN0D8() -> Decimal128:
+def LN0D8() -> Decimal128:
     """Returns ln(0.8) = -0.22314355131420975576629509030983..."""
     return Decimal128(0xA03765F7, 0x8E35251B, 0x735CCD9, 0x801C0000)
 
 
 @always_inline
-fn LN0D9() -> Decimal128:
+def LN0D9() -> Decimal128:
     """Returns ln(0.9) = -0.10536051565782630122750098083931..."""
     return Decimal128(0xB7763910, 0xFC3656AD, 0x3678591, 0x801C0000)
 
@@ -568,54 +568,54 @@ fn LN0D9() -> Decimal128:
 
 
 @always_inline
-fn LN1D1() -> Decimal128:
+def LN1D1() -> Decimal128:
     """Returns ln(1.1) = 0.09531017980432486004395212328077..."""
     return Decimal128(0x7212FFD1, 0x7D9A10, 0x3146328, 0x1C0000)
 
 
 @always_inline
-fn LN1D2() -> Decimal128:
+def LN1D2() -> Decimal128:
     """Returns ln(1.2) = 0.18232155679395462621171802515451..."""
     return Decimal128(0x2966635C, 0xFBC4D99C, 0x5E420E9, 0x1C0000)
 
 
 @always_inline
-fn LN1D3() -> Decimal128:
+def LN1D3() -> Decimal128:
     """Returns ln(1.3) = 0.26236426446749105203549598688095..."""
     return Decimal128(0xE0BE71FD, 0xC254E078, 0x87A39F0, 0x1C0000)
 
 
 @always_inline
-fn LN1D4() -> Decimal128:
+def LN1D4() -> Decimal128:
     """Returns ln(1.4) = 0.33647223662121293050459341021699..."""
     return Decimal128(0x75EEA016, 0xF67FD1F9, 0xADF3BAC, 0x1C0000)
 
 
 @always_inline
-fn LN1D5() -> Decimal128:
+def LN1D5() -> Decimal128:
     """Returns ln(1.5) = 0.40546510810816438197801311546435..."""
     return Decimal128(0xC99DC953, 0x89F9FEB7, 0xD19EDC3, 0x1C0000)
 
 
 @always_inline
-fn LN1D6() -> Decimal128:
+def LN1D6() -> Decimal128:
     """Returns ln(1.6) = 0.47000362924573555365093703114834..."""
     return Decimal128(0xA42FFC8, 0xF3C009E6, 0xF2FC765, 0x1C0000)
 
 
 @always_inline
-fn LN1D7() -> Decimal128:
+def LN1D7() -> Decimal128:
     """Returns ln(1.7) = 0.53062825106217039623154316318876..."""
     return Decimal128(0x64BB9ED0, 0x4AB9978F, 0x11254107, 0x1C0000)
 
 
 @always_inline
-fn LN1D8() -> Decimal128:
+def LN1D8() -> Decimal128:
     """Returns ln(1.8) = 0.58778666490211900818973114061886..."""
     return Decimal128(0xF3042CAE, 0x85BED853, 0x12FE0EAD, 0x1C0000)
 
 
 @always_inline
-fn LN1D9() -> Decimal128:
+def LN1D9() -> Decimal128:
     """Returns ln(1.9) = 0.64185388617239477599103597720349..."""
     return Decimal128(0x12F992DC, 0xE7374425, 0x14BD4A78, 0x1C0000)

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -23,8 +23,8 @@ operation dunders, and other dunders that implement traits, as well as
 mathematical methods that do not implement a trait.
 """
 
-from memory import UnsafePointer
-import testing
+from std.memory import UnsafePointer
+from std import testing
 
 import decimo.decimal128.arithmetics
 import decimo.decimal128.comparison
@@ -38,15 +38,13 @@ comptime Dec128 = Decimal128
 """A 128-bit fixed-point decimal number."""
 
 
-@register_passable("trivial")
 struct Decimal128(
     Absable,
     Comparable,
     Floatable,
     IntableRaising,
-    Representable,
     Roundable,
-    Stringable,
+    TrivialRegisterPassable,
     Writable,
 ):
     """A 128-bit fixed-point decimal number.
@@ -307,7 +305,7 @@ struct Decimal128(
             Error: If the scale is greater than MAX_SCALE.
         """
 
-        if scale > Self.MAX_SCALE:
+        if scale > UInt32(Self.MAX_SCALE):
             raise Error(
                 String(
                     "Error in Decimal128 constructor with five components:"
@@ -351,7 +349,8 @@ struct Decimal128(
             ).format(flags),
         )
         testing.assert_true(
-            ((flags & 0x00FF0000) >> Self.SCALE_SHIFT) <= Self.MAX_SCALE,
+            ((flags & 0x00FF0000) >> Self.SCALE_SHIFT)
+            <= UInt32(Self.MAX_SCALE),
             String(
                 "Error in Decimal128 constructor with four words: Scale must"
                 " be between 0 and 28, but got {}"
@@ -430,7 +429,7 @@ struct Decimal128(
         var mid: UInt32
         var flags: UInt32
 
-        if scale > Self.MAX_SCALE:
+        if scale > UInt32(Self.MAX_SCALE):
             raise Error(
                 String(
                     "Error in Decimal128 constructor with Int: Scale must be"
@@ -480,7 +479,7 @@ struct Decimal128(
                 ).format(value)
             )
 
-        if scale > Self.MAX_SCALE:
+        if scale > UInt32(Self.MAX_SCALE):
             raise Error(
                 String(
                     "Error in Decimal128 constructor with five components:"
@@ -522,7 +521,7 @@ struct Decimal128(
         - Underscore "_". It can appear anywhere between digits it is ignored.
         """
 
-        var value_string_slice = value.as_string_slice()
+        var value_string_slice = StringSlice(value)
         var value_bytes = value_string_slice.as_bytes()
         var value_bytes_len = len(value_bytes)
 
@@ -713,20 +712,20 @@ struct Decimal128(
         # TODO: The following part can be written into a function
         # because it is used in many cases
         if coef <= Decimal128.MAX_AS_UINT128:
-            if scale > Decimal128.MAX_SCALE:
+            if scale > UInt32(Decimal128.MAX_SCALE):
                 coef = decimo.decimal128.utility.round_to_keep_first_n_digits(
                     coef,
                     False,
                     Int(num_mantissa_digits)
-                    - Int(scale - Decimal128.MAX_SCALE),
+                    - Int(scale - UInt32(Decimal128.MAX_SCALE)),
                 )
-                scale = Decimal128.MAX_SCALE
+                scale = UInt32(Decimal128.MAX_SCALE)
 
             return Decimal128.from_uint128(coef, scale, mantissa_sign)
 
         else:
             var ndigits_coef = decimo.decimal128.utility.number_of_digits(coef)
-            var ndigits_quot_int_part = ndigits_coef - scale
+            var ndigits_quot_int_part = UInt32(ndigits_coef) - scale
 
             var truncated_coef = (
                 decimo.decimal128.utility.round_to_keep_first_n_digits(
@@ -734,7 +733,7 @@ struct Decimal128(
                 )
             )
             var scale_of_truncated_coef = (
-                Decimal128.MAX_NUM_DIGITS - ndigits_quot_int_part
+                UInt32(Decimal128.MAX_NUM_DIGITS) - ndigits_quot_int_part
             )
 
             if truncated_coef > Decimal128.MAX_AS_UINT128:
@@ -745,7 +744,7 @@ struct Decimal128(
                 )
                 scale_of_truncated_coef -= 1
 
-            if scale_of_truncated_coef > Decimal128.MAX_SCALE:
+            if scale_of_truncated_coef > UInt32(Decimal128.MAX_SCALE):
                 var num_digits_truncated_coef = (
                     decimo.decimal128.utility.number_of_digits(truncated_coef)
                 )
@@ -754,10 +753,13 @@ struct Decimal128(
                         truncated_coef,
                         False,
                         num_digits_truncated_coef
-                        - Int(scale_of_truncated_coef - Decimal128.MAX_SCALE),
+                        - Int(
+                            scale_of_truncated_coef
+                            - UInt32(Decimal128.MAX_SCALE)
+                        ),
                     )
                 )
-                scale_of_truncated_coef = Decimal128.MAX_SCALE
+                scale_of_truncated_coef = UInt32(Decimal128.MAX_SCALE)
 
             return Decimal128.from_uint128(
                 truncated_coef, scale_of_truncated_coef, mantissa_sign
@@ -820,7 +822,7 @@ struct Decimal128(
 
         # CASE: Denormalized number that is very close to zero
         if biased_exponent == 0:
-            return Self(0, 0, 0, Decimal128.MAX_SCALE, is_negative)
+            return Self(0, 0, 0, UInt32(Decimal128.MAX_SCALE), is_negative)
 
         # CASE: Infinity or NaN
         if biased_exponent == 0x7FF:
@@ -877,7 +879,7 @@ struct Decimal128(
         var high = UInt32((coefficient >> 64) & 0xFFFFFFFF)
 
         # Return both the significant digits and the scale
-        return Self(low, mid, high, scale, is_negative)
+        return Self(low, mid, high, UInt32(scale), is_negative)
 
     @always_inline
     fn copy(self) -> Self:
@@ -922,6 +924,10 @@ struct Decimal128(
         """Returns a string representation of the Decimal128."""
         return 'Decimal128("' + self.__str__() + '")'
 
+    fn write_repr_to[W: Writer](self, mut writer: W):
+        """Writes the debug representation to a writer."""
+        writer.write('Decimal128("', self.__str__(), '")')
+
     # ===------------------------------------------------------------------=== #
     # Type-transfer or output methods that are not dunders
     # ===------------------------------------------------------------------=== #
@@ -930,7 +936,7 @@ struct Decimal128(
         """Writes the Decimal128 to a writer.
         This implement the `write` method of the `Writer` trait.
         """
-        writer.write(String(self))
+        writer.write(self.__str__())
 
     fn repr_words(self) -> String:
         """Returns a string representation of the Decimal128's internal words.
@@ -1058,7 +1064,7 @@ struct Decimal128(
         else:
             # Insert decimal128 point at appropriate position
             var insert_pos = len(coef) - scale
-            result = coef[:insert_pos] + "." + coef[insert_pos:]
+            result = coef[byte=:insert_pos] + "." + coef[byte=insert_pos:]
 
             # Ensure we have exactly 'scale' digits after decimal128 point
             var decimal_point_pos = result.find(".")
@@ -1118,7 +1124,7 @@ struct Decimal128(
         if len(coef_str) == 1:
             result = result + coef_str + String(".0")
         else:
-            result = result + coef_str[byte=0] + String(".") + coef_str[1:]
+            result = result + coef_str[byte=0] + String(".") + coef_str[byte=1:]
 
         # Add exponent (E+XX or E-XX)
         if exponent >= 0:
@@ -1574,7 +1580,8 @@ struct Decimal128(
 
         # Set the new scale
         result.flags = (self.flags & ~Decimal128.SCALE_MASK) | (
-            UInt32(new_scale << Decimal128.SCALE_SHIFT) & Decimal128.SCALE_MASK
+            (UInt32(new_scale) << UInt32(Decimal128.SCALE_SHIFT))
+            & UInt32(Decimal128.SCALE_MASK)
         )
 
         return result
@@ -1610,7 +1617,7 @@ struct Decimal128(
 
         var result = String("\nInternal Representation Details of Decimal128\n")
         result += sep_line + "\n"
-        result += pad("Decimal128:") + String(self) + "\n"
+        result += pad("Decimal128:") + self.__str__() + "\n"
         result += pad("coefficient:") + String(self.coefficient()) + "\n"
         result += pad("scale:") + String(self.scale()) + "\n"
         result += pad("is negative:") + String(self.is_negative()) + "\n"

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -129,7 +129,7 @@ struct Decimal128(
     # Special values
     @always_inline
     @staticmethod
-    fn INFINITY() -> Self:
+    def INFINITY() -> Self:
         """Returns a Decimal representing positive infinity.
         Internal representation: `0b0000_0000_0000_0000_0000_0000_0001`.
         """
@@ -137,7 +137,7 @@ struct Decimal128(
 
     @always_inline
     @staticmethod
-    fn NEGATIVE_INFINITY() -> Self:
+    def NEGATIVE_INFINITY() -> Self:
         """Returns a Decimal128 representing negative infinity.
         Internal representation: `0b1000_0000_0000_0000_0000_0000_0001`.
         """
@@ -145,7 +145,7 @@ struct Decimal128(
 
     @always_inline
     @staticmethod
-    fn NAN() -> Self:
+    def NAN() -> Self:
         """Returns a Decimal128 representing Not a Number (NaN).
         Internal representation: `0b0000_0000_0000_0000_0000_0000_0010`.
         """
@@ -153,7 +153,7 @@ struct Decimal128(
 
     @always_inline
     @staticmethod
-    fn NEGATIVE_NAN() -> Self:
+    def NEGATIVE_NAN() -> Self:
         """Returns a Decimal128 representing negative Not a Number.
         Internal representation: `0b1000_0000_0000_0000_0000_0000_0010`.
         """
@@ -161,19 +161,19 @@ struct Decimal128(
 
     @always_inline
     @staticmethod
-    fn ZERO() -> Decimal128:
+    def ZERO() -> Decimal128:
         """Returns a Decimal128 representing 0."""
         return Self(0, 0, 0, 0)
 
     @always_inline
     @staticmethod
-    fn ONE() -> Decimal128:
+    def ONE() -> Decimal128:
         """Returns a Decimal128 representing 1."""
         return Self(1, 0, 0, 0)
 
     @always_inline
     @staticmethod
-    fn MAX() -> Decimal128:
+    def MAX() -> Decimal128:
         """
         Returns the maximum possible Decimal128 value.
         This is equivalent to 79228162514264337593543950335.
@@ -182,7 +182,7 @@ struct Decimal128(
 
     @always_inline
     @staticmethod
-    fn MIN() -> Decimal128:
+    def MIN() -> Decimal128:
         """Returns the minimum possible Decimal128 value (negative of MAX).
         This is equivalent to -79228162514264337593543950335.
         """
@@ -190,13 +190,13 @@ struct Decimal128(
 
     @always_inline
     @staticmethod
-    fn PI() -> Decimal128:
+    def PI() -> Decimal128:
         """Returns the value of pi (π) as a Decimal128."""
         return decimo.decimal128.constants.PI()
 
     @always_inline
     @staticmethod
-    fn E() -> Decimal128:
+    def E() -> Decimal128:
         """Returns the value of Euler's number (e) as a Decimal128."""
         return decimo.decimal128.constants.E()
 
@@ -204,14 +204,14 @@ struct Decimal128(
     # Constructors and life time dunder methods
     # ===------------------------------------------------------------------=== #
 
-    fn __init__(out self):
+    def __init__(out self):
         """Initializes a decimal128 instance with value 0."""
         self.low = 0x00000000
         self.mid = 0x00000000
         self.high = 0x00000000
         self.flags = 0x00000000
 
-    fn __init__(
+    def __init__(
         out self, low: UInt32, mid: UInt32, high: UInt32, flags: UInt32
     ):
         """Initializes a Decimal128 with four raw words of internal representation.
@@ -224,7 +224,7 @@ struct Decimal128(
         self.high = high
         self.flags = flags
 
-    fn __init__(
+    def __init__(
         out self,
         low: UInt32,
         mid: UInt32,
@@ -243,13 +243,13 @@ struct Decimal128(
                 "Error in `Decimal128.__init__()` with five components: ", e
             )
 
-    fn __init__(out self, value: Int):
+    def __init__(out self, value: Int):
         """Initializes a Decimal128 from an integer.
         See `from_int()` for more information.
         """
         self = Decimal128.from_int(value)
 
-    fn __init__(out self, value: Int, scale: UInt32) raises:
+    def __init__(out self, value: Int, scale: UInt32) raises:
         """Initializes a Decimal128 from an integer.
         See `from_int()` for more information.
         """
@@ -258,7 +258,7 @@ struct Decimal128(
         except e:
             raise Error("Error in `Decimal128.__init__()` with Int: ", e)
 
-    fn __init__(out self, value: String) raises:
+    def __init__(out self, value: String) raises:
         """Initializes a Decimal128 from a string representation.
         See `from_string()` for more information.
         """
@@ -267,7 +267,7 @@ struct Decimal128(
         except e:
             raise Error("Error in `Decimal__init__()` with String: ", e)
 
-    fn __init__(out self, value: Float64) raises:
+    def __init__(out self, value: Float64) raises:
         """Initializes a Decimal128 from a floating-point value.
         See `from_float` for more information.
         """
@@ -282,7 +282,7 @@ struct Decimal128(
     # ===------------------------------------------------------------------=== #
 
     @staticmethod
-    fn from_components(
+    def from_components(
         low: UInt32,
         mid: UInt32,
         high: UInt32,
@@ -320,7 +320,7 @@ struct Decimal128(
         return Self(low, mid, high, flags)
 
     @staticmethod
-    fn from_words(
+    def from_words(
         low: UInt32, mid: UInt32, high: UInt32, flags: UInt32
     ) raises -> Self:
         """Initializes a Decimal128 with four raw words of internal representation.
@@ -360,7 +360,7 @@ struct Decimal128(
         return Self(low, mid, high, flags)
 
     @staticmethod
-    fn from_int(value: Int) -> Self:
+    def from_int(value: Int) -> Self:
         """Initializes a Decimal128 from an integer.
 
         Args:
@@ -399,7 +399,7 @@ struct Decimal128(
         return Self(low, mid, 0, flags)
 
     @staticmethod
-    fn from_int(value: Int, scale: UInt32) raises -> Self:
+    def from_int(value: Int, scale: UInt32) raises -> Self:
         """Initializes a Decimal128 from an integer and a scale.
 
         Args:
@@ -453,7 +453,7 @@ struct Decimal128(
         return Self(low, mid, 0, flags)
 
     @staticmethod
-    fn from_uint128(
+    def from_uint128(
         value: UInt128, scale: UInt32 = 0, sign: Bool = False
     ) raises -> Decimal128:
         """Initializes a Decimal128 from a UInt128 value.
@@ -494,7 +494,7 @@ struct Decimal128(
         return result
 
     @staticmethod
-    fn from_string(value: String) raises -> Decimal128:
+    def from_string(value: String) raises -> Decimal128:
         """Initializes a Decimal128 from a string representation.
 
         Args:
@@ -766,7 +766,7 @@ struct Decimal128(
             )
 
     @staticmethod
-    fn from_float(value: Float64) raises -> Decimal128:
+    def from_float(value: Float64) raises -> Decimal128:
         """Initializes a Decimal128 from a floating-point value.
         The reliability of this method is limited by the precision of Float64.
         Float64 is reliable up to 15 significant digits and marginally
@@ -882,12 +882,12 @@ struct Decimal128(
         return Self(low, mid, high, UInt32(scale), is_negative)
 
     @always_inline
-    fn copy(self) -> Self:
+    def copy(self) -> Self:
         """Returns a copy of the Decimal128."""
         return Self(self.low, self.mid, self.high, self.flags)
 
     @always_inline
-    fn clone(self) -> Self:
+    def clone(self) -> Self:
         """Returns a copy of the Decimal128."""
         return Self(self.low, self.mid, self.high, self.flags)
 
@@ -895,7 +895,7 @@ struct Decimal128(
     # Output dunders, type-transfer dunders
     # ===------------------------------------------------------------------=== #
 
-    fn __float__(self) -> Float64:
+    def __float__(self) -> Float64:
         """Converts this Decimal128 to a floating-point value.
         Because Decimal128 is fixed-point, this may lose precision.
 
@@ -908,13 +908,13 @@ struct Decimal128(
 
         return result
 
-    fn __int__(self) raises -> Int:
+    def __int__(self) raises -> Int:
         """Returns the integral part of the Decimal128 as Int.
         See `to_int()` for more information.
         """
         return self.to_int()
 
-    fn write_repr_to[W: Writer](self, mut writer: W):
+    def write_repr_to[W: Writer](self, mut writer: W):
         """Writes the debug representation to a writer."""
         writer.write('Decimal128("', self.to_str(), '")')
 
@@ -922,13 +922,13 @@ struct Decimal128(
     # Type-transfer or output methods that are not dunders
     # ===------------------------------------------------------------------=== #
 
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """Writes the Decimal128 to a writer.
         This implement the `write` method of the `Writer` trait.
         """
         writer.write(self.to_str())
 
-    fn repr_words(self) -> String:
+    def repr_words(self) -> String:
         """Returns a string representation of the Decimal128's internal words.
         `Decimal128.from_words(low, mid, high, flags)`.
         """
@@ -944,7 +944,7 @@ struct Decimal128(
             + ")"
         )
 
-    fn repr_components(self) -> String:
+    def repr_components(self) -> String:
         """Returns a string representation of the Decimal128's five components.
         `Decimal128.from_components(low, mid, high, scale, sign)`.
         """
@@ -964,7 +964,7 @@ struct Decimal128(
             + ")"
         )
 
-    fn to_int(self) raises -> Int:
+    def to_int(self) raises -> Int:
         """Returns the integral part of the Decimal128 as Int.
         If the Decimal128 is too large to fit in Int, an error is raised.
 
@@ -979,7 +979,7 @@ struct Decimal128(
         except e:
             raise Error("Error in `to_int()`: ", e)
 
-    fn to_int64(self) raises -> Int64:
+    def to_int64(self) raises -> Int64:
         """Returns the integral part of the Decimal128 as Int64.
         If the Decimal128 is too large to fit in Int64, an error is raised.
 
@@ -999,14 +999,14 @@ struct Decimal128(
 
         return Int64(result & 0xFFFF_FFFF_FFFF_FFFF)
 
-    fn to_int128(self) -> Int128:
+    def to_int128(self) -> Int128:
         """Returns the signed integral part of the Decimal128."""
 
         var res = Int128(self.to_uint128())
 
         return -res if self.is_negative() else res
 
-    fn to_uint128(self) -> UInt128:
+    def to_uint128(self) -> UInt128:
         """Returns the absolute integral part of the Decimal128 as UInt128."""
         var res: UInt128
 
@@ -1028,7 +1028,7 @@ struct Decimal128(
 
         return res
 
-    fn to_str(self) -> String:
+    def to_str(self) -> String:
         """Returns string representation of the Decimal128.
         Preserves trailing zeros after decimal128 point to match the scale.
         """
@@ -1070,7 +1070,7 @@ struct Decimal128(
 
         return result
 
-    fn to_str_scientific(self) raises -> String:
+    def to_str_scientific(self) raises -> String:
         """Returns a string representation of this Decimal128 in scientific notation.
 
         Returns:
@@ -1124,7 +1124,7 @@ struct Decimal128(
 
         return result
 
-    fn as_tuple(self) -> Tuple[Bool, UInt128, Int]:
+    def as_tuple(self) -> Tuple[Bool, UInt128, Int]:
         """Returns a tuple representation of the number.
         Tuple(sign, signficand, exponent).
 
@@ -1141,14 +1141,14 @@ struct Decimal128(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __abs__(self) -> Self:
+    def __abs__(self) -> Self:
         """Returns the absolute value of this Decimal128.
         See `absolute()` for more information.
         """
         return decimo.decimal128.arithmetics.absolute(self)
 
     @always_inline
-    fn __neg__(self) -> Self:
+    def __neg__(self) -> Self:
         """Returns the negation of this Decimal128.
         See `negative()` for more information.
         """
@@ -1161,63 +1161,63 @@ struct Decimal128(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __add__(self, other: Self) raises -> Self:
+    def __add__(self, other: Self) raises -> Self:
         return decimo.decimal128.arithmetics.add(self, other)
 
     @always_inline
-    fn __add__(self, other: Int) raises -> Self:
+    def __add__(self, other: Int) raises -> Self:
         return decimo.decimal128.arithmetics.add(self, Self(other))
 
     @always_inline
-    fn __sub__(self, other: Self) raises -> Self:
+    def __sub__(self, other: Self) raises -> Self:
         return decimo.decimal128.arithmetics.subtract(self, other)
 
     @always_inline
-    fn __sub__(self, other: Int) raises -> Self:
+    def __sub__(self, other: Int) raises -> Self:
         return decimo.decimal128.arithmetics.subtract(self, Self(other))
 
     @always_inline
-    fn __mul__(self, other: Self) raises -> Self:
+    def __mul__(self, other: Self) raises -> Self:
         return decimo.decimal128.arithmetics.multiply(self, other)
 
     @always_inline
-    fn __mul__(self, other: Int) raises -> Self:
+    def __mul__(self, other: Int) raises -> Self:
         return decimo.decimal128.arithmetics.multiply(self, Self(other))
 
     @always_inline
-    fn __truediv__(self, other: Self) raises -> Self:
+    def __truediv__(self, other: Self) raises -> Self:
         return decimo.decimal128.arithmetics.divide(self, other)
 
     @always_inline
-    fn __truediv__(self, other: Int) raises -> Self:
+    def __truediv__(self, other: Int) raises -> Self:
         return decimo.decimal128.arithmetics.divide(self, Self(other))
 
     @always_inline
-    fn __floordiv__(self, other: Self) raises -> Self:
+    def __floordiv__(self, other: Self) raises -> Self:
         """Performs truncate division with // operator."""
         return decimo.decimal128.arithmetics.truncate_divide(self, other)
 
     @always_inline
-    fn __floordiv__(self, other: Int) raises -> Self:
+    def __floordiv__(self, other: Int) raises -> Self:
         """Performs truncate division with // operator."""
         return decimo.decimal128.arithmetics.truncate_divide(self, Self(other))
 
     @always_inline
-    fn __mod__(self, other: Self) raises -> Self:
+    def __mod__(self, other: Self) raises -> Self:
         """Performs truncate modulo."""
         return decimo.decimal128.arithmetics.modulo(self, other)
 
     @always_inline
-    fn __mod__(self, other: Int) raises -> Self:
+    def __mod__(self, other: Int) raises -> Self:
         """Performs truncate modulo."""
         return decimo.decimal128.arithmetics.modulo(self, Self(other))
 
     @always_inline
-    fn __pow__(self, exponent: Self) raises -> Self:
+    def __pow__(self, exponent: Self) raises -> Self:
         return decimo.decimal128.exponential.power(self, exponent)
 
     @always_inline
-    fn __pow__(self, exponent: Int) raises -> Self:
+    def __pow__(self, exponent: Int) raises -> Self:
         return decimo.decimal128.exponential.power(self, exponent)
 
     # ===------------------------------------------------------------------=== #
@@ -1228,28 +1228,28 @@ struct Decimal128(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __radd__(self, other: Int) raises -> Self:
+    def __radd__(self, other: Int) raises -> Self:
         return decimo.decimal128.arithmetics.add(Self(other), self)
 
     @always_inline
-    fn __rsub__(self, other: Int) raises -> Self:
+    def __rsub__(self, other: Int) raises -> Self:
         return decimo.decimal128.arithmetics.subtract(Self(other), self)
 
     @always_inline
-    fn __rmul__(self, other: Int) raises -> Self:
+    def __rmul__(self, other: Int) raises -> Self:
         return decimo.decimal128.arithmetics.multiply(Self(other), self)
 
     @always_inline
-    fn __rtruediv__(self, other: Int) raises -> Self:
+    def __rtruediv__(self, other: Int) raises -> Self:
         return decimo.decimal128.arithmetics.divide(Self(other), self)
 
     @always_inline
-    fn __rfloordiv__(self, other: Int) raises -> Self:
+    def __rfloordiv__(self, other: Int) raises -> Self:
         """Performs truncate division with // operator."""
         return decimo.decimal128.arithmetics.truncate_divide(Self(other), self)
 
     @always_inline
-    fn __rmod__(self, other: Int) raises -> Self:
+    def __rmod__(self, other: Int) raises -> Self:
         """Performs truncate modulo."""
         return decimo.decimal128.arithmetics.modulo(Self(other), self)
 
@@ -1261,49 +1261,49 @@ struct Decimal128(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __iadd__(mut self, other: Self) raises:
+    def __iadd__(mut self, other: Self) raises:
         self = decimo.decimal128.arithmetics.add(self, other)
 
     @always_inline
-    fn __iadd__(mut self, other: Int) raises:
+    def __iadd__(mut self, other: Int) raises:
         self = decimo.decimal128.arithmetics.add(self, Self(other))
 
     @always_inline
-    fn __isub__(mut self, other: Self) raises:
+    def __isub__(mut self, other: Self) raises:
         self = decimo.decimal128.arithmetics.subtract(self, other)
 
     @always_inline
-    fn __isub__(mut self, other: Int) raises:
+    def __isub__(mut self, other: Int) raises:
         self = decimo.decimal128.arithmetics.subtract(self, Self(other))
 
     @always_inline
-    fn __imul__(mut self, other: Self) raises:
+    def __imul__(mut self, other: Self) raises:
         self = decimo.decimal128.arithmetics.multiply(self, other)
 
     @always_inline
-    fn __imul__(mut self, other: Int) raises:
+    def __imul__(mut self, other: Int) raises:
         self = decimo.decimal128.arithmetics.multiply(self, Self(other))
 
     @always_inline
-    fn __itruediv__(mut self, other: Self) raises:
+    def __itruediv__(mut self, other: Self) raises:
         self = decimo.decimal128.arithmetics.divide(self, other)
 
     @always_inline
-    fn __itruediv__(mut self, other: Int) raises:
+    def __itruediv__(mut self, other: Int) raises:
         self = decimo.decimal128.arithmetics.divide(self, Self(other))
 
     @always_inline
-    fn __ifloordiv__(mut self, other: Self) raises:
+    def __ifloordiv__(mut self, other: Self) raises:
         """Performs truncate division with // operator."""
         self = decimo.decimal128.arithmetics.truncate_divide(self, other)
 
     @always_inline
-    fn __ifloordiv__(mut self, other: Int) raises:
+    def __ifloordiv__(mut self, other: Int) raises:
         """Performs truncate division with // operator."""
         self = decimo.decimal128.arithmetics.truncate_divide(self, Self(other))
 
     @always_inline
-    fn __imod__(mut self, other: Self) raises:
+    def __imod__(mut self, other: Self) raises:
         """Performs truncate modulo."""
         self = decimo.decimal128.arithmetics.modulo(self, other)
 
@@ -1313,42 +1313,42 @@ struct Decimal128(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __gt__(self, other: Decimal128) -> Bool:
+    def __gt__(self, other: Decimal128) -> Bool:
         """Greater than comparison operator.
         See `greater()` for more information.
         """
         return decimo.decimal128.comparison.greater(self, other)
 
     @always_inline
-    fn __lt__(self, other: Decimal128) -> Bool:
+    def __lt__(self, other: Decimal128) -> Bool:
         """Less than comparison operator.
         See `less()` for more information.
         """
         return decimo.decimal128.comparison.less(self, other)
 
     @always_inline
-    fn __ge__(self, other: Decimal128) -> Bool:
+    def __ge__(self, other: Decimal128) -> Bool:
         """Greater than or equal comparison operator.
         See `greater_equal()` for more information.
         """
         return decimo.decimal128.comparison.greater_equal(self, other)
 
     @always_inline
-    fn __le__(self, other: Decimal128) -> Bool:
+    def __le__(self, other: Decimal128) -> Bool:
         """Less than or equal comparison operator.
         See `less_equal()` for more information.
         """
         return decimo.decimal128.comparison.less_equal(self, other)
 
     @always_inline
-    fn __eq__(self, other: Decimal128) -> Bool:
+    def __eq__(self, other: Decimal128) -> Bool:
         """Equality comparison operator.
         See `equal()` for more information.
         """
         return decimo.decimal128.comparison.equal(self, other)
 
     @always_inline
-    fn __ne__(self, other: Decimal128) -> Bool:
+    def __ne__(self, other: Decimal128) -> Bool:
         """Inequality comparison operator.
         See `not_equal()` for more information.
         """
@@ -1360,7 +1360,7 @@ struct Decimal128(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn __round__(self, ndigits: Int) -> Self:
+    def __round__(self, ndigits: Int) -> Self:
         """Rounds this Decimal128 to the specified number of decimal128 places.
         If `ndigits` is not given, rounds to 0 decimal128 places.
         If rounding causes overflow, returns the value itself.
@@ -1378,7 +1378,7 @@ struct Decimal128(
             return self
 
     @always_inline
-    fn __round__(self) -> Self:
+    def __round__(self) -> Self:
         """**OVERLOAD**."""
         try:
             return decimo.decimal128.rounding.round(
@@ -1393,7 +1393,7 @@ struct Decimal128(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn round(
+    def round(
         self,
         ndigits: Int = 0,
         rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,
@@ -1409,7 +1409,7 @@ struct Decimal128(
         )
 
     @always_inline
-    fn quantize(
+    def quantize(
         self,
         exp: Decimal128,
         rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,
@@ -1420,48 +1420,48 @@ struct Decimal128(
         return decimo.decimal128.rounding.quantize(self, exp, rounding_mode)
 
     @always_inline
-    fn exp(self) raises -> Self:
+    def exp(self) raises -> Self:
         """Calculates the exponential of this Decimal128.
         See `exp()` for more information.
         """
         return decimo.decimal128.exponential.exp(self)
 
     @always_inline
-    fn ln(self) raises -> Self:
+    def ln(self) raises -> Self:
         """Calculates the natural logarithm of this Decimal128.
         See `ln()` for more information.
         """
         return decimo.decimal128.exponential.ln(self)
 
     @always_inline
-    fn log10(self) raises -> Decimal128:
+    def log10(self) raises -> Decimal128:
         """Computes the base-10 logarithm of this Decimal128."""
         return decimo.decimal128.exponential.log10(self)
 
     @always_inline
-    fn log(self, base: Decimal128) raises -> Decimal128:
+    def log(self, base: Decimal128) raises -> Decimal128:
         """Computes the logarithm of this Decimal128 with an arbitrary base."""
         return decimo.decimal128.exponential.log(self, base)
 
     @always_inline
-    fn power(self, exponent: Int) raises -> Decimal128:
+    def power(self, exponent: Int) raises -> Decimal128:
         """Raises this Decimal128 to the power of an integer."""
         return decimo.decimal128.exponential.power(self, Self(exponent))
 
     @always_inline
-    fn power(self, exponent: Decimal128) raises -> Decimal128:
+    def power(self, exponent: Decimal128) raises -> Decimal128:
         """Raises this Decimal128 to the power of another Decimal128."""
         return decimo.decimal128.exponential.power(self, exponent)
 
     @always_inline
-    fn root(self, n: Int) raises -> Self:
+    def root(self, n: Int) raises -> Self:
         """Calculates the n-th root of this Decimal128.
         See `root()` for more information.
         """
         return decimo.decimal128.exponential.root(self, n)
 
     @always_inline
-    fn sqrt(self) raises -> Self:
+    def sqrt(self) raises -> Self:
         """Calculates the square root of this Decimal128.
         See `sqrt()` for more information.
         """
@@ -1472,7 +1472,7 @@ struct Decimal128(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    fn coefficient(self) -> UInt128:
+    def coefficient(self) -> UInt128:
         """Returns the unscaled integer coefficient as an UInt128 value.
         This is the absolute value of the decimal128 digits without considering
         the scale.
@@ -1495,7 +1495,7 @@ struct Decimal128(
         #     | UInt128(self.low)
         # )
 
-    fn extend_precision(self, var precision_diff: Int) raises -> Decimal128:
+    def extend_precision(self, var precision_diff: Int) raises -> Decimal128:
         """Returns a number with additional decimal128 places (trailing zeros).
         This multiplies the coefficient by 10^precision_diff and increases
         the scale accordingly, preserving the numeric value.
@@ -1576,7 +1576,7 @@ struct Decimal128(
 
         return result
 
-    fn internal_representation(self) -> String:
+    def internal_representation(self) -> String:
         """Returns the internal representation details as a String."""
         # All labels
         var labels = List[String]()
@@ -1600,7 +1600,7 @@ struct Decimal128(
 
         var col = max_label_len + 4  # 4 spaces after longest label
 
-        fn pad(label: String) -> String:
+        def pad(label: String) -> String:
             return label + String(" ") * (col - len(label))
 
         var sep_line = String("-") * (col + 30)
@@ -1622,12 +1622,12 @@ struct Decimal128(
         result += sep_line
         return result^
 
-    fn print_internal_representation(self):
+    def print_internal_representation(self):
         """Prints the internal representation details of a Decimal128."""
         print(self.internal_representation())
 
     @always_inline
-    fn is_integer(self) -> Bool:
+    def is_integer(self) -> Bool:
         """Determines whether this Decimal128 value represents an integer.
         A Decimal128 represents an integer when it has no fractional part
         (i.e., all digits after the decimal128 point are zero).
@@ -1655,12 +1655,12 @@ struct Decimal128(
         ) == 0
 
     @always_inline
-    fn is_negative(self) -> Bool:
+    def is_negative(self) -> Bool:
         """Returns True if this Decimal128 is negative."""
         return (self.flags & Self.SIGN_MASK) != 0
 
     @always_inline
-    fn is_one(self) -> Bool:
+    def is_one(self) -> Bool:
         """Returns True if this Decimal128 represents the value 1.
         If 10^scale == coefficient, then it's one.
         `1` and `1.00` are considered ones.
@@ -1680,7 +1680,7 @@ struct Decimal128(
         return False
 
     @always_inline
-    fn is_zero(self) -> Bool:
+    def is_zero(self) -> Bool:
         """Returns True if this Decimal128 represents zero.
         A decimal128 is zero when all coefficient parts (low, mid, high) are zero,
         regardless of its sign or scale.
@@ -1688,23 +1688,23 @@ struct Decimal128(
         return self.low == 0 and self.mid == 0 and self.high == 0
 
     @always_inline
-    fn is_infinity(self) -> Bool:
+    def is_infinity(self) -> Bool:
         """Returns True if this Decimal128 is positive or negative infinity."""
         return (self.flags & Self.INFINITY_MASK) != 0
 
     @always_inline
-    fn is_nan(self) -> Bool:
+    def is_nan(self) -> Bool:
         """Returns True if this Decimal128 is NaN (Not a Number)."""
         return (self.flags & Self.NAN_MASK) != 0
 
     @always_inline
-    fn scale(self) -> Int:
+    def scale(self) -> Int:
         """Returns the scale (number of decimal128 places) of this Decimal128.
         """
         return Int((self.flags & Self.SCALE_MASK) >> Self.SCALE_SHIFT)
 
     @always_inline
-    fn number_of_significant_digits(self) -> Int:
+    def number_of_significant_digits(self) -> Int:
         """Returns the number of significant digits in the Decimal128.
         The number of significant digits is the total number of digits in the
         coefficient, excluding leading zeros but including trailing zeros.

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -914,19 +914,9 @@ struct Decimal128(
         """
         return self.to_int()
 
-    fn __str__(self) -> String:
-        """Returns string representation of the Decimal128.
-        See `to_str()` for more information.
-        """
-        return self.to_str()
-
-    fn __repr__(self) -> String:
-        """Returns a string representation of the Decimal128."""
-        return 'Decimal128("' + self.__str__() + '")'
-
     fn write_repr_to[W: Writer](self, mut writer: W):
         """Writes the debug representation to a writer."""
-        writer.write('Decimal128("', self.__str__(), '")')
+        writer.write('Decimal128("', self.to_str(), '")')
 
     # ===------------------------------------------------------------------=== #
     # Type-transfer or output methods that are not dunders
@@ -936,7 +926,7 @@ struct Decimal128(
         """Writes the Decimal128 to a writer.
         This implement the `write` method of the `Writer` trait.
         """
-        writer.write(self.__str__())
+        writer.write(self.to_str())
 
     fn repr_words(self) -> String:
         """Returns a string representation of the Decimal128's internal words.
@@ -1617,7 +1607,7 @@ struct Decimal128(
 
         var result = String("\nInternal Representation Details of Decimal128\n")
         result += sep_line + "\n"
-        result += pad("Decimal128:") + self.__str__() + "\n"
+        result += pad("Decimal128:") + self.to_str() + "\n"
         result += pad("coefficient:") + String(self.coefficient()) + "\n"
         result += pad("scale:") + String(self.scale()) + "\n"
         result += pad("is negative:") + String(self.is_negative()) + "\n"

--- a/src/decimo/decimal128/exponential.mojo
+++ b/src/decimo/decimal128/exponential.mojo
@@ -16,9 +16,9 @@
 
 """Implements exponential functions for the Decimal128 type."""
 
-import math as builtin_math
-import testing
-import time
+import std.math
+from std import testing
+from std import time
 
 import decimo.decimal128.constants
 import decimo.decimal128.special
@@ -241,7 +241,7 @@ fn root(x: Decimal128, n: Int) raises -> Decimal128:
             10
         ) ** (Float64(remainder) / Float64(n) - 1)
         guess = Decimal128.from_uint128(
-            UInt128(float_root), scale=dividend + 1, sign=False
+            UInt128(float_root), scale=UInt32(dividend + 1), sign=False
         )
 
     # var t_initial_guess = time.perf_counter_ns()
@@ -297,7 +297,7 @@ fn root(x: Decimal128, n: Int) raises -> Decimal128:
             if guess_coef_powered == x_coef:
                 return Decimal128.from_uint128(
                     guess_coef,
-                    scale=guess.scale() - num_digits_to_decrease,
+                    scale=UInt32(guess.scale() - num_digits_to_decrease),
                     sign=False,
                 )
             if (
@@ -307,7 +307,7 @@ fn root(x: Decimal128, n: Int) raises -> Decimal128:
             ):
                 return Decimal128.from_uint128(
                     guess_coef // 10,
-                    scale=guess.scale() - num_digits_to_decrease - 1,
+                    scale=UInt32(guess.scale() - num_digits_to_decrease - 1),
                     sign=False,
                 )
 
@@ -349,22 +349,22 @@ fn sqrt(x: Decimal128) raises -> Decimal128:
 
     # For numbers with zero scale (true integers)
     if x_scale == 0:
-        var float_sqrt = builtin_math.sqrt(Float64(x_coef))
+        var float_sqrt = std.math.sqrt(Float64(x_coef))
         guess = Decimal128.from_uint128(UInt128(round(float_sqrt)))
 
     # For numbers with even scale
     elif x_scale % 2 == 0:
-        var float_sqrt = builtin_math.sqrt(Float64(x_coef))
+        var float_sqrt = std.math.sqrt(Float64(x_coef))
         guess = Decimal128.from_uint128(
-            UInt128(float_sqrt), scale=x_scale >> 1, sign=False
+            UInt128(float_sqrt), scale=UInt32(x_scale >> 1), sign=False
         )
         # print("DEBUG: scale is even")
 
     # For numbers with odd scale
     else:
-        var float_sqrt = builtin_math.sqrt(Float64(x_coef)) * Float64(3.15625)
+        var float_sqrt = std.math.sqrt(Float64(x_coef)) * Float64(3.15625)
         guess = Decimal128.from_uint128(
-            UInt128(float_sqrt), scale=(x_scale + 1) >> 1, sign=False
+            UInt128(float_sqrt), scale=UInt32((x_scale + 1) >> 1), sign=False
         )
         # print("DEBUG: scale is odd")
 
@@ -432,7 +432,7 @@ fn sqrt(x: Decimal128) raises -> Decimal128:
             ):
                 return Decimal128.from_uint128(
                     guess_coef,
-                    scale=guess.scale() - num_digits_to_decrease,
+                    scale=UInt32(guess.scale() - num_digits_to_decrease),
                     sign=False,
                 )
 
@@ -1001,7 +1001,7 @@ fn log10(x: Decimal128) raises -> Decimal128:
         if x_scale == 0:
             return Decimal128.ZERO()
         else:
-            return Decimal128(x_scale, 0, 0, 0x8000_0000)
+            return Decimal128(UInt32(x_scale), 0, 0, 0x8000_0000)
 
     var ten_to_power_of_scale = decimo.decimal128.utility.power_of_10[
         DType.uint128
@@ -1020,7 +1020,7 @@ fn log10(x: Decimal128) raises -> Decimal128:
             integeral_part //= 10
             exponent += 1
         if integeral_part == 1:
-            return Decimal128(exponent, 0, 0, 0)
+            return Decimal128(UInt32(exponent), 0, 0, 0)
         else:
             pass
 

--- a/src/decimo/decimal128/exponential.mojo
+++ b/src/decimo/decimal128/exponential.mojo
@@ -29,7 +29,7 @@ import decimo.decimal128.utility
 # ===----------------------------------------------------------------------=== #
 
 
-fn power(base: Decimal128, exponent: Decimal128) raises -> Decimal128:
+def power(base: Decimal128, exponent: Decimal128) raises -> Decimal128:
     """Raises a Decimal128 base to an arbitrary Decimal128 exponent power.
 
     This function handles both integer and non-integer exponents using the
@@ -88,7 +88,7 @@ fn power(base: Decimal128, exponent: Decimal128) raises -> Decimal128:
         raise Error("Error in `power()` with Decimal128 exponent: ", e)
 
 
-fn power(base: Decimal128, exponent: Int) raises -> Decimal128:
+def power(base: Decimal128, exponent: Int) raises -> Decimal128:
     """Raises a Decimal128 base to an integer power.
 
     Args:
@@ -147,7 +147,7 @@ fn power(base: Decimal128, exponent: Int) raises -> Decimal128:
     return result
 
 
-fn root(x: Decimal128, n: Int) raises -> Decimal128:
+def root(x: Decimal128, n: Int) raises -> Decimal128:
     """Calculates the n-th root of a Decimal128 value using Newton-Raphson method.
 
     Args:
@@ -320,7 +320,7 @@ fn root(x: Decimal128, n: Int) raises -> Decimal128:
     return guess
 
 
-fn sqrt(x: Decimal128) raises -> Decimal128:
+def sqrt(x: Decimal128) raises -> Decimal128:
     """Computes the square root of a Decimal128 value using Newton-Raphson method.
 
     Args:
@@ -444,7 +444,7 @@ fn sqrt(x: Decimal128) raises -> Decimal128:
 # ===----------------------------------------------------------------------=== #
 
 
-fn exp(x: Decimal128) raises -> Decimal128:
+def exp(x: Decimal128) raises -> Decimal128:
     """Calculates e^x for any Decimal128 value using optimized range reduction.
     x should be no greater than 66 to avoid overflow.
 
@@ -597,7 +597,7 @@ fn exp(x: Decimal128) raises -> Decimal128:
     return exp_main * exp_remainder
 
 
-fn exp_series(x: Decimal128) raises -> Decimal128:
+def exp_series(x: Decimal128) raises -> Decimal128:
     """Calculates e^x using Taylor series expansion.
     Do not use this function for values larger than 1, but `exp()` instead.
 
@@ -652,7 +652,7 @@ fn exp_series(x: Decimal128) raises -> Decimal128:
 # ===----------------------------------------------------------------------=== #
 
 
-fn ln(x: Decimal128) raises -> Decimal128:
+def ln(x: Decimal128) raises -> Decimal128:
     """Calculates the natural logarithm (ln) of a Decimal128 value.
 
     Args:
@@ -857,7 +857,7 @@ fn ln(x: Decimal128) raises -> Decimal128:
     return result
 
 
-fn ln_series(z: Decimal128) raises -> Decimal128:
+def ln_series(z: Decimal128) raises -> Decimal128:
     """Calculates ln(1+z) using Taylor series expansion at 1.
     For best accuracy, |z| should be small (< 0.5).
 
@@ -915,7 +915,7 @@ fn ln_series(z: Decimal128) raises -> Decimal128:
     return result
 
 
-fn log(x: Decimal128, base: Decimal128) raises -> Decimal128:
+def log(x: Decimal128, base: Decimal128) raises -> Decimal128:
     """Calculates the logarithm of a Decimal128 with respect to an arbitrary base.
 
     Args:
@@ -970,7 +970,7 @@ fn log(x: Decimal128, base: Decimal128) raises -> Decimal128:
     return ln_x / ln_base
 
 
-fn log10(x: Decimal128) raises -> Decimal128:
+def log10(x: Decimal128) raises -> Decimal128:
     """Calculates the base-10 logarithm (log10) of a Decimal128 value.
 
     Args:

--- a/src/decimo/decimal128/rounding.mojo
+++ b/src/decimo/decimal128/rounding.mojo
@@ -29,7 +29,7 @@
 Implements functions for mathematical operations on Decimal128 objects.
 """
 
-import testing
+from std import testing
 
 from decimo.decimal128.decimal128 import Decimal128
 from decimo.rounding_mode import RoundingMode
@@ -125,7 +125,7 @@ fn round(
             # In other cases, return the result
             else:
                 return Decimal128.from_uint128(
-                    res_coef, scale=ndigits, sign=number.is_negative()
+                    res_coef, scale=UInt32(ndigits), sign=number.is_negative()
                 )
 
     # CASE: If ndigits is smaller than the current scale
@@ -155,14 +155,14 @@ fn round(
 
         if ndigits >= 0:
             return Decimal128.from_uint128(
-                res_coef, scale=ndigits, sign=number.is_negative()
+                res_coef, scale=UInt32(ndigits), sign=number.is_negative()
             )
 
         # if `ndigits` is negative and `ndigits_to_keep` >= 0, scale up the result
         elif ndigits_to_keep >= 0:
             res_coef *= UInt128(10) ** (-ndigits)
             return Decimal128.from_uint128(
-                res_coef, scale=0, sign=number.is_negative()
+                res_coef, scale=UInt32(0), sign=number.is_negative()
             )
 
         # if `ndigits` is negative and `ndigits_to_keep` < 0, return 0

--- a/src/decimo/decimal128/rounding.mojo
+++ b/src/decimo/decimal128/rounding.mojo
@@ -40,7 +40,7 @@ import decimo.decimal128.utility
 # ===------------------------------------------------------------------------===#
 
 
-fn round(
+def round(
     number: Decimal128,
     ndigits: Int = 0,
     rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,
@@ -170,7 +170,7 @@ fn round(
             return Decimal128.ZERO()
 
 
-fn quantize(
+def quantize(
     value: Decimal128,
     exp: Decimal128,
     rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,

--- a/src/decimo/decimal128/special.mojo
+++ b/src/decimo/decimal128/special.mojo
@@ -21,7 +21,7 @@
 """Implements functions for special operations on Decimal128 objects."""
 
 
-fn factorial(n: Int) raises -> Decimal128:
+def factorial(n: Int) raises -> Decimal128:
     """Calculates the factorial of a non-negative integer.
 
     Args:
@@ -121,7 +121,7 @@ fn factorial(n: Int) raises -> Decimal128:
         )  # 10888869450418352160768000000
 
 
-fn factorial_reciprocal(n: Int) raises -> Decimal128:
+def factorial_reciprocal(n: Int) raises -> Decimal128:
     """Calculates the reciprocal of factorial of a non-negative integer (1/n!).
 
     Args:

--- a/src/decimo/decimal128/utility.mojo
+++ b/src/decimo/decimal128/utility.mojo
@@ -19,9 +19,9 @@
 #
 # ===----------------------------------------------------------------------=== #
 
-from memory import UnsafePointer
-import sys
-import time
+from std.memory import UnsafePointer
+from std import sys
+from std import time
 
 from decimo.decimal128.decimal128 import Decimal128
 
@@ -48,10 +48,9 @@ fn bitcast[dtype: DType](dec: Decimal128) -> Scalar[dtype]:
     """
 
     # Compile-time checker: ensure the dtype is either uint128 or uint256
-    constrained[
-        dtype == DType.uint128 or dtype == DType.uint256,
-        "must be uint128 or uint256",
-    ]()
+    comptime assert (
+        dtype == DType.uint128 or dtype == DType.uint256
+    ), "must be uint128 or uint256"
 
     # Bitcast the Decimal128 to the desired Mojo scalar type
     var result = UnsafePointer(to=dec).bitcast[Scalar[dtype]]().load()
@@ -85,10 +84,9 @@ fn truncate_to_max[dtype: DType, //](value: Scalar[dtype]) -> Scalar[dtype]:
 
     comptime ValueType = Scalar[dtype]
 
-    constrained[
-        dtype == DType.uint128 or dtype == DType.uint256,
-        "must be uint128 or uint256",
-    ]()
+    comptime assert (
+        dtype == DType.uint128 or dtype == DType.uint256
+    ), "must be uint128 or uint256"
 
     # If the value is already less than the maximum possible value, return it
     if value <= ValueType(Decimal128.MAX_AS_UINT128):
@@ -209,7 +207,7 @@ fn sqrt(x: UInt128) -> UInt128:
     var r: UInt128 = 0
 
     for p in range(sys.bit_width_of[UInt128]() // 2 - 1, -1, -1):
-        var new_bit = UInt128(1) << p
+        var new_bit = UInt128(1) << UInt128(p)
         var would_be = r | new_bit
         var squared = would_be * would_be
         if squared <= x:
@@ -295,10 +293,9 @@ fn round_to_keep_first_n_digits[
 
     comptime ValueType = Scalar[dtype]
 
-    constrained[
-        dtype == DType.uint128 or dtype == DType.uint256,
-        "must be uint128 or uint256",
-    ]()
+    comptime assert (
+        dtype == DType.uint128 or dtype == DType.uint256
+    ), "must be uint128 or uint256"
 
     # CASE: The number of digits is less than 0
     # Return 0.
@@ -386,7 +383,7 @@ fn round_to_keep_first_n_digits[
             debug_assert(
                 False,
                 "Unknown rounding mode in round_to_keep_first_n_digits: "
-                + String(rounding_mode),
+                + rounding_mode.__str__(),
             )
 
         return truncated_value
@@ -411,10 +408,9 @@ fn number_of_digits[dtype: DType, //](value: Scalar[dtype]) -> Int:
         The number of digits in the integral value.
     """
 
-    constrained[
-        dtype == DType.uint128 or dtype == DType.uint256,
-        "must be uint128 or uint256",
-    ]()
+    comptime assert (
+        dtype == DType.uint128 or dtype == DType.uint256
+    ), "must be uint128 or uint256"
 
     comptime ValueType = Scalar[dtype]
 
@@ -567,10 +563,7 @@ fn number_of_bits[dtype: DType, //](var value: Scalar[dtype]) -> Int:
         `dtype` must be integral.
     """
 
-    constrained[
-        dtype.is_integral(),
-        "must be intergral",
-    ]()
+    comptime assert dtype.is_integral(), "must be intergral"
 
     if value < 0:
         value = -value
@@ -695,10 +688,9 @@ fn power_of_10[dtype: DType](n: Int) -> Scalar[dtype]:
 
     comptime ValueType = Scalar[dtype]
 
-    constrained[
-        dtype == DType.uint128 or dtype == DType.uint256,
-        "must be uint128 or uint256",
-    ]()
+    comptime assert (
+        dtype == DType.uint128 or dtype == DType.uint256
+    ), "must be uint128 or uint256"
 
     if n == 0:
         return ValueType(1)

--- a/src/decimo/decimal128/utility.mojo
+++ b/src/decimo/decimal128/utility.mojo
@@ -383,7 +383,7 @@ fn round_to_keep_first_n_digits[
             debug_assert(
                 False,
                 "Unknown rounding mode in round_to_keep_first_n_digits: "
-                + rounding_mode.__str__(),
+                + String(rounding_mode),
             )
 
         return truncated_value

--- a/src/decimo/decimal128/utility.mojo
+++ b/src/decimo/decimal128/utility.mojo
@@ -27,7 +27,7 @@ from decimo.decimal128.decimal128 import Decimal128
 
 
 # UNSAFE
-fn bitcast[dtype: DType](dec: Decimal128) -> Scalar[dtype]:
+def bitcast[dtype: DType](dec: Decimal128) -> Scalar[dtype]:
     """
     Direct memory bit copy from Decimal128 (low, mid, high) to Mojo's Scalar type.
     This performs a bitcast/reinterpretation rather than bit manipulation.
@@ -59,7 +59,7 @@ fn bitcast[dtype: DType](dec: Decimal128) -> Scalar[dtype]:
     return result
 
 
-fn truncate_to_max[dtype: DType, //](value: Scalar[dtype]) -> Scalar[dtype]:
+def truncate_to_max[dtype: DType, //](value: Scalar[dtype]) -> Scalar[dtype]:
     """
     Truncates a UInt256 or UInt128 value to be as closer to the max value of
     Decimal128 coefficient (`2^96 - 1`) as possible with rounding.
@@ -190,7 +190,7 @@ fn truncate_to_max[dtype: DType, //](value: Scalar[dtype]) -> Scalar[dtype]:
             return truncated_value
 
 
-fn sqrt(x: UInt128) -> UInt128:
+def sqrt(x: UInt128) -> UInt128:
     """
     Returns the square root of a UInt128 value.
 
@@ -217,7 +217,7 @@ fn sqrt(x: UInt128) -> UInt128:
 
 
 # TODO: Evaluate whether this can replace truncate_to_max in some cases.
-fn round_to_keep_first_n_digits[
+def round_to_keep_first_n_digits[
     dtype: DType, //
 ](
     value: Scalar[dtype],
@@ -390,7 +390,7 @@ fn round_to_keep_first_n_digits[
 
 
 @always_inline
-fn number_of_digits[dtype: DType, //](value: Scalar[dtype]) -> Int:
+def number_of_digits[dtype: DType, //](value: Scalar[dtype]) -> Int:
     """
     Returns the number of (significant) digits in an integral value using binary search.
     This implementation is significantly faster than loop division.
@@ -555,7 +555,7 @@ fn number_of_digits[dtype: DType, //](value: Scalar[dtype]) -> Int:
     return 59
 
 
-fn number_of_bits[dtype: DType, //](var value: Scalar[dtype]) -> Int:
+def number_of_bits[dtype: DType, //](var value: Scalar[dtype]) -> Int:
     """
     Returns the number of significant bits in an integer value.
 
@@ -598,19 +598,19 @@ fn number_of_bits[dtype: DType, //](var value: Scalar[dtype]) -> Int:
 
 # # Initialize with the first value
 # @always_inline
-# fn _init_power_of_10_as_uint128_cache():
+# def _init_power_of_10_as_uint128_cache():
 #     if len(_power_of_10_as_uint128_cache) == 0:
 #         _power_of_10_as_uint128_cache.append(1)  # 10^0 = 1
 
 
 # @always_inline
-# fn _init_power_of_10_as_uint256_cache():
+# def _init_power_of_10_as_uint256_cache():
 #     if len(_power_of_10_as_uint256_cache) == 0:
 #         _power_of_10_as_uint256_cache.append(1)  # 10^0 = 1
 
 
 # @always_inline
-# fn power_of_10_as_uint128(n: Int) raises -> UInt128:
+# def power_of_10_as_uint128(n: Int) raises -> UInt128:
 #     """
 #     Returns 10^n using cached values when available.
 #     """
@@ -636,7 +636,7 @@ fn number_of_bits[dtype: DType, //](var value: Scalar[dtype]) -> Int:
 
 
 # @always_inline
-# fn power_of_10_as_uint256(n: Int) raises -> UInt256:
+# def power_of_10_as_uint256(n: Int) raises -> UInt256:
 #     """
 #     Returns 10^n using cached values when available.
 #     """
@@ -662,7 +662,7 @@ fn number_of_bits[dtype: DType, //](var value: Scalar[dtype]) -> Int:
 
 
 @always_inline
-fn power_of_10[dtype: DType](n: Int) -> Scalar[dtype]:
+def power_of_10[dtype: DType](n: Int) -> Scalar[dtype]:
     """
     Returns 10^n using cached values when available.
     **WARNING**: The overflow is not checked in this function.

--- a/src/decimo/errors.mojo
+++ b/src/decimo/errors.mojo
@@ -18,7 +18,8 @@
 Implements error handling for Decimo.
 """
 
-from pathlib.path import cwd
+from std.pathlib.path import cwd
+import decimo.str
 
 comptime OverflowError = DecimoError[error_type="OverflowError"]
 """Type for overflow errors in Decimo.
@@ -95,7 +96,7 @@ DecimoError                             Traceback (most recent call last)
 """
 
 
-struct DecimoError[error_type: String = "DecimoError"](Stringable, Writable):
+struct DecimoError[error_type: String = "DecimoError"](Writable):
     """Base type for all Decimo errors.
 
     Parameters:
@@ -162,7 +163,7 @@ struct DecimoError[error_type: String = "DecimoError"](Stringable, Writable):
         writer.write("\n")
         writer.write(("-" * 80))
         writer.write("\n")
-        writer.write(Self.error_type.ljust(47, " "))
+        writer.write(decimo.str.ljust(String(Self.error_type), 47, " "))
         writer.write("Traceback (most recent call last)\n")
         writer.write('File "')
         try:

--- a/src/decimo/errors.mojo
+++ b/src/decimo/errors.mojo
@@ -115,7 +115,7 @@ struct DecimoError[error_type: String = "DecimoError"](Writable):
     var message: Optional[String]
     var previous_error: Optional[String]
 
-    fn __init__(
+    def __init__(
         out self,
         file: String,
         function: String,
@@ -132,7 +132,7 @@ struct DecimoError[error_type: String = "DecimoError"](Writable):
                 String(previous_error.value()).split("\n")[3:]
             )
 
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         writer.write("\n")
         writer.write(("-" * 80))
         writer.write("\n")

--- a/src/decimo/errors.mojo
+++ b/src/decimo/errors.mojo
@@ -132,33 +132,6 @@ struct DecimoError[error_type: String = "DecimoError"](Writable):
                 String(previous_error.value()).split("\n")[3:]
             )
 
-    fn __str__(self) -> String:
-        if self.message is None:
-            return (
-                "Traceback (most recent call last):\n"
-                + '  File "'
-                + self.file
-                + '"'
-                + " in "
-                + self.function
-                + "\n\n"
-            )
-
-        else:
-            return (
-                "Traceback (most recent call last):\n"
-                + '  File "'
-                + self.file
-                + '"'
-                + " in "
-                + self.function
-                + "\n\n"
-                + String(Self.error_type)
-                + ": "
-                + self.message.value()
-                + "\n"
-            )
-
     fn write_to[W: Writer](self, mut writer: W):
         writer.write("\n")
         writer.write(("-" * 80))

--- a/src/decimo/rounding_mode.mojo
+++ b/src/decimo/rounding_mode.mojo
@@ -108,25 +108,22 @@ struct RoundingMode(Copyable, ImplicitlyCopyable, Movable, Writable):
         return self.value == other.value
 
     fn __eq__(self, other: String) -> Bool:
-        return self.__str__() == other
-
-    fn __str__(self) -> String:
-        if self == Self.down():
-            return "ROUND_DOWN"
-        elif self == Self.half_up():
-            return "ROUND_HALF_UP"
-        elif self == Self.half_even():
-            return "ROUND_HALF_EVEN"
-        elif self == Self.up():
-            return "ROUND_UP"
-        elif self == Self.ceiling():
-            return "ROUND_CEILING"
-        elif self == Self.half_down():
-            return "ROUND_HALF_DOWN"
-        elif self == Self.floor():
-            return "ROUND_FLOOR"
-        else:
-            return "UNKNOWN_ROUNDING_MODE"
+        return String(self) == other
 
     fn write_to[W: Writer](self, mut writer: W):
-        writer.write(self.__str__())
+        if self == Self.down():
+            writer.write("ROUND_DOWN")
+        elif self == Self.half_up():
+            writer.write("ROUND_HALF_UP")
+        elif self == Self.half_even():
+            writer.write("ROUND_HALF_EVEN")
+        elif self == Self.up():
+            writer.write("ROUND_UP")
+        elif self == Self.ceiling():
+            writer.write("ROUND_CEILING")
+        elif self == Self.half_down():
+            writer.write("ROUND_HALF_DOWN")
+        elif self == Self.floor():
+            writer.write("ROUND_FLOOR")
+        else:
+            writer.write("UNKNOWN_ROUNDING_MODE")

--- a/src/decimo/rounding_mode.mojo
+++ b/src/decimo/rounding_mode.mojo
@@ -67,50 +67,50 @@ struct RoundingMode(Copyable, ImplicitlyCopyable, Movable, Writable):
 
     # Static constants for each rounding mode
     @staticmethod
-    fn down() -> Self:
+    def down() -> Self:
         """Truncate (toward zero)."""
         return Self(0)
 
     @staticmethod
-    fn half_up() -> Self:
+    def half_up() -> Self:
         """Round away from zero if >= 0.5."""
         return Self(1)
 
     @staticmethod
-    fn half_down() -> Self:
+    def half_down() -> Self:
         """Round toward zero if <= 0.5."""
         return Self(6)
 
     @staticmethod
-    fn half_even() -> Self:
+    def half_even() -> Self:
         """Round to nearest even digit if equidistant (banker's rounding)."""
         return Self(2)
 
     @staticmethod
-    fn up() -> Self:
+    def up() -> Self:
         """Round away from zero."""
         return Self(3)
 
     @staticmethod
-    fn ceiling() -> Self:
+    def ceiling() -> Self:
         """Round toward positive infinity."""
         return Self(4)
 
     @staticmethod
-    fn floor() -> Self:
+    def floor() -> Self:
         """Round toward negative infinity."""
         return Self(5)
 
-    fn __init__(out self, value: Int):
+    def __init__(out self, value: Int):
         self.value = value
 
-    fn __eq__(self, other: Self) -> Bool:
+    def __eq__(self, other: Self) -> Bool:
         return self.value == other.value
 
-    fn __eq__(self, other: String) -> Bool:
+    def __eq__(self, other: String) -> Bool:
         return String(self) == other
 
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         if self == Self.down():
             writer.write("ROUND_DOWN")
         elif self == Self.half_up():

--- a/src/decimo/rounding_mode.mojo
+++ b/src/decimo/rounding_mode.mojo
@@ -33,7 +33,7 @@ comptime ROUND_FLOOR = RoundingMode.ROUND_FLOOR
 """Rounding mode: Round toward negative infinity."""
 
 
-struct RoundingMode(Copyable, ImplicitlyCopyable, Movable, Stringable):
+struct RoundingMode(Copyable, ImplicitlyCopyable, Movable, Writable):
     """
     Represents different rounding modes for decimal operations.
 
@@ -108,7 +108,7 @@ struct RoundingMode(Copyable, ImplicitlyCopyable, Movable, Stringable):
         return self.value == other.value
 
     fn __eq__(self, other: String) -> Bool:
-        return String(self) == other
+        return self.__str__() == other
 
     fn __str__(self) -> String:
         if self == Self.down():
@@ -127,3 +127,6 @@ struct RoundingMode(Copyable, ImplicitlyCopyable, Movable, Stringable):
             return "ROUND_FLOOR"
         else:
             return "UNKNOWN_ROUNDING_MODE"
+
+    fn write_to[W: Writer](self, mut writer: W):
+        writer.write(self.__str__())

--- a/src/decimo/str.mojo
+++ b/src/decimo/str.mojo
@@ -16,7 +16,23 @@
 
 """String parsing and manipulation functions."""
 
-from algorithm import vectorize
+from std.algorithm import vectorize
+
+
+fn rjust(s: String, width: Int, fillchar: String = " ") -> String:
+    """Right-justifies a string by padding with fillchar on the left."""
+    var n = len(s)
+    if n >= width:
+        return s
+    return fillchar * (width - n) + s
+
+
+fn ljust(s: String, width: Int, fillchar: String = " ") -> String:
+    """Left-justifies a string by padding with fillchar on the right."""
+    var n = len(s)
+    if n >= width:
+        return s
+    return s + fillchar * (width - n)
 
 
 fn parse_numeric_string(
@@ -86,7 +102,7 @@ fn parse_numeric_string(
     #     # - Space ' ' may appear anywhere in the string and is ignored.
     #     # - Comma ',' and underscore '_' may appear anywhere between digits and are ignored.
 
-    var value_bytes = value.as_string_slice().as_bytes()
+    var value_bytes = StringSlice(value).as_bytes()
     var n = len(value_bytes)
 
     if n == 0:
@@ -300,11 +316,11 @@ fn parse_numeric_string(
         fn convert_fast[
             simd_width: Int
         ](i: Int) unified {mut coef, read value_bytes, read extract_start}:
-            coef._data.store[width=simd_width](
+            coef.unsafe_ptr().store[width=simd_width](
                 i,
-                (value_bytes.unsafe_ptr() + (extract_start + i)).load[
-                    width=simd_width
-                ]()
+                value_bytes.unsafe_ptr().load[width=simd_width](
+                    extract_start + i
+                )
                 - SIMD[DType.uint8, simd_width](48),
             )
 
@@ -324,11 +340,11 @@ fn parse_numeric_string(
             fn convert_before[
                 simd_width: Int
             ](i: Int) unified {mut coef, read value_bytes, read extract_start}:
-                coef._data.store[width=simd_width](
+                coef.unsafe_ptr().store[width=simd_width](
                     i,
-                    (value_bytes.unsafe_ptr() + (extract_start + i)).load[
-                        width=simd_width
-                    ]()
+                    value_bytes.unsafe_ptr().load[width=simd_width](
+                        extract_start + i
+                    )
                     - SIMD[DType.uint8, simd_width](48),
                 )
 
@@ -346,11 +362,11 @@ fn parse_numeric_string(
                 read decimal_point_pos,
                 read before_count,
             }:
-                coef._data.store[width=simd_width](
+                coef.unsafe_ptr().store[width=simd_width](
                     before_count + i,
-                    (
-                        value_bytes.unsafe_ptr() + (decimal_point_pos + 1 + i)
-                    ).load[width=simd_width]()
+                    value_bytes.unsafe_ptr().load[width=simd_width](
+                        decimal_point_pos + 1 + i
+                    )
                     - SIMD[DType.uint8, simd_width](48),
                 )
 

--- a/src/decimo/str.mojo
+++ b/src/decimo/str.mojo
@@ -19,7 +19,7 @@
 from std.algorithm import vectorize
 
 
-fn rjust(s: String, width: Int, fillchar: String = " ") -> String:
+def rjust(s: String, width: Int, fillchar: String = " ") -> String:
     """Right-justifies a string by padding with fillchar on the left."""
     var n = len(s)
     if n >= width:
@@ -27,7 +27,7 @@ fn rjust(s: String, width: Int, fillchar: String = " ") -> String:
     return fillchar * (width - n) + s
 
 
-fn ljust(s: String, width: Int, fillchar: String = " ") -> String:
+def ljust(s: String, width: Int, fillchar: String = " ") -> String:
     """Left-justifies a string by padding with fillchar on the right."""
     var n = len(s)
     if n >= width:
@@ -35,7 +35,7 @@ fn ljust(s: String, width: Int, fillchar: String = " ") -> String:
     return s + fillchar * (width - n)
 
 
-fn parse_numeric_string(
+def parse_numeric_string(
     value: String,
 ) raises -> Tuple[List[UInt8], Int, Bool]:
     """Parse the string of a number into normalized parts.
@@ -313,7 +313,7 @@ fn parse_numeric_string(
         coef.resize(significant_count, 0)
 
         @parameter
-        fn convert_fast[
+        def convert_fast[
             simd_width: Int
         ](i: Int) unified {mut coef, read value_bytes, read extract_start}:
             coef.unsafe_ptr().store[width=simd_width](
@@ -337,7 +337,7 @@ fn parse_numeric_string(
         if before_count > 0:
 
             @parameter
-            fn convert_before[
+            def convert_before[
                 simd_width: Int
             ](i: Int) unified {mut coef, read value_bytes, read extract_start}:
                 coef.unsafe_ptr().store[width=simd_width](
@@ -354,7 +354,7 @@ fn parse_numeric_string(
         if after_count > 0:
 
             @parameter
-            fn convert_after[
+            def convert_after[
                 simd_width: Int
             ](i: Int) unified {
                 mut coef,

--- a/src/decimo/tests.mojo
+++ b/src/decimo/tests.mojo
@@ -99,19 +99,6 @@ struct TestCase(Copyable, Movable, Writable):
         self.expected = take.expected^
         self.description = take.description^
 
-    fn __str__(self) -> String:
-        return (
-            "TestCase(a: "
-            + self.a
-            + ", b: "
-            + self.b
-            + ", expected: "
-            + self.expected
-            + ", description: "
-            + self.description
-            + ")"
-        )
-
     fn write_to[T: Writer](self, mut writer: T):
         writer.write("TestCase:\n")
         writer.write("  a: " + self.a + "\n")
@@ -147,19 +134,16 @@ struct BenchCase(Copyable, Movable, Writable):
         self.a = take.a^
         self.b = take.b^
 
-    fn __str__(self) -> String:
-        return (
-            "BenchCase(name='"
-            + self.name
-            + "', a='"
-            + self.a
-            + "', b='"
-            + self.b
-            + "')"
-        )
-
     fn write_to[T: Writer](self, mut writer: T):
-        writer.write(self.__str__())
+        writer.write(
+            "BenchCase(name='",
+            self.name,
+            "', a='",
+            self.a,
+            "', b='",
+            self.b,
+            "')",
+        )
 
 
 # ===----------------------------------------------------------------------=== #

--- a/src/decimo/tests.mojo
+++ b/src/decimo/tests.mojo
@@ -52,9 +52,9 @@ Pattern expansion in string values:
 
 from .toml import parse_file as parse_toml_file
 from .toml.parser import TOMLDocument
-from python import Python, PythonObject
-from collections import List
-import os
+from std.python import Python, PythonObject
+from std.collections import List
+from std import os
 
 
 # ===----------------------------------------------------------------------=== #
@@ -62,7 +62,7 @@ import os
 # ===----------------------------------------------------------------------=== #
 
 
-struct TestCase(Copyable, Movable, Stringable, Writable):
+struct TestCase(Copyable, Movable, Writable):
     """Structure to hold test case data.
 
     Attributes:
@@ -87,17 +87,17 @@ struct TestCase(Copyable, Movable, Stringable, Writable):
             description + " (a = " + self.a + ", b = " + self.b + ")"
         )
 
-    fn __copyinit__(out self, other: Self):
-        self.a = other.a
-        self.b = other.b
-        self.expected = other.expected
-        self.description = other.description
+    fn __init__(out self, *, copy: Self):
+        self.a = copy.a
+        self.b = copy.b
+        self.expected = copy.expected
+        self.description = copy.description
 
-    fn __moveinit__(out self, deinit other: Self):
-        self.a = other.a^
-        self.b = other.b^
-        self.expected = other.expected^
-        self.description = other.description^
+    fn __init__(out self, *, deinit take: Self):
+        self.a = take.a^
+        self.b = take.b^
+        self.expected = take.expected^
+        self.description = take.description^
 
     fn __str__(self) -> String:
         return (
@@ -125,7 +125,7 @@ struct TestCase(Copyable, Movable, Stringable, Writable):
 # ===----------------------------------------------------------------------=== #
 
 
-struct BenchCase(Copyable, Movable, Stringable, Writable):
+struct BenchCase(Copyable, Movable, Writable):
     """A benchmark case with a name and one or two operands."""
 
     var name: String
@@ -137,15 +137,15 @@ struct BenchCase(Copyable, Movable, Stringable, Writable):
         self.a = a
         self.b = b
 
-    fn __copyinit__(out self, other: Self):
-        self.name = other.name
-        self.a = other.a
-        self.b = other.b
+    fn __init__(out self, *, copy: Self):
+        self.name = copy.name
+        self.a = copy.a
+        self.b = copy.b
 
-    fn __moveinit__(out self, deinit other: Self):
-        self.name = other.name^
-        self.a = other.a^
-        self.b = other.b^
+    fn __init__(out self, *, deinit take: Self):
+        self.name = take.name^
+        self.a = take.a^
+        self.b = take.b^
 
     fn __str__(self) -> String:
         return (
@@ -210,7 +210,7 @@ fn expand_value(s: String) raises -> String:
                 continue
 
             # Extract inner content between braces
-            var inner = String(s[i + 1 : close])
+            var inner = String(s[byte = i + 1 : close])
 
             # Find the LAST comma (to handle multi-char repeat strings)
             var comma_pos = -1
@@ -229,8 +229,8 @@ fn expand_value(s: String) raises -> String:
                 i = close + 1
                 continue
 
-            var pattern = String(inner[:comma_pos])
-            var count_str = String(inner[comma_pos + 1 :])
+            var pattern = String(inner[byte=:comma_pos])
+            var count_str = String(inner[byte = comma_pos + 1 :])
             var count = atol(count_str)
 
             for _ in range(count):
@@ -392,13 +392,13 @@ struct PrecisionLevel(Copyable, Movable):
         self.precision = precision
         self.iterations = iterations
 
-    fn __copyinit__(out self, other: Self):
-        self.precision = other.precision
-        self.iterations = other.iterations
+    fn __init__(out self, *, copy: Self):
+        self.precision = copy.precision
+        self.iterations = copy.iterations
 
-    fn __moveinit__(out self, deinit other: Self):
-        self.precision = other.precision
-        self.iterations = other.iterations
+    fn __init__(out self, *, deinit take: Self):
+        self.precision = take.precision
+        self.iterations = take.iterations
 
 
 fn load_bench_precision_levels(

--- a/src/decimo/tests.mojo
+++ b/src/decimo/tests.mojo
@@ -77,7 +77,7 @@ struct TestCase(Copyable, Movable, Writable):
     var expected: String
     var description: String
 
-    fn __init__(
+    def __init__(
         out self, a: String, b: String, expected: String, description: String
     ):
         self.a = a
@@ -87,19 +87,19 @@ struct TestCase(Copyable, Movable, Writable):
             description + " (a = " + self.a + ", b = " + self.b + ")"
         )
 
-    fn __init__(out self, *, copy: Self):
+    def __init__(out self, *, copy: Self):
         self.a = copy.a
         self.b = copy.b
         self.expected = copy.expected
         self.description = copy.description
 
-    fn __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         self.a = take.a^
         self.b = take.b^
         self.expected = take.expected^
         self.description = take.description^
 
-    fn write_to[T: Writer](self, mut writer: T):
+    def write_to[T: Writer](self, mut writer: T):
         writer.write("TestCase:\n")
         writer.write("  a: " + self.a + "\n")
         writer.write("  b: " + self.b + "\n")
@@ -119,22 +119,22 @@ struct BenchCase(Copyable, Movable, Writable):
     var a: String
     var b: String
 
-    fn __init__(out self, name: String, a: String, b: String = ""):
+    def __init__(out self, name: String, a: String, b: String = ""):
         self.name = name
         self.a = a
         self.b = b
 
-    fn __init__(out self, *, copy: Self):
+    def __init__(out self, *, copy: Self):
         self.name = copy.name
         self.a = copy.a
         self.b = copy.b
 
-    fn __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         self.name = take.name^
         self.a = take.a^
         self.b = take.b^
 
-    fn write_to[T: Writer](self, mut writer: T):
+    def write_to[T: Writer](self, mut writer: T):
         writer.write(
             "BenchCase(name='",
             self.name,
@@ -151,7 +151,7 @@ struct BenchCase(Copyable, Movable, Writable):
 # ===----------------------------------------------------------------------=== #
 
 
-fn expand_value(s: String) raises -> String:
+def expand_value(s: String) raises -> String:
     """Expand {C,N} repeat patterns in a string.
 
     Scans the string for `{C,N}` patterns where C is the string to repeat
@@ -232,7 +232,7 @@ fn expand_value(s: String) raises -> String:
 # ===----------------------------------------------------------------------=== #
 
 
-fn parse_file(file_path: String) raises -> TOMLDocument:
+def parse_file(file_path: String) raises -> TOMLDocument:
     """Parse a TOML file and return the TOMLDocument."""
     try:
         return parse_toml_file(file_path)
@@ -245,7 +245,7 @@ fn parse_file(file_path: String) raises -> TOMLDocument:
         )
 
 
-fn load_test_cases[
+def load_test_cases[
     unary: Bool = False
 ](toml: TOMLDocument, table_name: String) raises -> List[TestCase]:
     """Load test cases from a TOMLDocument.
@@ -289,7 +289,7 @@ fn load_test_cases[
     return test_cases^
 
 
-fn load_bench_cases(toml_path: String) raises -> List[BenchCase]:
+def load_bench_cases(toml_path: String) raises -> List[BenchCase]:
     """Load benchmark cases from a TOML file.
 
     Uses decimo.toml to parse the TOML file. Operand values are expanded
@@ -319,7 +319,7 @@ fn load_bench_cases(toml_path: String) raises -> List[BenchCase]:
     return cases^
 
 
-fn load_bench_iterations(toml_path: String) raises -> Int:
+def load_bench_iterations(toml_path: String) raises -> Int:
     """Load the iterations count from TOML config section.
 
     Args:
@@ -338,7 +338,7 @@ fn load_bench_iterations(toml_path: String) raises -> Int:
     return 1000
 
 
-fn load_bench_precision(toml_path: String) raises -> Int:
+def load_bench_precision(toml_path: String) raises -> Int:
     """Load the precision from TOML config section.
 
     Args:
@@ -372,20 +372,20 @@ struct PrecisionLevel(Copyable, Movable):
     var precision: Int
     var iterations: Int
 
-    fn __init__(out self, precision: Int, iterations: Int):
+    def __init__(out self, precision: Int, iterations: Int):
         self.precision = precision
         self.iterations = iterations
 
-    fn __init__(out self, *, copy: Self):
+    def __init__(out self, *, copy: Self):
         self.precision = copy.precision
         self.iterations = copy.iterations
 
-    fn __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         self.precision = take.precision
         self.iterations = take.iterations
 
 
-fn load_bench_precision_levels(
+def load_bench_precision_levels(
     toml_path: String,
 ) raises -> List[PrecisionLevel]:
     """Load precision levels from a TOML file's [[precision_levels]] tables.
@@ -422,7 +422,7 @@ fn load_bench_precision_levels(
 # ===----------------------------------------------------------------------=== #
 
 
-fn open_log_file(prefix: String) raises -> PythonObject:
+def open_log_file(prefix: String) raises -> PythonObject:
     """Create and open a timestamped log file.
 
     Creates a `./logs/` directory if it doesn't exist, then opens a log
@@ -450,7 +450,7 @@ fn open_log_file(prefix: String) raises -> PythonObject:
     return python.open(log_filename, "w")
 
 
-fn log_print(msg: String, log_file: PythonObject) raises:
+def log_print(msg: String, log_file: PythonObject) raises:
     """Print a message to both console and log file.
 
     Args:
@@ -467,7 +467,7 @@ fn log_print(msg: String, log_file: PythonObject) raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn print_header(title: String, log_file: PythonObject) raises:
+def print_header(title: String, log_file: PythonObject) raises:
     """Print a benchmark header with title and system information.
 
     Args:
@@ -495,7 +495,7 @@ fn print_header(title: String, log_file: PythonObject) raises:
         log_print("Could not retrieve system information", log_file)
 
 
-fn print_summary(
+def print_summary(
     title: String,
     speedup_factors: List[Float64],
     label: String,
@@ -546,7 +546,7 @@ fn print_summary(
         )
 
 
-fn print_summary_dual(
+def print_summary_dual(
     title: String,
     sf1: List[Float64],
     label1: String,

--- a/src/decimo/toml/parser.mojo
+++ b/src/decimo/toml/parser.mojo
@@ -44,7 +44,7 @@ struct TOMLValue(Copyable, ImplicitlyCopyable, Movable):
     var array_values: List[TOMLValue]
     var table_values: Dict[String, TOMLValue]
 
-    fn __init__(out self):
+    def __init__(out self):
         """Initialize an empty TOML value."""
         self.type = TOMLValueType.NULL
         self.string_value = ""
@@ -54,7 +54,7 @@ struct TOMLValue(Copyable, ImplicitlyCopyable, Movable):
         self.array_values = List[TOMLValue]()
         self.table_values = Dict[String, TOMLValue]()
 
-    fn __init__(out self, string_value: String):
+    def __init__(out self, string_value: String):
         """Initialize a string TOML value."""
         self.type = TOMLValueType.STRING
         self.string_value = string_value
@@ -64,7 +64,7 @@ struct TOMLValue(Copyable, ImplicitlyCopyable, Movable):
         self.array_values = List[TOMLValue]()
         self.table_values = Dict[String, TOMLValue]()
 
-    fn __init__(out self, int_value: Int):
+    def __init__(out self, int_value: Int):
         """Initialize an integer TOML value."""
         self.type = TOMLValueType.INTEGER
         self.string_value = ""
@@ -74,7 +74,7 @@ struct TOMLValue(Copyable, ImplicitlyCopyable, Movable):
         self.array_values = List[TOMLValue]()
         self.table_values = Dict[String, TOMLValue]()
 
-    fn __init__(out self, float_value: Float64):
+    def __init__(out self, float_value: Float64):
         """Initialize a float TOML value."""
         self.type = TOMLValueType.FLOAT
         self.string_value = ""
@@ -84,7 +84,7 @@ struct TOMLValue(Copyable, ImplicitlyCopyable, Movable):
         self.array_values = List[TOMLValue]()
         self.table_values = Dict[String, TOMLValue]()
 
-    fn __init__(out self, bool_value: Bool):
+    def __init__(out self, bool_value: Bool):
         """Initialize a boolean TOML value."""
         self.type = TOMLValueType.BOOLEAN
         self.string_value = ""
@@ -94,7 +94,7 @@ struct TOMLValue(Copyable, ImplicitlyCopyable, Movable):
         self.array_values = List[TOMLValue]()
         self.table_values = Dict[String, TOMLValue]()
 
-    fn __init__(out self, *, copy: Self):
+    def __init__(out self, *, copy: Self):
         self.type = copy.type
         self.string_value = copy.string_value
         self.int_value = copy.int_value
@@ -103,15 +103,15 @@ struct TOMLValue(Copyable, ImplicitlyCopyable, Movable):
         self.array_values = copy.array_values.copy()
         self.table_values = copy.table_values.copy()
 
-    fn is_table(self) -> Bool:
+    def is_table(self) -> Bool:
         """Check if this value is a table."""
         return self.type == TOMLValueType.TABLE
 
-    fn is_array(self) -> Bool:
+    def is_array(self) -> Bool:
         """Check if this value is an array."""
         return self.type == TOMLValueType.ARRAY
 
-    fn as_string(self) -> String:
+    def as_string(self) -> String:
         """Get the value as a string."""
         if self.type == TOMLValueType.STRING:
             return self.string_value
@@ -124,14 +124,14 @@ struct TOMLValue(Copyable, ImplicitlyCopyable, Movable):
         else:
             return ""
 
-    fn as_int(self) -> Int:
+    def as_int(self) -> Int:
         """Get the value as an integer."""
         if self.type == TOMLValueType.INTEGER:
             return self.int_value
         else:
             return 0
 
-    fn as_float(self) -> Float64:
+    def as_float(self) -> Float64:
         """Get the value as a float."""
         if self.type == TOMLValueType.FLOAT:
             return self.float_value
@@ -140,20 +140,20 @@ struct TOMLValue(Copyable, ImplicitlyCopyable, Movable):
         else:
             return 0.0
 
-    fn as_bool(self) -> Bool:
+    def as_bool(self) -> Bool:
         """Get the value as a boolean."""
         if self.type == TOMLValueType.BOOLEAN:
             return self.bool_value
         else:
             return False
 
-    fn as_table(self) -> Dict[String, TOMLValue]:
+    def as_table(self) -> Dict[String, TOMLValue]:
         """Get the value as a table dictionary."""
         if self.type == TOMLValueType.TABLE:
             return self.table_values.copy()
         return Dict[String, TOMLValue]()
 
-    fn as_array(self) -> List[TOMLValue]:
+    def as_array(self) -> List[TOMLValue]:
         """Get the value as an array."""
         if self.type == TOMLValueType.ARRAY:
             return self.array_values.copy()
@@ -174,43 +174,43 @@ struct TOMLValueType(Copyable, ImplicitlyCopyable, Movable):
     var value: Int
 
     @staticmethod
-    fn null() -> TOMLValueType:
+    def null() -> TOMLValueType:
         return TOMLValueType(0)
 
     @staticmethod
-    fn string() -> TOMLValueType:
+    def string() -> TOMLValueType:
         return TOMLValueType(1)
 
     @staticmethod
-    fn integer() -> TOMLValueType:
+    def integer() -> TOMLValueType:
         return TOMLValueType(2)
 
     @staticmethod
-    fn float() -> TOMLValueType:
+    def float() -> TOMLValueType:
         return TOMLValueType(3)
 
     @staticmethod
-    fn boolean() -> TOMLValueType:
+    def boolean() -> TOMLValueType:
         return TOMLValueType(4)
 
     @staticmethod
-    fn array() -> TOMLValueType:
+    def array() -> TOMLValueType:
         return TOMLValueType(5)
 
     @staticmethod
-    fn table() -> TOMLValueType:
+    def table() -> TOMLValueType:
         return TOMLValueType(6)
 
-    fn __init__(out self, value: Int):
+    def __init__(out self, value: Int):
         self.value = value
 
-    fn __eq__(self, other: TOMLValueType) -> Bool:
+    def __eq__(self, other: TOMLValueType) -> Bool:
         return self.value == other.value
 
-    fn __ne__(self, other: TOMLValueType) -> Bool:
+    def __ne__(self, other: TOMLValueType) -> Bool:
         return self.value != other.value
 
-    fn to_string(self) -> String:
+    def to_string(self) -> String:
         if self == Self.NULL:
             return "NULL"
         elif self == Self.STRING:
@@ -234,16 +234,16 @@ struct TOMLDocument(Copyable, Movable):
 
     var root: Dict[String, TOMLValue]
 
-    fn __init__(out self):
+    def __init__(out self):
         self.root = Dict[String, TOMLValue]()
 
-    fn get(self, key: String) raises -> TOMLValue:
+    def get(self, key: String) raises -> TOMLValue:
         """Get a value from the document."""
         if key in self.root:
             return self.root[key]
         return TOMLValue()
 
-    fn get_table(self, table_name: String) raises -> Dict[String, TOMLValue]:
+    def get_table(self, table_name: String) raises -> Dict[String, TOMLValue]:
         """Get a table from the document."""
         if (
             table_name in self.root
@@ -252,13 +252,13 @@ struct TOMLDocument(Copyable, Movable):
             return self.root[table_name].table_values.copy()
         return Dict[String, TOMLValue]()
 
-    fn get_array(self, key: String) raises -> List[TOMLValue]:
+    def get_array(self, key: String) raises -> List[TOMLValue]:
         """Get an array from the document."""
         if key in self.root and self.root[key].type == TOMLValueType.ARRAY:
             return self.root[key].array_values.copy()
         return List[TOMLValue]()
 
-    fn get_array_of_tables(
+    def get_array_of_tables(
         self, key: String
     ) raises -> List[Dict[String, TOMLValue]]:
         """Get an array of tables from the document."""
@@ -277,7 +277,7 @@ struct TOMLDocument(Copyable, Movable):
 # ---------------------------------------------------------------------------
 # Helper: create a TOMLValue wrapping a Dict as a TABLE
 # ---------------------------------------------------------------------------
-fn _make_table(var d: Dict[String, TOMLValue]) -> TOMLValue:
+def _make_table(var d: Dict[String, TOMLValue]) -> TOMLValue:
     var v = TOMLValue()
     v.type = TOMLValueType.TABLE
     v.table_values = d^
@@ -289,7 +289,7 @@ fn _make_table(var d: Dict[String, TOMLValue]) -> TOMLValue:
 # intermediate tables as needed.  Detects duplicate keys.
 # path = ["a", "b"] and key = "c" means root["a"]["b"]["c"] = value
 # ---------------------------------------------------------------------------
-fn _set_value(
+def _set_value(
     mut root: Dict[String, TOMLValue],
     path: List[String],
     key: String,
@@ -351,7 +351,7 @@ fn _set_value(
 # Helper: ensure a table path exists and return a mutable reference-path
 # For [a.b.c], ensure root["a"]["b"]["c"] exists as a table.
 # ---------------------------------------------------------------------------
-fn _ensure_table_path(
+def _ensure_table_path(
     mut root: Dict[String, TOMLValue], path: List[String]
 ) raises:
     """Ensure all tables along `path` exist in `root`."""
@@ -389,7 +389,7 @@ fn _ensure_table_path(
 # Helper: for [[a.b.c]], ensure path and append a new empty table to the
 # array at the final key.
 # ---------------------------------------------------------------------------
-fn _append_array_of_tables(
+def _append_array_of_tables(
     mut root: Dict[String, TOMLValue], path: List[String]
 ) raises:
     """Append a new empty table to the array-of-tables at `path`."""
@@ -446,33 +446,33 @@ struct TOMLParser:
     var tokens: List[Token]
     var pos: Int
 
-    fn __init__(out self, source: String):
+    def __init__(out self, source: String):
         var tokenizer = Tokenizer(source)
         self.tokens = tokenizer.tokenize()
         self.pos = 0
 
-    fn __init__(out self, tokens: List[Token]):
+    def __init__(out self, tokens: List[Token]):
         self.tokens = tokens.copy()
         self.pos = 0
 
     # ---- token helpers ---------------------------------------------------
 
-    fn _tok(self) -> Token:
+    def _tok(self) -> Token:
         """Get current token."""
         if self.pos < len(self.tokens):
             return self.tokens[self.pos].copy()
         return Token(TokenType.EOF, "", 0, 0)
 
-    fn _advance(mut self):
+    def _advance(mut self):
         """Move to next token."""
         self.pos += 1
 
-    fn _skip_newlines(mut self):
+    def _skip_newlines(mut self):
         """Skip NEWLINE tokens."""
         while self._tok().type == TokenType.NEWLINE:
             self._advance()
 
-    fn _skip_ws(mut self):
+    def _skip_ws(mut self):
         """Skip NEWLINE and COMMA tokens (for arrays)."""
         while (
             self._tok().type == TokenType.NEWLINE
@@ -480,7 +480,7 @@ struct TOMLParser:
         ):
             self._advance()
 
-    fn _is_key_token(self) -> Bool:
+    def _is_key_token(self) -> Bool:
         """Check if current token can be a key (KEY or STRING)."""
         return (
             self._tok().type == TokenType.KEY
@@ -489,7 +489,7 @@ struct TOMLParser:
 
     # ---- key parsing (supports dotted and quoted keys) -------------------
 
-    fn _parse_key_path(mut self) raises -> List[String]:
+    def _parse_key_path(mut self) raises -> List[String]:
         """Parse a dotted key path like a.b."c d".e.
 
         Returns a list of key parts.  Accepts both KEY and STRING tokens
@@ -515,7 +515,7 @@ struct TOMLParser:
 
     # ---- value parsing ---------------------------------------------------
 
-    fn _parse_integer(self, val_str: String) raises -> TOMLValue:
+    def _parse_integer(self, val_str: String) raises -> TOMLValue:
         """Parse an integer string, handling hex/octal/binary prefixes."""
         if len(val_str) > 2:
             var prefix = String(val_str[byte=:2])
@@ -550,7 +550,7 @@ struct TOMLParser:
                 return TOMLValue(result)
         return TOMLValue(atol(val_str))
 
-    fn _parse_float(self, val_str: String) raises -> TOMLValue:
+    def _parse_float(self, val_str: String) raises -> TOMLValue:
         """Parse a float string, handling inf/nan."""
         if val_str == "inf" or val_str == "+inf":
             return TOMLValue(Float64.MAX)
@@ -560,7 +560,7 @@ struct TOMLParser:
             return TOMLValue(atof("nan"))
         return TOMLValue(atof(val_str))
 
-    fn _parse_value(mut self) raises -> TOMLValue:
+    def _parse_value(mut self) raises -> TOMLValue:
         """Parse a TOML value."""
         var token = self._tok()
         self._advance()
@@ -602,7 +602,7 @@ struct TOMLParser:
 
     # ---- arrays (with newline/comment support) ---------------------------
 
-    fn _parse_array(mut self) raises -> TOMLValue:
+    def _parse_array(mut self) raises -> TOMLValue:
         """Parse an array value (opening [ already consumed)."""
         var elements = List[TOMLValue]()
 
@@ -631,7 +631,7 @@ struct TOMLParser:
 
     # ---- inline tables ---------------------------------------------------
 
-    fn _parse_inline_table(mut self) raises -> TOMLValue:
+    def _parse_inline_table(mut self) raises -> TOMLValue:
         """Parse an inline table { key = value, ... } (opening { consumed)."""
         var table = Dict[String, TOMLValue]()
 
@@ -679,7 +679,7 @@ struct TOMLParser:
 
     # ---- table header parsing --------------------------------------------
 
-    fn _parse_table_header(mut self) raises -> List[String]:
+    def _parse_table_header(mut self) raises -> List[String]:
         """Parse [a.b.c] and return the path.  Opening [ already consumed."""
         var path = self._parse_key_path()
 
@@ -691,7 +691,7 @@ struct TOMLParser:
 
         return path^
 
-    fn _parse_array_of_tables_header(mut self) raises -> List[String]:
+    def _parse_array_of_tables_header(mut self) raises -> List[String]:
         """Parse [[a.b.c]] and return the path.  Opening [[ already consumed."""
         var path = self._parse_key_path()
 
@@ -709,7 +709,7 @@ struct TOMLParser:
 
     # ---- main parse loop -------------------------------------------------
 
-    fn parse(mut self) raises -> TOMLDocument:
+    def parse(mut self) raises -> TOMLDocument:
         """Parse the tokens into a TOMLDocument."""
         var document = TOMLDocument()
         var current_path = List[String]()
@@ -776,13 +776,13 @@ struct TOMLParser:
         return document^
 
 
-fn parse_string(input: String) raises -> TOMLDocument:
+def parse_string(input: String) raises -> TOMLDocument:
     """Parse a TOML string into a document."""
     var parser = TOMLParser(input)
     return parser.parse()
 
 
-fn parse_file(file_path: String) raises -> TOMLDocument:
+def parse_file(file_path: String) raises -> TOMLDocument:
     """Parse a TOML file into a document."""
 
     with open(file_path, "r") as file:

--- a/src/decimo/toml/parser.mojo
+++ b/src/decimo/toml/parser.mojo
@@ -29,7 +29,7 @@ Supports:
 - Duplicate key detection
 """
 
-from collections import Dict
+from std.collections import Dict
 from .tokenizer import Token, TokenType, Tokenizer
 
 
@@ -94,14 +94,14 @@ struct TOMLValue(Copyable, ImplicitlyCopyable, Movable):
         self.array_values = List[TOMLValue]()
         self.table_values = Dict[String, TOMLValue]()
 
-    fn __copyinit__(out self, other: Self):
-        self.type = other.type
-        self.string_value = other.string_value
-        self.int_value = other.int_value
-        self.float_value = other.float_value
-        self.bool_value = other.bool_value
-        self.array_values = other.array_values.copy()
-        self.table_values = other.table_values.copy()
+    fn __init__(out self, *, copy: Self):
+        self.type = copy.type
+        self.string_value = copy.string_value
+        self.int_value = copy.int_value
+        self.float_value = copy.float_value
+        self.bool_value = copy.bool_value
+        self.array_values = copy.array_values.copy()
+        self.table_values = copy.table_values.copy()
 
     fn is_table(self) -> Bool:
         """Check if this value is a table."""
@@ -518,9 +518,9 @@ struct TOMLParser:
     fn _parse_integer(self, val_str: String) raises -> TOMLValue:
         """Parse an integer string, handling hex/octal/binary prefixes."""
         if len(val_str) > 2:
-            var prefix = String(val_str[:2])
+            var prefix = String(val_str[byte=:2])
             if prefix == "0x" or prefix == "0X":
-                var hex_str = String(val_str[2:])
+                var hex_str = String(val_str[byte=2:])
                 var result: Int = 0
                 for i in range(len(hex_str)):
                     var ch = String(hex_str[byte=i])
@@ -533,7 +533,7 @@ struct TOMLParser:
                         result += ord(ch) - ord("A") + 10
                 return TOMLValue(result)
             elif prefix == "0o" or prefix == "0O":
-                var oct_str = String(val_str[2:])
+                var oct_str = String(val_str[byte=2:])
                 var result: Int = 0
                 for i in range(len(oct_str)):
                     result = result * 8 + (
@@ -541,7 +541,7 @@ struct TOMLParser:
                     )
                 return TOMLValue(result)
             elif prefix == "0b" or prefix == "0B":
-                var bin_str = String(val_str[2:])
+                var bin_str = String(val_str[byte=2:])
                 var result: Int = 0
                 for i in range(len(bin_str)):
                     result = result * 2 + (

--- a/src/decimo/toml/tokenizer.mojo
+++ b/src/decimo/toml/tokenizer.mojo
@@ -60,7 +60,7 @@ struct SourcePosition:
             self.column = 1
         else:
             self.column += 1
-        self.index += 1
+        self.index += len(char)
 
 
 struct TokenType(Copyable, ImplicitlyCopyable, Movable):
@@ -440,9 +440,7 @@ struct Tokenizer:
             result += self.current_char  # 'x'/'o'/'b'
             self._advance()
             # Determine valid digit set based on the base prefix
-            var base_char = String(
-                result[byte = len(result) - 1]
-            )  # 'x'/'o'/'b'
+            var base_char = String(result[byte=len(result) - 1])  # 'x'/'o'/'b'
             var digits_found = False
 
             if base_char == "x" or base_char == "X":

--- a/src/decimo/toml/tokenizer.mojo
+++ b/src/decimo/toml/tokenizer.mojo
@@ -32,7 +32,7 @@ struct Token(Copyable, Movable):
     var line: Int
     var column: Int
 
-    fn __init__(
+    def __init__(
         out self, type: TokenType, value: String, line: Int, column: Int
     ):
         self.type = type
@@ -48,12 +48,12 @@ struct SourcePosition:
     var column: Int
     var index: Int
 
-    fn __init__(out self, line: Int = 1, column: Int = 1, index: Int = 0):
+    def __init__(out self, line: Int = 1, column: Int = 1, index: Int = 0):
         self.line = line
         self.column = column
         self.index = index
 
-    fn advance(mut self, char: String):
+    def advance(mut self, char: String):
         """Update position after consuming a character."""
         if char == "\n":
             self.line += 1
@@ -94,90 +94,90 @@ struct TokenType(Copyable, ImplicitlyCopyable, Movable):
 
     # Token type constants (lowercase method names)
     @staticmethod
-    fn key() -> TokenType:
+    def key() -> TokenType:
         return TokenType(0)
 
     @staticmethod
-    fn string() -> TokenType:
+    def string() -> TokenType:
         return TokenType(1)
 
     @staticmethod
-    fn integer() -> TokenType:
+    def integer() -> TokenType:
         return TokenType(2)
 
     @staticmethod
-    fn float() -> TokenType:
+    def float() -> TokenType:
         return TokenType(3)
 
     @staticmethod
-    fn boolean() -> TokenType:
+    def boolean() -> TokenType:
         return TokenType(4)
 
     @staticmethod
-    fn datetime() -> TokenType:
+    def datetime() -> TokenType:
         return TokenType(5)
 
     @staticmethod
-    fn array_start() -> TokenType:
+    def array_start() -> TokenType:
         return TokenType(6)
 
     @staticmethod
-    fn array_end() -> TokenType:
+    def array_end() -> TokenType:
         return TokenType(7)
 
     @staticmethod
-    fn table_start() -> TokenType:
+    def table_start() -> TokenType:
         return TokenType(8)
 
     @staticmethod
-    fn table_end() -> TokenType:
+    def table_end() -> TokenType:
         return TokenType(9)
 
     @staticmethod
-    fn array_of_tables_start() -> TokenType:
+    def array_of_tables_start() -> TokenType:
         return TokenType(16)
 
     @staticmethod
-    fn equal() -> TokenType:
+    def equal() -> TokenType:
         return TokenType(10)
 
     @staticmethod
-    fn comma() -> TokenType:
+    def comma() -> TokenType:
         return TokenType(11)
 
     @staticmethod
-    fn newline() -> TokenType:
+    def newline() -> TokenType:
         return TokenType(12)
 
     @staticmethod
-    fn dot() -> TokenType:
+    def dot() -> TokenType:
         return TokenType(13)
 
     @staticmethod
-    fn eof() -> TokenType:
+    def eof() -> TokenType:
         return TokenType(14)
 
     @staticmethod
-    fn error() -> TokenType:
+    def error() -> TokenType:
         return TokenType(15)
 
     @staticmethod
-    fn inline_table_start() -> TokenType:
+    def inline_table_start() -> TokenType:
         return TokenType(17)
 
     @staticmethod
-    fn inline_table_end() -> TokenType:
+    def inline_table_end() -> TokenType:
         return TokenType(18)
 
     # Constructor
-    fn __init__(out self, value: Int):
+    def __init__(out self, value: Int):
         self.value = value
 
     # Comparison operators
-    fn __eq__(self, other: TokenType) -> Bool:
+    def __eq__(self, other: TokenType) -> Bool:
         return self.value == other.value
 
-    fn __ne__(self, other: TokenType) -> Bool:
+    def __ne__(self, other: TokenType) -> Bool:
         return self.value != other.value
 
 
@@ -188,7 +188,7 @@ struct Tokenizer:
     var position: SourcePosition
     var current_char: String
 
-    fn __init__(out self, source: String):
+    def __init__(out self, source: String):
         self.source = source
         self.position = SourcePosition()
         if len(source) > 0:
@@ -196,23 +196,23 @@ struct Tokenizer:
         else:
             self.current_char = ""
 
-    fn _get_char(self, index: Int) -> String:
+    def _get_char(self, index: Int) -> String:
         """Get character at given index or empty string if out of bounds."""
         if index >= len(self.source):
             return ""
         return String(self.source[byte=index])
 
-    fn _advance(mut self):
+    def _advance(mut self):
         """Move to the next character."""
         self.position.advance(self.current_char)
         self.current_char = self._get_char(self.position.index)
 
-    fn _skip_whitespace(mut self):
+    def _skip_whitespace(mut self):
         """Skip whitespace characters."""
         while self.current_char and self.current_char in WHITESPACE:
             self._advance()
 
-    fn _skip_comment(mut self):
+    def _skip_comment(mut self):
         """Skip comment lines."""
         if self.current_char == COMMENT_START:
             while self.current_char:
@@ -227,7 +227,7 @@ struct Tokenizer:
                         break
                 self._advance()
 
-    fn _read_string(mut self) -> Token:
+    def _read_string(mut self) -> Token:
         """Read a quoted string value (basic or literal).
 
         Handles:
@@ -332,7 +332,7 @@ struct Tokenizer:
             TokenType.ERROR, "Unterminated string", start_line, start_column
         )
 
-    fn _read_escape_sequence(mut self) -> String:
+    def _read_escape_sequence(mut self) -> String:
         """Read and return the character for a backslash escape sequence.
 
         Assumes current_char is '\\'. Advances past the full sequence.
@@ -414,7 +414,7 @@ struct Tokenizer:
             # Unknown escape: keep as-is (backslash + char)
             return "\\" + esc
 
-    fn _read_number(mut self, sign: String = "") -> Token:
+    def _read_number(mut self, sign: String = "") -> Token:
         """Read a number value.
 
         Handles:
@@ -504,7 +504,7 @@ struct Tokenizer:
         else:
             return Token(TokenType.INTEGER, result, start_line, start_column)
 
-    fn _read_key(mut self) -> Token:
+    def _read_key(mut self) -> Token:
         """Read a key identifier."""
         start_line = self.position.line
         start_column = self.position.column
@@ -522,7 +522,7 @@ struct Tokenizer:
 
         return Token(TokenType.KEY, result, start_line, start_column)
 
-    fn next_token(mut self) -> Token:
+    def next_token(mut self) -> Token:
         """Get the next token from the source."""
         self._skip_whitespace()
 
@@ -700,7 +700,7 @@ struct Tokenizer:
         self._advance()
         return token^
 
-    fn tokenize(mut self) -> List[Token]:
+    def tokenize(mut self) -> List[Token]:
         """Tokenize the entire source text."""
         var tokens = List[Token]()
         var token = self.next_token()

--- a/tests/bigdecimal/test_bigdecimal_arithmetics.mojo
+++ b/tests/bigdecimal/test_bigdecimal_arithmetics.mojo
@@ -7,8 +7,8 @@ Test BigDecimal arithmetic operations including:
 4. division
 """
 
-from python import Python
-import testing
+from std.python import Python
+from std import testing
 
 from decimo import BDec
 from decimo.tests import TestCase, parse_file, load_test_cases

--- a/tests/bigdecimal/test_bigdecimal_arithmetics.mojo
+++ b/tests/bigdecimal/test_bigdecimal_arithmetics.mojo
@@ -16,7 +16,7 @@ from decimo.tests import TestCase, parse_file, load_test_cases
 comptime file_path = "tests/bigdecimal/test_data/bigdecimal_arithmetics.toml"
 
 
-fn test_bigdecimal_arithmetics() raises:
+def test_bigdecimal_arithmetics() raises:
     # Load test cases from TOML file
     var pydecimal = Python.import_module("decimal")
     var toml = parse_file(file_path)
@@ -143,7 +143,7 @@ fn test_bigdecimal_arithmetics() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     # print("Running BigDecimal arithmetic tests")
 
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/bigdecimal/test_bigdecimal_compare.mojo
+++ b/tests/bigdecimal/test_bigdecimal_compare.mojo
@@ -12,7 +12,7 @@ from decimo.tests import TestCase, parse_file, load_test_cases
 comptime file_path = "tests/bigdecimal/test_data/bigdecimal_compare.toml"
 
 
-fn test_bigdecimal_compare() raises:
+def test_bigdecimal_compare() raises:
     # Load test cases from TOML file
     var pydecimal = Python.import_module("decimal")
     var toml = parse_file(file_path)
@@ -213,7 +213,7 @@ fn test_bigdecimal_compare() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     # print("Running BigDecimal comparison tests")
 
     # Run compare_absolute tests

--- a/tests/bigdecimal/test_bigdecimal_compare.mojo
+++ b/tests/bigdecimal/test_bigdecimal_compare.mojo
@@ -2,8 +2,8 @@
 Test BigDecimal comparison operations.
 """
 
-from python import Python
-import testing
+from std.python import Python
+from std import testing
 
 from decimo import BDec
 from decimo.bigdecimal.comparison import compare_absolute, compare

--- a/tests/bigdecimal/test_bigdecimal_creation.mojo
+++ b/tests/bigdecimal/test_bigdecimal_creation.mojo
@@ -8,7 +8,7 @@ from std.python import Python
 from decimo.bigdecimal.bigdecimal import BigDecimal
 
 
-fn test_from_python_decimal_basic() raises:
+def test_from_python_decimal_basic() raises:
     """Test basic Python Decimal to BigDecimal conversion."""
     var decimal = Python.import_module("decimal")
 
@@ -33,7 +33,7 @@ fn test_from_python_decimal_basic() raises:
     testing.assert_equal(String(mojo_int), "12345", "Integer (scale=0)")
 
 
-fn test_from_python_decimal_scale() raises:
+def test_from_python_decimal_scale() raises:
     """Test scale/exponent conversion."""
     var decimal = Python.import_module("decimal")
 
@@ -60,7 +60,7 @@ fn test_from_python_decimal_scale() raises:
     )
 
 
-fn test_from_python_decimal_scientific_notation() raises:
+def test_from_python_decimal_scientific_notation() raises:
     """Test scientific notation conversion."""
     var decimal = Python.import_module("decimal")
 
@@ -96,7 +96,7 @@ fn test_from_python_decimal_scientific_notation() raises:
     )
 
 
-fn test_from_python_decimal_high_precision() raises:
+def test_from_python_decimal_high_precision() raises:
     """Test high precision decimal conversion."""
     var decimal = Python.import_module("decimal")
 
@@ -116,7 +116,7 @@ fn test_from_python_decimal_high_precision() raises:
     testing.assert_equal(String(mojo_long), long_str, "Very long decimal")
 
 
-fn test_from_python_decimal_arithmetic() raises:
+def test_from_python_decimal_arithmetic() raises:
     """Test that converted BigDecimal can perform arithmetic correctly."""
     var decimal = Python.import_module("decimal")
 
@@ -153,7 +153,7 @@ fn test_from_python_decimal_arithmetic() raises:
     )
 
 
-fn test_from_python_decimal_sign() raises:
+def test_from_python_decimal_sign() raises:
     """Test sign handling in Python Decimal conversion."""
     var decimal = Python.import_module("decimal")
 
@@ -182,7 +182,7 @@ fn test_from_python_decimal_sign() raises:
     )
 
 
-fn test_from_python_decimal_edge_cases() raises:
+def test_from_python_decimal_edge_cases() raises:
     """Test edge cases for Python Decimal conversion."""
     var decimal = Python.import_module("decimal")
 
@@ -212,7 +212,7 @@ fn test_from_python_decimal_edge_cases() raises:
     )
 
 
-fn test_from_python_decimal_constructor() raises:
+def test_from_python_decimal_constructor() raises:
     """Test the py= constructor syntax."""
     var decimal = Python.import_module("decimal")
 
@@ -231,7 +231,7 @@ fn test_from_python_decimal_constructor() raises:
     )
 
 
-fn test_from_python_decimal_roundtrip() raises:
+def test_from_python_decimal_roundtrip() raises:
     """Test Python -> Mojo -> Python roundtrip."""
     var decimal = Python.import_module("decimal")
 
@@ -252,7 +252,7 @@ fn test_from_python_decimal_roundtrip() raises:
     )
 
 
-fn test_from_python_decimal_special_values() raises:
+def test_from_python_decimal_special_values() raises:
     """Test handling of special values."""
     var decimal = Python.import_module("decimal")
 
@@ -273,5 +273,5 @@ fn test_from_python_decimal_special_values() raises:
     # This is expected behavior and documented in the method
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/bigdecimal/test_bigdecimal_creation.mojo
+++ b/tests/bigdecimal/test_bigdecimal_creation.mojo
@@ -3,8 +3,8 @@ Test BigDecimal.from_python_decimal() method.
 Tests conversion from Python Decimal to Mojo BigDecimal.
 """
 
-import testing
-from python import Python
+from std import testing
+from std.python import Python
 from decimo.bigdecimal.bigdecimal import BigDecimal
 
 

--- a/tests/bigdecimal/test_bigdecimal_exponential.mojo
+++ b/tests/bigdecimal/test_bigdecimal_exponential.mojo
@@ -6,8 +6,8 @@ against TOML expected values), because Python's Decimal cannot compute most
 non-integer exponents.
 """
 
-from python import Python
-import testing
+from std.python import Python
+from std import testing
 
 from decimo import BDec
 from decimo.tests import TestCase, parse_file, load_test_cases

--- a/tests/bigdecimal/test_bigdecimal_exponential.mojo
+++ b/tests/bigdecimal/test_bigdecimal_exponential.mojo
@@ -15,7 +15,7 @@ from decimo.tests import TestCase, parse_file, load_test_cases
 comptime file_path = "tests/bigdecimal/test_data/bigdecimal_exponential.toml"
 
 
-fn test_bigdecimal_exponential() raises:
+def test_bigdecimal_exponential() raises:
     # Load test cases from TOML file
     var pydecimal = Python.import_module("decimal")
     pydecimal.getcontext().prec = 28
@@ -75,7 +75,7 @@ fn test_bigdecimal_exponential() raises:
     )
 
 
-fn test_sqrt_multi_precision() raises:
+def test_sqrt_multi_precision() raises:
     """Test sqrt at various precisions against Python's decimal module.
 
     Exercises both perfect squares (whose natural digit count may exceed the
@@ -146,7 +146,7 @@ fn test_sqrt_multi_precision() raises:
     )
 
 
-fn test_negative_sqrt() raises:
+def test_negative_sqrt() raises:
     """Test that square root of negative number raises an error."""
     var negative_number = BDec("-1")
 
@@ -162,7 +162,7 @@ fn test_negative_sqrt() raises:
     )
 
 
-fn test_ln_invalid_inputs() raises:
+def test_ln_invalid_inputs() raises:
     """Test that natural logarithm with invalid inputs raises appropriate errors.
     """
     # Test 1: ln of zero should raise an error
@@ -187,5 +187,5 @@ fn test_ln_invalid_inputs() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/bigdecimal/test_bigdecimal_exponential_toml.mojo
+++ b/tests/bigdecimal/test_bigdecimal_exponential_toml.mojo
@@ -6,7 +6,7 @@ compare against pre-computed expected values in the TOML data file instead
 of Python cross-checking.
 """
 
-import testing
+from std import testing
 
 from decimo import BDec
 from decimo.tests import TestCase, parse_file, load_test_cases

--- a/tests/bigdecimal/test_bigdecimal_exponential_toml.mojo
+++ b/tests/bigdecimal/test_bigdecimal_exponential_toml.mojo
@@ -14,7 +14,7 @@ from decimo.tests import TestCase, parse_file, load_test_cases
 comptime file_path = "tests/bigdecimal/test_data/bigdecimal_exponential.toml"
 
 
-fn test_bigdecimal_root() raises:
+def test_bigdecimal_root() raises:
     """Test BigDecimal root function against TOML expected values."""
     var toml = parse_file(file_path)
     var test_cases = load_test_cases(toml, "root_tests")
@@ -39,7 +39,7 @@ fn test_bigdecimal_root() raises:
     )
 
 
-fn test_bigdecimal_power() raises:
+def test_bigdecimal_power() raises:
     """Test BigDecimal power function against TOML expected values."""
     var toml = parse_file(file_path)
     var test_cases = load_test_cases(toml, "power_tests")
@@ -64,7 +64,7 @@ fn test_bigdecimal_power() raises:
     )
 
 
-fn test_root_invalid_inputs() raises:
+def test_root_invalid_inputs() raises:
     """Test that root function with invalid inputs raises appropriate errors."""
     var a1 = BDec("16")
     var n1 = BDec("0")
@@ -103,7 +103,7 @@ fn test_root_invalid_inputs() raises:
     )
 
 
-fn test_power_invalid_inputs() raises:
+def test_power_invalid_inputs() raises:
     """Test that power function with invalid inputs raises appropriate errors.
     """
     var base1 = BDec("0")
@@ -140,5 +140,5 @@ fn test_power_invalid_inputs() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/bigdecimal/test_bigdecimal_methods.mojo
+++ b/tests/bigdecimal/test_bigdecimal_methods.mojo
@@ -24,7 +24,7 @@ from decimo.biguint.biguint import BigUInt
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_is_positive_positive_values() raises:
+def test_is_positive_positive_values() raises:
     """Positive values return True."""
     testing.assert_true(BigDecimal("1").is_positive())
     testing.assert_true(BigDecimal("0.001").is_positive())
@@ -32,20 +32,20 @@ fn test_is_positive_positive_values() raises:
     testing.assert_true(BigDecimal("1E+50").is_positive())
 
 
-fn test_is_positive_negative_values() raises:
+def test_is_positive_negative_values() raises:
     """Negative values return False."""
     testing.assert_false(BigDecimal("-1").is_positive())
     testing.assert_false(BigDecimal("-0.001").is_positive())
     testing.assert_false(BigDecimal("-1E+50").is_positive())
 
 
-fn test_is_positive_zero() raises:
+def test_is_positive_zero() raises:
     """Zero is not positive."""
     testing.assert_false(BigDecimal("0").is_positive())
     testing.assert_false(BigDecimal("0.000").is_positive())
 
 
-fn test_is_positive_matches_bigint_semantics() raises:
+def test_is_positive_matches_bigint_semantics() raises:
     """Strictly positive (zero excluded), matching BigInt semantics."""
     var pos = BigDecimal("1")
     var neg = BigDecimal("-1")
@@ -65,7 +65,7 @@ fn test_is_positive_matches_bigint_semantics() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_rtruediv_basic() raises:
+def test_rtruediv_basic() raises:
     """Int / BigDecimal dispatches via __rtruediv__."""
     # 1 / 2  -> 0.5
     var result = BigDecimal("1") / BigDecimal("2")
@@ -80,7 +80,7 @@ fn test_rtruediv_basic() raises:
     testing.assert_equal(String(dispatched), String(result), "1 / x dispatch")
 
 
-fn test_rtruediv_integer_numerator() raises:
+def test_rtruediv_integer_numerator() raises:
     """Verify 1 / x == x.__rtruediv__(1)."""
     var x = BigDecimal("4")
     var expected = BigDecimal("1") / x
@@ -88,7 +88,7 @@ fn test_rtruediv_integer_numerator() raises:
     testing.assert_equal(String(got), String(expected))
 
 
-fn test_rtruediv_negative() raises:
+def test_rtruediv_negative() raises:
     """-1 / 2 == BigDecimal('2').__rtruediv__(BigDecimal('-1'))."""
     var x = BigDecimal("2")
     var got = x.__rtruediv__(BigDecimal("-1"))
@@ -96,7 +96,7 @@ fn test_rtruediv_negative() raises:
     testing.assert_equal(String(got), String(expected))
 
 
-fn test_rtruediv_symmetry() raises:
+def test_rtruediv_symmetry() raises:
     """Verify a / b == b.__rtruediv__(a) for various pairs."""
     var as_: List[String] = ["10", "1", "100", "-5"]
     var bs: List[String] = ["3", "7", "6", "2"]
@@ -117,7 +117,7 @@ fn test_rtruediv_symmetry() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_to_scientific_string_basic() raises:
+def test_to_scientific_string_basic() raises:
     """Basic scientific notation examples."""
     testing.assert_equal(
         BigDecimal("123456.789").to_scientific_string(), "1.23456789E+5"
@@ -129,7 +129,7 @@ fn test_to_scientific_string_basic() raises:
     testing.assert_equal(BigDecimal("10").to_scientific_string(), "1E+1")
 
 
-fn test_to_scientific_string_trailing_zeros_stripped() raises:
+def test_to_scientific_string_trailing_zeros_stripped() raises:
     """Trailing zeros are stripped in scientific notation."""
     # "1.23000" stored as coefficient=123000, scale=5
     var v = BigDecimal("1.23000")
@@ -138,14 +138,14 @@ fn test_to_scientific_string_trailing_zeros_stripped() raises:
     testing.assert_equal(s, "1.23E0")
 
 
-fn test_to_scientific_string_negative() raises:
+def test_to_scientific_string_negative() raises:
     """Negative numbers keep the minus sign."""
     testing.assert_equal(
         BigDecimal("-0.00123").to_scientific_string(), "-1.23E-3"
     )
 
 
-fn test_to_scientific_string_zero() raises:
+def test_to_scientific_string_zero() raises:
     """Zero renders correctly."""
     testing.assert_equal(BigDecimal("0").to_scientific_string(), "0E0")
 
@@ -155,7 +155,7 @@ fn test_to_scientific_string_zero() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_to_eng_string_basic() raises:
+def test_to_eng_string_basic() raises:
     """Engineering notation: exponent is a multiple of 3."""
     testing.assert_equal(
         BigDecimal("123456.789").to_eng_string(), "123.456789E+3"
@@ -164,7 +164,7 @@ fn test_to_eng_string_basic() raises:
     testing.assert_equal(BigDecimal("1000000").to_eng_string(), "1E+6")
 
 
-fn test_to_eng_string_trailing_zeros_stripped() raises:
+def test_to_eng_string_trailing_zeros_stripped() raises:
     """Trailing zeros are stripped in engineering notation."""
     var v = BigDecimal("1230.00")
     var s = v.to_eng_string()
@@ -174,13 +174,13 @@ fn test_to_eng_string_trailing_zeros_stripped() raises:
     )
 
 
-fn test_to_eng_string_negative() raises:
+def test_to_eng_string_negative() raises:
     """Negative numbers keep the minus sign."""
     var s = BigDecimal("-123456").to_eng_string()
     testing.assert_true(s.startswith("-"), "negative sign preserved: " + s)
 
 
-fn test_to_eng_string_is_alias() raises:
+def test_to_eng_string_is_alias() raises:
     """Verify to_eng_string() returns the same as to_string(engineering=True).
     """
     var values: List[String] = ["123456.789", "0.00123", "-9.99E+10", "0"]
@@ -193,7 +193,7 @@ fn test_to_eng_string_is_alias() raises:
         )
 
 
-fn test_to_scientific_string_is_alias() raises:
+def test_to_scientific_string_is_alias() raises:
     """Verify to_scientific_string() returns the same as to_string(scientific=True).
     """
     var values: List[String] = ["123456.789", "0.00123", "-9.99E+10", "0"]
@@ -212,7 +212,7 @@ fn test_to_scientific_string_is_alias() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_number_of_digits_basic() raises:
+def test_number_of_digits_basic() raises:
     """Counts all coefficient digits."""
     testing.assert_equal(BigDecimal("123.456").number_of_digits(), 6)
     testing.assert_equal(BigDecimal("0.00123").number_of_digits(), 3)
@@ -222,13 +222,13 @@ fn test_number_of_digits_basic() raises:
     testing.assert_equal(BigDecimal("1.0000").number_of_digits(), 5)
 
 
-fn test_number_of_digits_zero() raises:
+def test_number_of_digits_zero() raises:
     """Zero has one digit."""
     testing.assert_equal(BigDecimal("0").number_of_digits(), 1)
     testing.assert_equal(BigDecimal("0.0").number_of_digits(), 1)
 
 
-fn test_number_of_digits_after_normalize() raises:
+def test_number_of_digits_after_normalize() raises:
     """After normalize(), trailing zeros are stripped, reducing digit count."""
     # "1.0000" normalizes to "1" (coefficient = 1, scale = 0)
     var one_with_zeros = BigDecimal("1.0000")
@@ -237,7 +237,7 @@ fn test_number_of_digits_after_normalize() raises:
     testing.assert_equal(normalized.number_of_digits(), 1)
 
 
-fn test_number_of_digits_zero_normalize() raises:
+def test_number_of_digits_zero_normalize() raises:
     """Normalizing zero keeps 1 digit."""
     var z = BigDecimal("0")
     testing.assert_equal(z.number_of_digits(), 1)
@@ -245,7 +245,7 @@ fn test_number_of_digits_zero_normalize() raises:
     testing.assert_equal(zn.number_of_digits(), 1)
 
 
-fn test_number_of_digits_large_integer() raises:
+def test_number_of_digits_large_integer() raises:
     """Large integers keep all digits in the coefficient."""
     var big = BigDecimal("100")
     testing.assert_equal(big.number_of_digits(), 3)
@@ -259,7 +259,7 @@ fn test_number_of_digits_large_integer() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_as_tuple_positive_decimal() raises:
+def test_as_tuple_positive_decimal() raises:
     """7.25 → (False, [7,2,5], -2)."""
     var t = BigDecimal("7.25").as_tuple()
     testing.assert_false(t[0], "sign should be False for positive")
@@ -270,7 +270,7 @@ fn test_as_tuple_positive_decimal() raises:
     testing.assert_equal(t[2], -2, "exponent")
 
 
-fn test_as_tuple_negative_decimal() raises:
+def test_as_tuple_negative_decimal() raises:
     """-0.001 → (True, [1], -3)."""
     var t = BigDecimal("-0.001").as_tuple()
     testing.assert_true(t[0], "sign should be True for negative")
@@ -279,7 +279,7 @@ fn test_as_tuple_negative_decimal() raises:
     testing.assert_equal(t[2], -3, "exponent")
 
 
-fn test_as_tuple_integer() raises:
+def test_as_tuple_integer() raises:
     """12345 → (False, [1,2,3,4,5], 0)."""
     var t = BigDecimal("12345").as_tuple()
     testing.assert_false(t[0])
@@ -289,7 +289,7 @@ fn test_as_tuple_integer() raises:
     testing.assert_equal(t[2], 0)
 
 
-fn test_as_tuple_scientific_positive_exp() raises:
+def test_as_tuple_scientific_positive_exp() raises:
     """1E+5 → (False, [1], 5)."""
     var t = BigDecimal("1E+5").as_tuple()
     testing.assert_false(t[0])
@@ -298,7 +298,7 @@ fn test_as_tuple_scientific_positive_exp() raises:
     testing.assert_equal(t[2], 5)
 
 
-fn test_as_tuple_zero() raises:
+def test_as_tuple_zero() raises:
     """0 → (False, [0], 0)."""
     var t = BigDecimal("0").as_tuple()
     testing.assert_false(t[0], "zero is not negative")
@@ -307,7 +307,7 @@ fn test_as_tuple_zero() raises:
     testing.assert_equal(t[2], 0)
 
 
-fn test_as_tuple_reconstruct() raises:
+def test_as_tuple_reconstruct() raises:
     """Round-trip: reconstruct BigDecimal from (sign, digits, exponent)."""
     var values: List[String] = ["123.456", "-0.001", "12345", "0"]
     for vi in range(len(values)):
@@ -333,74 +333,74 @@ fn test_as_tuple_reconstruct() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_copy_abs_positive() raises:
+def test_copy_abs_positive() raises:
     """Positive value unchanged."""
     var x = BigDecimal("3.14")
     testing.assert_equal(String(x.copy_abs()), "3.14")
 
 
-fn test_copy_abs_negative() raises:
+def test_copy_abs_negative() raises:
     """Negative value becomes positive."""
     var x = BigDecimal("-3.14")
     testing.assert_equal(String(x.copy_abs()), "3.14")
 
 
-fn test_copy_abs_zero() raises:
+def test_copy_abs_zero() raises:
     """Zero stays zero."""
     testing.assert_equal(String(BigDecimal("0").copy_abs()), "0")
 
 
-fn test_copy_abs_matches_abs() raises:
+def test_copy_abs_matches_abs() raises:
     """Verify copy_abs() == abs(x)."""
     var x = BigDecimal("-42.5")
     testing.assert_equal(String(x.copy_abs()), String(x.__abs__()))
 
 
-fn test_copy_negate_positive() raises:
+def test_copy_negate_positive() raises:
     """Positive becomes negative."""
     testing.assert_equal(String(BigDecimal("3.14").copy_negate()), "-3.14")
 
 
-fn test_copy_negate_negative() raises:
+def test_copy_negate_negative() raises:
     """Negative becomes positive."""
     testing.assert_equal(String(BigDecimal("-3.14").copy_negate()), "3.14")
 
 
-fn test_copy_negate_zero() raises:
+def test_copy_negate_zero() raises:
     """Negating zero."""
     var z = BigDecimal("0").copy_negate()
     # Zero negated — coefficient is still 0
     testing.assert_true(z.is_zero())
 
 
-fn test_copy_negate_matches_neg() raises:
+def test_copy_negate_matches_neg() raises:
     """Verify copy_negate() == -x."""
     var x = BigDecimal("42.5")
     testing.assert_equal(String(x.copy_negate()), String(x.__neg__()))
 
 
-fn test_copy_sign_positive_to_negative() raises:
+def test_copy_sign_positive_to_negative() raises:
     """Copy sign of negative onto positive value."""
     var x = BigDecimal("3.14")
     var y = BigDecimal("-1")
     testing.assert_equal(String(x.copy_sign(y)), "-3.14")
 
 
-fn test_copy_sign_negative_to_positive() raises:
+def test_copy_sign_negative_to_positive() raises:
     """Copy sign of positive onto negative value."""
     var x = BigDecimal("-3.14")
     var y = BigDecimal("1")
     testing.assert_equal(String(x.copy_sign(y)), "3.14")
 
 
-fn test_copy_sign_same_sign() raises:
+def test_copy_sign_same_sign() raises:
     """Same sign leaves value unchanged."""
     var x = BigDecimal("3.14")
     var y = BigDecimal("99")
     testing.assert_equal(String(x.copy_sign(y)), "3.14")
 
 
-fn test_copy_sign_zero_source() raises:
+def test_copy_sign_zero_source() raises:
     """Zero takes sign of other."""
     var x = BigDecimal("0")
     var y = BigDecimal("-5")
@@ -415,7 +415,7 @@ fn test_copy_sign_zero_source() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_adjusted_basic() raises:
+def test_adjusted_basic() raises:
     """Basic adjusted exponent values."""
     testing.assert_equal(BigDecimal("123.45").adjusted(), 2)
     testing.assert_equal(BigDecimal("0.00123").adjusted(), -3)
@@ -424,7 +424,7 @@ fn test_adjusted_basic() raises:
     testing.assert_equal(BigDecimal("10").adjusted(), 1)
 
 
-fn test_adjusted_zero() raises:
+def test_adjusted_zero() raises:
     """Zero has adjusted exponent 0 regardless of scale."""
     testing.assert_equal(BigDecimal("0").adjusted(), 0)
     testing.assert_equal(BigDecimal("0.00").adjusted(), 0)
@@ -432,7 +432,7 @@ fn test_adjusted_zero() raises:
     testing.assert_equal(BigDecimal("0E+10").adjusted(), 0)
 
 
-fn test_adjusted_scientific() raises:
+def test_adjusted_scientific() raises:
     """Scientific notation inputs."""
     testing.assert_equal(BigDecimal("1E+5").adjusted(), 5)
     testing.assert_equal(BigDecimal("1E-5").adjusted(), -5)
@@ -444,27 +444,27 @@ fn test_adjusted_scientific() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_same_quantum_same_scale() raises:
+def test_same_quantum_same_scale() raises:
     """Same scale returns True."""
     testing.assert_true(BigDecimal("1.23").same_quantum(BigDecimal("4.56")))
     testing.assert_true(BigDecimal("100").same_quantum(BigDecimal("1")))
     testing.assert_true(BigDecimal("0").same_quantum(BigDecimal("5")))
 
 
-fn test_same_quantum_different_scale() raises:
+def test_same_quantum_different_scale() raises:
     """Different scale returns False."""
     testing.assert_false(BigDecimal("1.2").same_quantum(BigDecimal("4.56")))
     testing.assert_false(BigDecimal("1").same_quantum(BigDecimal("1.0")))
     testing.assert_false(BigDecimal("0").same_quantum(BigDecimal("0.00")))
 
 
-fn test_same_quantum_negative() raises:
+def test_same_quantum_negative() raises:
     """Sign does not affect quantum comparison."""
     testing.assert_true(BigDecimal("1.23").same_quantum(BigDecimal("-4.56")))
     testing.assert_true(BigDecimal("-1.23").same_quantum(BigDecimal("4.56")))
 
 
-fn test_same_quantum_zero_variants() raises:
+def test_same_quantum_zero_variants() raises:
     """Zeros with different scales have different quanta."""
     testing.assert_true(BigDecimal("0").same_quantum(BigDecimal("0")))
     testing.assert_true(BigDecimal("0.00").same_quantum(BigDecimal("0.00")))
@@ -476,24 +476,24 @@ fn test_same_quantum_zero_variants() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_scaleb_positive() raises:
+def test_scaleb_positive() raises:
     """Tests scaleb with positive n multiplies value by 10^n."""
     testing.assert_equal(String(BigDecimal("1.23").scaleb(2)), "123")
     testing.assert_equal(String(BigDecimal("5").scaleb(3)), "5E+3")
 
 
-fn test_scaleb_negative() raises:
+def test_scaleb_negative() raises:
     """Tests scaleb with negative n divides value by 10^|n|."""
     testing.assert_equal(String(BigDecimal("1.23").scaleb(-2)), "0.0123")
     testing.assert_equal(String(BigDecimal("100").scaleb(-1)), "10.0")
 
 
-fn test_scaleb_zero() raises:
+def test_scaleb_zero() raises:
     """Tests scaleb(0) returns the same value."""
     testing.assert_equal(String(BigDecimal("42.5").scaleb(0)), "42.5")
 
 
-fn test_scaleb_on_zero() raises:
+def test_scaleb_on_zero() raises:
     """Tests scaleb on zero adjusts scale but value stays zero."""
     var result = BigDecimal("0").scaleb(5)
     testing.assert_true(result.is_zero())
@@ -504,25 +504,25 @@ fn test_scaleb_on_zero() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_fma_basic() raises:
+def test_fma_basic() raises:
     """Tests fma(a, b) = self * a + b."""
     var result = BigDecimal("2").fma(BigDecimal("3"), BigDecimal("4"))
     testing.assert_equal(String(result), "10")
 
 
-fn test_fma_decimal() raises:
+def test_fma_decimal() raises:
     """Tests fma with fractional values."""
     var result = BigDecimal("1.5").fma(BigDecimal("2"), BigDecimal("0.1"))
     testing.assert_equal(String(result), "3.1")
 
 
-fn test_fma_negative() raises:
+def test_fma_negative() raises:
     """Tests fma with negative values."""
     var result = BigDecimal("-3").fma(BigDecimal("4"), BigDecimal("15"))
     testing.assert_equal(String(result), "3")
 
 
-fn test_fma_zero_multiplier() raises:
+def test_fma_zero_multiplier() raises:
     """Tests fma with zero multiplier: 0 * a + b = b."""
     var result = BigDecimal("0").fma(BigDecimal("999"), BigDecimal("42"))
     testing.assert_equal(String(result), "42")
@@ -533,14 +533,14 @@ fn test_fma_zero_multiplier() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_to_string_with_separators_default() raises:
+def test_to_string_with_separators_default() raises:
     """Tests to_string_with_separators with default separator."""
     testing.assert_equal(
         BigDecimal("1234567").to_string_with_separators(), "1_234_567"
     )
 
 
-fn test_to_string_with_separators_comma() raises:
+def test_to_string_with_separators_comma() raises:
     """Tests to_string_with_separators with custom comma separator."""
     testing.assert_equal(
         BigDecimal("1234567.89").to_string_with_separators(","),
@@ -548,18 +548,18 @@ fn test_to_string_with_separators_comma() raises:
     )
 
 
-fn test_to_string_with_separators_small() raises:
+def test_to_string_with_separators_small() raises:
     """Tests to_string_with_separators with numbers having fewer than 4 digits.
     """
     testing.assert_equal(BigDecimal("123").to_string_with_separators(), "123")
 
 
-fn test_to_string_with_separators_negative() raises:
+def test_to_string_with_separators_negative() raises:
     """Tests to_string_with_separators with negative numbers."""
     testing.assert_equal(
         BigDecimal("-1234567").to_string_with_separators(), "-1_234_567"
     )
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/bigdecimal/test_bigdecimal_methods.mojo
+++ b/tests/bigdecimal/test_bigdecimal_methods.mojo
@@ -14,7 +14,7 @@ Tests for BigDecimal utility methods added in v0.8.x:
   - to_string_with_separators()
 """
 
-import testing
+from std import testing
 from decimo.bigdecimal.bigdecimal import BigDecimal
 from decimo.biguint.biguint import BigUInt
 

--- a/tests/bigdecimal/test_bigdecimal_rounding.mojo
+++ b/tests/bigdecimal/test_bigdecimal_rounding.mojo
@@ -12,7 +12,7 @@ from decimo.tests import TestCase, parse_file, load_test_cases
 comptime file_path = "tests/bigdecimal/test_data/bigdecimal_rounding.toml"
 
 
-fn test_bigdecimal_rounding() raises:
+def test_bigdecimal_rounding() raises:
     # Load test cases from TOML file
     var pydecimal = Python.import_module("decimal")
     # Set high precision so Python's quantize doesn't raise InvalidOperation
@@ -293,7 +293,7 @@ fn test_bigdecimal_rounding() raises:
     )
 
 
-fn test_default_rounding_mode() raises:
+def test_default_rounding_mode() raises:
     """Test that the default rounding mode is ROUND_HALF_EVEN."""
     # print("------------------------------------------------------")
     # print("Testing BigDecimal default rounding mode...")
@@ -321,7 +321,7 @@ fn test_default_rounding_mode() raises:
     # print("✓ Default rounding mode tests passed")
 
 
-fn test_quantize_basic() raises:
+def test_quantize_basic() raises:
     """Test basic quantize() functionality."""
     var pydecimal = Python.import_module("decimal")
     var toml = parse_file(file_path)
@@ -356,7 +356,7 @@ fn test_quantize_basic() raises:
     )
 
 
-fn test_quantize_financial() raises:
+def test_quantize_financial() raises:
     """Test quantize() for financial calculations."""
     var pydecimal = Python.import_module("decimal")
     var toml = parse_file(file_path)
@@ -391,7 +391,7 @@ fn test_quantize_financial() raises:
     )
 
 
-fn test_quantize_scientific() raises:
+def test_quantize_scientific() raises:
     """Test quantize() for scientific measurements."""
     var pydecimal = Python.import_module("decimal")
     var toml = parse_file(file_path)
@@ -426,7 +426,7 @@ fn test_quantize_scientific() raises:
     )
 
 
-fn test_quantize_negative_scale() raises:
+def test_quantize_negative_scale() raises:
     """Test quantize() with negative scale (scientific notation)."""
     var pydecimal = Python.import_module("decimal")
     var toml = parse_file(file_path)
@@ -461,7 +461,7 @@ fn test_quantize_negative_scale() raises:
     )
 
 
-fn test_quantize_add_zeros() raises:
+def test_quantize_add_zeros() raises:
     """Test quantize() adding trailing zeros."""
     var pydecimal = Python.import_module("decimal")
     var toml = parse_file(file_path)
@@ -496,7 +496,7 @@ fn test_quantize_add_zeros() raises:
     )
 
 
-fn test_quantize_same_scale() raises:
+def test_quantize_same_scale() raises:
     """Test quantize() when scales are already the same."""
     var pydecimal = Python.import_module("decimal")
     var toml = parse_file(file_path)
@@ -531,7 +531,7 @@ fn test_quantize_same_scale() raises:
     )
 
 
-fn test_quantize_normalization() raises:
+def test_quantize_normalization() raises:
     """Test quantize() with normalized templates ('3.1E+2' vs '31E1')."""
     var pydecimal = Python.import_module("decimal")
     var toml = parse_file(file_path)
@@ -566,7 +566,7 @@ fn test_quantize_normalization() raises:
     )
 
 
-fn test_quantize_edge_cases() raises:
+def test_quantize_edge_cases() raises:
     """Test quantize() edge cases with banker's rounding."""
     var pydecimal = Python.import_module("decimal")
     var toml = parse_file(file_path)
@@ -601,7 +601,7 @@ fn test_quantize_edge_cases() raises:
     )
 
 
-fn test_quantize_rounding_modes() raises:
+def test_quantize_rounding_modes() raises:
     """Test quantize() with different rounding modes."""
     var pydecimal = Python.import_module("decimal")
     var toml = parse_file(file_path)
@@ -655,7 +655,7 @@ fn test_quantize_rounding_modes() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     # print("Running BigDecimal rounding tests")
 
     # Test different rounding modes

--- a/tests/bigdecimal/test_bigdecimal_rounding.mojo
+++ b/tests/bigdecimal/test_bigdecimal_rounding.mojo
@@ -2,8 +2,8 @@
 Test BigDecimal rounding operations with various rounding modes and precision values.
 """
 
-from python import Python
-import testing
+from std.python import Python
+from std import testing
 
 from decimo.bigdecimal.bigdecimal import BDec
 from decimo.rounding_mode import RoundingMode

--- a/tests/bigdecimal/test_bigdecimal_trigonometric.mojo
+++ b/tests/bigdecimal/test_bigdecimal_trigonometric.mojo
@@ -13,7 +13,7 @@ comptime file_path = "tests/bigdecimal/test_data/bigdecimal_trigonometric.toml"
 
 
 fn run_test[
-    func: fn (BDec, Int) raises -> BDec
+    func: fn(BDec, Int) raises -> BDec
 ](toml: TOMLDocument, table_name: String, msg: String) raises:
     """Run a specific test case from the TOML document."""
     # print("------------------------------------------------------")
@@ -48,27 +48,27 @@ fn test_bigdecimal_trignometric() raises:
     # Load test cases from TOML file
     var toml = parse_file(file_path)
 
-    run_test[func = decimo.bigdecimal.trigonometric.sin](
+    run_test[func=decimo.bigdecimal.trigonometric.sin](
         toml,
         "sin_tests",
         "sin",
     )
-    run_test[func = decimo.bigdecimal.trigonometric.cos](
+    run_test[func=decimo.bigdecimal.trigonometric.cos](
         toml,
         "cos_tests",
         "cos",
     )
-    run_test[func = decimo.bigdecimal.trigonometric.tan](
+    run_test[func=decimo.bigdecimal.trigonometric.tan](
         toml,
         "tan_tests",
         "tan",
     )
-    run_test[func = decimo.bigdecimal.trigonometric.cot](
+    run_test[func=decimo.bigdecimal.trigonometric.cot](
         toml,
         "cot_tests",
         "cot",
     )
-    run_test[func = decimo.bigdecimal.trigonometric.arctan](
+    run_test[func=decimo.bigdecimal.trigonometric.arctan](
         toml,
         "arctan_tests",
         "arctan",

--- a/tests/bigdecimal/test_bigdecimal_trigonometric.mojo
+++ b/tests/bigdecimal/test_bigdecimal_trigonometric.mojo
@@ -2,8 +2,8 @@
 Test BigDecimal trigonometric functions
 """
 
-from python import Python
-import testing
+from std.python import Python
+from std import testing
 
 from decimo import BDec
 from decimo.tests import TestCase, parse_file, load_test_cases

--- a/tests/bigdecimal/test_bigdecimal_trigonometric.mojo
+++ b/tests/bigdecimal/test_bigdecimal_trigonometric.mojo
@@ -12,8 +12,8 @@ from decimo.toml.parser import TOMLDocument
 comptime file_path = "tests/bigdecimal/test_data/bigdecimal_trigonometric.toml"
 
 
-fn run_test[
-    func: fn(BDec, Int) raises -> BDec
+def run_test[
+    func: def(BDec, Int) raises -> BDec
 ](toml: TOMLDocument, table_name: String, msg: String) raises:
     """Run a specific test case from the TOML document."""
     # print("------------------------------------------------------")
@@ -44,7 +44,7 @@ fn run_test[
     )
 
 
-fn test_bigdecimal_trignometric() raises:
+def test_bigdecimal_trignometric() raises:
     # Load test cases from TOML file
     var toml = parse_file(file_path)
 
@@ -75,7 +75,7 @@ fn test_bigdecimal_trignometric() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     # print("Running BigDecimal trigonometric tests")
 
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/bigint/test_bigint_arithmetics.mojo
+++ b/tests/bigint/test_bigint_arithmetics.mojo
@@ -21,7 +21,7 @@ comptime file_path_biguint_arithmetics = "tests/biguint/test_data/biguint_arithm
 comptime file_path_biguint_truncate_divide = "tests/biguint/test_data/biguint_truncate_divide.toml"
 
 
-fn _set_max_str_digits(limit: Int) raises:
+def _set_max_str_digits(limit: Int) raises:
     """Set Python's int-to-string digit limit (Python 3.11+). No-op if unavailable.
     """
     try:
@@ -30,7 +30,7 @@ fn _set_max_str_digits(limit: Int) raises:
         pass
 
 
-fn test_bigint_addition() raises:
+def test_bigint_addition() raises:
     """Test BigInt addition using shared TOML test data."""
     _set_max_str_digits(500000)
     var toml = parse_file(file_path_arithmetics)
@@ -57,7 +57,7 @@ fn test_bigint_addition() raises:
     )
 
 
-fn test_bigint_subtraction() raises:
+def test_bigint_subtraction() raises:
     """Test BigInt subtraction using shared TOML test data."""
     _set_max_str_digits(500000)
     var toml = parse_file(file_path_arithmetics)
@@ -84,7 +84,7 @@ fn test_bigint_subtraction() raises:
     )
 
 
-fn test_bigint_negation() raises:
+def test_bigint_negation() raises:
     """Test BigInt negation using shared TOML test data."""
     _set_max_str_digits(500000)
     var toml = parse_file(file_path_arithmetics)
@@ -111,7 +111,7 @@ fn test_bigint_negation() raises:
     )
 
 
-fn test_bigint_abs() raises:
+def test_bigint_abs() raises:
     """Test BigInt absolute value using shared TOML test data."""
     var pybuiltins = Python.import_module("builtins")
     _set_max_str_digits(500000)
@@ -139,7 +139,7 @@ fn test_bigint_abs() raises:
     )
 
 
-fn test_bigint_multiply() raises:
+def test_bigint_multiply() raises:
     """Test BigInt multiplication using shared TOML test data."""
     _set_max_str_digits(500000)
     var toml = parse_file(file_path_multiply)
@@ -166,7 +166,7 @@ fn test_bigint_multiply() raises:
     )
 
 
-fn test_bigint_floor_divide() raises:
+def test_bigint_floor_divide() raises:
     """Test BigInt floor division using shared TOML test data."""
     _set_max_str_digits(500000)
     var toml = parse_file(file_path_floor_divide)
@@ -193,7 +193,7 @@ fn test_bigint_floor_divide() raises:
     )
 
 
-fn test_bigint_truncate_divide() raises:
+def test_bigint_truncate_divide() raises:
     """Test BigInt truncate division using shared TOML test data."""
     var pybuiltins = Python.import_module("builtins")
     _set_max_str_digits(500000)
@@ -228,7 +228,7 @@ fn test_bigint_truncate_divide() raises:
     )
 
 
-fn test_bigint_comparison() raises:
+def test_bigint_comparison() raises:
     """Test BigInt comparison operators."""
     # Basic comparisons
     var a = BigInt(42)
@@ -283,7 +283,7 @@ fn test_bigint_comparison() raises:
     testing.assert_true(neg1 > neg2, "-100 > -200")
 
 
-fn test_bigint_division_by_zero() raises:
+def test_bigint_division_by_zero() raises:
     """Test that division by zero raises an error."""
     var a = BigInt(42)
     var zero = BigInt(0)
@@ -305,7 +305,7 @@ fn test_bigint_division_by_zero() raises:
     testing.assert_true(raised, "Truncate division by zero should raise")
 
 
-fn test_bigint_zero_quotient_mixed_sign() raises:
+def test_bigint_zero_quotient_mixed_sign() raises:
     """Regression test: 0 // negative should be +0 with sign == False."""
     # Floor divide: 0 // -5
     var result_floor = BigInt(0) // BigInt(-5)
@@ -347,7 +347,7 @@ fn test_bigint_zero_quotient_mixed_sign() raises:
     )
 
 
-fn test_bigint_augmented_assignment() raises:
+def test_bigint_augmented_assignment() raises:
     """Test augmented assignment operators (+=, -=, *=)."""
     var a = BigInt(100)
 
@@ -366,7 +366,7 @@ fn test_bigint_augmented_assignment() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_bigint_biguint_addition() raises:
+def test_bigint_biguint_addition() raises:
     """Test BigInt addition with BigUInt TOML test data (all positive)."""
     _set_max_str_digits(500000)
     var toml = parse_file(file_path_biguint_arithmetics)
@@ -393,7 +393,7 @@ fn test_bigint_biguint_addition() raises:
     )
 
 
-fn test_bigint_biguint_subtraction() raises:
+def test_bigint_biguint_subtraction() raises:
     """Test BigInt subtraction with BigUInt TOML test data (a >= b cases)."""
     _set_max_str_digits(500000)
     var toml = parse_file(file_path_biguint_arithmetics)
@@ -437,7 +437,7 @@ fn test_bigint_biguint_subtraction() raises:
     )
 
 
-fn test_bigint_biguint_subtraction_underflow() raises:
+def test_bigint_biguint_subtraction_underflow() raises:
     """Test that BigInt handles subtraction underflow (smaller - larger).
 
     Unlike BigUInt which errors, BigInt should return a negative result.
@@ -451,7 +451,7 @@ fn test_bigint_biguint_subtraction_underflow() raises:
     )
 
 
-fn test_bigint_floor_divide_burnikel_ziegler() raises:
+def test_bigint_floor_divide_burnikel_ziegler() raises:
     """Test floor division with large operands that exercise the
     Burnikel-Ziegler dispatch path (divisor > 64 words ≈ 617 digits).
 
@@ -541,7 +541,7 @@ fn test_bigint_floor_divide_burnikel_ziegler() raises:
     )
 
 
-fn test_bigint_biguint_multiplication() raises:
+def test_bigint_biguint_multiplication() raises:
     """Test BigInt multiplication with BigUInt TOML test data (all positive)."""
     _set_max_str_digits(500000)
     var toml = parse_file(file_path_biguint_arithmetics)
@@ -568,7 +568,7 @@ fn test_bigint_biguint_multiplication() raises:
     )
 
 
-fn test_bigint_biguint_truncate_divide() raises:
+def test_bigint_biguint_truncate_divide() raises:
     """Test BigInt truncate division with BigUInt TOML test data (all positive).
     """
     _set_max_str_digits(500000)
@@ -596,5 +596,5 @@ fn test_bigint_biguint_truncate_divide() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/bigint/test_bigint_arithmetics.mojo
+++ b/tests/bigint/test_bigint_arithmetics.mojo
@@ -6,8 +6,8 @@ Reuses TOML test data from the BigInt10 test suite, since the test cases
 use decimal string representations that are valid for both BigInt10 and BigInt.
 """
 
-from python import Python
-import testing
+from std.python import Python
+from std import testing
 from decimo.bigint.bigint import BigInt
 from decimo.tests import TestCase, parse_file, load_test_cases
 

--- a/tests/bigint/test_bigint_basic.mojo
+++ b/tests/bigint/test_bigint_basic.mojo
@@ -2,7 +2,7 @@
 # Test BigInt basic functionality
 # ===----------------------------------------------------------------------=== #
 
-import testing
+from std import testing
 from decimo.bigint.bigint import BigInt
 
 

--- a/tests/bigint/test_bigint_basic.mojo
+++ b/tests/bigint/test_bigint_basic.mojo
@@ -6,7 +6,7 @@ from std import testing
 from decimo.bigint.bigint import BigInt
 
 
-fn test_default_constructor() raises:
+def test_default_constructor() raises:
     """Test that default constructor creates zero."""
     var x = BigInt()
     assert_true(x.is_zero(), "Default constructor should be zero")
@@ -16,7 +16,7 @@ fn test_default_constructor() raises:
     print("  PASS: default constructor")
 
 
-fn test_from_int() raises:
+def test_from_int() raises:
     """Test construction from Int."""
     var zero = BigInt(0)
     assert_true(zero.is_zero(), "BigInt(0) should be zero")
@@ -52,7 +52,7 @@ fn test_from_int() raises:
     print("  PASS: from_int")
 
 
-fn test_from_string() raises:
+def test_from_string() raises:
     """Test construction from String."""
     var zero = BigInt("0")
     assert_true(zero.is_zero(), "from_string('0') should be zero")
@@ -88,7 +88,7 @@ fn test_from_string() raises:
     print("  PASS: from_string")
 
 
-fn test_negation_and_abs() raises:
+def test_negation_and_abs() raises:
     """Test __neg__ and __abs__."""
     var pos = BigInt(42)
     var neg = -pos
@@ -105,7 +105,7 @@ fn test_negation_and_abs() raises:
     print("  PASS: negation and abs")
 
 
-fn test_hex_and_binary_string() raises:
+def test_hex_and_binary_string() raises:
     """Test to_hex_string and to_binary_string."""
     var zero = BigInt(0)
     assert_true(
@@ -135,7 +135,7 @@ fn test_hex_and_binary_string() raises:
     print("  PASS: hex and binary string")
 
 
-fn test_bit_length() raises:
+def test_bit_length() raises:
     """Test bit_length."""
     var zero = BigInt(0)
     assert_true(zero.bit_length() == 0, "bit_length(0)")
@@ -155,7 +155,7 @@ fn test_bit_length() raises:
     print("  PASS: bit_length")
 
 
-fn test_copy() raises:
+def test_copy() raises:
     """Test copy method."""
     var original = BigInt("12345678901234567890")
     var copied = original.copy()
@@ -172,7 +172,7 @@ fn test_copy() raises:
     print("  PASS: copy")
 
 
-fn test_normalize() raises:
+def test_normalize() raises:
     """Test _normalize strips leading zeros and normalizes -0."""
     var x = BigInt(raw_words=[UInt32(42), UInt32(0), UInt32(0)], sign=False)
     x._normalize()
@@ -187,17 +187,17 @@ fn test_normalize() raises:
     print("  PASS: normalize")
 
 
-fn test_print_internal() raises:
+def test_print_internal() raises:
     """Smoke test for print_internal_representation."""
     var x = BigInt("1234567890123456789")
     x.print_internal_representation()
     print("  PASS: print_internal_representation (visual check above)")
 
 
-fn assert_true(cond: Bool, msg: String) raises:
+def assert_true(cond: Bool, msg: String) raises:
     if not cond:
         raise Error("FAIL: " + msg)
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/bigint/test_bigint_bitwise.mojo
+++ b/tests/bigint/test_bigint_bitwise.mojo
@@ -4,7 +4,7 @@ and augmented assignment (&=, |=, ^=). All tests compare against Python's
 arbitrary-precision integer bitwise semantics.
 """
 
-import testing
+from std import testing
 from decimo.bigint.bigint import BigInt
 
 

--- a/tests/bigint/test_bigint_bitwise.mojo
+++ b/tests/bigint/test_bigint_bitwise.mojo
@@ -13,12 +13,12 @@ from decimo.bigint.bigint import BigInt
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_invert_zero() raises:
+def test_invert_zero() raises:
     """Tests ~0 = -1."""
     testing.assert_equal(String(~BigInt(0)), "-1")
 
 
-fn test_invert_positive() raises:
+def test_invert_positive() raises:
     """Tests ~x = -(x+1) for positive x."""
     testing.assert_equal(String(~BigInt(1)), "-2")
     testing.assert_equal(String(~BigInt(2)), "-3")
@@ -27,7 +27,7 @@ fn test_invert_positive() raises:
     testing.assert_equal(String(~BigInt(1000000)), "-1000001")
 
 
-fn test_invert_negative() raises:
+def test_invert_negative() raises:
     """Tests ~(-x) = x - 1 for negative x."""
     testing.assert_equal(String(~BigInt(-1)), "0")
     testing.assert_equal(String(~BigInt(-2)), "1")
@@ -37,7 +37,7 @@ fn test_invert_negative() raises:
     testing.assert_equal(String(~BigInt(-1000001)), "1000000")
 
 
-fn test_invert_double() raises:
+def test_invert_double() raises:
     """Tests ~~x = x (involution)."""
     testing.assert_equal(String(~(~BigInt(0))), "0")
     testing.assert_equal(String(~(~BigInt(42))), "42")
@@ -48,7 +48,7 @@ fn test_invert_double() raises:
     )
 
 
-fn test_invert_large() raises:
+def test_invert_large() raises:
     """Tests ~x for large multi-word values."""
     # ~(2^32) = -(2^32 + 1)
     testing.assert_equal(String(~BigInt("4294967296")), "-4294967297")
@@ -67,7 +67,7 @@ fn test_invert_large() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_and_both_positive() raises:
+def test_and_both_positive() raises:
     """Tests Positive & Positive → Positive."""
     # 0xFF & 0x0F = 0x0F = 15
     testing.assert_equal(String(BigInt(255) & BigInt(15)), "15")
@@ -79,7 +79,7 @@ fn test_and_both_positive() raises:
     testing.assert_equal(String(BigInt(42) & BigInt(42)), "42")
 
 
-fn test_and_positive_negative() raises:
+def test_and_positive_negative() raises:
     """Tests Positive & Negative → Positive (Python semantics).
     In Python: 5 & -3 = 5.
     5    = ...00000101
@@ -98,7 +98,7 @@ fn test_and_positive_negative() raises:
     testing.assert_equal(String(BigInt(12) & BigInt(-8)), "8")
 
 
-fn test_and_both_negative() raises:
+def test_and_both_negative() raises:
     """Tests Negative & Negative → Negative (Python semantics).
     In Python: -5 & -3 = -7.
     -5   = ...11111011
@@ -117,7 +117,7 @@ fn test_and_both_negative() raises:
     testing.assert_equal(String(BigInt(-256) & BigInt(-16)), "-256")
 
 
-fn test_and_large_values() raises:
+def test_and_large_values() raises:
     """AND with multi-word values."""
     # (2^64 - 1) & (2^32 - 1) = 2^32 - 1
     var all_64 = BigInt("18446744073709551615")
@@ -130,7 +130,7 @@ fn test_and_large_values() raises:
     )
 
 
-fn test_and_with_int() raises:
+def test_and_with_int() raises:
     """AND with Int overload."""
     testing.assert_equal(String(BigInt(255) & 15), "15")
     testing.assert_equal(String(BigInt(-5) & -3), "-7")
@@ -141,7 +141,7 @@ fn test_and_with_int() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_or_both_positive() raises:
+def test_or_both_positive() raises:
     """Tests Positive | Positive → Positive."""
     # 0b1010 | 0b1100 = 0b1110 = 14
     testing.assert_equal(String(BigInt(10) | BigInt(12)), "14")
@@ -153,7 +153,7 @@ fn test_or_both_positive() raises:
     testing.assert_equal(String(BigInt(42) | BigInt(42)), "42")
 
 
-fn test_or_positive_negative() raises:
+def test_or_positive_negative() raises:
     """Tests Positive | Negative → Negative (Python semantics).
     In Python: 5 | -3 = -3.
     5    = ...00000101
@@ -172,7 +172,7 @@ fn test_or_positive_negative() raises:
     testing.assert_equal(String(BigInt(12) | BigInt(-8)), "-4")
 
 
-fn test_or_both_negative() raises:
+def test_or_both_negative() raises:
     """Tests Negative | Negative → Negative (Python semantics).
     In Python: -5 | -3 = -1.
     -5   = ...11111011
@@ -185,13 +185,13 @@ fn test_or_both_negative() raises:
     testing.assert_equal(String(BigInt(-256) | BigInt(-16)), "-16")
 
 
-fn test_or_large_values() raises:
+def test_or_large_values() raises:
     """OR with multi-word values."""
     # (2^32) | 1 = 2^32 + 1
     testing.assert_equal(String(BigInt("4294967296") | BigInt(1)), "4294967297")
 
 
-fn test_or_with_int() raises:
+def test_or_with_int() raises:
     """OR with Int overload."""
     testing.assert_equal(String(BigInt(10) | 12), "14")
     testing.assert_equal(String(BigInt(5) | -3), "-3")
@@ -202,7 +202,7 @@ fn test_or_with_int() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_xor_both_positive() raises:
+def test_xor_both_positive() raises:
     """Positive ^ Positive → Positive."""
     # 0b1010 ^ 0b1100 = 0b0110 = 6
     testing.assert_equal(String(BigInt(10) ^ BigInt(12)), "6")
@@ -214,7 +214,7 @@ fn test_xor_both_positive() raises:
     testing.assert_equal(String(BigInt(255) ^ BigInt(15)), "240")
 
 
-fn test_xor_positive_negative() raises:
+def test_xor_positive_negative() raises:
     """Tests Positive ^ Negative → Negative (Python semantics).
     In Python: 5 ^ -3 = -8.
     5    = ...00000101
@@ -234,7 +234,7 @@ fn test_xor_positive_negative() raises:
     testing.assert_equal(String(BigInt(12) ^ BigInt(-8)), "-12")
 
 
-fn test_xor_both_negative() raises:
+def test_xor_both_negative() raises:
     """Tests Negative ^ Negative → Positive (Python semantics).
     In Python: -5 ^ -3 = 6.
     -5   = ...11111011
@@ -250,7 +250,7 @@ fn test_xor_both_negative() raises:
     testing.assert_equal(String(BigInt(-256) ^ BigInt(-16)), "240")
 
 
-fn test_xor_large_values() raises:
+def test_xor_large_values() raises:
     """XOR with multi-word values."""
     # (2^32) ^ 1 = 2^32 + 1
     testing.assert_equal(String(BigInt("4294967296") ^ BigInt(1)), "4294967297")
@@ -260,7 +260,7 @@ fn test_xor_large_values() raises:
     testing.assert_equal(String(big ^ big.copy()), "0")
 
 
-fn test_xor_with_int() raises:
+def test_xor_with_int() raises:
     """XOR with Int overload."""
     testing.assert_equal(String(BigInt(10) ^ 12), "6")
     testing.assert_equal(String(BigInt(5) ^ -3), "-8")
@@ -271,21 +271,21 @@ fn test_xor_with_int() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_augmented_and() raises:
+def test_augmented_and() raises:
     """Test &= operator."""
     var x = BigInt(255)
     x &= BigInt(15)
     testing.assert_equal(String(x), "15")
 
 
-fn test_augmented_or() raises:
+def test_augmented_or() raises:
     """Test |= operator."""
     var x = BigInt(10)
     x |= BigInt(12)
     testing.assert_equal(String(x), "14")
 
 
-fn test_augmented_xor() raises:
+def test_augmented_xor() raises:
     """Test ^= operator."""
     var x = BigInt(10)
     x ^= BigInt(12)
@@ -297,7 +297,7 @@ fn test_augmented_xor() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_demorgan_laws() raises:
+def test_demorgan_laws() raises:
     """De Morgan's laws: ~(a & b) = ~a | ~b, ~(a | b) = ~a & ~b."""
     var a = BigInt(42)
     var b = BigInt(99)
@@ -327,7 +327,7 @@ fn test_demorgan_laws() raises:
     )
 
 
-fn test_xor_self_cancels() raises:
+def test_xor_self_cancels() raises:
     """Tests a ^ a = 0 for various values."""
     testing.assert_equal(String(BigInt(0) ^ BigInt(0)), "0")
     testing.assert_equal(String(BigInt(42) ^ BigInt(42)), "0")
@@ -336,7 +336,7 @@ fn test_xor_self_cancels() raises:
     testing.assert_equal(String(big ^ big.copy()), "0")
 
 
-fn test_and_with_minus_one() raises:
+def test_and_with_minus_one() raises:
     """Tests a & -1 = a (AND with all-ones is identity)."""
     testing.assert_equal(String(BigInt(0) & BigInt(-1)), "0")
     testing.assert_equal(String(BigInt(42) & BigInt(-1)), "42")
@@ -347,20 +347,20 @@ fn test_and_with_minus_one() raises:
     )
 
 
-fn test_or_with_zero() raises:
+def test_or_with_zero() raises:
     """Tests a | 0 = a (OR with zero is identity)."""
     testing.assert_equal(String(BigInt(0) | BigInt(0)), "0")
     testing.assert_equal(String(BigInt(42) | BigInt(0)), "42")
     testing.assert_equal(String(BigInt(-42) | BigInt(0)), "-42")
 
 
-fn test_xor_with_zero() raises:
+def test_xor_with_zero() raises:
     """Tests a ^ 0 = a (XOR with zero is identity)."""
     testing.assert_equal(String(BigInt(42) ^ BigInt(0)), "42")
     testing.assert_equal(String(BigInt(-42) ^ BigInt(0)), "-42")
 
 
-fn test_commutativity() raises:
+def test_commutativity() raises:
     """Tests a op b = b op a for all binary bitwise ops."""
     var a = BigInt(123)
     var b = BigInt(-456)
@@ -370,7 +370,7 @@ fn test_commutativity() raises:
     testing.assert_equal(String(a ^ b), String(b ^ a))
 
 
-fn test_python_cross_check() raises:
+def test_python_cross_check() raises:
     """Cross-check specific values against Python results.
     Computed in Python 3.13:
         123 & -456 = 56
@@ -388,7 +388,7 @@ fn test_python_cross_check() raises:
     testing.assert_equal(String(BigInt(-100) ^ BigInt(-200)), "164")
 
 
-fn test_word_boundary_values() raises:
+def test_word_boundary_values() raises:
     """Test values at word boundaries (32-bit, 64-bit)."""
     # 2^32 - 1 = 0xFFFFFFFF (single word, all bits set)
     var w32 = BigInt("4294967295")
@@ -421,24 +421,24 @@ fn test_word_boundary_values() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_bit_count_zero() raises:
+def test_bit_count_zero() raises:
     """Tests bit_count(0) = 0."""
     testing.assert_equal(BigInt(0).bit_count(), 0)
 
 
-fn test_bit_count_one() raises:
+def test_bit_count_one() raises:
     """Tests bit_count(1) = 1."""
     testing.assert_equal(BigInt(1).bit_count(), 1)
 
 
-fn test_bit_count_powers_of_two() raises:
+def test_bit_count_powers_of_two() raises:
     """Powers of 2 have exactly 1 bit set."""
     testing.assert_equal(BigInt(2).bit_count(), 1)
     testing.assert_equal(BigInt(4).bit_count(), 1)
     testing.assert_equal(BigInt(1024).bit_count(), 1)
 
 
-fn test_bit_count_small() raises:
+def test_bit_count_small() raises:
     """Small values: 7 = 0b111 (3 bits), 13 = 0b1101 (3 bits)."""
     testing.assert_equal(BigInt(7).bit_count(), 3)
     testing.assert_equal(BigInt(13).bit_count(), 3)
@@ -446,18 +446,18 @@ fn test_bit_count_small() raises:
     testing.assert_equal(BigInt(255).bit_count(), 8)
 
 
-fn test_bit_count_negative() raises:
+def test_bit_count_negative() raises:
     """Tests bit_count on negative values counts bits in the magnitude."""
     testing.assert_equal(BigInt(-7).bit_count(), 3)
     testing.assert_equal(BigInt(-1).bit_count(), 1)
 
 
-fn test_bit_count_large() raises:
+def test_bit_count_large() raises:
     """2^32 - 1 = 0xFFFFFFFF has 32 bits set."""
     var n = BigInt(1) << 32
     n = n - BigInt(1)  # 2^32 - 1
     testing.assert_equal(n.bit_count(), 32)
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/bigint/test_bigint_compare_utility.mojo
+++ b/tests/bigint/test_bigint_compare_utility.mojo
@@ -12,7 +12,7 @@ from decimo.bigint.bigint import BigInt
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_is_one_or_minus_one() raises:
+def test_is_one_or_minus_one() raises:
     """Test is_one_or_minus_one method."""
     testing.assert_true(BigInt(1).is_one_or_minus_one(), "1 is ±1")
     testing.assert_true(BigInt(-1).is_one_or_minus_one(), "-1 is ±1")
@@ -26,7 +26,7 @@ fn test_is_one_or_minus_one() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_compare_instance_method() raises:
+def test_compare_instance_method() raises:
     """Test compare() instance method."""
     testing.assert_equal(BigInt(5).compare(BigInt(3)), Int8(1))
     testing.assert_equal(BigInt(3).compare(BigInt(5)), Int8(-1))
@@ -36,7 +36,7 @@ fn test_compare_instance_method() raises:
     testing.assert_equal(BigInt(0).compare(BigInt(0)), Int8(0))
 
 
-fn test_compare_magnitudes_instance_method() raises:
+def test_compare_magnitudes_instance_method() raises:
     """Test compare_magnitudes() instance method."""
     testing.assert_equal(BigInt(5).compare_magnitudes(BigInt(3)), Int8(1))
     testing.assert_equal(BigInt(3).compare_magnitudes(BigInt(5)), Int8(-1))
@@ -53,7 +53,7 @@ fn test_compare_magnitudes_instance_method() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_iadd_int() raises:
+def test_iadd_int() raises:
     """Test optimized += with Int."""
     var x = BigInt(100)
     x += 1
@@ -69,5 +69,5 @@ fn test_iadd_int() raises:
     testing.assert_equal(String(x), "1099")
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/bigint/test_bigint_compare_utility.mojo
+++ b/tests/bigint/test_bigint_compare_utility.mojo
@@ -3,7 +3,7 @@ Test BigInt comparison and utility methods: compare, compare_magnitudes,
 is_one_or_minus_one, and __iadd__(Int).
 """
 
-import testing
+from std import testing
 from decimo.bigint.bigint import BigInt
 
 

--- a/tests/bigint/test_bigint_conversion.mojo
+++ b/tests/bigint/test_bigint_conversion.mojo
@@ -4,7 +4,7 @@ various formats (commas, underscores, spaces, scientific notation, decimal
 point), and D&C from_string for large numbers.
 """
 
-import testing
+from std import testing
 from decimo.bigint.bigint import BigInt
 from decimo.bigint10.bigint10 import BigInt10
 

--- a/tests/bigint/test_bigint_conversion.mojo
+++ b/tests/bigint/test_bigint_conversion.mojo
@@ -14,7 +14,7 @@ from decimo.bigint10.bigint10 import BigInt10
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_to_int_small_positive() raises:
+def test_to_int_small_positive() raises:
     """Test to_int with small positive numbers."""
     testing.assert_equal(Int(BigInt(0)), 0)
     testing.assert_equal(Int(BigInt(1)), 1)
@@ -22,14 +22,14 @@ fn test_to_int_small_positive() raises:
     testing.assert_equal(Int(BigInt(1000000)), 1000000)
 
 
-fn test_to_int_small_negative() raises:
+def test_to_int_small_negative() raises:
     """Test to_int with small negative numbers."""
     testing.assert_equal(Int(BigInt(-1)), -1)
     testing.assert_equal(Int(BigInt(-42)), -42)
     testing.assert_equal(Int(BigInt(-1000000)), -1000000)
 
 
-fn test_to_int_large_values() raises:
+def test_to_int_large_values() raises:
     """Test to_int with values near Int.MAX and Int.MIN."""
     # Int.MAX = 9_223_372_036_854_775_807
     var max_val = BigInt("9223372036854775807")
@@ -40,7 +40,7 @@ fn test_to_int_large_values() raises:
     testing.assert_equal(Int(min_val), Int.MIN)
 
 
-fn test_to_int_overflow() raises:
+def test_to_int_overflow() raises:
     """Test to_int raises on overflow."""
     var too_large = BigInt("9223372036854775808")  # Int.MAX + 1
     var raised = False
@@ -72,7 +72,7 @@ fn test_to_int_overflow() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_from_integral_scalar() raises:
+def test_from_integral_scalar() raises:
     """Test construction from Scalar types."""
     # UInt8
     var u8 = BigInt(UInt8(255))
@@ -112,7 +112,7 @@ fn test_from_integral_scalar() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_from_string_large_dc() raises:
+def test_from_string_large_dc() raises:
     """Test from_string round-trip for large numbers (500–2000 digits).
     These sizes exercise the simple O(n²) path. The D&C path is only
     entered at >10000 digits and is tested in test_from_string_dc_path.
@@ -160,7 +160,7 @@ fn test_from_string_large_dc() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_from_string_dc_path() raises:
+def test_from_string_dc_path() raises:
     """Test that from_string exercises the D&C conversion path by parsing
     a string with >10000 digits (_DC_FROM_STR_ENTRY_THRESHOLD).
     """
@@ -197,7 +197,7 @@ fn test_from_string_dc_path() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_from_string_with_commas() raises:
+def test_from_string_with_commas() raises:
     """Test from_string handles commas as thousand separators."""
     testing.assert_equal(String(BigInt("1,234,567")), "1234567")
     testing.assert_equal(String(BigInt("-1,000,000")), "-1000000")
@@ -206,21 +206,21 @@ fn test_from_string_with_commas() raises:
     )
 
 
-fn test_from_string_with_underscores() raises:
+def test_from_string_with_underscores() raises:
     """Test from_string handles underscores as digit separators."""
     testing.assert_equal(String(BigInt("1_000_000")), "1000000")
     testing.assert_equal(String(BigInt("-99_999")), "-99999")
     testing.assert_equal(String(BigInt("1_2_3_4_5")), "12345")
 
 
-fn test_from_string_with_spaces() raises:
+def test_from_string_with_spaces() raises:
     """Test from_string handles spaces in the string."""
     testing.assert_equal(String(BigInt(" 42 ")), "42")
     testing.assert_equal(String(BigInt("1 000 000")), "1000000")
     testing.assert_equal(String(BigInt("- 123")), "-123")
 
 
-fn test_from_string_with_scientific_notation() raises:
+def test_from_string_with_scientific_notation() raises:
     """Test from_string handles scientific/exponential notation."""
     # 1.23e5 = 123000
     testing.assert_equal(String(BigInt("1.23e5")), "123000")
@@ -234,14 +234,14 @@ fn test_from_string_with_scientific_notation() raises:
     testing.assert_equal(String(BigInt("100e2")), "10000")
 
 
-fn test_from_string_with_decimal_point_integer() raises:
+def test_from_string_with_decimal_point_integer() raises:
     """Test from_string with decimal point where fractional part is zero."""
     testing.assert_equal(String(BigInt("123.0")), "123")
     testing.assert_equal(String(BigInt("100.00")), "100")
     testing.assert_equal(String(BigInt("-42.000")), "-42")
 
 
-fn test_from_string_non_integer_raises() raises:
+def test_from_string_non_integer_raises() raises:
     """Test from_string raises error for non-integer values."""
     var raised = False
     try:
@@ -266,7 +266,7 @@ fn test_from_string_non_integer_raises() raises:
     testing.assert_true(raised, msg="Should raise for non-integer '1.23e1'")
 
 
-fn test_from_string_plus_sign() raises:
+def test_from_string_plus_sign() raises:
     """Tests from_string handles explicit positive sign."""
     testing.assert_equal(String(BigInt("+42")), "42")
     testing.assert_equal(String(BigInt("+0")), "0")
@@ -278,7 +278,7 @@ fn test_from_string_plus_sign() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_float_small() raises:
+def test_float_small() raises:
     """Tests __float__ with small integers."""
     testing.assert_equal(Float64(BigInt(0)), 0.0)
     testing.assert_equal(Float64(BigInt(1)), 1.0)
@@ -286,10 +286,10 @@ fn test_float_small() raises:
     testing.assert_equal(Float64(BigInt(-7)), -7.0)
 
 
-fn test_float_large() raises:
+def test_float_large() raises:
     """Tests __float__ with a large-ish integer."""
     testing.assert_equal(Float64(BigInt(1000000)), 1000000.0)
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/bigint/test_bigint_inplace.mojo
+++ b/tests/bigint/test_bigint_inplace.mojo
@@ -15,70 +15,70 @@ from decimo.bigint.bigint import BigInt
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_iadd_basic() raises:
+def test_iadd_basic() raises:
     """Basic iadd: positive + positive."""
     var x = BigInt(100)
     x += BigInt(23)
     testing.assert_equal(String(x), "123")
 
 
-fn test_iadd_zero_lhs() raises:
+def test_iadd_zero_lhs() raises:
     """Iadd: 0 += other."""
     var x = BigInt(0)
     x += BigInt(42)
     testing.assert_equal(String(x), "42")
 
 
-fn test_iadd_zero_rhs() raises:
+def test_iadd_zero_rhs() raises:
     """Iadd: x += 0 is no-op."""
     var x = BigInt(42)
     x += BigInt(0)
     testing.assert_equal(String(x), "42")
 
 
-fn test_iadd_both_zero() raises:
+def test_iadd_both_zero() raises:
     """Iadd: 0 += 0 = 0."""
     var x = BigInt(0)
     x += BigInt(0)
     testing.assert_equal(String(x), "0")
 
 
-fn test_iadd_negative_result() raises:
+def test_iadd_negative_result() raises:
     """Iadd with negative result: positive + negative where |neg| > |pos|."""
     var x = BigInt(10)
     x += BigInt(-30)
     testing.assert_equal(String(x), "-20")
 
 
-fn test_iadd_cancel_to_zero() raises:
+def test_iadd_cancel_to_zero() raises:
     """Iadd: x + (-x) = 0."""
     var x = BigInt(42)
     x += BigInt(-42)
     testing.assert_equal(String(x), "0")
 
 
-fn test_iadd_both_negative() raises:
+def test_iadd_both_negative() raises:
     """Iadd: negative + negative."""
     var x = BigInt(-10)
     x += BigInt(-20)
     testing.assert_equal(String(x), "-30")
 
 
-fn test_iadd_neg_plus_pos() raises:
+def test_iadd_neg_plus_pos() raises:
     """Iadd: negative + positive where |pos| > |neg|."""
     var x = BigInt(-10)
     x += BigInt(30)
     testing.assert_equal(String(x), "20")
 
 
-fn test_iadd_carry_propagation() raises:
+def test_iadd_carry_propagation() raises:
     """Iadd with carry: (2^32 - 1) + 1 = 2^32."""
     var x = BigInt("4294967295")
     x += BigInt(1)
     testing.assert_equal(String(x), "4294967296")
 
 
-fn test_iadd_large_values() raises:
+def test_iadd_large_values() raises:
     """Iadd with large multi-word values."""
     var x = BigInt("999999999999999999999999999999")
     x += BigInt(1)
@@ -89,10 +89,10 @@ fn test_iadd_large_values() raises:
     testing.assert_equal(String(y), "1000000000000000000000000000000")
 
 
-fn test_iadd_matches_add() raises:
+def test_iadd_matches_add() raises:
     """Iadd produces same result as add for various values."""
 
-    fn _check(a: String, b: String) raises:
+    def _check(a: String, b: String) raises:
         var expected = String(BigInt(a) + BigInt(b))
         var x = BigInt(a)
         x += BigInt(b)
@@ -114,14 +114,14 @@ fn test_iadd_matches_add() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_iadd_int_basic() raises:
+def test_iadd_int_basic() raises:
     """Iadd with Int: positive + positive."""
     var x = BigInt(100)
     x += 23
     testing.assert_equal(String(x), "123")
 
 
-fn test_iadd_int_zero() raises:
+def test_iadd_int_zero() raises:
     """Iadd with Int: x += 0 is no-op."""
     var x = BigInt(42)
     x += 0
@@ -132,7 +132,7 @@ fn test_iadd_int_zero() raises:
     testing.assert_equal(String(y), "42")
 
 
-fn test_iadd_int_negative() raises:
+def test_iadd_int_negative() raises:
     """Iadd with Int: adding negative Int."""
     var x = BigInt(10)
     x += -30
@@ -143,7 +143,7 @@ fn test_iadd_int_negative() raises:
     testing.assert_equal(String(y), "-5")
 
 
-fn test_iadd_int_cancel() raises:
+def test_iadd_int_cancel() raises:
     """Iadd with Int: cancellation to zero."""
     var x = BigInt(42)
     x += -42
@@ -154,14 +154,14 @@ fn test_iadd_int_cancel() raises:
     testing.assert_equal(String(y), "0")
 
 
-fn test_iadd_int_large_base() raises:
+def test_iadd_int_large_base() raises:
     """Iadd with Int: large BigInt + small Int."""
     var x = BigInt("999999999999999999999999999999")
     x += 1
     testing.assert_equal(String(x), "1000000000000000000000000000000")
 
 
-fn test_iadd_int_accumulator_loop() raises:
+def test_iadd_int_accumulator_loop() raises:
     """Iadd Int in a loop: simulate accumulator pattern."""
     var sum = BigInt(0)
     for i in range(1, 101):
@@ -175,21 +175,21 @@ fn test_iadd_int_accumulator_loop() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_isub_basic() raises:
+def test_isub_basic() raises:
     """Basic isub: positive - positive."""
     var x = BigInt(100)
     x -= BigInt(23)
     testing.assert_equal(String(x), "77")
 
 
-fn test_isub_zero_rhs() raises:
+def test_isub_zero_rhs() raises:
     """Isub: x -= 0 is no-op."""
     var x = BigInt(42)
     x -= BigInt(0)
     testing.assert_equal(String(x), "42")
 
 
-fn test_isub_zero_lhs() raises:
+def test_isub_zero_lhs() raises:
     """Isub: 0 -= other = -other."""
     var x = BigInt(0)
     x -= BigInt(42)
@@ -200,21 +200,21 @@ fn test_isub_zero_lhs() raises:
     testing.assert_equal(String(y), "42")
 
 
-fn test_isub_cancel_to_zero() raises:
+def test_isub_cancel_to_zero() raises:
     """Isub: x - x = 0."""
     var x = BigInt(42)
     x -= BigInt(42)
     testing.assert_equal(String(x), "0")
 
 
-fn test_isub_negative_result() raises:
+def test_isub_negative_result() raises:
     """Isub: positive - larger positive = negative."""
     var x = BigInt(10)
     x -= BigInt(30)
     testing.assert_equal(String(x), "-20")
 
 
-fn test_isub_both_negative() raises:
+def test_isub_both_negative() raises:
     """Isub: negative - negative."""
     # -10 - (-30) = -10 + 30 = 20
     var x = BigInt(-10)
@@ -227,24 +227,24 @@ fn test_isub_both_negative() raises:
     testing.assert_equal(String(y), "-20")
 
 
-fn test_isub_borrow_propagation() raises:
+def test_isub_borrow_propagation() raises:
     """Isub with borrow: 2^32 - 1 = 2^32 - 1."""
     var x = BigInt("4294967296")
     x -= BigInt(1)
     testing.assert_equal(String(x), "4294967295")
 
 
-fn test_isub_large_values() raises:
+def test_isub_large_values() raises:
     """Isub with large multi-word values."""
     var x = BigInt("1000000000000000000000000000000")
     x -= BigInt(1)
     testing.assert_equal(String(x), "999999999999999999999999999999")
 
 
-fn test_isub_matches_sub() raises:
+def test_isub_matches_sub() raises:
     """Isub produces same result as subtract for various values."""
 
-    fn _check(a: String, b: String) raises:
+    def _check(a: String, b: String) raises:
         var expected = String(BigInt(a) - BigInt(b))
         var x = BigInt(a)
         x -= BigInt(b)
@@ -266,35 +266,35 @@ fn test_isub_matches_sub() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_imul_basic() raises:
+def test_imul_basic() raises:
     """Basic imul: positive * positive."""
     var x = BigInt(12)
     x *= BigInt(10)
     testing.assert_equal(String(x), "120")
 
 
-fn test_imul_zero_lhs() raises:
+def test_imul_zero_lhs() raises:
     """Imul: 0 *= other = 0."""
     var x = BigInt(0)
     x *= BigInt(42)
     testing.assert_equal(String(x), "0")
 
 
-fn test_imul_zero_rhs() raises:
+def test_imul_zero_rhs() raises:
     """Imul: x *= 0 = 0."""
     var x = BigInt(42)
     x *= BigInt(0)
     testing.assert_equal(String(x), "0")
 
 
-fn test_imul_one() raises:
+def test_imul_one() raises:
     """Imul: x *= 1 is no-op."""
     var x = BigInt(42)
     x *= BigInt(1)
     testing.assert_equal(String(x), "42")
 
 
-fn test_imul_minus_one() raises:
+def test_imul_minus_one() raises:
     """Imul: x *= -1 negates."""
     var x = BigInt(42)
     x *= BigInt(-1)
@@ -305,7 +305,7 @@ fn test_imul_minus_one() raises:
     testing.assert_equal(String(y), "42")
 
 
-fn test_imul_sign_combinations() raises:
+def test_imul_sign_combinations() raises:
     """Imul: all sign combinations."""
     # pos * pos = pos
     var a = BigInt(7)
@@ -328,24 +328,24 @@ fn test_imul_sign_combinations() raises:
     testing.assert_equal(String(d), "42")
 
 
-fn test_imul_carry_propagation() raises:
+def test_imul_carry_propagation() raises:
     """Imul with carry: (2^32 - 1) * (2^32 - 1)."""
     var x = BigInt("4294967295")
     x *= BigInt("4294967295")
     testing.assert_equal(String(x), "18446744065119617025")
 
 
-fn test_imul_large_values() raises:
+def test_imul_large_values() raises:
     """Imul with large multi-word values."""
     var x = BigInt("123456789012345678901234567890")
     x *= BigInt("2")
     testing.assert_equal(String(x), "246913578024691357802469135780")
 
 
-fn test_imul_matches_mul() raises:
+def test_imul_matches_mul() raises:
     """Imul produces same result as multiply for various values."""
 
-    fn _check(a: String, b: String) raises:
+    def _check(a: String, b: String) raises:
         var expected = String(BigInt(a) * BigInt(b))
         var x = BigInt(a)
         x *= BigInt(b)
@@ -367,7 +367,7 @@ fn test_imul_matches_mul() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_chained_iadd() raises:
+def test_chained_iadd() raises:
     """Multiple iadd operations in sequence."""
     var x = BigInt(0)
     x += BigInt(10)
@@ -376,7 +376,7 @@ fn test_chained_iadd() raises:
     testing.assert_equal(String(x), "60")
 
 
-fn test_chained_isub() raises:
+def test_chained_isub() raises:
     """Multiple isub operations in sequence."""
     var x = BigInt(100)
     x -= BigInt(10)
@@ -385,7 +385,7 @@ fn test_chained_isub() raises:
     testing.assert_equal(String(x), "40")
 
 
-fn test_chained_imul() raises:
+def test_chained_imul() raises:
     """Multiple imul operations: factorial-like."""
     var x = BigInt(1)
     x *= BigInt(2)
@@ -395,7 +395,7 @@ fn test_chained_imul() raises:
     testing.assert_equal(String(x), "120")
 
 
-fn test_mixed_inplace() raises:
+def test_mixed_inplace() raises:
     """Mixed in-place operations."""
     var x = BigInt(10)
     x += BigInt(5)  # 15
@@ -405,7 +405,7 @@ fn test_mixed_inplace() raises:
     testing.assert_equal(String(x), "0")
 
 
-fn test_iadd_int_accumulator_vs_direct() raises:
+def test_iadd_int_accumulator_vs_direct() raises:
     """Int iadd accumulator gives same result as direct computation."""
     # Compute 1 + 2 + ... + 1000 via iadd
     var sum_iadd = BigInt(0)
@@ -415,7 +415,7 @@ fn test_iadd_int_accumulator_vs_direct() raises:
     testing.assert_equal(String(sum_iadd), "500500")
 
 
-fn test_imul_factorial_20() raises:
+def test_imul_factorial_20() raises:
     """Compute 20! via repeated imul."""
     var factorial = BigInt(1)
     for i in range(2, 21):
@@ -424,5 +424,5 @@ fn test_imul_factorial_20() raises:
     testing.assert_equal(String(factorial), "2432902008176640000")
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/bigint/test_bigint_inplace.mojo
+++ b/tests/bigint/test_bigint_inplace.mojo
@@ -6,7 +6,7 @@ identical to the non-in-place operators, but mutate self.words directly
 instead of creating a new BigInt.
 """
 
-import testing
+from std import testing
 from decimo.bigint.bigint import BigInt
 
 

--- a/tests/bigint/test_bigint_inplace_extended.mojo
+++ b/tests/bigint/test_bigint_inplace_extended.mojo
@@ -14,73 +14,73 @@ from decimo.bigint.bigint import BigInt
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_ilshift_zero_shift() raises:
+def test_ilshift_zero_shift() raises:
     """Left shift by 0 is no-op."""
     var x = BigInt(42)
     x <<= 0
     testing.assert_equal(String(x), "42")
 
 
-fn test_ilshift_zero_value() raises:
+def test_ilshift_zero_value() raises:
     """Left shift of 0 is 0."""
     var x = BigInt(0)
     x <<= 10
     testing.assert_equal(String(x), "0")
 
 
-fn test_ilshift_basic() raises:
+def test_ilshift_basic() raises:
     """Basic left shift: 1 << 1 = 2."""
     var x = BigInt(1)
     x <<= 1
     testing.assert_equal(String(x), "2")
 
 
-fn test_ilshift_byte() raises:
+def test_ilshift_byte() raises:
     """Left shift by 8: 1 << 8 = 256."""
     var x = BigInt(1)
     x <<= 8
     testing.assert_equal(String(x), "256")
 
 
-fn test_ilshift_word_boundary() raises:
+def test_ilshift_word_boundary() raises:
     """Left shift by 32: crosses word boundary."""
     var x = BigInt(1)
     x <<= 32
     testing.assert_equal(String(x), "4294967296")
 
 
-fn test_ilshift_multi_word() raises:
+def test_ilshift_multi_word() raises:
     """Left shift by 64: two full words."""
     var x = BigInt(1)
     x <<= 64
     testing.assert_equal(String(x), "18446744073709551616")
 
 
-fn test_ilshift_partial() raises:
+def test_ilshift_partial() raises:
     """Left shift by non-word-aligned amount."""
     var x = BigInt(5)
     x <<= 3
     testing.assert_equal(String(x), "40")
 
 
-fn test_ilshift_negative() raises:
+def test_ilshift_negative() raises:
     """Left shift of negative number."""
     var x = BigInt(-3)
     x <<= 4
     testing.assert_equal(String(x), "-48")
 
 
-fn test_ilshift_large() raises:
+def test_ilshift_large() raises:
     """Left shift of large multi-word number."""
     var x = BigInt("123456789012345678901234567890")
     x <<= 1
     testing.assert_equal(String(x), "246913578024691357802469135780")
 
 
-fn test_ilshift_matches_lshift() raises:
+def test_ilshift_matches_lshift() raises:
     """Inplace left shift produces same result as non-inplace."""
 
-    fn _check(val: String, shift: Int) raises:
+    def _check(val: String, shift: Int) raises:
         var expected = String(BigInt(val) << shift)
         var x = BigInt(val)
         x <<= shift
@@ -104,49 +104,49 @@ fn test_ilshift_matches_lshift() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_irshift_zero_shift() raises:
+def test_irshift_zero_shift() raises:
     """Right shift by 0 is no-op."""
     var x = BigInt(42)
     x >>= 0
     testing.assert_equal(String(x), "42")
 
 
-fn test_irshift_zero_value() raises:
+def test_irshift_zero_value() raises:
     """Right shift of 0 is 0."""
     var x = BigInt(0)
     x >>= 10
     testing.assert_equal(String(x), "0")
 
 
-fn test_irshift_basic() raises:
+def test_irshift_basic() raises:
     """Basic right shift: 4 >> 1 = 2."""
     var x = BigInt(4)
     x >>= 1
     testing.assert_equal(String(x), "2")
 
 
-fn test_irshift_truncate() raises:
+def test_irshift_truncate() raises:
     """Right shift truncates: 5 >> 1 = 2."""
     var x = BigInt(5)
     x >>= 1
     testing.assert_equal(String(x), "2")
 
 
-fn test_irshift_word_boundary() raises:
+def test_irshift_word_boundary() raises:
     """Right shift by 32: drops full word."""
     var x = BigInt("4294967296")  # 2^32
     x >>= 32
     testing.assert_equal(String(x), "1")
 
 
-fn test_irshift_to_zero() raises:
+def test_irshift_to_zero() raises:
     """Right shift beyond all bits → 0."""
     var x = BigInt(255)
     x >>= 100
     testing.assert_equal(String(x), "0")
 
 
-fn test_irshift_negative_floor() raises:
+def test_irshift_negative_floor() raises:
     """Negative right shift rounds toward -inf: -1 >> 1 = -1."""
     var x = BigInt(-1)
     x >>= 1
@@ -157,24 +157,24 @@ fn test_irshift_negative_floor() raises:
     testing.assert_equal(String(y), "-2")
 
 
-fn test_irshift_negative_large() raises:
+def test_irshift_negative_large() raises:
     """Negative number shifted beyond all bits → -1."""
     var x = BigInt(-42)
     x >>= 100
     testing.assert_equal(String(x), "-1")
 
 
-fn test_irshift_large() raises:
+def test_irshift_large() raises:
     """Right shift of large multi-word number."""
     var x = BigInt("123456789012345678901234567890")
     x >>= 1
     testing.assert_equal(String(x), "61728394506172839450617283945")
 
 
-fn test_irshift_matches_rshift() raises:
+def test_irshift_matches_rshift() raises:
     """Inplace right shift produces same result as non-inplace."""
 
-    fn _check(val: String, shift: Int) raises:
+    def _check(val: String, shift: Int) raises:
         var expected = String(BigInt(val) >> shift)
         var x = BigInt(val)
         x >>= shift
@@ -198,56 +198,56 @@ fn test_irshift_matches_rshift() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_ifloordiv_basic() raises:
+def test_ifloordiv_basic() raises:
     """Basic floor division: 10 // 3 = 3."""
     var x = BigInt(10)
     x //= BigInt(3)
     testing.assert_equal(String(x), "3")
 
 
-fn test_ifloordiv_exact() raises:
+def test_ifloordiv_exact() raises:
     """Exact division: 12 // 4 = 3."""
     var x = BigInt(12)
     x //= BigInt(4)
     testing.assert_equal(String(x), "3")
 
 
-fn test_ifloordiv_by_one() raises:
+def test_ifloordiv_by_one() raises:
     """Division by 1 is no-op."""
     var x = BigInt(42)
     x //= BigInt(1)
     testing.assert_equal(String(x), "42")
 
 
-fn test_ifloordiv_negative_dividend() raises:
+def test_ifloordiv_negative_dividend() raises:
     """Floor division with negative dividend: -10 // 3 = -4."""
     var x = BigInt(-10)
     x //= BigInt(3)
     testing.assert_equal(String(x), "-4")
 
 
-fn test_ifloordiv_negative_divisor() raises:
+def test_ifloordiv_negative_divisor() raises:
     """Floor division with negative divisor: 10 // -3 = -4."""
     var x = BigInt(10)
     x //= BigInt(-3)
     testing.assert_equal(String(x), "-4")
 
 
-fn test_ifloordiv_both_negative() raises:
+def test_ifloordiv_both_negative() raises:
     """Floor division both negative: -10 // -3 = 3."""
     var x = BigInt(-10)
     x //= BigInt(-3)
     testing.assert_equal(String(x), "3")
 
 
-fn test_ifloordiv_zero_dividend() raises:
+def test_ifloordiv_zero_dividend() raises:
     """Zero divided by anything: 0 // x = 0."""
     var x = BigInt(0)
     x //= BigInt(42)
     testing.assert_equal(String(x), "0")
 
 
-fn test_ifloordiv_large() raises:
+def test_ifloordiv_large() raises:
     """Floor division with large values."""
     var x = BigInt("123456789012345678901234567890")
     x //= BigInt("987654321")
@@ -257,10 +257,10 @@ fn test_ifloordiv_large() raises:
     )
 
 
-fn test_ifloordiv_matches_floordiv() raises:
+def test_ifloordiv_matches_floordiv() raises:
     """Inplace floor division produces same result as non-inplace."""
 
-    fn _check(a: String, b: String) raises:
+    def _check(a: String, b: String) raises:
         var expected = String(BigInt(a) // BigInt(b))
         var x = BigInt(a)
         x //= BigInt(b)
@@ -281,42 +281,42 @@ fn test_ifloordiv_matches_floordiv() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_imod_basic() raises:
+def test_imod_basic() raises:
     """Basic modulo: 10 % 3 = 1."""
     var x = BigInt(10)
     x %= BigInt(3)
     testing.assert_equal(String(x), "1")
 
 
-fn test_imod_exact() raises:
+def test_imod_exact() raises:
     """Exact division: 12 % 4 = 0."""
     var x = BigInt(12)
     x %= BigInt(4)
     testing.assert_equal(String(x), "0")
 
 
-fn test_imod_negative_dividend() raises:
+def test_imod_negative_dividend() raises:
     """Floor modulo with negative dividend: -10 % 3 = 2."""
     var x = BigInt(-10)
     x %= BigInt(3)
     testing.assert_equal(String(x), "2")
 
 
-fn test_imod_negative_divisor() raises:
+def test_imod_negative_divisor() raises:
     """Floor modulo with negative divisor: 10 % -3 = -2."""
     var x = BigInt(10)
     x %= BigInt(-3)
     testing.assert_equal(String(x), "-2")
 
 
-fn test_imod_both_negative() raises:
+def test_imod_both_negative() raises:
     """Floor modulo both negative: -10 % -3 = -1."""
     var x = BigInt(-10)
     x %= BigInt(-3)
     testing.assert_equal(String(x), "-1")
 
 
-fn test_imod_large() raises:
+def test_imod_large() raises:
     """Modulo with large values."""
     var x = BigInt("123456789012345678901234567890")
     x %= BigInt("987654321")
@@ -326,10 +326,10 @@ fn test_imod_large() raises:
     )
 
 
-fn test_imod_matches_mod() raises:
+def test_imod_matches_mod() raises:
     """Inplace modulo produces same result as non-inplace."""
 
-    fn _check(a: String, b: String) raises:
+    def _check(a: String, b: String) raises:
         var expected = String(BigInt(a) % BigInt(b))
         var x = BigInt(a)
         x %= BigInt(b)
@@ -350,42 +350,42 @@ fn test_imod_matches_mod() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_iand_basic() raises:
+def test_iand_basic() raises:
     """Basic AND: 0b1111 & 0b1010 = 0b1010."""
     var x = BigInt(15)
     x &= BigInt(10)
     testing.assert_equal(String(x), "10")
 
 
-fn test_iand_zero() raises:
+def test_iand_zero() raises:
     """AND with zero: x & 0 = 0."""
     var x = BigInt(42)
     x &= BigInt(0)
     testing.assert_equal(String(x), "0")
 
 
-fn test_iand_all_ones() raises:
+def test_iand_all_ones() raises:
     """AND with all-ones mask: x & 0xFF = x & 255."""
     var x = BigInt(300)
     x &= BigInt(255)
     testing.assert_equal(String(x), "44")
 
 
-fn test_iand_negative() raises:
+def test_iand_negative() raises:
     """AND with negative (two's complement semantics)."""
     var x = BigInt(-1)
     x &= BigInt(255)
     testing.assert_equal(String(x), "255")
 
 
-fn test_iand_both_negative() raises:
+def test_iand_both_negative() raises:
     """AND of two negatives."""
     var x = BigInt(-3)
     x &= BigInt(-5)
     testing.assert_equal(String(x), String(BigInt(-3) & BigInt(-5)))
 
 
-fn test_iand_large() raises:
+def test_iand_large() raises:
     """AND of large multi-word values."""
     var x = BigInt("123456789012345678901234567890")
     var y = BigInt("987654321098765432109876543210")
@@ -394,10 +394,10 @@ fn test_iand_large() raises:
     testing.assert_equal(String(x), expected)
 
 
-fn test_iand_matches_and() raises:
+def test_iand_matches_and() raises:
     """Inplace AND produces same result as non-inplace."""
 
-    fn _check(a: String, b: String) raises:
+    def _check(a: String, b: String) raises:
         var expected = String(BigInt(a) & BigInt(b))
         var x = BigInt(a)
         x &= BigInt(b)
@@ -418,35 +418,35 @@ fn test_iand_matches_and() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_ior_basic() raises:
+def test_ior_basic() raises:
     """Basic OR: 0b1010 | 0b0101 = 0b1111."""
     var x = BigInt(10)
     x |= BigInt(5)
     testing.assert_equal(String(x), "15")
 
 
-fn test_ior_zero() raises:
+def test_ior_zero() raises:
     """OR with zero: x | 0 = x."""
     var x = BigInt(42)
     x |= BigInt(0)
     testing.assert_equal(String(x), "42")
 
 
-fn test_ior_self() raises:
+def test_ior_self() raises:
     """OR with self: x | x = x."""
     var x = BigInt(42)
     x |= BigInt(42)
     testing.assert_equal(String(x), "42")
 
 
-fn test_ior_negative() raises:
+def test_ior_negative() raises:
     """OR with negative (two's complement semantics)."""
     var x = BigInt(0)
     x |= BigInt(-1)
     testing.assert_equal(String(x), "-1")
 
 
-fn test_ior_large() raises:
+def test_ior_large() raises:
     """OR of large multi-word values."""
     var x = BigInt("123456789012345678901234567890")
     var y = BigInt("987654321098765432109876543210")
@@ -455,10 +455,10 @@ fn test_ior_large() raises:
     testing.assert_equal(String(x), expected)
 
 
-fn test_ior_matches_or() raises:
+def test_ior_matches_or() raises:
     """Inplace OR produces same result as non-inplace."""
 
-    fn _check(a: String, b: String) raises:
+    def _check(a: String, b: String) raises:
         var expected = String(BigInt(a) | BigInt(b))
         var x = BigInt(a)
         x |= BigInt(b)
@@ -479,35 +479,35 @@ fn test_ior_matches_or() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_ixor_basic() raises:
+def test_ixor_basic() raises:
     """Basic XOR: 0b1111 ^ 0b1010 = 0b0101."""
     var x = BigInt(15)
     x ^= BigInt(10)
     testing.assert_equal(String(x), "5")
 
 
-fn test_ixor_zero() raises:
+def test_ixor_zero() raises:
     """XOR with zero: x ^ 0 = x."""
     var x = BigInt(42)
     x ^= BigInt(0)
     testing.assert_equal(String(x), "42")
 
 
-fn test_ixor_self_cancel() raises:
+def test_ixor_self_cancel() raises:
     """XOR with self cancels: x ^ x = 0."""
     var x = BigInt(42)
     x ^= BigInt(42)
     testing.assert_equal(String(x), "0")
 
 
-fn test_ixor_negative() raises:
+def test_ixor_negative() raises:
     """XOR with negative (two's complement semantics)."""
     var x = BigInt(0)
     x ^= BigInt(-1)
     testing.assert_equal(String(x), "-1")
 
 
-fn test_ixor_large() raises:
+def test_ixor_large() raises:
     """XOR of large multi-word values."""
     var x = BigInt("123456789012345678901234567890")
     var y = BigInt("987654321098765432109876543210")
@@ -516,10 +516,10 @@ fn test_ixor_large() raises:
     testing.assert_equal(String(x), expected)
 
 
-fn test_ixor_matches_xor() raises:
+def test_ixor_matches_xor() raises:
     """Inplace XOR produces same result as non-inplace."""
 
-    fn _check(a: String, b: String) raises:
+    def _check(a: String, b: String) raises:
         var expected = String(BigInt(a) ^ BigInt(b))
         var x = BigInt(a)
         x ^= BigInt(b)
@@ -541,7 +541,7 @@ fn test_ixor_matches_xor() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_chained_shift() raises:
+def test_chained_shift() raises:
     """Chained shift operations: (1 << 10) >> 5 = 32."""
     var x = BigInt(1)
     x <<= 10
@@ -549,7 +549,7 @@ fn test_chained_shift() raises:
     testing.assert_equal(String(x), "32")
 
 
-fn test_chained_divmod() raises:
+def test_chained_divmod() raises:
     """Chained div/mod: verify divmod identity x = (x // y) * y + (x % y)."""
     var original = BigInt(12345)
     var divisor = BigInt(67)
@@ -565,7 +565,7 @@ fn test_chained_divmod() raises:
     testing.assert_equal(String(reconstructed), String(original))
 
 
-fn test_chained_bitwise() raises:
+def test_chained_bitwise() raises:
     """Chained bitwise: (0xFF | 0x100) & 0x1FF ^ 0x0FF = 0x100."""
     var x = BigInt(0xFF)
     x |= BigInt(0x100)  # 0x1FF
@@ -574,7 +574,7 @@ fn test_chained_bitwise() raises:
     testing.assert_equal(String(x), "256")
 
 
-fn test_mixed_all_inplace() raises:
+def test_mixed_all_inplace() raises:
     """Mix all in-place operations together."""
     var x = BigInt(100)
     x += BigInt(28)  # 128
@@ -590,5 +590,5 @@ fn test_mixed_all_inplace() raises:
     testing.assert_equal(String(x), "16")
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/bigint/test_bigint_inplace_extended.mojo
+++ b/tests/bigint/test_bigint_inplace_extended.mojo
@@ -5,7 +5,7 @@ These tests verify that each in-place operator produces results identical
 to the corresponding non-in-place operator.
 """
 
-import testing
+from std import testing
 from decimo.bigint.bigint import BigInt
 
 

--- a/tests/bigint/test_bigint_number_theory.mojo
+++ b/tests/bigint/test_bigint_number_theory.mojo
@@ -17,7 +17,7 @@ from decimo.bigint.number_theory import (
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_gcd_zero_cases() raises:
+def test_gcd_zero_cases() raises:
     """Tests gcd involving zeros follows Python convention."""
     testing.assert_equal(String(gcd(BigInt(0), BigInt(0))), "0")
     testing.assert_equal(String(gcd(BigInt(12), BigInt(0))), "12")
@@ -26,7 +26,7 @@ fn test_gcd_zero_cases() raises:
     testing.assert_equal(String(gcd(BigInt(0), BigInt(-9))), "9")
 
 
-fn test_gcd_basic() raises:
+def test_gcd_basic() raises:
     """Tests basic GCD of small positive integers."""
     testing.assert_equal(String(gcd(BigInt(12), BigInt(8))), "4")
     testing.assert_equal(String(gcd(BigInt(48), BigInt(18))), "6")
@@ -38,7 +38,7 @@ fn test_gcd_basic() raises:
     testing.assert_equal(String(gcd(BigInt(270), BigInt(192))), "6")
 
 
-fn test_gcd_negative() raises:
+def test_gcd_negative() raises:
     """Tests GCD is always non-negative regardless of input signs."""
     testing.assert_equal(String(gcd(BigInt(-12), BigInt(8))), "4")
     testing.assert_equal(String(gcd(BigInt(12), BigInt(-8))), "4")
@@ -47,7 +47,7 @@ fn test_gcd_negative() raises:
     testing.assert_equal(String(gcd(BigInt(-48), BigInt(-18))), "6")
 
 
-fn test_gcd_commutativity() raises:
+def test_gcd_commutativity() raises:
     """Tests gcd(a, b) == gcd(b, a)."""
     testing.assert_equal(
         String(gcd(BigInt(48), BigInt(18))),
@@ -63,21 +63,21 @@ fn test_gcd_commutativity() raises:
     )
 
 
-fn test_gcd_one() raises:
+def test_gcd_one() raises:
     """Tests gcd(1, n) = 1 and gcd(n, 1) = 1."""
     testing.assert_equal(String(gcd(BigInt(1), BigInt(999999))), "1")
     testing.assert_equal(String(gcd(BigInt(999999), BigInt(1))), "1")
     testing.assert_equal(String(gcd(BigInt(1), BigInt(1))), "1")
 
 
-fn test_gcd_same_value() raises:
+def test_gcd_same_value() raises:
     """Tests gcd(n, n) = |n|."""
     testing.assert_equal(String(gcd(BigInt(42), BigInt(42))), "42")
     testing.assert_equal(String(gcd(BigInt(-42), BigInt(42))), "42")
     testing.assert_equal(String(gcd(BigInt(-42), BigInt(-42))), "42")
 
 
-fn test_gcd_common_factor() raises:
+def test_gcd_common_factor() raises:
     """Tests gcd(a*m, b*m) = m when gcd(a,b) = 1."""
     # gcd(17*m, 13*m) = m since gcd(17,13) = 1
     var m = BigInt(123456789)
@@ -86,7 +86,7 @@ fn test_gcd_common_factor() raises:
     testing.assert_equal(String(gcd(a, b)), "123456789")
 
 
-fn test_gcd_powers_of_two() raises:
+def test_gcd_powers_of_two() raises:
     """Tests GCD of powers of two uses the binary GCD fast path."""
     # gcd(2^16, 2^8) = 2^8 = 256
     var a = BigInt(1) << 16
@@ -104,7 +104,7 @@ fn test_gcd_powers_of_two() raises:
     testing.assert_equal(String(gcd(e, f)), "4294967296")
 
 
-fn test_gcd_large_coprime() raises:
+def test_gcd_large_coprime() raises:
     """Tests large coprime primes."""
     var p = BigInt(1000000007)
     var q = BigInt(999999937)
@@ -116,7 +116,7 @@ fn test_gcd_large_coprime() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_extended_gcd_basic() raises:
+def test_extended_gcd_basic() raises:
     """Tests extended GCD with known Bézout coefficients."""
     # gcd(35, 15) = 5, with 35*1 + 15*(-2) = 5
     var r = extended_gcd(BigInt(35), BigInt(15))
@@ -126,7 +126,7 @@ fn test_extended_gcd_basic() raises:
     testing.assert_equal(String(check), "5")
 
 
-fn test_extended_gcd_240_46() raises:
+def test_extended_gcd_240_46() raises:
     """Tests extended GCD(240, 46) = 2."""
     var r = extended_gcd(BigInt(240), BigInt(46))
     testing.assert_equal(String(r[0]), "2")
@@ -134,7 +134,7 @@ fn test_extended_gcd_240_46() raises:
     testing.assert_equal(String(check), "2")
 
 
-fn test_extended_gcd_coprime() raises:
+def test_extended_gcd_coprime() raises:
     """Tests extended GCD of coprime numbers gives gcd=1."""
     var r = extended_gcd(BigInt(17), BigInt(13))
     testing.assert_equal(String(r[0]), "1")
@@ -142,7 +142,7 @@ fn test_extended_gcd_coprime() raises:
     testing.assert_equal(String(check), "1")
 
 
-fn test_extended_gcd_zero_cases() raises:
+def test_extended_gcd_zero_cases() raises:
     """Tests extended GCD with zero arguments."""
     var r1 = extended_gcd(BigInt(0), BigInt(5))
     testing.assert_equal(String(r1[0]), "5")
@@ -158,7 +158,7 @@ fn test_extended_gcd_zero_cases() raises:
     testing.assert_equal(String(r3[0]), "0")
 
 
-fn test_extended_gcd_negative() raises:
+def test_extended_gcd_negative() raises:
     """Tests extended GCD correctly adjusts signs for negative inputs."""
     var r1 = extended_gcd(BigInt(-35), BigInt(15))
     testing.assert_equal(String(r1[0]), "5")
@@ -176,11 +176,11 @@ fn test_extended_gcd_negative() raises:
     testing.assert_equal(String(check3), "5")
 
 
-fn test_extended_gcd_bezout_various() raises:
+def test_extended_gcd_bezout_various() raises:
     """Tests Bézout identity for a range of input pairs."""
 
     # (a, b) pairs
-    fn _check(a_val: Int, b_val: Int) raises:
+    def _check(a_val: Int, b_val: Int) raises:
         var a = BigInt(a_val)
         var b = BigInt(b_val)
         var r = extended_gcd(a, b)
@@ -208,7 +208,7 @@ fn test_extended_gcd_bezout_various() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_lcm_basic() raises:
+def test_lcm_basic() raises:
     """Tests basic LCM of small integers."""
     testing.assert_equal(String(lcm(BigInt(12), BigInt(18))), "36")
     testing.assert_equal(String(lcm(BigInt(4), BigInt(6))), "12")
@@ -217,21 +217,21 @@ fn test_lcm_basic() raises:
     testing.assert_equal(String(lcm(BigInt(1), BigInt(100))), "100")
 
 
-fn test_lcm_zero() raises:
+def test_lcm_zero() raises:
     """Tests lcm(0, n) = lcm(n, 0) = 0."""
     testing.assert_equal(String(lcm(BigInt(0), BigInt(5))), "0")
     testing.assert_equal(String(lcm(BigInt(5), BigInt(0))), "0")
     testing.assert_equal(String(lcm(BigInt(0), BigInt(0))), "0")
 
 
-fn test_lcm_negative() raises:
+def test_lcm_negative() raises:
     """Tests LCM is always non-negative."""
     testing.assert_equal(String(lcm(BigInt(-4), BigInt(6))), "12")
     testing.assert_equal(String(lcm(BigInt(4), BigInt(-6))), "12")
     testing.assert_equal(String(lcm(BigInt(-4), BigInt(-6))), "12")
 
 
-fn test_lcm_gcd_product_identity() raises:
+def test_lcm_gcd_product_identity() raises:
     """Tests gcd(a,b) * lcm(a,b) = |a * b| for non-zero a, b."""
     var a = BigInt(48)
     var b = BigInt(18)
@@ -249,7 +249,7 @@ fn test_lcm_gcd_product_identity() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_mod_pow_basic() raises:
+def test_mod_pow_basic() raises:
     """Basic modular exponentiation."""
     # 2^10 mod 1000 = 1024 mod 1000 = 24
     testing.assert_equal(
@@ -265,7 +265,7 @@ fn test_mod_pow_basic() raises:
     testing.assert_equal(String(mod_pow(BigInt(7), BigInt(2), BigInt(10))), "9")
 
 
-fn test_mod_pow_edge_cases() raises:
+def test_mod_pow_edge_cases() raises:
     """Edge cases: zero exponent, zero base, modulus 1."""
     # base^0 = 1 (for mod > 1)
     testing.assert_equal(String(mod_pow(BigInt(5), BigInt(0), BigInt(3))), "1")
@@ -279,7 +279,7 @@ fn test_mod_pow_edge_cases() raises:
     testing.assert_equal(String(mod_pow(BigInt(0), BigInt(0), BigInt(1))), "0")
 
 
-fn test_mod_pow_fermat_little_theorem() raises:
+def test_mod_pow_fermat_little_theorem() raises:
     """Fermat: a^(p-1) ≡ 1 (mod p) for prime p, gcd(a,p)=1."""
     # 3^6 mod 7 = 1
     testing.assert_equal(String(mod_pow(BigInt(3), BigInt(6), BigInt(7))), "1")
@@ -293,7 +293,7 @@ fn test_mod_pow_fermat_little_theorem() raises:
     )
 
 
-fn test_mod_pow_larger_exponent() raises:
+def test_mod_pow_larger_exponent() raises:
     """Larger exponents that benefit from binary exponentiation."""
     # 7^256 mod 13 = 9
     testing.assert_equal(
@@ -306,7 +306,7 @@ fn test_mod_pow_larger_exponent() raises:
     )
 
 
-fn test_mod_pow_negative_base() raises:
+def test_mod_pow_negative_base() raises:
     """Negative base is reduced via floor modulo first."""
     # (-2)^3 mod 5 = (-8) mod 5 = 2
     testing.assert_equal(String(mod_pow(BigInt(-2), BigInt(3), BigInt(5))), "2")
@@ -322,13 +322,13 @@ fn test_mod_pow_negative_base() raises:
     )
 
 
-fn test_mod_pow_int_overload() raises:
+def test_mod_pow_int_overload() raises:
     """Convenience overload with Int exponent."""
     testing.assert_equal(String(mod_pow(BigInt(2), 10, BigInt(1000))), "24")
     testing.assert_equal(String(mod_pow(BigInt(3), 13, BigInt(100))), "23")
 
 
-fn test_mod_pow_errors() raises:
+def test_mod_pow_errors() raises:
     """Tests mod_pow raises on negative exponent or non-positive modulus."""
     var raised = False
 
@@ -361,7 +361,7 @@ fn test_mod_pow_errors() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_mod_inverse_basic() raises:
+def test_mod_inverse_basic() raises:
     """Known modular inverses."""
     # 3 * 5 = 15 ≡ 1 (mod 7)
     testing.assert_equal(String(mod_inverse(BigInt(3), BigInt(7))), "5")
@@ -371,13 +371,13 @@ fn test_mod_inverse_basic() raises:
     testing.assert_equal(String(mod_inverse(BigInt(3), BigInt(11))), "4")
 
 
-fn test_mod_inverse_one() raises:
+def test_mod_inverse_one() raises:
     """Inverse of 1 is always 1."""
     testing.assert_equal(String(mod_inverse(BigInt(1), BigInt(7))), "1")
     testing.assert_equal(String(mod_inverse(BigInt(1), BigInt(100))), "1")
 
 
-fn test_mod_inverse_verify_roundtrip() raises:
+def test_mod_inverse_verify_roundtrip() raises:
     """Verify (a * inv(a)) mod m == 1."""
     var a = BigInt(17)
     var m = BigInt(100)
@@ -390,14 +390,14 @@ fn test_mod_inverse_verify_roundtrip() raises:
     testing.assert_equal(String((a2 * inv2) % m2), "1")
 
 
-fn test_mod_inverse_negative_input() raises:
+def test_mod_inverse_negative_input() raises:
     """Modular inverse of a negative number."""
     # (-3) mod 7 = 4, inv(4) mod 7: 4*2=8≡1 mod 7 → inv=2
     var inv = mod_inverse(BigInt(-3), BigInt(7))
     testing.assert_equal(String((BigInt(-3) * inv) % BigInt(7)), "1")
 
 
-fn test_mod_inverse_not_exists() raises:
+def test_mod_inverse_not_exists() raises:
     """Tests mod_inverse raises when gcd(a, m) != 1."""
     var raised = False
     try:
@@ -426,5 +426,5 @@ fn test_mod_inverse_not_exists() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/bigint/test_bigint_number_theory.mojo
+++ b/tests/bigint/test_bigint_number_theory.mojo
@@ -1,7 +1,7 @@
 """Tests for BigInt number theory operations: GCD, Extended GCD, LCM,
 modular exponentiation, and modular inverse."""
 
-import testing
+from std import testing
 from decimo.bigint.bigint import BigInt
 from decimo.bigint.number_theory import (
     gcd,

--- a/tests/bigint/test_bigint_power_shift.mojo
+++ b/tests/bigint/test_bigint_power_shift.mojo
@@ -3,7 +3,7 @@ Test BigInt power and shift operations: __pow__, __lshift__, __rshift__,
 augmented assignment (<<=, >>=), and power-of-2 vs shift cross-checks.
 """
 
-import testing
+from std import testing
 from decimo.bigint.bigint import BigInt
 
 

--- a/tests/bigint/test_bigint_power_shift.mojo
+++ b/tests/bigint/test_bigint_power_shift.mojo
@@ -12,7 +12,7 @@ from decimo.bigint.bigint import BigInt
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_power_basic() raises:
+def test_power_basic() raises:
     """Test basic exponentiation."""
     # 2^10 = 1024
     testing.assert_equal(String(BigInt(2) ** 10), "1024")
@@ -36,7 +36,7 @@ fn test_power_basic() raises:
     testing.assert_equal(String(BigInt(0) ** 5), "0")
 
 
-fn test_power_negative_base() raises:
+def test_power_negative_base() raises:
     """Test exponentiation with negative base."""
     # (-2)^3 = -8
     testing.assert_equal(String(BigInt(-2) ** 3), "-8")
@@ -57,7 +57,7 @@ fn test_power_negative_base() raises:
     testing.assert_equal(String(BigInt(-1) ** 99), "-1")
 
 
-fn test_power_large() raises:
+def test_power_large() raises:
     """Test exponentiation with large results."""
     # 2^64 = 18446744073709551616
     testing.assert_equal(String(BigInt(2) ** 64), "18446744073709551616")
@@ -72,14 +72,14 @@ fn test_power_large() raises:
     testing.assert_equal(String(BigInt(10) ** 20), "100000000000000000000")
 
 
-fn test_power_bigint_exponent() raises:
+def test_power_bigint_exponent() raises:
     """Test exponentiation with BigInt exponent."""
     var base = BigInt(2)
     var exp = BigInt(10)
     testing.assert_equal(String(base**exp), "1024")
 
 
-fn test_power_negative_exponent_raises() raises:
+def test_power_negative_exponent_raises() raises:
     """Test that negative exponent raises an error."""
     var raised = False
     try:
@@ -94,7 +94,7 @@ fn test_power_negative_exponent_raises() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_left_shift_basic() raises:
+def test_left_shift_basic() raises:
     """Test basic left shift operations."""
     # 1 << 0 == 1
     testing.assert_equal(String(BigInt(1) << 0), "1")
@@ -115,7 +115,7 @@ fn test_left_shift_basic() raises:
     testing.assert_equal(String(BigInt(0) << 100), "0")
 
 
-fn test_left_shift_negative() raises:
+def test_left_shift_negative() raises:
     """Test left shift with negative numbers."""
     # -1 << 1 == -2
     testing.assert_equal(String(BigInt(-1) << 1), "-2")
@@ -124,7 +124,7 @@ fn test_left_shift_negative() raises:
     testing.assert_equal(String(BigInt(-5) << 3), "-40")
 
 
-fn test_right_shift_basic() raises:
+def test_right_shift_basic() raises:
     """Test basic right shift operations."""
     # 1 >> 0 == 1
     testing.assert_equal(String(BigInt(1) >> 0), "1")
@@ -142,7 +142,7 @@ fn test_right_shift_basic() raises:
     testing.assert_equal(String(BigInt(0) >> 100), "0")
 
 
-fn test_right_shift_large() raises:
+def test_right_shift_large() raises:
     """Test right shift with large values."""
     # 2^64 >> 32 = 2^32 = 4294967296
     var val = BigInt(1) << 64
@@ -155,7 +155,7 @@ fn test_right_shift_large() raises:
     testing.assert_equal(String(val >> 65), "0")
 
 
-fn test_right_shift_negative() raises:
+def test_right_shift_negative() raises:
     """Test right shift with negative numbers (Python-compatible arithmetic)."""
     # -1 >> 1 == -1 (Python behavior: floor toward -inf)
     testing.assert_equal(String(BigInt(-1) >> 1), "-1")
@@ -173,7 +173,7 @@ fn test_right_shift_negative() raises:
     testing.assert_equal(String(BigInt(-1) >> 100), "-1")
 
 
-fn test_shift_augmented_assignment() raises:
+def test_shift_augmented_assignment() raises:
     """Test <<= and >>= augmented assignment operators."""
     var x = BigInt(1)
     x <<= 10
@@ -183,7 +183,7 @@ fn test_shift_augmented_assignment() raises:
     testing.assert_equal(String(x), "32")
 
 
-fn test_shift_roundtrip() raises:
+def test_shift_roundtrip() raises:
     """Test that left shift then right shift recovers original value."""
     var original = BigInt("123456789012345678901234567890")
     var shifted = original << 100
@@ -196,7 +196,7 @@ fn test_shift_roundtrip() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_power_of_2_vs_shift() raises:
+def test_power_of_2_vs_shift() raises:
     """Verify that 2**n equals 1 << n for various n."""
     testing.assert_equal(String(BigInt(2) ** 0), String(BigInt(1) << 0))
     testing.assert_equal(String(BigInt(2) ** 1), String(BigInt(1) << 1))
@@ -208,5 +208,5 @@ fn test_power_of_2_vs_shift() raises:
     testing.assert_equal(String(BigInt(2) ** 128), String(BigInt(1) << 128))
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/bigint/test_bigint_sqrt_divmod.mojo
+++ b/tests/bigint/test_bigint_sqrt_divmod.mojo
@@ -3,7 +3,7 @@ Test BigInt sqrt and divmod operations: sqrt, isqrt, __divmod__
 with positive, negative, mixed-sign, and consistency checks.
 """
 
-import testing
+from std import testing
 from decimo.bigint.bigint import BigInt
 
 

--- a/tests/bigint/test_bigint_sqrt_divmod.mojo
+++ b/tests/bigint/test_bigint_sqrt_divmod.mojo
@@ -12,7 +12,7 @@ from decimo.bigint.bigint import BigInt
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_sqrt_perfect_squares() raises:
+def test_sqrt_perfect_squares() raises:
     """Test sqrt with perfect squares."""
     testing.assert_equal(String(BigInt(0).sqrt()), "0")
     testing.assert_equal(String(BigInt(1).sqrt()), "1")
@@ -25,7 +25,7 @@ fn test_sqrt_perfect_squares() raises:
     testing.assert_equal(String(BigInt(1000000).sqrt()), "1000")
 
 
-fn test_sqrt_non_perfect() raises:
+def test_sqrt_non_perfect() raises:
     """Test sqrt with non-perfect squares (floor)."""
     # sqrt(2) = 1
     testing.assert_equal(String(BigInt(2).sqrt()), "1")
@@ -46,7 +46,7 @@ fn test_sqrt_non_perfect() raises:
     testing.assert_equal(String(BigInt(101).sqrt()), "10")
 
 
-fn test_sqrt_large() raises:
+def test_sqrt_large() raises:
     """Test sqrt with large perfect squares."""
     # 10^20 → sqrt = 10^10 = 10000000000
     var x = BigInt(10) ** 20
@@ -65,7 +65,7 @@ fn test_sqrt_large() raises:
     testing.assert_true(s1_sq > n, "(sqrt+1)^2 > n")
 
 
-fn test_sqrt_negative_raises() raises:
+def test_sqrt_negative_raises() raises:
     """Test that sqrt of negative number raises."""
     var raised = False
     try:
@@ -75,7 +75,7 @@ fn test_sqrt_negative_raises() raises:
     testing.assert_true(raised, "sqrt(-4) should raise")
 
 
-fn test_isqrt_equals_sqrt() raises:
+def test_isqrt_equals_sqrt() raises:
     """Test that isqrt and sqrt produce the same result."""
     testing.assert_equal(String(BigInt(49).isqrt()), String(BigInt(49).sqrt()))
     testing.assert_equal(String(BigInt(50).isqrt()), String(BigInt(50).sqrt()))
@@ -86,7 +86,7 @@ fn test_isqrt_equals_sqrt() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_divmod_basic() raises:
+def test_divmod_basic() raises:
     """Test divmod with positive numbers."""
     var result = BigInt(7).__divmod__(BigInt(3))
     testing.assert_equal(String(result[0]), "2", "7 divmod 3: q")
@@ -101,7 +101,7 @@ fn test_divmod_basic() raises:
     testing.assert_equal(String(result[1]), "0", "0 divmod 5: r")
 
 
-fn test_divmod_mixed_sign() raises:
+def test_divmod_mixed_sign() raises:
     """Test divmod with mixed signs (floor semantics)."""
     # Python: divmod(7, -3) = (-3, -2) since 7 = (-3)*(-3) + (-2)
     var result = BigInt(7).__divmod__(BigInt(-3))
@@ -119,10 +119,10 @@ fn test_divmod_mixed_sign() raises:
     testing.assert_equal(String(result[1]), "-1", "-7 divmod -3: r")
 
 
-fn test_divmod_consistency() raises:
+def test_divmod_consistency() raises:
     """Test that divmod(a, b) satisfies a = q * b + r."""
 
-    fn _check_divmod(a_val: Int, b_val: Int) raises:
+    def _check_divmod(a_val: Int, b_val: Int) raises:
         var a = BigInt(a_val)
         var b = BigInt(b_val)
         var result = a.__divmod__(b)
@@ -143,7 +143,7 @@ fn test_divmod_consistency() raises:
     _check_divmod(-100, 7)
 
 
-fn test_divmod_by_zero_raises() raises:
+def test_divmod_by_zero_raises() raises:
     """Test divmod by zero raises."""
     var raised = False
     try:
@@ -153,5 +153,5 @@ fn test_divmod_by_zero_raises() raises:
     testing.assert_true(raised, "divmod by zero should raise")
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/bigint/test_bigint_string_format.mojo
+++ b/tests/bigint/test_bigint_string_format.mojo
@@ -12,7 +12,7 @@ from decimo.bigint.bigint import BigInt
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_to_string_with_separators() raises:
+def test_to_string_with_separators() raises:
     """Test to_string_with_separators."""
     testing.assert_equal(BigInt(0).to_string_with_separators(), "0")
     testing.assert_equal(BigInt(1).to_string_with_separators(), "1")
@@ -36,7 +36,7 @@ fn test_to_string_with_separators() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_to_string_line_width() raises:
+def test_to_string_line_width() raises:
     """Test to_string with line_width parameter."""
     # Default: no wrapping
     var val = BigInt("12345678901234567890")
@@ -59,7 +59,7 @@ fn test_to_string_line_width() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_number_of_digits() raises:
+def test_number_of_digits() raises:
     """Test number_of_digits method."""
     testing.assert_equal(BigInt(0).number_of_digits(), 1)
     testing.assert_equal(BigInt(1).number_of_digits(), 1)
@@ -83,12 +83,12 @@ fn test_number_of_digits() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_repr() raises:
+def test_repr() raises:
     """Test __repr__ (Representable trait)."""
     testing.assert_equal(repr(BigInt(42)), 'BigInt("42")')
     testing.assert_equal(repr(BigInt(-7)), 'BigInt("-7")')
     testing.assert_equal(repr(BigInt(0)), 'BigInt("0")')
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/bigint/test_bigint_string_format.mojo
+++ b/tests/bigint/test_bigint_string_format.mojo
@@ -84,7 +84,7 @@ def test_number_of_digits() raises:
 
 
 def test_repr() raises:
-    """Test __repr__ (Representable trait)."""
+    """Test __repr__ (Writable trait)."""
     testing.assert_equal(repr(BigInt(42)), 'BigInt("42")')
     testing.assert_equal(repr(BigInt(-7)), 'BigInt("-7")')
     testing.assert_equal(repr(BigInt(0)), 'BigInt("0")')

--- a/tests/bigint/test_bigint_string_format.mojo
+++ b/tests/bigint/test_bigint_string_format.mojo
@@ -3,7 +3,7 @@ Test BigInt string formatting: to_string_with_separators,
 to_string with line_width, number_of_digits, and __repr__.
 """
 
-import testing
+from std import testing
 from decimo.bigint.bigint import BigInt
 
 

--- a/tests/bigint10/test_bigint10_arithmetics.mojo
+++ b/tests/bigint10/test_bigint10_arithmetics.mojo
@@ -2,8 +2,8 @@
 Test BigInt10 arithmetic operations including addition, subtraction, and negation.
 """
 
-from python import Python
-import testing
+from std.python import Python
+from std import testing
 from decimo.bigint10.bigint10 import BigInt10
 from decimo.tests import TestCase, parse_file, load_test_cases
 

--- a/tests/bigint10/test_bigint10_arithmetics.mojo
+++ b/tests/bigint10/test_bigint10_arithmetics.mojo
@@ -13,7 +13,7 @@ comptime file_path_floor_divide = "tests/bigint10/test_data/bigint10_floor_divid
 comptime file_path_truncate_divide = "tests/bigint10/test_data/bigint10_truncate_divide.toml"
 
 
-fn _set_max_str_digits(limit: Int) raises:
+def _set_max_str_digits(limit: Int) raises:
     """Set Python's int-to-string digit limit (Python 3.11+). No-op if unavailable.
     """
     try:
@@ -22,7 +22,7 @@ fn _set_max_str_digits(limit: Int) raises:
         pass
 
 
-fn test_bigint10_arithmetics() raises:
+def test_bigint10_arithmetics() raises:
     # Load test cases from TOML file
     var pybuiltins = Python.import_module("builtins")
     _set_max_str_digits(500000)
@@ -134,7 +134,7 @@ fn test_bigint10_arithmetics() raises:
     )
 
 
-fn test_bigint10_multiply() raises:
+def test_bigint10_multiply() raises:
     # Load test cases from TOML file
     _set_max_str_digits(500000)
     var toml = parse_file(file_path_multiply)
@@ -167,7 +167,7 @@ fn test_bigint10_multiply() raises:
     )
 
 
-fn test_bigint10_floor_divide() raises:
+def test_bigint10_floor_divide() raises:
     # Load test cases from TOML file
     _set_max_str_digits(500000)
     var toml = parse_file(file_path_floor_divide)
@@ -200,7 +200,7 @@ fn test_bigint10_floor_divide() raises:
     )
 
 
-fn test_bigint10_truncate_divide() raises:
+def test_bigint10_truncate_divide() raises:
     # Load test cases from TOML file
     var pybuiltins = Python.import_module("builtins")
     _set_max_str_digits(500000)
@@ -243,5 +243,5 @@ fn test_bigint10_truncate_divide() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/bigint10/test_bigint10_creation.mojo
+++ b/tests/bigint10/test_bigint10_creation.mojo
@@ -3,8 +3,8 @@ Test BigInt10.from_python_int() method.
 Tests conversion from Python integers to Mojo BigInt10.
 """
 
-import testing
-from python import Python
+from std import testing
+from std.python import Python
 from decimo.bigint10.bigint10 import BigInt10
 
 

--- a/tests/bigint10/test_bigint10_creation.mojo
+++ b/tests/bigint10/test_bigint10_creation.mojo
@@ -8,7 +8,7 @@ from std.python import Python
 from decimo.bigint10.bigint10 import BigInt10
 
 
-fn test_from_python_int_basic() raises:
+def test_from_python_int_basic() raises:
     """Test basic Python int to BigInt10 conversion."""
     var py = Python.import_module("builtins")
 
@@ -28,7 +28,7 @@ fn test_from_python_int_basic() raises:
     testing.assert_equal(String(mojo_neg), "-456", "Small negative integer")
 
 
-fn test_from_python_int_large() raises:
+def test_from_python_int_large() raises:
     """Test large Python int to BigInt10 conversion."""
     var py = Python.import_module("builtins")
 
@@ -59,7 +59,7 @@ fn test_from_python_int_large() raises:
     )
 
 
-fn test_from_python_int_edge_cases() raises:
+def test_from_python_int_edge_cases() raises:
     """Test edge cases for Python int conversion."""
     var py = Python.import_module("builtins")
 
@@ -84,7 +84,7 @@ fn test_from_python_int_edge_cases() raises:
     )
 
 
-fn test_from_python_int_arithmetic() raises:
+def test_from_python_int_arithmetic() raises:
     """Test that converted BigInt10 can perform arithmetic correctly."""
     var py = Python.import_module("builtins")
 
@@ -121,7 +121,7 @@ fn test_from_python_int_arithmetic() raises:
     )
 
 
-fn test_from_python_int_sign() raises:
+def test_from_python_int_sign() raises:
     """Test sign handling in Python int conversion."""
     var py = Python.import_module("builtins")
 
@@ -141,7 +141,7 @@ fn test_from_python_int_sign() raises:
     testing.assert_false(mojo_zero.sign, "Zero has sign=False")
 
 
-fn test_from_python_int_constructor() raises:
+def test_from_python_int_constructor() raises:
     """Test the py= constructor syntax."""
     var py = Python.import_module("builtins")
 
@@ -162,7 +162,7 @@ fn test_from_python_int_constructor() raises:
     )
 
 
-fn test_from_python_int_roundtrip() raises:
+def test_from_python_int_roundtrip() raises:
     """Test Python -> Mojo -> Python roundtrip."""
     var py = Python.import_module("builtins")
 
@@ -185,5 +185,5 @@ fn test_from_python_int_roundtrip() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/bigint10/test_bigint10_to_int.mojo
+++ b/tests/bigint10/test_bigint10_to_int.mojo
@@ -9,7 +9,7 @@ from decimo.bigint10.bigint10 import BigInt10
 import decimo.bigint10.arithmetics as arithmetics
 
 
-fn test_int_conversion() raises:
+def test_int_conversion() raises:
     # print("------------------------------------------------------")
     # print("--- Testing BigInt10 to Int Conversion ---")
 
@@ -61,7 +61,7 @@ fn test_int_conversion() raises:
     testing.assert_equal(i7, Int.MIN)
 
 
-fn test_error_cases() raises:
+def test_error_cases() raises:
     # print("------------------------------------------------------")
     # print("--- Testing Error Cases ---")
 
@@ -102,7 +102,7 @@ fn test_error_cases() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     # print("Starting BigInt10 to Int conversion tests...")
 
     # test_int_conversion()

--- a/tests/bigint10/test_bigint10_to_int.mojo
+++ b/tests/bigint10/test_bigint10_to_int.mojo
@@ -3,7 +3,7 @@ Test BigInt10 conversion methods: to_int() and __int__
 for different numerical cases.
 """
 
-import testing
+from std import testing
 
 from decimo.bigint10.bigint10 import BigInt10
 import decimo.bigint10.arithmetics as arithmetics

--- a/tests/biguint/test_biguint_arithmetics.mojo
+++ b/tests/biguint/test_biguint_arithmetics.mojo
@@ -4,10 +4,10 @@ BigUInt is an unsigned integer type, so it doesn't support negative values.
 """
 
 
-from python import Python
-from random import random_ui64
-import testing
-from testing import assert_equal, assert_true
+from std.python import Python
+from std.random import random_ui64
+from std import testing
+from std.testing import assert_equal, assert_true
 from decimo.biguint.biguint import BigUInt
 from decimo.tests import TestCase, parse_file, load_test_cases
 

--- a/tests/biguint/test_biguint_arithmetics.mojo
+++ b/tests/biguint/test_biguint_arithmetics.mojo
@@ -15,7 +15,7 @@ comptime file_path_arithmetics = "tests/biguint/test_data/biguint_arithmetics.to
 comptime file_path_truncate_divide = "tests/biguint/test_data/biguint_truncate_divide.toml"
 
 
-fn _set_max_str_digits(limit: Int) raises:
+def _set_max_str_digits(limit: Int) raises:
     """Set Python's int-to-string digit limit (Python 3.11+). No-op if unavailable.
     """
     try:
@@ -24,7 +24,7 @@ fn _set_max_str_digits(limit: Int) raises:
         pass
 
 
-fn test_biguint_arithmetics() raises:
+def test_biguint_arithmetics() raises:
     # Load test cases from TOML file
     _set_max_str_digits(500000)
 
@@ -153,7 +153,7 @@ fn test_biguint_arithmetics() raises:
             print("Implementation correctly throws error on underflow")
 
 
-fn test_biguint_truncate_divide() raises:
+def test_biguint_truncate_divide() raises:
     # Load test cases from TOML file
     _set_max_str_digits(500000)
 
@@ -188,7 +188,7 @@ fn test_biguint_truncate_divide() raises:
     )
 
 
-fn test_biguint_truncate_divide_random_numbers_against_python() raises:
+def test_biguint_truncate_divide_random_numbers_against_python() raises:
     # print("------------------------------------------------------")
     # print("Testing BigUInt truncate division on random numbers with python...")
 
@@ -222,7 +222,7 @@ fn test_biguint_truncate_divide_random_numbers_against_python() raises:
     # print("BigUInt truncate division tests passed!")
 
 
-fn main() raises:
+def main() raises:
     # test_biguint_arithmetics()
     # test_biguint_truncate_divide()
     # test_biguint_truncate_divide_random_numbers_against_python()

--- a/tests/biguint/test_biguint_exponential.mojo
+++ b/tests/biguint/test_biguint_exponential.mojo
@@ -3,10 +3,10 @@ Test BigUInt exponential functions.
 """
 
 
-from python import Python
-from random import random_ui64
-import testing
-from testing import assert_equal, assert_true
+from std.python import Python
+from std.random import random_ui64
+from std import testing
+from std.testing import assert_equal, assert_true
 from decimo.biguint.biguint import BigUInt
 from decimo.tests import TestCase, parse_file, load_test_cases
 

--- a/tests/biguint/test_biguint_exponential.mojo
+++ b/tests/biguint/test_biguint_exponential.mojo
@@ -13,7 +13,7 @@ from decimo.tests import TestCase, parse_file, load_test_cases
 comptime file_path_sqrt = "tests/biguint/test_data/biguint_sqrt.toml"
 
 
-fn _set_max_str_digits(limit: Int) raises:
+def _set_max_str_digits(limit: Int) raises:
     """Set Python's int-to-string digit limit (Python 3.11+). No-op if unavailable.
     """
     try:
@@ -22,7 +22,7 @@ fn _set_max_str_digits(limit: Int) raises:
         pass
 
 
-fn test_biguint_sqrt() raises:
+def test_biguint_sqrt() raises:
     # Load test cases from TOML file
     var pymath = Python.import_module("math")
     _set_max_str_digits(25000)
@@ -58,7 +58,7 @@ fn test_biguint_sqrt() raises:
     )
 
 
-fn test_biguint_sqrt_random_numbers_against_python() raises:
+def test_biguint_sqrt_random_numbers_against_python() raises:
     # print("------------------------------------------------------")
     # print("Testing BigUInt sqrt on random numbers with python...")
 
@@ -87,7 +87,7 @@ fn test_biguint_sqrt_random_numbers_against_python() raises:
     # print("BigUInt sqrt tests passed!")
 
 
-fn main() raises:
+def main() raises:
     # test_biguint_sqrt()
     # test_biguint_sqrt_random_numbers_against_python()
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/cli/test_error_handling.mojo
+++ b/tests/cli/test_error_handling.mojo
@@ -5,7 +5,7 @@ and proper handling of edge cases (empty expression, division by zero,
 negative sqrt, etc.).
 """
 
-import testing
+from std import testing
 
 from calculator import evaluate
 from calculator.tokenizer import tokenize

--- a/tests/cli/test_error_handling.mojo
+++ b/tests/cli/test_error_handling.mojo
@@ -17,7 +17,7 @@ from calculator.tokenizer import tokenize
 # ===----------------------------------------------------------------------=== #
 
 
-fn assert_error_contains(expr: String, expected_substr: String) raises:
+def assert_error_contains(expr: String, expected_substr: String) raises:
     """Evaluate `expr` and assert that it raises an Error containing
     `expected_substr` in its message.
     """
@@ -43,7 +43,9 @@ fn assert_error_contains(expr: String, expected_substr: String) raises:
             )
 
 
-fn assert_tokenize_error_contains(expr: String, expected_substr: String) raises:
+def assert_tokenize_error_contains(
+    expr: String, expected_substr: String
+) raises:
     """Tokenize `expr` and assert that it raises an Error containing
     `expected_substr`.
     """
@@ -75,15 +77,15 @@ fn assert_tokenize_error_contains(expr: String, expected_substr: String) raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_empty_expression() raises:
+def test_empty_expression() raises:
     assert_tokenize_error_contains("", "Empty expression")
 
 
-fn test_whitespace_only() raises:
+def test_whitespace_only() raises:
     assert_tokenize_error_contains("   ", "Empty expression")
 
 
-fn test_tabs_only() raises:
+def test_tabs_only() raises:
     assert_tokenize_error_contains("\t\t", "Empty expression")
 
 
@@ -92,11 +94,11 @@ fn test_tabs_only() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_unknown_identifier() raises:
+def test_unknown_identifier() raises:
     assert_error_contains("foo + 1", "unknown identifier 'foo'")
 
 
-fn test_unknown_identifier_position() raises:
+def test_unknown_identifier_position() raises:
     assert_error_contains("1 + bar", "position 4")
 
 
@@ -105,11 +107,11 @@ fn test_unknown_identifier_position() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_unexpected_character() raises:
+def test_unexpected_character() raises:
     assert_error_contains("1 @ 2", "unexpected character '@'")
 
 
-fn test_unexpected_character_position() raises:
+def test_unexpected_character_position() raises:
     assert_error_contains("1 + 2 # 3", "position 6")
 
 
@@ -118,19 +120,19 @@ fn test_unexpected_character_position() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_missing_closing_paren() raises:
+def test_missing_closing_paren() raises:
     assert_error_contains("(1 + 2", "unmatched '('")
 
 
-fn test_missing_opening_paren() raises:
+def test_missing_opening_paren() raises:
     assert_error_contains("1 + 2)", "unmatched ')'")
 
 
-fn test_nested_missing_close() raises:
+def test_nested_missing_close() raises:
     assert_error_contains("((1+2) * 3", "unmatched '('")
 
 
-fn test_extra_closing_paren() raises:
+def test_extra_closing_paren() raises:
     assert_error_contains("(1+2))", "unmatched ')'")
 
 
@@ -139,15 +141,15 @@ fn test_extra_closing_paren() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_division_by_zero() raises:
+def test_division_by_zero() raises:
     assert_error_contains("1/0", "division by zero")
 
 
-fn test_division_by_zero_expression() raises:
+def test_division_by_zero_expression() raises:
     assert_error_contains("10 / (5-5)", "division by zero")
 
 
-fn test_division_by_zero_decimal() raises:
+def test_division_by_zero_decimal() raises:
     assert_error_contains("1 / 0.0", "division by zero")
 
 
@@ -156,11 +158,11 @@ fn test_division_by_zero_decimal() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_sqrt_negative() raises:
+def test_sqrt_negative() raises:
     assert_error_contains("sqrt(-4)", "sqrt() is undefined for negative")
 
 
-fn test_sqrt_negative_expression() raises:
+def test_sqrt_negative_expression() raises:
     assert_error_contains("sqrt(-1)", "sqrt() is undefined for negative")
 
 
@@ -169,19 +171,19 @@ fn test_sqrt_negative_expression() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_ln_zero() raises:
+def test_ln_zero() raises:
     assert_error_contains("ln(0)", "ln() is undefined for zero")
 
 
-fn test_ln_negative() raises:
+def test_ln_negative() raises:
     assert_error_contains("ln(-1)", "ln() is undefined for negative")
 
 
-fn test_log10_zero() raises:
+def test_log10_zero() raises:
     assert_error_contains("log10(0)", "log10() is undefined for zero")
 
 
-fn test_log10_negative() raises:
+def test_log10_negative() raises:
     assert_error_contains("log10(-5)", "log10() is undefined for negative")
 
 
@@ -190,7 +192,7 @@ fn test_log10_negative() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_comma_outside_function() raises:
+def test_comma_outside_function() raises:
     assert_error_contains("1, 2", "misplaced ','")
 
 
@@ -199,23 +201,23 @@ fn test_comma_outside_function() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_trailing_plus() raises:
+def test_trailing_plus() raises:
     assert_error_contains("1 +", "missing operand for '+'")
 
 
-fn test_trailing_star() raises:
+def test_trailing_star() raises:
     assert_error_contains("1 *", "missing operand for '*'")
 
 
-fn test_trailing_slash() raises:
+def test_trailing_slash() raises:
     assert_error_contains("1 /", "missing operand for '/'")
 
 
-fn test_leading_star() raises:
+def test_leading_star() raises:
     assert_error_contains("* 1", "missing operand for '*'")
 
 
-fn test_leading_slash() raises:
+def test_leading_slash() raises:
     assert_error_contains("/ 1", "missing operand for '/'")
 
 
@@ -224,12 +226,12 @@ fn test_leading_slash() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_double_plus() raises:
+def test_double_plus() raises:
     """1 ++ should fail: the second + has no left operand."""
     assert_error_contains("1 ++ 2", "missing operand")
 
 
-fn test_double_star() raises:
+def test_double_star() raises:
     """1 * * 2 should fail."""
     assert_error_contains("1 * * 2", "missing operand")
 
@@ -239,17 +241,17 @@ fn test_double_star() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_position_in_unknown_char() raises:
+def test_position_in_unknown_char() raises:
     """The '@' is at position 4 in '1 + @'."""
     assert_error_contains("1 + @", "position 4")
 
 
-fn test_position_in_div_by_zero() raises:
+def test_position_in_div_by_zero() raises:
     """The '/' is at position 1 in '1/0'."""
     assert_error_contains("1/0", "position 1")
 
 
-fn test_position_in_sqrt_negative() raises:
+def test_position_in_sqrt_negative() raises:
     """'sqrt' starts at position 0 in 'sqrt(-1)'."""
     assert_error_contains("sqrt(-1)", "position 0")
 
@@ -259,7 +261,7 @@ fn test_position_in_sqrt_negative() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_negative_zero() raises:
+def test_negative_zero() raises:
     """Negation of zero should not raise an error."""
     var result = String(evaluate("-0"))
     testing.assert_true(
@@ -268,19 +270,19 @@ fn test_negative_zero() raises:
     )
 
 
-fn test_deeply_nested_parens() raises:
+def test_deeply_nested_parens() raises:
     """((((1)))) should be fine."""
     testing.assert_equal(String(evaluate("((((1))))")), "1", "((((1))))")
 
 
-fn test_many_operations() raises:
+def test_many_operations() raises:
     """1+2+3+4+5+6+7+8+9+10 = 55."""
     testing.assert_equal(
         String(evaluate("1+2+3+4+5+6+7+8+9+10")), "55", "sum 1..10"
     )
 
 
-fn test_function_of_constant() raises:
+def test_function_of_constant() raises:
     """Compute sqrt(pi) — should not crash."""
     var result = String(evaluate("sqrt(pi)", precision=10))
     testing.assert_true(
@@ -294,5 +296,5 @@ fn test_function_of_constant() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/cli/test_evaluator.mojo
+++ b/tests/cli/test_evaluator.mojo
@@ -1,6 +1,6 @@
 """Test the evaluator: end-to-end expression evaluation with BigDecimal."""
 
-import testing
+from std import testing
 
 from calculator import evaluate
 from decimo.rounding_mode import RoundingMode

--- a/tests/cli/test_evaluator.mojo
+++ b/tests/cli/test_evaluator.mojo
@@ -11,33 +11,33 @@ from decimo.rounding_mode import RoundingMode
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_addition() raises:
+def test_addition() raises:
     testing.assert_equal(String(evaluate("2+3")), "5", "2+3")
 
 
-fn test_subtraction() raises:
+def test_subtraction() raises:
     testing.assert_equal(String(evaluate("10-7")), "3", "10-7")
 
 
-fn test_multiplication() raises:
+def test_multiplication() raises:
     testing.assert_equal(String(evaluate("6*7")), "42", "6*7")
 
 
-fn test_division_exact() raises:
+def test_division_exact() raises:
     testing.assert_equal(String(evaluate("10/2")), "5", "10/2")
 
 
-fn test_division_repeating() raises:
+def test_division_repeating() raises:
     """1/3 with precision=10 should give 10 decimal digits."""
     var result = String(evaluate("1/3", precision=10))
     testing.assert_equal(result, "0.3333333333", "1/3 p=10")
 
 
-fn test_zero() raises:
+def test_zero() raises:
     testing.assert_equal(String(evaluate("0+0")), "0", "0+0")
 
 
-fn test_add_zero() raises:
+def test_add_zero() raises:
     testing.assert_equal(String(evaluate("42+0")), "42", "42+0")
 
 
@@ -46,15 +46,15 @@ fn test_add_zero() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_mul_before_add() raises:
+def test_mul_before_add() raises:
     testing.assert_equal(String(evaluate("2+3*4")), "14", "2+3*4")
 
 
-fn test_div_before_sub() raises:
+def test_div_before_sub() raises:
     testing.assert_equal(String(evaluate("10-6/3")), "8", "10-6/3")
 
 
-fn test_left_to_right() raises:
+def test_left_to_right() raises:
     testing.assert_equal(String(evaluate("10-3-2")), "5", "10-3-2")
 
 
@@ -63,17 +63,17 @@ fn test_left_to_right() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_parens_simple() raises:
+def test_parens_simple() raises:
     testing.assert_equal(String(evaluate("(2+3)*4")), "20", "(2+3)*4")
 
 
-fn test_nested_parens() raises:
+def test_nested_parens() raises:
     testing.assert_equal(
         String(evaluate("((1+2)*(3+4))")), "21", "((1+2)*(3+4))"
     )
 
 
-fn test_parens_division() raises:
+def test_parens_division() raises:
     testing.assert_equal(String(evaluate("(10+2)/(3+1)")), "3", "(10+2)/(3+1)")
 
 
@@ -82,23 +82,23 @@ fn test_parens_division() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_unary_minus_simple() raises:
+def test_unary_minus_simple() raises:
     testing.assert_equal(String(evaluate("-5+3")), "-2", "-5+3")
 
 
-fn test_unary_minus_in_parens() raises:
+def test_unary_minus_in_parens() raises:
     testing.assert_equal(String(evaluate("(-5+2)*3")), "-9", "(-5+2)*3")
 
 
-fn test_multiply_negative() raises:
+def test_multiply_negative() raises:
     testing.assert_equal(String(evaluate("2*-3")), "-6", "2*-3")
 
 
-fn test_double_negative() raises:
+def test_double_negative() raises:
     testing.assert_equal(String(evaluate("--5")), "5", "--5")
 
 
-fn test_negative_times_negative() raises:
+def test_negative_times_negative() raises:
     testing.assert_equal(String(evaluate("-2*-3")), "6", "-2*-3")
 
 
@@ -107,15 +107,15 @@ fn test_negative_times_negative() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_decimal_addition() raises:
+def test_decimal_addition() raises:
     testing.assert_equal(String(evaluate("1.5+2.5")), "4.0", "1.5+2.5")
 
 
-fn test_decimal_multiplication() raises:
+def test_decimal_multiplication() raises:
     testing.assert_equal(String(evaluate("0.1*0.2")), "0.02", "0.1*0.2")
 
 
-fn test_large_integer() raises:
+def test_large_integer() raises:
     """Test with numbers exceeding 64-bit integer range."""
     var result = String(evaluate("999999999999999999999999999999 + 1"))
     testing.assert_equal(
@@ -130,7 +130,7 @@ fn test_large_integer() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_precision_20() raises:
+def test_precision_20() raises:
     var result = String(evaluate("1/7", precision=20))
     testing.assert_equal(
         result,
@@ -139,7 +139,7 @@ fn test_precision_20() raises:
     )
 
 
-fn test_precision_5() raises:
+def test_precision_5() raises:
     var result = String(evaluate("1/3", precision=5))
     testing.assert_equal(result, "0.33333", "1/3 p=5")
 
@@ -149,7 +149,7 @@ fn test_precision_5() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_showcase_expression() raises:
+def test_showcase_expression() raises:
     """100 * 12 - 23/17 at default precision (50 significant digits)."""
     var result = String(evaluate("100*12-23/17"))
     # 50 significant digits: 4 integer digits + 46 decimal digits.
@@ -165,24 +165,24 @@ fn test_showcase_expression() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_power_simple() raises:
+def test_power_simple() raises:
     testing.assert_equal(String(evaluate("2^10")), "1024", "2^10")
 
 
-fn test_power_double_star() raises:
+def test_power_double_star() raises:
     """** alias for ^."""
     testing.assert_equal(String(evaluate("2**10")), "1024", "2**10")
 
 
-fn test_power_zero() raises:
+def test_power_zero() raises:
     testing.assert_equal(String(evaluate("5^0")), "1", "5^0")
 
 
-fn test_power_one() raises:
+def test_power_one() raises:
     testing.assert_equal(String(evaluate("7^1")), "7", "7^1")
 
 
-fn test_power_large() raises:
+def test_power_large() raises:
     """2^256 should produce the correct value."""
     var result = String(evaluate("2^256"))
     # BigDecimal may render this in scientific notation
@@ -194,17 +194,17 @@ fn test_power_large() raises:
     )
 
 
-fn test_power_right_associative() raises:
+def test_power_right_associative() raises:
     """2^3^2 = 2^(3^2) = 2^9 = 512."""
     testing.assert_equal(String(evaluate("2^3^2")), "512", "2^3^2")
 
 
-fn test_power_with_subtraction() raises:
+def test_power_with_subtraction() raises:
     """10^2 - 1 = 99."""
     testing.assert_equal(String(evaluate("10^2-1")), "99", "10^2-1")
 
 
-fn test_power_negative_exponent() raises:
+def test_power_negative_exponent() raises:
     """2^-3 = 0.125."""
     testing.assert_equal(String(evaluate("2^-3")), "0.125", "2^-3")
 
@@ -214,11 +214,11 @@ fn test_power_negative_exponent() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_sqrt_perfect() raises:
+def test_sqrt_perfect() raises:
     testing.assert_equal(String(evaluate("sqrt(9)")), "3", "sqrt(9)")
 
 
-fn test_sqrt_irrational() raises:
+def test_sqrt_irrational() raises:
     """Irrational sqrt(2) with precision 20."""
     var result = String(evaluate("sqrt(2)", precision=20))
     testing.assert_true(
@@ -227,40 +227,40 @@ fn test_sqrt_irrational() raises:
     )
 
 
-fn test_ln_1() raises:
+def test_ln_1() raises:
     testing.assert_equal(String(evaluate("ln(1)")), "0", "ln(1)")
 
 
-fn test_exp_0() raises:
+def test_exp_0() raises:
     testing.assert_equal(String(evaluate("exp(0)")), "1", "exp(0)")
 
 
-fn test_abs_negative() raises:
+def test_abs_negative() raises:
     testing.assert_equal(String(evaluate("abs(-42)")), "42", "abs(-42)")
 
 
-fn test_abs_positive() raises:
+def test_abs_positive() raises:
     testing.assert_equal(String(evaluate("abs(7)")), "7", "abs(7)")
 
 
-fn test_root_cube() raises:
+def test_root_cube() raises:
     """Cube root(27, 3) = 3."""
     testing.assert_equal(String(evaluate("root(27, 3)")), "3", "root(27,3)")
 
 
-fn test_function_in_expression() raises:
+def test_function_in_expression() raises:
     """1 + sqrt(4) = 3."""
     testing.assert_equal(String(evaluate("1+sqrt(4)")), "3", "1+sqrt(4)")
 
 
-fn test_nested_functions() raises:
+def test_nested_functions() raises:
     """Nested sqrt(abs(-9)) = 3."""
     testing.assert_equal(
         String(evaluate("sqrt(abs(-9))")), "3", "sqrt(abs(-9))"
     )
 
 
-fn test_function_with_power() raises:
+def test_function_with_power() raises:
     """Power of sqrt(2)^2 should be very close to 2."""
     var result = String(evaluate("sqrt(2)^2"))
     testing.assert_true(
@@ -274,7 +274,7 @@ fn test_function_with_power() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_pi_constant() raises:
+def test_pi_constant() raises:
     """Constant pi with precision 20."""
     var result = String(evaluate("pi", precision=20))
     testing.assert_true(
@@ -283,7 +283,7 @@ fn test_pi_constant() raises:
     )
 
 
-fn test_e_constant() raises:
+def test_e_constant() raises:
     """Constant e with precision 20."""
     var result = String(evaluate("e", precision=20))
     testing.assert_true(
@@ -292,7 +292,7 @@ fn test_e_constant() raises:
     )
 
 
-fn test_pi_in_expression() raises:
+def test_pi_in_expression() raises:
     """Expression 2*pi should start with 6.2831853..."""
     var result = String(evaluate("2*pi", precision=20))
     testing.assert_true(
@@ -301,7 +301,7 @@ fn test_pi_in_expression() raises:
     )
 
 
-fn test_ln_e_is_one() raises:
+def test_ln_e_is_one() raises:
     """Expression ln(e) should be approximately 1."""
     var result = String(evaluate("ln(e)", precision=20))
     testing.assert_true(
@@ -315,7 +315,7 @@ fn test_ln_e_is_one() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_cbrt_27() raises:
+def test_cbrt_27() raises:
     """Tests cbrt(27) ≈ 3."""
     var result = String(evaluate("cbrt(27)"))
     testing.assert_true(
@@ -324,17 +324,17 @@ fn test_cbrt_27() raises:
     )
 
 
-fn test_log10_1000() raises:
+def test_log10_1000() raises:
     """Tests log10(1000) = 3."""
     testing.assert_equal(String(evaluate("log10(1000)")), "3", "log10(1000)")
 
 
-fn test_log10_1() raises:
+def test_log10_1() raises:
     """Tests log10(1) = 0."""
     testing.assert_equal(String(evaluate("log10(1)")), "0", "log10(1)")
 
 
-fn test_log_base_2() raises:
+def test_log_base_2() raises:
     """Tests log(8, 2) ≈ 3."""
     var result = String(evaluate("log(8, 2)"))
     testing.assert_true(
@@ -343,7 +343,7 @@ fn test_log_base_2() raises:
     )
 
 
-fn test_log_base_100() raises:
+def test_log_base_100() raises:
     """Tests log(1000000, 100) ≈ 3."""
     var result = String(evaluate("log(1000000, 100)"))
     testing.assert_true(
@@ -352,17 +352,17 @@ fn test_log_base_100() raises:
     )
 
 
-fn test_cos_0() raises:
+def test_cos_0() raises:
     """Tests cos(0) = 1."""
     testing.assert_equal(String(evaluate("cos(0)")), "1", "cos(0)")
 
 
-fn test_tan_0() raises:
+def test_tan_0() raises:
     """Tests tan(0) = 0."""
     testing.assert_equal(String(evaluate("tan(0)")), "0", "tan(0)")
 
 
-fn test_cot_pi_over_4() raises:
+def test_cot_pi_over_4() raises:
     """Tests cot(pi/4) is very close to 1."""
     var result = String(evaluate("cot(pi/4)", precision=20))
     testing.assert_true(
@@ -371,7 +371,7 @@ fn test_cot_pi_over_4() raises:
     )
 
 
-fn test_csc_pi_over_2() raises:
+def test_csc_pi_over_2() raises:
     """Tests csc(pi/2) is very close to 1."""
     var result = String(evaluate("csc(pi/2)", precision=20))
     testing.assert_true(
@@ -385,7 +385,7 @@ fn test_csc_pi_over_2() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_rounding_half_even_tie() raises:
+def test_rounding_half_even_tie() raises:
     """2.5 rounded to 1 significant digit with half_even → 2 (round to even)."""
     var result = String(
         evaluate("2.5", precision=1, rounding_mode=RoundingMode.half_even())
@@ -393,7 +393,7 @@ fn test_rounding_half_even_tie() raises:
     testing.assert_equal(result, "2", "2.5 half_even p=1")
 
 
-fn test_rounding_half_up_tie() raises:
+def test_rounding_half_up_tie() raises:
     """2.5 rounded to 1 significant digit with half_up → 3 (round away from 0).
     """
     var result = String(
@@ -402,7 +402,7 @@ fn test_rounding_half_up_tie() raises:
     testing.assert_equal(result, "3", "2.5 half_up p=1")
 
 
-fn test_rounding_floor() raises:
+def test_rounding_floor() raises:
     """1.9 rounded to 1 significant digit with floor → 1."""
     var result = String(
         evaluate("1.9", precision=1, rounding_mode=RoundingMode.floor())
@@ -410,7 +410,7 @@ fn test_rounding_floor() raises:
     testing.assert_equal(result, "1", "1.9 floor p=1")
 
 
-fn test_rounding_ceiling() raises:
+def test_rounding_ceiling() raises:
     """1.1 rounded to 1 significant digit with ceiling → 2."""
     var result = String(
         evaluate("1.1", precision=1, rounding_mode=RoundingMode.ceiling())
@@ -418,7 +418,7 @@ fn test_rounding_ceiling() raises:
     testing.assert_equal(result, "2", "1.1 ceiling p=1")
 
 
-fn test_rounding_half_even_division() raises:
+def test_rounding_half_even_division() raises:
     """1/3 with half_even should produce a correctly rounded trailing digit."""
     var result = String(
         evaluate("1/3", precision=4, rounding_mode=RoundingMode.half_even())
@@ -426,7 +426,7 @@ fn test_rounding_half_even_division() raises:
     testing.assert_equal(result, "0.3333", "1/3 half_even p=4")
 
 
-fn test_rounding_half_up_division() raises:
+def test_rounding_half_up_division() raises:
     """2/3 with half_up should round trailing 6… → 7."""
     var result = String(
         evaluate("2/3", precision=4, rounding_mode=RoundingMode.half_up())
@@ -439,5 +439,5 @@ fn test_rounding_half_up_division() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/cli/test_parser.mojo
+++ b/tests/cli/test_parser.mojo
@@ -1,6 +1,6 @@
 """Test the shunting-yard parser: infix to RPN conversion."""
 
-import testing
+from std import testing
 
 from calculator.tokenizer import (
     Token,

--- a/tests/cli/test_parser.mojo
+++ b/tests/cli/test_parser.mojo
@@ -25,7 +25,7 @@ from calculator.parser import parse_to_rpn
 # ===----------------------------------------------------------------------=== #
 
 
-fn rpn_to_string(rpn: List[Token]) -> String:
+def rpn_to_string(rpn: List[Token]) -> String:
     """Convert an RPN token list to a space-separated string."""
     var parts = List[String]()
     for i in range(len(rpn)):
@@ -38,7 +38,7 @@ fn rpn_to_string(rpn: List[Token]) -> String:
     return result^
 
 
-fn parse_expr(expr: String) raises -> String:
+def parse_expr(expr: String) raises -> String:
     """Tokenize and parse an expression, return RPN as string."""
     var tokens = tokenize(expr)
     var rpn = parse_to_rpn(tokens^)
@@ -50,30 +50,30 @@ fn parse_expr(expr: String) raises -> String:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_simple_addition() raises:
+def test_simple_addition() raises:
     testing.assert_equal(parse_expr("2+3"), "2 3 +", "simple addition")
 
 
-fn test_simple_subtraction() raises:
+def test_simple_subtraction() raises:
     testing.assert_equal(parse_expr("5-3"), "5 3 -", "simple subtraction")
 
 
-fn test_mul_before_add() raises:
+def test_mul_before_add() raises:
     """Multiplication has higher precedence than addition."""
     testing.assert_equal(parse_expr("2+3*4"), "2 3 4 * +", "mul before add")
 
 
-fn test_div_before_sub() raises:
+def test_div_before_sub() raises:
     """Division has higher precedence than subtraction."""
     testing.assert_equal(parse_expr("10-6/3"), "10 6 3 / -", "div before sub")
 
 
-fn test_left_associativity_add() raises:
+def test_left_associativity_add() raises:
     """Addition is left-associative: 1+2+3 = (1+2)+3."""
     testing.assert_equal(parse_expr("1+2+3"), "1 2 + 3 +", "left assoc add")
 
 
-fn test_left_associativity_mul() raises:
+def test_left_associativity_mul() raises:
     """Multiplication is left-associative: 2*3*4 = (2*3)*4."""
     testing.assert_equal(parse_expr("2*3*4"), "2 3 * 4 *", "left assoc mul")
 
@@ -83,18 +83,18 @@ fn test_left_associativity_mul() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_parens_override_precedence() raises:
+def test_parens_override_precedence() raises:
     """Parentheses override normal precedence."""
     testing.assert_equal(parse_expr("(2+3)*4"), "2 3 + 4 *", "parens override")
 
 
-fn test_nested_parens() raises:
+def test_nested_parens() raises:
     testing.assert_equal(
         parse_expr("((1+2)*(3+4))"), "1 2 + 3 4 + *", "nested parens"
     )
 
 
-fn test_parens_around_single() raises:
+def test_parens_around_single() raises:
     testing.assert_equal(parse_expr("(42)"), "42", "parens around single")
 
 
@@ -103,15 +103,15 @@ fn test_parens_around_single() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_unary_minus_simple() raises:
+def test_unary_minus_simple() raises:
     testing.assert_equal(parse_expr("-5"), "5 neg", "unary minus simple")
 
 
-fn test_unary_minus_in_expr() raises:
+def test_unary_minus_in_expr() raises:
     testing.assert_equal(parse_expr("-5+3"), "5 neg 3 +", "unary minus in expr")
 
 
-fn test_unary_minus_after_mul() raises:
+def test_unary_minus_after_mul() raises:
     testing.assert_equal(
         parse_expr("2*-3"), "2 3 neg *", "unary minus after mul"
     )
@@ -122,7 +122,7 @@ fn test_unary_minus_after_mul() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_complex_mixed() raises:
+def test_complex_mixed() raises:
     """100*12-23/17 should parse correctly."""
     testing.assert_equal(
         parse_expr("100*12-23/17"),
@@ -131,7 +131,7 @@ fn test_complex_mixed() raises:
     )
 
 
-fn test_complex_parens() raises:
+def test_complex_parens() raises:
     """(1+2)*(3-4)/(5+6)."""
     testing.assert_equal(
         parse_expr("(1+2)*(3-4)/(5+6)"),
@@ -145,7 +145,7 @@ fn test_complex_parens() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_mismatched_lparen() raises:
+def test_mismatched_lparen() raises:
     var raised = False
     try:
         var tokens = tokenize("(2+3")
@@ -155,7 +155,7 @@ fn test_mismatched_lparen() raises:
     testing.assert_true(raised, "should raise on missing ')'")
 
 
-fn test_mismatched_rparen() raises:
+def test_mismatched_rparen() raises:
     var raised = False
     try:
         var tokens = tokenize("2+3)")
@@ -170,30 +170,30 @@ fn test_mismatched_rparen() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_caret_simple() raises:
+def test_caret_simple() raises:
     testing.assert_equal(parse_expr("2^3"), "2 3 ^", "simple power")
 
 
-fn test_caret_right_associative() raises:
+def test_caret_right_associative() raises:
     """2^3^4 should be parsed as 2^(3^4), i.e. RPN: 2 3 4 ^ ^."""
     testing.assert_equal(parse_expr("2^3^4"), "2 3 4 ^ ^", "right assoc ^")
 
 
-fn test_caret_vs_mul_precedence() raises:
+def test_caret_vs_mul_precedence() raises:
     """^ binds tighter than *: 2*3^4 = 2*(3^4)."""
     testing.assert_equal(parse_expr("2*3^4"), "2 3 4 ^ *", "^ before *")
 
 
-fn test_caret_vs_add_precedence() raises:
+def test_caret_vs_add_precedence() raises:
     """^ binds tighter than +: 1+2^3 = 1+(2^3)."""
     testing.assert_equal(parse_expr("1+2^3"), "1 2 3 ^ +", "^ before +")
 
 
-fn test_caret_with_parens() raises:
+def test_caret_with_parens() raises:
     testing.assert_equal(parse_expr("(2+3)^4"), "2 3 + 4 ^", "(2+3)^4")
 
 
-fn test_double_star() raises:
+def test_double_star() raises:
     """** is alias for ^."""
     testing.assert_equal(parse_expr("2**3"), "2 3 ^", "** as ^")
 
@@ -203,34 +203,34 @@ fn test_double_star() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_func_single_arg() raises:
+def test_func_single_arg() raises:
     """Sqrt(4) should produce RPN: 4 sqrt."""
     testing.assert_equal(parse_expr("sqrt(4)"), "4 sqrt", "sqrt(4)")
 
 
-fn test_func_nested_expr() raises:
+def test_func_nested_expr() raises:
     """Sqrt(2+2) should produce RPN: 2 2 + sqrt."""
     testing.assert_equal(parse_expr("sqrt(2+2)"), "2 2 + sqrt", "sqrt(2+2)")
 
 
-fn test_func_in_expression() raises:
+def test_func_in_expression() raises:
     """1+sqrt(4) should produce RPN: 1 4 sqrt +."""
     testing.assert_equal(parse_expr("1+sqrt(4)"), "1 4 sqrt +", "1+sqrt(4)")
 
 
-fn test_func_two_args() raises:
+def test_func_two_args() raises:
     """Root(27, 3) should produce RPN: 27 3 root."""
     testing.assert_equal(parse_expr("root(27, 3)"), "27 3 root", "root(27,3)")
 
 
-fn test_func_chained() raises:
+def test_func_chained() raises:
     """Nested sqrt(abs(-9)) should produce RPN: 9 neg abs sqrt."""
     testing.assert_equal(
         parse_expr("sqrt(abs(-9))"), "9 neg abs sqrt", "chained functions"
     )
 
 
-fn test_func_with_power() raises:
+def test_func_with_power() raises:
     """Function sqrt(2)^2 should produce RPN: 2 sqrt 2 ^."""
     testing.assert_equal(parse_expr("sqrt(2)^2"), "2 sqrt 2 ^", "sqrt(2)^2")
 
@@ -240,17 +240,17 @@ fn test_func_with_power() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_constant_pi_rpn() raises:
+def test_constant_pi_rpn() raises:
     """Constant pi alone should produce RPN: pi."""
     testing.assert_equal(parse_expr("pi"), "pi", "pi alone")
 
 
-fn test_constant_in_expression() raises:
+def test_constant_in_expression() raises:
     """2*pi should produce RPN: 2 pi *."""
     testing.assert_equal(parse_expr("2*pi"), "2 pi *", "2*pi")
 
 
-fn test_constant_e_in_function() raises:
+def test_constant_e_in_function() raises:
     """Expression ln(e) should produce RPN: e ln."""
     testing.assert_equal(parse_expr("ln(e)"), "e ln", "ln(e)")
 
@@ -260,5 +260,5 @@ fn test_constant_e_in_function() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/cli/test_tokenizer.mojo
+++ b/tests/cli/test_tokenizer.mojo
@@ -25,7 +25,7 @@ from calculator.tokenizer import (
 # ===----------------------------------------------------------------------=== #
 
 
-fn assert_token(
+def assert_token(
     tokens: List[Token],
     index: Int,
     expected_kind: Int,
@@ -46,25 +46,25 @@ fn assert_token(
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_single_number() raises:
+def test_single_number() raises:
     var toks = tokenize("42")
     testing.assert_equal(len(toks), 1, "single number token count")
     assert_token(toks, 0, TOKEN_NUMBER, "42", "single number")
 
 
-fn test_decimal_number() raises:
+def test_decimal_number() raises:
     var toks = tokenize("3.14")
     testing.assert_equal(len(toks), 1, "decimal number token count")
     assert_token(toks, 0, TOKEN_NUMBER, "3.14", "decimal number")
 
 
-fn test_leading_dot() raises:
+def test_leading_dot() raises:
     var toks = tokenize(".5")
     testing.assert_equal(len(toks), 1, "leading dot token count")
     assert_token(toks, 0, TOKEN_NUMBER, ".5", "leading dot")
 
 
-fn test_simple_addition() raises:
+def test_simple_addition() raises:
     var toks = tokenize("2 + 3")
     testing.assert_equal(len(toks), 3, "2+3 token count")
     assert_token(toks, 0, TOKEN_NUMBER, "2", "first operand")
@@ -72,7 +72,7 @@ fn test_simple_addition() raises:
     assert_token(toks, 2, TOKEN_NUMBER, "3", "second operand")
 
 
-fn test_all_operators() raises:
+def test_all_operators() raises:
     var toks = tokenize("1+2-3*4/5")
     testing.assert_equal(len(toks), 9, "all ops token count")
     assert_token(toks, 1, TOKEN_PLUS, "+", "plus")
@@ -81,14 +81,14 @@ fn test_all_operators() raises:
     assert_token(toks, 7, TOKEN_SLASH, "/", "slash")
 
 
-fn test_parentheses() raises:
+def test_parentheses() raises:
     var toks = tokenize("(2+3)*4")
     testing.assert_equal(len(toks), 7, "parens token count")
     assert_token(toks, 0, TOKEN_LPAREN, "(", "left paren")
     assert_token(toks, 4, TOKEN_RPAREN, ")", "right paren")
 
 
-fn test_whitespace_handling() raises:
+def test_whitespace_handling() raises:
     var toks_no_space = tokenize("2+3")
     var toks_spaces = tokenize("  2  +  3  ")
     testing.assert_equal(
@@ -104,14 +104,14 @@ fn test_whitespace_handling() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_unary_minus_at_start() raises:
+def test_unary_minus_at_start() raises:
     var toks = tokenize("-5")
     testing.assert_equal(len(toks), 2, "-5 token count")
     assert_token(toks, 0, TOKEN_UNARY_MINUS, "neg", "unary at start")
     assert_token(toks, 1, TOKEN_NUMBER, "5", "operand after unary")
 
 
-fn test_unary_minus_after_lparen() raises:
+def test_unary_minus_after_lparen() raises:
     var toks = tokenize("(-5)")
     testing.assert_equal(len(toks), 4, "(-5) token count")
     assert_token(toks, 0, TOKEN_LPAREN, "(", "lparen")
@@ -120,7 +120,7 @@ fn test_unary_minus_after_lparen() raises:
     assert_token(toks, 3, TOKEN_RPAREN, ")", "rparen")
 
 
-fn test_unary_minus_after_operator() raises:
+def test_unary_minus_after_operator() raises:
     var toks = tokenize("2*-3")
     testing.assert_equal(len(toks), 4, "2*-3 token count")
     assert_token(toks, 0, TOKEN_NUMBER, "2", "first operand")
@@ -129,13 +129,13 @@ fn test_unary_minus_after_operator() raises:
     assert_token(toks, 3, TOKEN_NUMBER, "3", "second operand")
 
 
-fn test_binary_minus() raises:
+def test_binary_minus() raises:
     var toks = tokenize("5-3")
     testing.assert_equal(len(toks), 3, "5-3 token count")
     assert_token(toks, 1, TOKEN_MINUS, "-", "binary minus")
 
 
-fn test_double_unary_minus() raises:
+def test_double_unary_minus() raises:
     var toks = tokenize("--5")
     testing.assert_equal(len(toks), 3, "--5 token count")
     assert_token(toks, 0, TOKEN_UNARY_MINUS, "neg", "first neg")
@@ -148,7 +148,7 @@ fn test_double_unary_minus() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_large_integer() raises:
+def test_large_integer() raises:
     var toks = tokenize("123456789012345678901234567890")
     testing.assert_equal(len(toks), 1, "large integer token count")
     assert_token(
@@ -160,7 +160,7 @@ fn test_large_integer() raises:
     )
 
 
-fn test_long_decimal() raises:
+def test_long_decimal() raises:
     var toks = tokenize("3.141592653589793238462643383279")
     testing.assert_equal(len(toks), 1, "long decimal token count")
     assert_token(
@@ -177,7 +177,7 @@ fn test_long_decimal() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_invalid_character() raises:
+def test_invalid_character() raises:
     var raised = False
     try:
         _ = tokenize("2 @ 3")
@@ -186,7 +186,7 @@ fn test_invalid_character() raises:
     testing.assert_true(raised, "should raise on invalid character '@'")
 
 
-fn test_empty_string() raises:
+def test_empty_string() raises:
     """Empty string should raise an error since Phase 3."""
     var raised = False
     try:
@@ -201,7 +201,7 @@ fn test_empty_string() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_caret_operator() raises:
+def test_caret_operator() raises:
     var toks = tokenize("2^3")
     testing.assert_equal(len(toks), 3, "2^3 token count")
     assert_token(toks, 0, TOKEN_NUMBER, "2", "base")
@@ -209,20 +209,20 @@ fn test_caret_operator() raises:
     assert_token(toks, 2, TOKEN_NUMBER, "3", "exponent")
 
 
-fn test_double_star_as_power() raises:
+def test_double_star_as_power() raises:
     """'**' should be tokenized as TOKEN_CARET."""
     var toks = tokenize("2**3")
     testing.assert_equal(len(toks), 3, "2**3 token count")
     assert_token(toks, 1, TOKEN_CARET, "^", "** -> ^")
 
 
-fn test_caret_precedence() raises:
+def test_caret_precedence() raises:
     """Verify the caret token has precedence 3."""
     var toks = tokenize("^")
     testing.assert_equal(toks[0].precedence(), 3, "^ precedence")
 
 
-fn test_caret_right_associative() raises:
+def test_caret_right_associative() raises:
     """Verify the caret token is right-associative."""
     var toks = tokenize("^")
     testing.assert_equal(toks[0].is_left_associative(), False, "^ right assoc")
@@ -233,7 +233,7 @@ fn test_caret_right_associative() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_function_sqrt() raises:
+def test_function_sqrt() raises:
     var toks = tokenize("sqrt(4)")
     testing.assert_equal(len(toks), 4, "sqrt(4) token count")
     assert_token(toks, 0, TOKEN_FUNC, "sqrt", "sqrt function")
@@ -242,23 +242,23 @@ fn test_function_sqrt() raises:
     assert_token(toks, 3, TOKEN_RPAREN, ")", "rparen")
 
 
-fn test_function_ln() raises:
+def test_function_ln() raises:
     var toks = tokenize("ln(2)")
     testing.assert_equal(len(toks), 4, "ln(2) token count")
     assert_token(toks, 0, TOKEN_FUNC, "ln", "ln function")
 
 
-fn test_function_sin() raises:
+def test_function_sin() raises:
     var toks = tokenize("sin(3.14)")
     assert_token(toks, 0, TOKEN_FUNC, "sin", "sin function")
 
 
-fn test_function_log10() raises:
+def test_function_log10() raises:
     var toks = tokenize("log10(100)")
     assert_token(toks, 0, TOKEN_FUNC, "log10", "log10 function")
 
 
-fn test_function_abs() raises:
+def test_function_abs() raises:
     var toks = tokenize("abs(-5)")
     assert_token(toks, 0, TOKEN_FUNC, "abs", "abs function")
 
@@ -268,19 +268,19 @@ fn test_function_abs() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_constant_pi() raises:
+def test_constant_pi() raises:
     var toks = tokenize("pi")
     testing.assert_equal(len(toks), 1, "pi token count")
     assert_token(toks, 0, TOKEN_CONST, "pi", "pi constant")
 
 
-fn test_constant_e() raises:
+def test_constant_e() raises:
     var toks = tokenize("e")
     testing.assert_equal(len(toks), 1, "e token count")
     assert_token(toks, 0, TOKEN_CONST, "e", "e constant")
 
 
-fn test_constant_in_expression() raises:
+def test_constant_in_expression() raises:
     var toks = tokenize("2*pi")
     testing.assert_equal(len(toks), 3, "2*pi token count")
     assert_token(toks, 0, TOKEN_NUMBER, "2", "number")
@@ -293,7 +293,7 @@ fn test_constant_in_expression() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_comma_in_function() raises:
+def test_comma_in_function() raises:
     var toks = tokenize("root(27, 3)")
     testing.assert_equal(len(toks), 6, "root(27,3) token count")
     assert_token(toks, 0, TOKEN_FUNC, "root", "root function")
@@ -309,18 +309,18 @@ fn test_comma_in_function() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn test_unary_minus_after_caret() raises:
+def test_unary_minus_after_caret() raises:
     var toks = tokenize("2^-3")
     testing.assert_equal(len(toks), 4, "2^-3 token count")
     assert_token(toks, 2, TOKEN_UNARY_MINUS, "neg", "unary after ^")
 
 
-fn test_unary_minus_after_comma() raises:
+def test_unary_minus_after_comma() raises:
     var toks = tokenize("root(-8, 3)")
     assert_token(toks, 2, TOKEN_UNARY_MINUS, "neg", "unary after (")
 
 
-fn test_unknown_identifier() raises:
+def test_unknown_identifier() raises:
     var raised = False
     try:
         _ = tokenize("foo(1)")
@@ -334,5 +334,5 @@ fn test_unknown_identifier() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/cli/test_tokenizer.mojo
+++ b/tests/cli/test_tokenizer.mojo
@@ -1,6 +1,6 @@
 """Test the tokenizer: lexical analysis of expression strings."""
 
-import testing
+from std import testing
 
 from calculator.tokenizer import (
     Token,

--- a/tests/decimal128/test_decimal128_arithmetics.mojo
+++ b/tests/decimal128/test_decimal128_arithmetics.mojo
@@ -17,7 +17,7 @@ from decimo.tests import TestCase, parse_file, load_test_cases
 comptime file_path = "tests/decimal128/test_data/decimal128_arithmetics.toml"
 
 
-fn test_decimal128_arithmetics() raises:
+def test_decimal128_arithmetics() raises:
     """Test addition, subtraction, negation, and absolute value using TOML
     data-driven test cases.
     """
@@ -186,7 +186,7 @@ fn test_decimal128_arithmetics() raises:
     )
 
 
-fn test_repeated_addition() raises:
+def test_repeated_addition() raises:
     """Test that repeated addition of 0.1 accumulates correctly."""
     var acc = Dec128(0)
     for _ in range(10):
@@ -194,14 +194,14 @@ fn test_repeated_addition() raises:
     testing.assert_equal(String(acc), "1.0", "Repeated addition of 0.1")
 
 
-fn test_double_and_triple_negation() raises:
+def test_double_and_triple_negation() raises:
     """Test double and triple negation."""
     var a = Dec128("123.45")
     testing.assert_equal(String(-(-a)), "123.45", "Double negation")
     testing.assert_equal(String(-(-(-a))), "-123.45", "Triple negation")
 
 
-fn test_addition_overflow() raises:
+def test_addition_overflow() raises:
     """Test that adding beyond MAX raises an error."""
     try:
         var a = Dec128("79228162514264337593543950335")  # MAX
@@ -213,7 +213,7 @@ fn test_addition_overflow() raises:
         pass  # Expected: overflow correctly detected
 
 
-fn test_subtraction_commutativity() raises:
+def test_subtraction_commutativity() raises:
     """Verify that a - b = -(b - a)."""
     var a = Dec128("123.456")
     var b = Dec128("789.012")
@@ -224,5 +224,5 @@ fn test_subtraction_commutativity() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/decimal128/test_decimal128_arithmetics.mojo
+++ b/tests/decimal128/test_decimal128_arithmetics.mojo
@@ -8,8 +8,8 @@ Test Decimal128 arithmetic operations including:
 5. extreme / edge cases
 """
 
-from python import Python
-import testing
+from std.python import Python
+from std import testing
 
 from decimo import Dec128
 from decimo.tests import TestCase, parse_file, load_test_cases

--- a/tests/decimal128/test_decimal128_comparison.mojo
+++ b/tests/decimal128/test_decimal128_comparison.mojo
@@ -22,7 +22,7 @@ from decimo.decimal128.comparison import (
 )
 
 
-fn test_equality() raises:
+def test_equality() raises:
     """Test equality comparisons."""
     testing.assert_true(equal(Decimal128(12345, 2), Decimal128(12345, 2)))
     testing.assert_true(equal(Dec128("123.450"), Decimal128(12345, 2)))
@@ -32,7 +32,7 @@ fn test_equality() raises:
     testing.assert_false(equal(Decimal128(12345, 2), Dec128("-123.45")))
 
 
-fn test_inequality() raises:
+def test_inequality() raises:
     """Test inequality comparisons."""
     testing.assert_false(not_equal(Decimal128(12345, 2), Decimal128(12345, 2)))
     testing.assert_false(not_equal(Decimal128(123450, 3), Decimal128(12345, 2)))
@@ -40,7 +40,7 @@ fn test_inequality() raises:
     testing.assert_true(not_equal(Decimal128(12345, 2), Decimal128(-12345, 2)))
 
 
-fn test_greater() raises:
+def test_greater() raises:
     """Test greater-than comparisons."""
     testing.assert_true(greater(Decimal128(12346, 2), Decimal128(12345, 2)))
     testing.assert_false(greater(Decimal128(12345, 2), Decimal128(12346, 2)))
@@ -53,7 +53,7 @@ fn test_greater() raises:
     testing.assert_true(greater(Dec128("123.5"), Decimal128(12345, 2)))
 
 
-fn test_greater_equal() raises:
+def test_greater_equal() raises:
     """Test greater-or-equal comparisons."""
     testing.assert_true(greater_equal(Dec128("123.46"), Decimal128(12345, 2)))
     testing.assert_true(
@@ -64,7 +64,7 @@ fn test_greater_equal() raises:
     testing.assert_false(greater_equal(Decimal128(12345, 2), Dec128("123.46")))
 
 
-fn test_less() raises:
+def test_less() raises:
     """Test less-than comparisons."""
     testing.assert_true(less(Decimal128(12345, 2), Dec128("123.46")))
     testing.assert_false(less(Decimal128(12345, 2), Decimal128(12345, 2)))
@@ -73,7 +73,7 @@ fn test_less() raises:
     testing.assert_true(less(Dec128(0), Decimal128(12345, 2)))
 
 
-fn test_less_equal() raises:
+def test_less_equal() raises:
     """Test less-or-equal comparisons."""
     testing.assert_true(less_equal(Decimal128(12345, 2), Dec128("123.46")))
     testing.assert_true(less_equal(Decimal128(12345, 2), Decimal128(12345, 2)))
@@ -82,7 +82,7 @@ fn test_less_equal() raises:
     testing.assert_false(less_equal(Dec128("123.46"), Decimal128(12345, 2)))
 
 
-fn test_zero_comparison() raises:
+def test_zero_comparison() raises:
     """Test zero comparison edge cases."""
     var zero = Dec128(0)
     var pos = Dec128("0.0000000000000000001")
@@ -111,7 +111,7 @@ fn test_zero_comparison() raises:
     testing.assert_true(less_equal(zero, neg_zero))
 
 
-fn test_edge_cases() raises:
+def test_edge_cases() raises:
     """Test comparison edge cases."""
     # Very close values
     testing.assert_true(
@@ -141,7 +141,7 @@ fn test_edge_cases() raises:
     testing.assert_true(greater(Dec128(1000), Dec128(-1000)))
 
 
-fn test_exact_comparison() raises:
+def test_exact_comparison() raises:
     """Test exact comparison with precision and trailing zeros."""
     # Zeros with different scales
     testing.assert_true(equal(Dec128(0), Dec128("0.0")))
@@ -158,7 +158,7 @@ fn test_exact_comparison() raises:
     testing.assert_true(less(Dec128("1.2"), Dec128("1.20000001")))
 
 
-fn test_comparison_operators() raises:
+def test_comparison_operators() raises:
     """Test comparison operator overloads."""
     var a = Decimal128(12345, 2)  # 123.45
     var b = Dec128("67.89")
@@ -209,5 +209,5 @@ fn test_comparison_operators() raises:
     testing.assert_false(f != g)
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/decimal128/test_decimal128_comparison.mojo
+++ b/tests/decimal128/test_decimal128_comparison.mojo
@@ -8,7 +8,7 @@ Test Decimal128 comparison operations including:
 5. exact comparison with trailing zeros
 """
 
-import testing
+from std import testing
 
 from decimo import Dec128
 from decimo import Decimal128

--- a/tests/decimal128/test_decimal128_conversions.mojo
+++ b/tests/decimal128/test_decimal128_conversions.mojo
@@ -13,7 +13,7 @@ from decimo.tests import TestCase, parse_file, load_test_cases
 comptime file_path = "tests/decimal128/test_data/decimal128_conversions.toml"
 
 
-fn test_str_conversion() raises:
+def test_str_conversion() raises:
     """Test __str__ using TOML data-driven test cases."""
     var toml = parse_file(file_path)
     var test_cases = load_test_cases[unary=True](toml, "str_conversion_tests")
@@ -37,7 +37,7 @@ fn test_str_conversion() raises:
     testing.assert_equal(count_wrong, 0, "Some str conversion tests failed.")
 
 
-fn test_int_conversion() raises:
+def test_int_conversion() raises:
     """Test __int__ conversion."""
     # Positive integer
     testing.assert_equal(Int(Dec128(123)), 123)
@@ -58,7 +58,7 @@ fn test_int_conversion() raises:
     testing.assert_equal(Int(Dec128(9999999999)), 9999999999)
 
 
-fn test_float_basic_integers() raises:
+def test_float_basic_integers() raises:
     """Test __float__ conversion for basic integers."""
     testing.assert_equal(Float64(Dec128(0)), 0.0)
     testing.assert_equal(Float64(Dec128(1)), 1.0)
@@ -66,7 +66,7 @@ fn test_float_basic_integers() raises:
     testing.assert_equal(Float64(Dec128(123456)), 123456.0)
 
 
-fn test_float_decimals() raises:
+def test_float_decimals() raises:
     """Test __float__ conversion for decimal values."""
     testing.assert_equal(Float64(Dec128("3.14")), 3.14)
     testing.assert_true(
@@ -79,14 +79,14 @@ fn test_float_decimals() raises:
     )
 
 
-fn test_float_negatives() raises:
+def test_float_negatives() raises:
     """Test __float__ conversion for negative values."""
     testing.assert_equal(Float64(Dec128("-123")), -123.0)
     testing.assert_equal(Float64(Dec128("-0.5")), -0.5)
     testing.assert_equal(Float64(Dec128("-0")), 0.0)
 
 
-fn test_float_edge_cases() raises:
+def test_float_edge_cases() raises:
     """Test __float__ conversion edge cases."""
     # Very small positive
     var very_small = Dec128("0." + "0" * 20 + "1")
@@ -107,7 +107,7 @@ fn test_float_edge_cases() raises:
     )
 
 
-fn test_float_special_values() raises:
+def test_float_special_values() raises:
     """Test __float__ conversion of special values."""
     testing.assert_equal(Float64(Dec128("5.0000")), 5.0)
     testing.assert_equal(Float64(Dec128("000123.456")), 123.456)
@@ -126,5 +126,5 @@ fn test_float_special_values() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/decimal128/test_decimal128_conversions.mojo
+++ b/tests/decimal128/test_decimal128_conversions.mojo
@@ -3,7 +3,7 @@ Test Decimal128 conversion methods: __str__, __int__, __float__
 Merges former to_string, to_int, to_float test files.
 """
 
-import testing
+from std import testing
 from decimo.toml.parser import TOMLDocument
 
 from decimo import Dec128

--- a/tests/decimal128/test_decimal128_divide.mojo
+++ b/tests/decimal128/test_decimal128_divide.mojo
@@ -7,7 +7,7 @@ startswith checks, scale properties, overflow/error handling, and
 mathematical relationship verification.
 """
 
-import testing
+from std import testing
 from decimo.toml.parser import TOMLDocument
 
 from decimo import Decimal128, RoundingMode

--- a/tests/decimal128/test_decimal128_divide.mojo
+++ b/tests/decimal128/test_decimal128_divide.mojo
@@ -19,7 +19,7 @@ comptime data_path = "tests/decimal128/test_data/decimal128_divide.toml"
 # ─── TOML-driven helpers ────────────────────────────────────────────────────
 
 
-fn _run_division_section(doc: TOMLDocument, section: String) raises:
+def _run_division_section(doc: TOMLDocument, section: String) raises:
     """Run division (/) test cases from a TOML section."""
     var cases = load_test_cases(doc, section)
     for tc in cases:
@@ -27,7 +27,7 @@ fn _run_division_section(doc: TOMLDocument, section: String) raises:
         testing.assert_equal(String(result), tc.expected, tc.description)
 
 
-fn _run_truncate_section(doc: TOMLDocument, section: String) raises:
+def _run_truncate_section(doc: TOMLDocument, section: String) raises:
     """Run truncate division (//) test cases from a TOML section."""
     var cases = load_test_cases(doc, section)
     for tc in cases:
@@ -38,37 +38,37 @@ fn _run_truncate_section(doc: TOMLDocument, section: String) raises:
 # ─── TOML-driven test functions ─────────────────────────────────────────────
 
 
-fn test_division_basic() raises:
+def test_division_basic() raises:
     """10 basic division cases: integer, decimal, signed."""
     var doc = parse_file(data_path)
     _run_division_section(doc, "division_basic")
 
 
-fn test_division_precision() raises:
+def test_division_precision() raises:
     """6 precision/rounding cases at the 28-digit limit."""
     var doc = parse_file(data_path)
     _run_division_section(doc, "division_precision")
 
 
-fn test_division_scale() raises:
+def test_division_scale() raises:
     """10 scale handling cases: powers of 10, trailing zeros."""
     var doc = parse_file(data_path)
     _run_division_section(doc, "division_scale")
 
 
-fn test_division_special() raises:
+def test_division_special() raises:
     """30 special cases: exact results, large numbers, rounding."""
     var doc = parse_file(data_path)
     _run_division_section(doc, "division_special")
 
 
-fn test_truncate_basic() raises:
+def test_truncate_basic() raises:
     """11 basic truncate division cases: positive and negative."""
     var doc = parse_file(data_path)
     _run_truncate_section(doc, "truncate_basic")
 
 
-fn test_truncate_edge() raises:
+def test_truncate_edge() raises:
     """6 truncate edge cases: div by 1, zero dividend, small numbers."""
     var doc = parse_file(data_path)
     _run_truncate_section(doc, "truncate_edge")
@@ -77,7 +77,7 @@ fn test_truncate_edge() raises:
 # ─── Inline tests: repeating decimals (startswith checks) ───────────────────
 
 
-fn test_repeating_decimals() raises:
+def test_repeating_decimals() raises:
     """10 cases testing repeating decimal results (cases 11-20)."""
     testing.assert_true(
         String(Decimal128(1) / Decimal128(3)).startswith("0.33333333333333"),
@@ -126,7 +126,7 @@ fn test_repeating_decimals() raises:
 # ─── Inline tests: scale/precision properties and edge cases ────────────────
 
 
-fn test_properties_and_edge() raises:
+def test_properties_and_edge() raises:
     """Scale property checks, edge cases with comparisons and overflow."""
     # Scale property checks
     var a25 = Decimal128(1) / Decimal128(81)
@@ -220,7 +220,7 @@ fn test_properties_and_edge() raises:
 # ─── Inline tests: special equality and precision cases ──────────────────────
 
 
-fn test_special_and_precision() raises:
+def test_special_and_precision() raises:
     """Decimal128 equality, mixed precision, and rounding edge cases."""
     # 1.000 / 1.000 should equal 1 (Decimal128 value equality)
     testing.assert_equal(
@@ -301,7 +301,7 @@ fn test_special_and_precision() raises:
 # ─── Inline tests: error handling ────────────────────────────────────────────
 
 
-fn test_error_handling() raises:
+def test_error_handling() raises:
     """Division by zero, overflow, and boundary conditions."""
     # Division by zero
     try:
@@ -372,7 +372,7 @@ fn test_error_handling() raises:
 # ─── Inline tests: truncate division mathematical relationships ──────────────
 
 
-fn test_truncate_math_relationships() raises:
+def test_truncate_math_relationships() raises:
     """Mathematical properties of truncate division."""
     # a = (a // b) * b + (a % b) for positive
     var a1 = Decimal128(10)
@@ -419,5 +419,5 @@ fn test_truncate_math_relationships() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/decimal128/test_decimal128_exp_ln.mojo
+++ b/tests/decimal128/test_decimal128_exp_ln.mojo
@@ -4,7 +4,7 @@ Merged from test_decimal128_exp.mojo and test_decimal128_ln.mojo.
 Most tests use startswith prefix matching for high-precision results.
 """
 
-import testing
+from std import testing
 from decimo.decimal128.decimal128 import Decimal128
 from decimo.rounding_mode import RoundingMode
 from decimo.decimal128.exponential import exp, ln

--- a/tests/decimal128/test_decimal128_exp_ln.mojo
+++ b/tests/decimal128/test_decimal128_exp_ln.mojo
@@ -13,7 +13,7 @@ from decimo.decimal128.exponential import exp, ln
 # ─── exp() tests ────────────────────────────────────────────────────────────
 
 
-fn test_exp_values() raises:
+def test_exp_values() raises:
     """Test e^x for basic, negative, fractional, and high-precision inputs."""
     # e^0 = 1 (exact)
     testing.assert_equal(String(exp(Decimal128("0"))), "1", "e^0 should be 1")
@@ -89,7 +89,7 @@ fn test_exp_values() raises:
     )
 
 
-fn test_exp_identities() raises:
+def test_exp_identities() raises:
     """Test e^(a+b) = e^a * e^b and e^(-x) = 1/e^x."""
     # e^(a+b) = e^a * e^b
     var a = Decimal128("2")
@@ -112,7 +112,7 @@ fn test_exp_identities() raises:
     testing.assert_equal(String(exp(Decimal128("0"))), "1", "e^0 should be 1")
 
 
-fn test_exp_extreme() raises:
+def test_exp_extreme() raises:
     """Test exp with very small inputs and large inputs."""
     testing.assert_true(
         String(exp(Decimal128("0.0000001"))).startswith("1.0000001"),
@@ -134,7 +134,7 @@ fn test_exp_extreme() raises:
 # ─── ln() tests ─────────────────────────────────────────────────────────────
 
 
-fn test_ln_values() raises:
+def test_ln_values() raises:
     """Test ln(x) for basic, fractional, and precision inputs."""
     # ln(1) = 0 (exact)
     testing.assert_equal(String(ln(Decimal128(1))), "0", "ln(1) should be 0")
@@ -177,7 +177,7 @@ fn test_ln_values() raises:
     )
 
 
-fn test_ln_identities() raises:
+def test_ln_identities() raises:
     """Test ln(a*b)=ln(a)+ln(b), ln(a/b)=ln(a)-ln(b), ln(e^x)=x."""
     var a = Decimal128(2)
     var b = Decimal128(3)
@@ -200,7 +200,7 @@ fn test_ln_identities() raises:
     )
 
 
-fn test_ln_edge_cases() raises:
+def test_ln_edge_cases() raises:
     """Test ln(0), ln(negative), and extreme values."""
     # ln(0) should raise
     var caught = False
@@ -236,7 +236,7 @@ fn test_ln_edge_cases() raises:
     )
 
 
-fn test_ln_properties() raises:
+def test_ln_properties() raises:
     """Test ln monotonicity and sign properties."""
     # ln(x) > 0 for x > 1
     testing.assert_true(Decimal128(3).ln() > Decimal128(0), "ln(3) > 0")
@@ -256,5 +256,5 @@ fn test_ln_properties() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/decimal128/test_decimal128_factorial.mojo
+++ b/tests/decimal128/test_decimal128_factorial.mojo
@@ -18,7 +18,7 @@ comptime data_path = "tests/decimal128/test_data/decimal128_factorial.toml"
 # ─── TOML-driven tests ──────────────────────────────────────────────────────
 
 
-fn test_factorial_values() raises:
+def test_factorial_values() raises:
     """Exact factorial values for 0..27 (16 cases via TOML)."""
     var doc = parse_file(data_path)
     var cases = load_test_cases[unary=True](doc, "factorial")
@@ -30,7 +30,7 @@ fn test_factorial_values() raises:
 # ─── Inline tests ───────────────────────────────────────────────────────────
 
 
-fn test_factorial_properties() raises:
+def test_factorial_properties() raises:
     """Mathematical property: (n+1)! = (n+1) * n! for n = 0..26."""
     for n in range(0, 26):
         var n_fact = factorial(n)
@@ -43,7 +43,7 @@ fn test_factorial_properties() raises:
         )
 
 
-fn test_factorial_exceptions() raises:
+def test_factorial_exceptions() raises:
     """Factorial of negative or > 27 should raise."""
     # Negative input
     var caught = False
@@ -64,7 +64,7 @@ fn test_factorial_exceptions() raises:
     testing.assert_true(caught, "factorial(28) exception")
 
 
-fn test_factorial_reciprocal() raises:
+def test_factorial_reciprocal() raises:
     """Factorial_reciprocal(n) should equal 1/factorial(n) for all n in 0..27.
     """
     var all_equal = True
@@ -89,5 +89,5 @@ fn test_factorial_reciprocal() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/decimal128/test_decimal128_factorial.mojo
+++ b/tests/decimal128/test_decimal128_factorial.mojo
@@ -4,7 +4,7 @@ TOML-driven for exact factorial values; inline for properties,
 edge cases, and reciprocal tests.
 """
 
-import testing
+from std import testing
 from decimo.toml.parser import TOMLDocument
 
 from decimo.decimal128.decimal128 import Decimal128, Dec128

--- a/tests/decimal128/test_decimal128_from_float.mojo
+++ b/tests/decimal128/test_decimal128_from_float.mojo
@@ -4,7 +4,7 @@ Most tests use startswith assertions due to float precision, so they remain
 inline rather than TOML-driven.
 """
 
-import testing
+from std import testing
 from decimo import Dec128
 
 

--- a/tests/decimal128/test_decimal128_from_float.mojo
+++ b/tests/decimal128/test_decimal128_from_float.mojo
@@ -8,7 +8,7 @@ from std import testing
 from decimo import Dec128
 
 
-fn test_simple_integers() raises:
+def test_simple_integers() raises:
     """Test conversion of simple integer float values."""
     testing.assert_equal(String(Dec128.from_float(0.0)), "0")
     testing.assert_equal(String(Dec128.from_float(1.0)), "1")
@@ -17,7 +17,7 @@ fn test_simple_integers() raises:
     testing.assert_equal(String(Dec128.from_float(1000.0)), "1000")
 
 
-fn test_simple_decimals() raises:
+def test_simple_decimals() raises:
     """Test conversion of simple decimal float values."""
     testing.assert_equal(String(Dec128.from_float(0.5)), "0.5")
     testing.assert_equal(String(Dec128.from_float(0.25)), "0.25")
@@ -26,7 +26,7 @@ fn test_simple_decimals() raises:
     testing.assert_true(String(Dec128.from_float(2.71828)).startswith("2.7182"))
 
 
-fn test_negative_numbers() raises:
+def test_negative_numbers() raises:
     """Test conversion of negative float values."""
     testing.assert_equal(String(Dec128.from_float(-1.0)), "-1")
     testing.assert_equal(String(Dec128.from_float(-0.5)), "-0.5")
@@ -39,7 +39,7 @@ fn test_negative_numbers() raises:
     )
 
 
-fn test_very_large_numbers() raises:
+def test_very_large_numbers() raises:
     """Test conversion of very large float values."""
     testing.assert_equal(String(Dec128.from_float(1e10)), "10000000000")
     testing.assert_equal(String(Dec128.from_float(1e15)), "1000000000000000")
@@ -54,7 +54,7 @@ fn test_very_large_numbers() raises:
     )
 
 
-fn test_very_small_numbers() raises:
+def test_very_small_numbers() raises:
     """Test conversion of very small float values."""
     testing.assert_true(
         String(Dec128.from_float(1e-10)).startswith("0.00000000")
@@ -71,7 +71,7 @@ fn test_very_small_numbers() raises:
     testing.assert_true(String(Dec128.from_float(1e-310)).startswith("0."))
 
 
-fn test_binary_to_decimal_conversion() raises:
+def test_binary_to_decimal_conversion() raises:
     """Test float values that are inexact in binary."""
     testing.assert_true(String(Dec128.from_float(0.1)).startswith("0.1"))
     testing.assert_true(String(Dec128.from_float(0.2)).startswith("0.2"))
@@ -80,7 +80,7 @@ fn test_binary_to_decimal_conversion() raises:
     testing.assert_true(String(Dec128.from_float(0.1)).startswith("0.1"))
 
 
-fn test_rounding_behavior() raises:
+def test_rounding_behavior() raises:
     """Test rounding behavior during float to Decimal128 conversion."""
     testing.assert_true(
         String(Dec128.from_float(3.141592653589793)).startswith(
@@ -101,7 +101,7 @@ fn test_rounding_behavior() raises:
     )
 
 
-fn test_special_values() raises:
+def test_special_values() raises:
     """Test handling of special float values."""
     testing.assert_equal(String(Dec128.from_float(0.0)), "0")
     testing.assert_true(
@@ -114,7 +114,7 @@ fn test_special_values() raises:
     testing.assert_true(String(Dec128.from_float(9.9999)).startswith("9.9999"))
 
 
-fn test_scientific_notation() raises:
+def test_scientific_notation() raises:
     """Test handling of scientific notation values."""
     testing.assert_equal(String(Dec128.from_float(1.23e5)), "123000")
     testing.assert_true(
@@ -129,7 +129,7 @@ fn test_scientific_notation() raises:
     testing.assert_true(String(Dec128.from_float(5e20)).startswith("5"))
 
 
-fn test_boundary_cases() raises:
+def test_boundary_cases() raises:
     """Test boundary cases for float to Decimal128 conversion."""
     testing.assert_equal(String(Dec128.from_float(1000.0)), "1000")
     testing.assert_equal(
@@ -144,5 +144,5 @@ fn test_boundary_cases() raises:
     testing.assert_equal(String(Dec128.from_float(0.125)), "0.125")
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/decimal128/test_decimal128_from_int.mojo
+++ b/tests/decimal128/test_decimal128_from_int.mojo
@@ -22,7 +22,7 @@ from decimo.tests import TestCase, parse_file, load_test_cases
 comptime file_path = "tests/decimal128/test_data/decimal128_from_int.toml"
 
 
-fn _run_from_int_section(
+def _run_from_int_section(
     toml: TOMLDocument,
     section: String,
     mut count_wrong: Int,
@@ -49,7 +49,7 @@ fn _run_from_int_section(
             count_wrong += 1
 
 
-fn test_from_int() raises:
+def test_from_int() raises:
     """Test from_int conversions using TOML data-driven test cases."""
     var toml = parse_file(file_path)
     var count_wrong = 0
@@ -85,7 +85,7 @@ fn test_from_int() raises:
     )
 
 
-fn test_operations_with_from_int() raises:
+def test_operations_with_from_int() raises:
     """Test arithmetic operations using from_int results."""
     # Addition
     var result1 = Dec128.from_int(100) + Dec128.from_int(50)
@@ -112,7 +112,7 @@ fn test_operations_with_from_int() raises:
     testing.assert_equal(String(result6), "15")
 
 
-fn test_comparison_with_from_int() raises:
+def test_comparison_with_from_int() raises:
     """Test comparison operations using from_int results."""
     # Equality with same value
     testing.assert_true(
@@ -145,7 +145,7 @@ fn test_comparison_with_from_int() raises:
     )
 
 
-fn test_properties() raises:
+def test_properties() raises:
     """Test properties of from_int results."""
     # Sign of positive
     testing.assert_false(
@@ -172,7 +172,7 @@ fn test_properties() raises:
     testing.assert_equal(Dec128.from_int(9876).coefficient(), UInt128(9876))
 
 
-fn test_edge_cases() raises:
+def test_edge_cases() raises:
     """Test edge cases for from_int."""
     # Zero remains zero
     testing.assert_equal(String(Dec128.from_int(0)), "0")
@@ -199,7 +199,7 @@ fn test_edge_cases() raises:
     testing.assert_equal(String(Dec128.from_int(10**9)), "1000000000")
 
 
-fn test_from_int_with_scale_advanced() raises:
+def test_from_int_with_scale_advanced() raises:
     """Test from_int with scale - advanced cases requiring inline assertions."""
     # Scale is correctly stored
     var r1 = Dec128.from_int(123, 2)
@@ -233,7 +233,7 @@ fn test_from_int_with_scale_advanced() raises:
     testing.assert_true(a8 != b8, "from_int(123, 0) != from_int(123, 2)")
 
 
-fn test_decimal_from_components() raises:
+def test_decimal_from_components() raises:
     """Test Decimal128 5-argument component constructor."""
     # Zero with zero scale
     testing.assert_equal(String(Decimal128(0, 0, 0, 0, False)), "0")
@@ -285,5 +285,5 @@ fn test_decimal_from_components() raises:
         pass
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/decimal128/test_decimal128_from_int.mojo
+++ b/tests/decimal128/test_decimal128_from_int.mojo
@@ -12,7 +12,7 @@ Test Decimal128.from_int() and Decimal128 component constructor including:
 9. from_components (inline - 5-arg constructor)
 """
 
-import testing
+from std import testing
 from decimo.toml.parser import TOMLDocument
 
 from decimo import Dec128

--- a/tests/decimal128/test_decimal128_from_string.mojo
+++ b/tests/decimal128/test_decimal128_from_string.mojo
@@ -13,7 +13,7 @@ Test Decimal128.from_string() constructor including:
 10. special cases
 """
 
-import testing
+from std import testing
 from decimo.toml.parser import TOMLDocument
 
 from decimo import Dec128

--- a/tests/decimal128/test_decimal128_from_string.mojo
+++ b/tests/decimal128/test_decimal128_from_string.mojo
@@ -22,7 +22,7 @@ from decimo.tests import TestCase, parse_file, load_test_cases
 comptime file_path = "tests/decimal128/test_data/decimal128_from_string.toml"
 
 
-fn _run_unary_section(
+def _run_unary_section(
     toml: TOMLDocument,
     section: String,
     mut count_wrong: Int,
@@ -49,7 +49,7 @@ fn _run_unary_section(
             count_wrong += 1
 
 
-fn test_from_string() raises:
+def test_from_string() raises:
     """Test from_string conversions using TOML data-driven test cases."""
     var toml = parse_file(file_path)
     var count_wrong = 0
@@ -71,7 +71,7 @@ fn test_from_string() raises:
     )
 
 
-fn test_from_string_high_precision_truncation() raises:
+def test_from_string_high_precision_truncation() raises:
     """Test that very long decimals are truncated to max precision."""
     var long_decimal = Dec128.from_string(
         "0.11111111111111111111111111111111111"
@@ -79,13 +79,13 @@ fn test_from_string_high_precision_truncation() raises:
     testing.assert_true(String(long_decimal).startswith("0.11111111111"))
 
 
-fn test_from_string_boundary_large_scale() raises:
+def test_from_string_boundary_large_scale() raises:
     """Test large integer part with scale causing rounding."""
     var large = Dec128.from_string("9999999999999999999999999999.5")
     testing.assert_equal(String(large), "10000000000000000000000000000")
 
 
-fn test_invalid_inputs() raises:
+def test_invalid_inputs() raises:
     """Test handling of invalid input strings that should raise exceptions."""
 
     # Test: Empty string
@@ -149,5 +149,5 @@ fn test_invalid_inputs() raises:
     testing.assert_true(caught)
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/decimal128/test_decimal128_logarithm.mojo
+++ b/tests/decimal128/test_decimal128_logarithm.mojo
@@ -5,7 +5,7 @@ TOML-driven tests for exact-result cases; inline for startswith,
 tolerance, exception, and mathematical property tests.
 """
 
-import testing
+from std import testing
 from decimo.toml.parser import TOMLDocument
 
 from decimo.decimal128.decimal128 import Decimal128, Dec128

--- a/tests/decimal128/test_decimal128_logarithm.mojo
+++ b/tests/decimal128/test_decimal128_logarithm.mojo
@@ -18,7 +18,7 @@ comptime data_path = "tests/decimal128/test_data/decimal128_logarithm.toml"
 # ─── TOML-driven tests ──────────────────────────────────────────────────────
 
 
-fn test_log_exact() raises:
+def test_log_exact() raises:
     """5 exact log(value, base) results via TOML."""
     var doc = parse_file(data_path)
     var cases = load_test_cases(doc, "log_exact")
@@ -27,7 +27,7 @@ fn test_log_exact() raises:
         testing.assert_equal(String(result), tc.expected, tc.description)
 
 
-fn test_log10_exact() raises:
+def test_log10_exact() raises:
     """8 exact log10(value) results via TOML."""
     var doc = parse_file(data_path)
     var cases = load_test_cases[unary=True](doc, "log10_exact")
@@ -39,7 +39,7 @@ fn test_log10_exact() raises:
 # ─── log() inline tests ─────────────────────────────────────────────────────
 
 
-fn test_log_rounded() raises:
+def test_log_rounded() raises:
     """Log results that are exact after rounding."""
     # log_3(27) ≈ 3, log_5(125) ≈ 3, log_0.1(0.001) ≈ 3, log_2(1024) ≈ 10
     testing.assert_equal(
@@ -78,7 +78,7 @@ fn test_log_rounded() raises:
     )
 
 
-fn test_log_non_integer() raises:
+def test_log_non_integer() raises:
     """Log results with non-integer values (startswith checks)."""
     testing.assert_true(
         String(Decimal128(10).log(Decimal128(2))).startswith(
@@ -122,7 +122,7 @@ fn test_log_non_integer() raises:
     )
 
 
-fn test_log_exceptions() raises:
+def test_log_exceptions() raises:
     """Invalid log inputs should raise exceptions."""
     # log of negative
     var caught = False
@@ -170,7 +170,7 @@ fn test_log_exceptions() raises:
     testing.assert_true(caught, "log negative base exception")
 
 
-fn test_log_properties() raises:
+def test_log_properties() raises:
     """Mathematical properties: product, quotient, power, inverse, change of base.
     """
     var tol = Decimal128("0.000000000001")
@@ -238,7 +238,7 @@ fn test_log_properties() raises:
 # ─── log10() inline tests ───────────────────────────────────────────────────
 
 
-fn test_log10_non_powers() raises:
+def test_log10_non_powers() raises:
     """Tests log10 of non-powers of 10 (startswith checks)."""
     testing.assert_true(
         String(Decimal128(2).log10()).startswith("0.301029995663981"),
@@ -262,7 +262,7 @@ fn test_log10_non_powers() raises:
     )
 
 
-fn test_log10_exceptions() raises:
+def test_log10_exceptions() raises:
     """Tests log10 of negative and zero should raise."""
     var caught = False
     try:
@@ -281,7 +281,7 @@ fn test_log10_exceptions() raises:
     testing.assert_true(caught, "log10(0) exception")
 
 
-fn test_log10_precision() raises:
+def test_log10_precision() raises:
     """Precision tests for log10."""
     testing.assert_true(
         String(Decimal128("3.14159265358979323846").log10()).startswith(
@@ -308,7 +308,7 @@ fn test_log10_precision() raises:
     )
 
 
-fn test_log10_properties() raises:
+def test_log10_properties() raises:
     """Mathematical properties of log10."""
     var tol = Decimal128("0.000000000001")
 
@@ -362,5 +362,5 @@ fn test_log10_properties() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/decimal128/test_decimal128_modulo.mojo
+++ b/tests/decimal128/test_decimal128_modulo.mojo
@@ -5,7 +5,7 @@ Inline tests for exception handling, mathematical relationships,
 and consistency with floor division.
 """
 
-import testing
+from std import testing
 from decimo.toml.parser import TOMLDocument
 
 from decimo.decimal128.decimal128 import Decimal128, Dec128

--- a/tests/decimal128/test_decimal128_modulo.mojo
+++ b/tests/decimal128/test_decimal128_modulo.mojo
@@ -15,7 +15,7 @@ from decimo.tests import parse_file, load_test_cases
 comptime data_path = "tests/decimal128/test_data/decimal128_modulo.toml"
 
 
-fn _run_section(doc: TOMLDocument, section: String) raises:
+def _run_section(doc: TOMLDocument, section: String) raises:
     """Run modulo test cases from a TOML section."""
     var cases = load_test_cases(doc, section)
     for tc in cases:
@@ -23,25 +23,25 @@ fn _run_section(doc: TOMLDocument, section: String) raises:
         testing.assert_equal(String(result), tc.expected, tc.description)
 
 
-fn test_modulo_basic() raises:
+def test_modulo_basic() raises:
     """5 basic modulo cases with positive values."""
     var doc = parse_file(data_path)
     _run_section(doc, "modulo_basic")
 
 
-fn test_modulo_negative() raises:
+def test_modulo_negative() raises:
     """6 modulo cases with negative numbers."""
     var doc = parse_file(data_path)
     _run_section(doc, "modulo_negative")
 
 
-fn test_modulo_edge() raises:
+def test_modulo_edge() raises:
     """6 edge cases: mod by 1, zero dividend, small/large numbers."""
     var doc = parse_file(data_path)
     _run_section(doc, "modulo_edge")
 
 
-fn test_modulo_exception() raises:
+def test_modulo_exception() raises:
     """Modulo by zero should raise an error."""
     var exception_caught = False
     try:
@@ -52,7 +52,7 @@ fn test_modulo_exception() raises:
     testing.assert_true(exception_caught, "Modulo by zero should raise error")
 
 
-fn test_mathematical_relationships() raises:
+def test_mathematical_relationships() raises:
     """Mathematical properties of modulo."""
     # a = (a // b) * b + (a % b) for positive
     var a1 = Decimal128(10)
@@ -96,10 +96,10 @@ fn test_mathematical_relationships() raises:
     )
 
 
-fn test_consistency_with_floor_division() raises:
+def test_consistency_with_floor_division() raises:
     """Verify a % b equals a - (a // b) * b for various inputs."""
 
-    fn _check(a_str: String, b_str: String) raises:
+    def _check(a_str: String, b_str: String) raises:
         var a = Decimal128(a_str)
         var b = Decimal128(b_str)
         testing.assert_equal(
@@ -114,5 +114,5 @@ fn test_consistency_with_floor_division() raises:
     _check("10", "-3")
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/decimal128/test_decimal128_multiply.mojo
+++ b/tests/decimal128/test_decimal128_multiply.mojo
@@ -9,8 +9,8 @@ Test Decimal128 multiplication operations including:
 6. commutative property (TOML)
 """
 
-from python import Python, PythonObject
-import testing
+from std.python import Python, PythonObject
+from std import testing
 from decimo.toml.parser import TOMLDocument
 
 from decimo import Dec128

--- a/tests/decimal128/test_decimal128_multiply.mojo
+++ b/tests/decimal128/test_decimal128_multiply.mojo
@@ -20,7 +20,7 @@ from decimo.tests import TestCase, parse_file, load_test_cases
 comptime file_path = "tests/decimal128/test_data/decimal128_multiply.toml"
 
 
-fn _run_multiply_section(
+def _run_multiply_section(
     toml: TOMLDocument,
     pydecimal: PythonObject,
     section: String,
@@ -48,7 +48,7 @@ fn _run_multiply_section(
             count_wrong += 1
 
 
-fn test_multiplication() raises:
+def test_multiplication() raises:
     """Test multiplication using TOML data-driven test cases."""
     var pydecimal = Python.import_module("decimal")
     var toml = parse_file(file_path)
@@ -63,7 +63,7 @@ fn test_multiplication() raises:
     testing.assert_equal(count_wrong, 0, "Some multiplication tests failed.")
 
 
-fn test_commutative_property() raises:
+def test_commutative_property() raises:
     """Test that a*b == b*a for all commutative test cases."""
     var toml = parse_file(file_path)
     var test_cases = load_test_cases(toml, "commutative_tests")
@@ -93,7 +93,7 @@ fn test_commutative_property() raises:
     testing.assert_equal(count_wrong, 0, "Some commutative tests failed.")
 
 
-fn test_precision_scale_properties() raises:
+def test_precision_scale_properties() raises:
     """Test scale and precision properties of multiplication results."""
     # Scale addition: scale(0.5) + scale(0.25) = 1 + 2 = 3
     var r1 = Dec128("0.5") * Dec128("0.25")
@@ -116,7 +116,7 @@ fn test_precision_scale_properties() raises:
     testing.assert_equal(r5.scale(), 28)
 
 
-fn test_boundary_cases_inline() raises:
+def test_boundary_cases_inline() raises:
     """Test boundary cases that require assertions beyond simple equality."""
     # Near max value
     var near_max = Dec128("38614081257132168796771975168")
@@ -141,5 +141,5 @@ fn test_boundary_cases_inline() raises:
     testing.assert_equal(String(small * one), String(small))
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/decimal128/test_decimal128_quantize.mojo
+++ b/tests/decimal128/test_decimal128_quantize.mojo
@@ -4,8 +4,8 @@ Tests various scenarios to ensure proper quantization behavior and compatibility
 with Python's decimal module implementation.
 """
 
-import testing
-from python import Python, PythonObject
+from std import testing
+from std.python import Python, PythonObject
 from decimo.decimal128.decimal128 import Decimal128
 from decimo.rounding_mode import RoundingMode
 

--- a/tests/decimal128/test_decimal128_quantize.mojo
+++ b/tests/decimal128/test_decimal128_quantize.mojo
@@ -10,7 +10,7 @@ from decimo.decimal128.decimal128 import Decimal128
 from decimo.rounding_mode import RoundingMode
 
 
-fn test_basic_quantization() raises:
+def test_basic_quantization() raises:
     """Test basic quantization with different scales."""
     # print("Testing basic quantization...")
 
@@ -86,7 +86,7 @@ fn test_basic_quantization() raises:
     # print("✓ Basic quantization tests passed!")
 
 
-fn test_rounding_modes() raises:
+def test_rounding_modes() raises:
     """Test quantization with different rounding modes."""
     # print("Testing quantization with different rounding modes...")
 
@@ -163,7 +163,7 @@ fn test_rounding_modes() raises:
     # print("✓ Rounding mode tests passed!")
 
 
-fn test_edge_cases() raises:
+def test_edge_cases() raises:
     """Test edge cases for quantization."""
     # print("Testing quantization edge cases...")
 
@@ -242,7 +242,7 @@ fn test_edge_cases() raises:
     # print("✓ Edge cases tests passed!")
 
 
-fn test_special_cases() raises:
+def test_special_cases() raises:
     """Test special cases for quantization."""
     # print("Testing special quantization cases...")
 
@@ -320,7 +320,7 @@ fn test_special_cases() raises:
     # print("✓ Special cases tests passed!")
 
 
-fn test_quantize_exceptions() raises:
+def test_quantize_exceptions() raises:
     """Test exception conditions for quantize()."""
     # print("Testing quantize exceptions...")
 
@@ -355,7 +355,7 @@ fn test_quantize_exceptions() raises:
     # print("✓ Exception tests passed!")
 
 
-fn test_comprehensive_comparison() raises:
+def test_comprehensive_comparison() raises:
     """Test a wide range of values to ensure compatibility with Python's decimal.
     """
     # print("Testing comprehensive comparison with Python's decimal...")
@@ -574,7 +574,7 @@ fn test_comprehensive_comparison() raises:
     # print("✓ Comprehensive comparison tests passed!")
 
 
-fn run_single_quantize_case(
+def run_single_quantize_case(
     value_str: String,
     quant_str: String,
     mojo_mode: RoundingMode,
@@ -608,5 +608,5 @@ fn run_single_quantize_case(
         # Both implementations should either both succeed or both fail
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/decimal128/test_decimal128_root_power.mojo
+++ b/tests/decimal128/test_decimal128_root_power.mojo
@@ -19,7 +19,7 @@ comptime data_path = "tests/decimal128/test_data/decimal128_root_power.toml"
 # ─── TOML-driven tests ──────────────────────────────────────────────────────
 
 
-fn test_root_exact() raises:
+def test_root_exact() raises:
     """Exact nth-root results (9 cases via TOML)."""
     var doc = parse_file(data_path)
     var cases = load_test_cases(doc, "root_exact")
@@ -28,7 +28,7 @@ fn test_root_exact() raises:
         testing.assert_equal(String(result), tc.expected, tc.description)
 
 
-fn test_power_int() raises:
+def test_power_int() raises:
     """Power with integer exponents (5 cases via TOML)."""
     var doc = parse_file(data_path)
     var cases = load_test_cases(doc, "power_int")
@@ -37,7 +37,7 @@ fn test_power_int() raises:
         testing.assert_equal(String(result), tc.expected, tc.description)
 
 
-fn test_power_decimal() raises:
+def test_power_decimal() raises:
     """Power with decimal exponents — exact results (4 cases via TOML)."""
     var doc = parse_file(data_path)
     var cases = load_test_cases(doc, "power_decimal")
@@ -49,10 +49,10 @@ fn test_power_decimal() raises:
 # ─── root() inline tests ────────────────────────────────────────────────────
 
 
-fn test_root_approximate() raises:
+def test_root_approximate() raises:
     """Non-exact roots (startswith checks)."""
 
-    fn _check(a: String, n: Int, prefix: String, desc: String) raises:
+    def _check(a: String, n: Int, prefix: String, desc: String) raises:
         testing.assert_true(String(root(Dec128(a), n)).startswith(prefix), desc)
 
     _check("2", 2, "1.4142135623730950488", "√2")
@@ -62,7 +62,7 @@ fn test_root_approximate() raises:
     _check("10", 100, "1.02329299228075413096627517", "100th root of 10")
 
 
-fn test_root_exceptions() raises:
+def test_root_exceptions() raises:
     """Error conditions for root()."""
     # 0th root
     var caught = False
@@ -92,10 +92,10 @@ fn test_root_exceptions() raises:
     testing.assert_true(caught, "even root of negative exception")
 
 
-fn test_root_precision() raises:
+def test_root_precision() raises:
     """High-precision root checks."""
 
-    fn _check(a: String, n: Int, prefix: String, desc: String) raises:
+    def _check(a: String, n: Int, prefix: String, desc: String) raises:
         testing.assert_true(String(root(Dec128(a), n)).startswith(prefix), desc)
 
     _check("2", 2, "1.414213562373095048801688724", "√2 high precision")
@@ -103,7 +103,7 @@ fn test_root_precision() raises:
     _check("5", 2, "2.236067977499789696", "√5 high precision")
 
 
-fn test_root_identities() raises:
+def test_root_identities() raises:
     """Mathematical identities for root()."""
     var tol = Dec128("0.0000000001")
 
@@ -136,7 +136,7 @@ fn test_root_identities() raises:
 # ─── power() inline tests ───────────────────────────────────────────────────
 
 
-fn test_power_approximate() raises:
+def test_power_approximate() raises:
     """Non-exact power results (startswith checks)."""
     testing.assert_true(
         String(power(Dec128(2), Dec128("1.5"))).startswith(
@@ -152,7 +152,7 @@ fn test_power_approximate() raises:
     )
 
 
-fn test_power_exceptions() raises:
+def test_power_exceptions() raises:
     """Error conditions for power()."""
     # 0^(-2) should raise
     var caught = False
@@ -173,5 +173,5 @@ fn test_power_exceptions() raises:
     testing.assert_true(caught, "(-2)^0.5 exception")
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/decimal128/test_decimal128_root_power.mojo
+++ b/tests/decimal128/test_decimal128_root_power.mojo
@@ -5,7 +5,7 @@ TOML-driven tests for exact-result cases; inline for startswith,
 tolerance, exception, and mathematical property tests.
 """
 
-import testing
+from std import testing
 from decimo.toml.parser import TOMLDocument
 
 from decimo.decimal128.decimal128 import Decimal128, Dec128

--- a/tests/decimal128/test_decimal128_round.mojo
+++ b/tests/decimal128/test_decimal128_round.mojo
@@ -3,7 +3,7 @@ Tests for Decimal128 round operations with different rounding modes.
 TOML-driven tests for standard cases; inline for dynamic/consistency tests.
 """
 
-import testing
+from std import testing
 from decimo.toml.parser import TOMLDocument
 
 from decimo.decimal128.decimal128 import Decimal128, Dec128
@@ -79,8 +79,8 @@ fn test_rounding_consistency() raises:
     var d1 = Decimal128("123.45")
     var d2 = Decimal128(123.45)
     testing.assert_equal(
-        String(round(d1, 1))[:3],
-        String(round(d2, 1))[:3],
+        String(round(d1, 1))[byte=:3],
+        String(round(d2, 1))[byte=:3],
         "Rounding consistency across different constructors",
     )
 

--- a/tests/decimal128/test_decimal128_round.mojo
+++ b/tests/decimal128/test_decimal128_round.mojo
@@ -13,7 +13,7 @@ from decimo.tests import parse_file, load_test_cases
 comptime data_path = "tests/decimal128/test_data/decimal128_round.toml"
 
 
-fn _run_round_section(
+def _run_round_section(
     doc: TOMLDocument,
     section: String,
     mode: RoundingMode,
@@ -25,7 +25,7 @@ fn _run_round_section(
         testing.assert_equal(String(result), tc.expected, tc.description)
 
 
-fn _run_round_default_section(doc: TOMLDocument, section: String) raises:
+def _run_round_default_section(doc: TOMLDocument, section: String) raises:
     """Run round test cases using builtin round() (banker's rounding)."""
     var cases = load_test_cases(doc, section)
     for tc in cases:
@@ -33,37 +33,37 @@ fn _run_round_default_section(doc: TOMLDocument, section: String) raises:
         testing.assert_equal(String(result), tc.expected, tc.description)
 
 
-fn test_round_default() raises:
+def test_round_default() raises:
     """6 cases using builtin round() with banker's rounding."""
     var doc = parse_file(data_path)
     _run_round_default_section(doc, "round_default")
 
 
-fn test_round_down() raises:
+def test_round_down() raises:
     """3 cases rounding toward zero."""
     var doc = parse_file(data_path)
     _run_round_section(doc, "round_down", RoundingMode.down())
 
 
-fn test_round_up() raises:
+def test_round_up() raises:
     """3 cases rounding away from zero."""
     var doc = parse_file(data_path)
     _run_round_section(doc, "round_up", RoundingMode.up())
 
 
-fn test_round_half_up() raises:
+def test_round_half_up() raises:
     """2 cases rounding half up."""
     var doc = parse_file(data_path)
     _run_round_section(doc, "round_half_up", RoundingMode.half_up())
 
 
-fn test_round_half_even() raises:
+def test_round_half_even() raises:
     """4 cases with banker's rounding via method."""
     var doc = parse_file(data_path)
     _run_round_section(doc, "round_half_even", RoundingMode.half_even())
 
 
-fn test_round_small_value() raises:
+def test_round_small_value() raises:
     """Round a dynamically-constructed very small number."""
     var small_value = Decimal128("0." + "0" * 27 + "1")
     testing.assert_equal(
@@ -73,7 +73,7 @@ fn test_round_small_value() raises:
     )
 
 
-fn test_rounding_consistency() raises:
+def test_rounding_consistency() raises:
     """Consistency across constructors and sequential rounding."""
     # Two ways to create 123.45
     var d1 = Decimal128("123.45")
@@ -95,5 +95,5 @@ fn test_rounding_consistency() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/decimal128/test_decimal128_sqrt.mojo
+++ b/tests/decimal128/test_decimal128_sqrt.mojo
@@ -17,7 +17,7 @@ comptime data_path = "tests/decimal128/test_data/decimal128_sqrt.toml"
 # ─── helpers ─────────────────────────────────────────────────────────────────
 
 
-fn _run_sqrt_section(doc: TOMLDocument, section: String) raises:
+def _run_sqrt_section(doc: TOMLDocument, section: String) raises:
     var cases = load_test_cases[unary=True](doc, section)
     for tc in cases:
         var result = Dec128(tc.a).sqrt()
@@ -27,19 +27,19 @@ fn _run_sqrt_section(doc: TOMLDocument, section: String) raises:
 # ─── TOML-driven tests ──────────────────────────────────────────────────────
 
 
-fn test_sqrt_perfect() raises:
+def test_sqrt_perfect() raises:
     """Perfect square inputs (12 cases via TOML)."""
     var doc = parse_file(data_path)
     _run_sqrt_section(doc, "sqrt_perfect")
 
 
-fn test_sqrt_decimal() raises:
+def test_sqrt_decimal() raises:
     """Decimal inputs with exact square roots (7 cases via TOML)."""
     var doc = parse_file(data_path)
     _run_sqrt_section(doc, "sqrt_decimal")
 
 
-fn test_sqrt_edge_exact() raises:
+def test_sqrt_edge_exact() raises:
     """Edge cases with exact results (via TOML): sqrt(0)=0, sqrt(1)=1."""
     var doc = parse_file(data_path)
     _run_sqrt_section(doc, "sqrt_edge")
@@ -48,10 +48,10 @@ fn test_sqrt_edge_exact() raises:
 # ─── Inline tests ───────────────────────────────────────────────────────────
 
 
-fn test_sqrt_non_perfect() raises:
+def test_sqrt_non_perfect() raises:
     """Non-perfect squares (startswith checks)."""
 
-    fn _check(input: String, prefix: String, desc: String) raises:
+    def _check(input: String, prefix: String, desc: String) raises:
         testing.assert_true(
             String(Dec128(input).sqrt()).startswith(prefix), desc
         )
@@ -65,7 +65,7 @@ fn test_sqrt_non_perfect() raises:
     _check("999", "31.6069612585582165452042139", "sqrt(999)")
 
 
-fn test_sqrt_edge_special() raises:
+def test_sqrt_edge_special() raises:
     """Edge cases needing special constructors or exceptions."""
     # sqrt(1e-28) = 1e-14
     var very_small = Decimal128(1, 28)
@@ -94,10 +94,10 @@ fn test_sqrt_edge_special() raises:
     testing.assert_true(caught, "sqrt(-1) exception")
 
 
-fn test_sqrt_precision() raises:
+def test_sqrt_precision() raises:
     """Precision tests (startswith checks)."""
 
-    fn _check(input: String, prefix: String, desc: String) raises:
+    def _check(input: String, prefix: String, desc: String) raises:
         testing.assert_true(
             String(Dec128(input).sqrt()).startswith(prefix), desc
         )
@@ -120,11 +120,11 @@ fn test_sqrt_precision() raises:
     )
 
 
-fn test_sqrt_identities() raises:
+def test_sqrt_identities() raises:
     """Mathematical identities: sqrt(x)^2 ≈ x and sqrt(x*y) ≈ sqrt(x)*sqrt(y).
     """
 
-    fn _check_squared(s: String) raises:
+    def _check_squared(s: String) raises:
         var x = Dec128(s)
         testing.assert_true(
             round(x.sqrt() * x.sqrt(), 10) == round(x, 10),
@@ -140,7 +140,7 @@ fn test_sqrt_identities() raises:
     _check_squared("0.25")
     _check_squared("1.44")
 
-    fn _check_product(xs: String, ys: String) raises:
+    def _check_product(xs: String, ys: String) raises:
         var x = Dec128(xs)
         var y = Dec128(ys)
         testing.assert_true(
@@ -153,12 +153,12 @@ fn test_sqrt_identities() raises:
     _check_product("2", "8")
 
 
-fn test_sqrt_convergence() raises:
+def test_sqrt_convergence() raises:
     """Convergence: sqrt(x)^2 ≈ x within relative tolerance."""
 
     var tol = Dec128("0.00001")
 
-    fn _check_rel(s: String, tol: Dec128) raises:
+    def _check_rel(s: String, tol: Dec128) raises:
         var x = Dec128(s)
         var sq = x.sqrt()
         var diff = sq * sq - x
@@ -193,5 +193,5 @@ fn test_sqrt_convergence() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/decimal128/test_decimal128_sqrt.mojo
+++ b/tests/decimal128/test_decimal128_sqrt.mojo
@@ -4,7 +4,7 @@ Migrated from verbose inline format; TOML for exact-result cases,
 inline for startswith, tolerance, identity, and exception tests.
 """
 
-import testing
+from std import testing
 from decimo.toml.parser import TOMLDocument
 
 from decimo.decimal128.decimal128 import Decimal128, Dec128

--- a/tests/decimal128/test_decimal128_utility.mojo
+++ b/tests/decimal128/test_decimal128_utility.mojo
@@ -3,8 +3,8 @@ Tests for utility functions: number_of_digits, truncate_to_max,
 round_to_keep_first_n_digits, and bitcast.
 """
 
-import testing
-from testing import assert_equal, assert_true
+from std import testing
+from std.testing import assert_equal, assert_true
 
 from decimo.decimal128.decimal128 import Decimal128
 from decimo.rounding_mode import RoundingMode

--- a/tests/decimal128/test_decimal128_utility.mojo
+++ b/tests/decimal128/test_decimal128_utility.mojo
@@ -16,7 +16,7 @@ from decimo.decimal128.utility import (
 )
 
 
-fn test_number_of_digits() raises:
+def test_number_of_digits() raises:
     """Tests for number_of_digits function."""
     # UInt128
     assert_equal(number_of_digits(UInt128(0)), 0)
@@ -38,7 +38,7 @@ fn test_number_of_digits() raises:
     )
 
 
-fn test_truncate_to_max_below() raises:
+def test_truncate_to_max_below() raises:
     """Truncate_to_max with values at or below MAX — should be unchanged."""
     assert_equal(truncate_to_max(UInt128(123456)), UInt128(123456))
     assert_equal(truncate_to_max(UInt256(7654321)), UInt256(7654321))
@@ -52,7 +52,7 @@ fn test_truncate_to_max_below() raises:
     )
 
 
-fn test_truncate_to_max_above() raises:
+def test_truncate_to_max_above() raises:
     """Truncate_to_max with values above MAX — should be truncated."""
     # MAX + 1
     var max_plus_1 = UInt256(Decimal128.MAX_AS_UINT128) + UInt256(1)
@@ -92,7 +92,7 @@ fn test_truncate_to_max_above() raises:
     )
 
 
-fn test_truncate_banker_rounding() raises:
+def test_truncate_banker_rounding() raises:
     """Banker's rounding edge cases in truncate_to_max."""
     # Round down to even (5 as rounding digit, preceding even)
     assert_equal(
@@ -131,7 +131,7 @@ fn test_truncate_banker_rounding() raises:
     )
 
 
-fn test_round_to_keep_first_n_digits() raises:
+def test_round_to_keep_first_n_digits() raises:
     """Tests for round_to_keep_first_n_digits."""
     # Keep 0 digits (round to nearest power of 10)
     assert_equal(
@@ -183,10 +183,10 @@ fn test_round_to_keep_first_n_digits() raises:
     )
 
 
-fn test_bitcast() raises:
+def test_bitcast() raises:
     """Test bitcast returns coefficient bits."""
 
-    fn _check(d: Decimal128) raises:
+    def _check(d: Decimal128) raises:
         assert_equal(d.coefficient(), bitcast[DType.uint128](d))
 
     _check(Decimal128("123.456"))
@@ -197,5 +197,5 @@ fn test_bitcast() raises:
     _check(Decimal128(12345, 67890, 0xABCDEF, 0x55))
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/toml/test_decimo_toml.mojo
+++ b/tests/toml/test_decimo_toml.mojo
@@ -4,14 +4,14 @@ from decimo.toml import parse_string, parse_file
 from std import testing
 
 
-fn main() raises:
+def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()
 
 
 # ---------------------------------------------------------------------------
 # 1. Basic key-value pairs
 # ---------------------------------------------------------------------------
-fn test_basic_key_value() raises:
+def test_basic_key_value() raises:
     var doc = parse_string(
         """
 title = "TOML Example"
@@ -29,7 +29,7 @@ enabled = true
 # ---------------------------------------------------------------------------
 # 2. Standard tables
 # ---------------------------------------------------------------------------
-fn test_table() raises:
+def test_table() raises:
     var doc = parse_string(
         """
 [server]
@@ -46,7 +46,7 @@ port = 1018
 # ---------------------------------------------------------------------------
 # 3. Simple array
 # ---------------------------------------------------------------------------
-fn test_array() raises:
+def test_array() raises:
     var doc = parse_string(
         """
 colors = ["red", "green", "blue"]
@@ -63,7 +63,7 @@ numbers = [1, 2, 3]
 # ---------------------------------------------------------------------------
 # 4. Multiline array with trailing comma & comments
 # ---------------------------------------------------------------------------
-fn test_multiline_array() raises:
+def test_multiline_array() raises:
     var doc = parse_string(
         """
 fruits = [
@@ -82,7 +82,7 @@ fruits = [
 # ---------------------------------------------------------------------------
 # 5. Dotted keys
 # ---------------------------------------------------------------------------
-fn test_dotted_keys() raises:
+def test_dotted_keys() raises:
     var doc = parse_string(
         """
 fruit.name = "apple"
@@ -106,7 +106,7 @@ fruit.size.height = 20
 # ---------------------------------------------------------------------------
 # 6. Dotted table headers
 # ---------------------------------------------------------------------------
-fn test_dotted_table_headers() raises:
+def test_dotted_table_headers() raises:
     var doc = parse_string(
         """
 [a.b.c]
@@ -126,7 +126,7 @@ key = "value"
 # ---------------------------------------------------------------------------
 # 7. Quoted keys
 # ---------------------------------------------------------------------------
-fn test_quoted_keys() raises:
+def test_quoted_keys() raises:
     var doc = parse_string(
         """
 "my key" = "value1"
@@ -140,7 +140,7 @@ fn test_quoted_keys() raises:
 # ---------------------------------------------------------------------------
 # 8. Inline tables
 # ---------------------------------------------------------------------------
-fn test_inline_table() raises:
+def test_inline_table() raises:
     var doc = parse_string(
         """
 point = {x = 1, y = 2}
@@ -157,7 +157,7 @@ point = {x = 1, y = 2}
 # ---------------------------------------------------------------------------
 # 9. Nested inline tables
 # ---------------------------------------------------------------------------
-fn test_inline_table_nested() raises:
+def test_inline_table_nested() raises:
     var doc = parse_string(
         """
 animal = {type.name = "cat"}
@@ -172,7 +172,7 @@ animal = {type.name = "cat"}
 # ---------------------------------------------------------------------------
 # 10. Array of tables
 # ---------------------------------------------------------------------------
-fn test_array_of_tables() raises:
+def test_array_of_tables() raises:
     var doc = parse_string(
         """
 [[products]]
@@ -194,7 +194,7 @@ sku = 284758393
 # ---------------------------------------------------------------------------
 # 11. Array of tables with dotted header
 # ---------------------------------------------------------------------------
-fn test_array_of_tables_dotted() raises:
+def test_array_of_tables_dotted() raises:
     var doc = parse_string(
         """
 [[fruits]]
@@ -214,7 +214,7 @@ name = "banana"
 # ---------------------------------------------------------------------------
 # 12. Unicode escape sequences
 # ---------------------------------------------------------------------------
-fn test_unicode_escapes() raises:
+def test_unicode_escapes() raises:
     var doc = parse_string(
         """
 smile = "\\u0041"
@@ -228,7 +228,7 @@ smile = "\\u0041"
 # ---------------------------------------------------------------------------
 # 13. Integer bases: hex, octal, binary
 # ---------------------------------------------------------------------------
-fn test_integer_bases() raises:
+def test_integer_bases() raises:
     var doc = parse_string(
         """
 hex = 0xDEADBEEF
@@ -247,7 +247,7 @@ dec = 1_000_000
 # ---------------------------------------------------------------------------
 # 14. Special float values (inf, nan)
 # ---------------------------------------------------------------------------
-fn test_special_floats() raises:
+def test_special_floats() raises:
     var doc = parse_string(
         """
 pos_inf = inf
@@ -263,7 +263,7 @@ not_a_number = nan
 # ---------------------------------------------------------------------------
 # 15. Multiline basic strings
 # ---------------------------------------------------------------------------
-fn test_multiline_strings() raises:
+def test_multiline_strings() raises:
     var src = String('[test]\nml = """line1\nline2\nline3"""\n')
     var doc = parse_string(src)
     var tbl = doc.get_table("test")
@@ -276,7 +276,7 @@ fn test_multiline_strings() raises:
 # ---------------------------------------------------------------------------
 # 16. Nested tables via dotted keys + standard tables
 # ---------------------------------------------------------------------------
-fn test_nested_tables_via_dotted() raises:
+def test_nested_tables_via_dotted() raises:
     var doc = parse_string(
         """
 [server]
@@ -300,7 +300,7 @@ port = 1314
 # ---------------------------------------------------------------------------
 # 17. Duplicate key detection
 # ---------------------------------------------------------------------------
-fn test_duplicate_key_detection() raises:
+def test_duplicate_key_detection() raises:
     var caught = False
     try:
         var doc = parse_string(
@@ -318,7 +318,7 @@ name = "second"
 # ---------------------------------------------------------------------------
 # 18. Mixed features
 # ---------------------------------------------------------------------------
-fn test_mixed_features() raises:
+def test_mixed_features() raises:
     var doc = parse_string(
         """
 title = "Mixed Test"
@@ -363,7 +363,7 @@ role = "backend"
 # ---------------------------------------------------------------------------
 # 19. Parse our actual pixi.toml to make sure it still works
 # ---------------------------------------------------------------------------
-fn test_our_pixi_toml() raises:
+def test_our_pixi_toml() raises:
     var doc = parse_file("pixi.toml")
     var ws = doc.get_table("workspace")
     assert_true(len(ws) > 0, "pixi.toml workspace table non-empty")
@@ -374,6 +374,6 @@ fn test_our_pixi_toml() raises:
 
 
 # ---------------------------------------------------------------------------
-fn assert_true(cond: Bool, msg: String) raises:
+def assert_true(cond: Bool, msg: String) raises:
     if not cond:
         raise Error("ASSERTION FAILED: " + msg)

--- a/tests/toml/test_decimo_toml.mojo
+++ b/tests/toml/test_decimo_toml.mojo
@@ -1,7 +1,7 @@
 """Comprehensive test suite for decimo.toml — covers all TOML features."""
 
 from decimo.toml import parse_string, parse_file
-import testing
+from std import testing
 
 
 fn main() raises:


### PR DESCRIPTION
This PR updates the codebase to Mojo v0.26.2. It migrates Decimo's sources, tests, benches, and build tooling to Mojo v0.26.2 while keeping all library APIs and test coverage intact.

**Changes:**
- Replace `fn` with `def` throughout (v0.26.2 `def`/`fn` unification).
- Migrate imports to `std.*` namespace (e.g., `std.testing`, `std.collections`, `std.memory`, `std.python`, `std.time`).
- Update string slicing and pointer/SIMD access patterns for v0.26.2 stdlib.
- Remove redundant `AnyType` trait conformances from `BigDecimal` and `BigInt10`.
- Adjust CLI build pipeline to vendor/build ArgMojo from a pinned git commit.