### PR TITLE
[doc] Update documents for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ An arbitrary-precision integer and decimal library for [Mojo](https://www.modula
 [![Version](https://img.shields.io/github/v/tag/forfudan/decimo?label=version&color=blue)](https://github.com/forfudan/decimo/releases)
 [![Mojo](https://img.shields.io/badge/mojo-0.26.2-orange)](https://docs.modular.com/mojo/manual/)
 [![pixi](https://img.shields.io/badge/pixi%20add-decimo-purple)](https://prefix.dev/channels/modular-community/packages/decimo)
-[![CI](https://img.shields.io/github/actions/workflow/status/forfudan/argmojo/run_tests.yaml?branch=main&label=tests)](https://github.com/forfudan/argmojo/actions/workflows/run_tests.yaml)
+[![CI](https://img.shields.io/github/actions/workflow/status/forfudan/decimo/run_tests.yaml?branch=main&label=tests)](https://github.com/forfudan/decimo/actions/workflows/run_tests.yaml)
 
 <!-- 
-[![License](https://img.shields.io/github/license/forfudan/argmojo)](LICENSE)
-[![Stars](https://img.shields.io/github/stars/forfudan/argmojo?style=flat)](https://github.com/forfudan/argmojo/stargazers)
-[![Issues](https://img.shields.io/github/issues/forfudan/argmojo)](https://github.com/forfudan/argmojo/issues)
+[![License](https://img.shields.io/github/license/forfudan/decimo)](LICENSE)
+[![Stars](https://img.shields.io/github/stars/forfudan/decimo?style=flat)](https://github.com/forfudan/decimo/stargazers)
+[![Issues](https://img.shields.io/github/issues/forfudan/decimo)](https://github.com/forfudan/decimo/issues)
 ![Platforms](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey)
-[![Last Commit](https://img.shields.io/github/last-commit/forfudan/argmojo?color=red)](https://github.com/forfudan/argmojo/commits/main)
+[![Last Commit](https://img.shields.io/github/last-commit/forfudan/decimo?color=red)](https://github.com/forfudan/decimo/commits/main)
 -->
 
 <!-- 

--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@
 An arbitrary-precision integer and decimal library for [Mojo](https://www.modular.com/mojo), inspired by Python's `int` and `Decimal`.
 
 [![Version](https://img.shields.io/github/v/tag/forfudan/decimo?label=version&color=blue)](https://github.com/forfudan/decimo/releases)
+[![Mojo](https://img.shields.io/badge/mojo-0.26.2-orange)](https://docs.modular.com/mojo/manual/)
 [![pixi](https://img.shields.io/badge/pixi%20add-decimo-purple)](https://prefix.dev/channels/modular-community/packages/decimo)
 [![CI](https://img.shields.io/github/actions/workflow/status/forfudan/argmojo/run_tests.yaml?branch=main&label=tests)](https://github.com/forfudan/argmojo/actions/workflows/run_tests.yaml)
-[![Last Commit](https://img.shields.io/github/last-commit/forfudan/argmojo?color=red)](https://github.com/forfudan/argmojo/commits/main)
 
 <!-- 
-[![Mojo](https://img.shields.io/badge/mojo-0.26.1-orange)](https://docs.modular.com/mojo/manual/)
 [![License](https://img.shields.io/github/license/forfudan/argmojo)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/forfudan/argmojo?style=flat)](https://github.com/forfudan/argmojo/stargazers)
 [![Issues](https://img.shields.io/github/issues/forfudan/argmojo)](https://github.com/forfudan/argmojo/issues)
 ![Platforms](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey)
+[![Last Commit](https://img.shields.io/github/last-commit/forfudan/argmojo?color=red)](https://github.com/forfudan/argmojo/commits/main)
 -->
 
 <!-- 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Then, you can install Decimo using any of these methods:
 1. In the `mojoproject.toml` file of your project, add the following dependency:
 
     ```toml
-    decimo = "==0.8.0"
+    decimo = "==0.9.0"
     ```
 
     Then run `pixi install` to download and install the package.
@@ -83,6 +83,7 @@ The following table summarizes the package versions and their corresponding Mojo
 | `decimojo` | v0.6.0  | ==0.25.7      | pixi            |
 | `decimojo` | v0.7.0  | ==0.26.1      | pixi            |
 | `decimo`   | v0.8.0  | ==0.26.1      | pixi            |
+| `decimo`   | v0.9.0  | ==0.26.2      | pixi            |
 
 ## Quick start
 
@@ -330,7 +331,7 @@ If you find Decimo useful, consider listing it in your citations.
     year         = {2026},
     title        = {Decimo: An arbitrary-precision integer and decimal library for Mojo},
     url          = {https://github.com/forfudan/decimo},
-    version      = {0.8.0},
+    version      = {0.9.0},
     note         = {Computer Software}
 }
 ```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,53 @@
 
 This is a list of changes for the Decimo package (formerly DeciMojo).
 
+## 20260323 (v0.9.0)
+
+Decimo v0.9.0 updates the codebase to **Mojo v0.26.2** and marks the **"make it useful"** phase. This release introduces three major additions:
+
+First, a full-featured **CLI arbitrary-precision calculator** (`decimo`), powered by Decimo's `BigDecimal`. It includes a complete tokenizer, a shunting-yard parser, and an RPN evaluator with working-precision guard digits, supporting built-in mathematical functions (`sqrt`, `cbrt`, `root`, `ln`, `log`, `log10`, `exp`, trigonometric functions, `abs`), constants (`pi`, `e`), and configurable output formatting (scientific/engineering notation, digit delimiters, rounding modes, and precision control).
+
+Second, the `BigDecimal` API is significantly expanded with methods aligned to Python's `decimal.Decimal` and the IEEE 754 specification, including `as_tuple()`, `adjusted()`, `same_quantum()`, `scaleb()`, `fma()`, `copy_abs()`, `copy_negate()`, `copy_sign()`, `bit_count()`, `__float__()`, engineering notation, and digit-group delimiters for `to_string()`. The `ROUND_HALF_DOWN` rounding mode is added, bringing the total to seven.
+
+Third, Decimo gains **Python bindings** via Mojo's `PythonModuleBuilder`, exposing `BigDecimal` as a native Python extension module (`_decimo.so`) with a Pythonic `Decimal` wrapper for seamless interoperability.
+
+### ⭐️ New in v0.9.0
+
+**CLI Calculator:**
+
+1. Implement an arbitrary-precision CLI calculator with tokenizer, shunting-yard parser, and RPN evaluator, supporting arithmetic expressions with parentheses and operator precedence (PR #170).
+1. Add built-in functions (`sqrt`, `cbrt`, `root`, `ln`, `log`, `log10`, `exp`, `sin`, `cos`, `tan`, `cot`, `csc`, `abs`), constants (`pi`, `e`), and configurable output formatting (scientific/engineering notation, digit delimiter, padding, rounding mode) (PR #171).
+1. Improve CLI error handling with token location tracing and ANSI-coloured diagnostic output (PR #178).
+1. Use working precision (user precision + guard digits) for intermediate calculations to improve result accuracy (PR #182).
+
+**BigDecimal:**
+
+1. Add **engineering notation** (`to_eng_string()`) and **digit-group delimiters** (`to_string_with_separators()`) to `to_string()`, with optional line-width wrapping (PR #172).
+1. Add utility methods: `is_integer()`, `is_signed()`, `number_class()`, `logb()`, `normalize()`, `radix()` (PR #173).
+1. Implement `as_tuple()` returning `(sign, digits, exponent)`, matching Python's `Decimal.as_tuple()` (PR #174).
+1. Implement `adjusted()`, `copy_abs()`, `copy_negate()`, and `copy_sign()` aligned with Python's `decimal` API (PR #176).
+1. Implement `same_quantum()` and add the `ROUND_HALF_DOWN` rounding mode, bringing the total to seven (PR #177).
+1. Implement `scaleb()`, `fma()`, `bit_count()`, and `__float__()` (implements `FloatableRaising`) (PR #183).
+
+**Python Bindings:**
+
+1. Implement Python bindings via Mojo's `PythonModuleBuilder`, exposing `BigDecimal` as a native extension module `_decimo.so` with arithmetic, comparison, and string operations (PR #179).
+1. Restructure `python/` to a `src` layout with `pyproject.toml` for PyPI packaging (PR #180).
+
+### 🦋 Changed in v0.9.0
+
+1. Update the codebase to **Mojo v0.26.2**, adopting `byte=` slicing syntax, `out` parameter convention for constructors, and updated `String`/`StringSlice` APIs (PR #185).
+1. Merge `TOMLMojo` into Decimo as the sub-package `decimo.toml`, removing standalone packaging (PR #181).
+1. Rename `exponent()` to `adjusted()` for `BigDecimal` to align with Python's `decimal` module naming (PR #176).
+1. Change default precision of `BigDecimal` to **28** significant digits, matching Python's `decimal` module default.
+1. Remove deprecated free-function comparison aliases and legacy method names from `BigDecimal` (PR #173).
+1. Align `print_internal_representation()` output style across `BigInt`, `BigUInt`, `BigDecimal`, and `Decimal128` with dynamic column alignment (PR #169).
+
+### 📚 Documentation and testing in v0.9.0
+
+- Add comprehensive user manuals for the Decimo library and the CLI calculator (PR #184).
+- Add info badges to the README file.
+
 ## 20260225 (v0.8.0)
 
 > **Library renamed from `decimojo` to `decimo`.** The package name, import path, and all public references have been updated. GitHub repository will be renamed to `forfudan/decimo` (GitHub auto-redirects the old URL).

--- a/docs/readme_unreleased.md
+++ b/docs/readme_unreleased.md
@@ -4,14 +4,14 @@ An arbitrary-precision integer and decimal library for [Mojo](https://www.modula
 
 [![Version](https://img.shields.io/github/v/tag/forfudan/decimo?label=version&color=blue)](https://github.com/forfudan/decimo/releases)
 [![pixi](https://img.shields.io/badge/pixi%20add-decimo-purple)](https://prefix.dev/channels/modular-community/packages/decimo)
-[![CI](https://img.shields.io/github/actions/workflow/status/forfudan/argmojo/run_tests.yaml?branch=main&label=tests)](https://github.com/forfudan/argmojo/actions/workflows/run_tests.yaml)
-[![Last Commit](https://img.shields.io/github/last-commit/forfudan/argmojo?color=red)](https://github.com/forfudan/argmojo/commits/main)
+[![CI](https://img.shields.io/github/actions/workflow/status/forfudan/decimo/run_tests.yaml?branch=main&label=tests)](https://github.com/forfudan/decimo/actions/workflows/run_tests.yaml)
+[![Last Commit](https://img.shields.io/github/last-commit/forfudan/decimo?color=red)](https://github.com/forfudan/decimo/commits/main)
 
 <!-- 
 [![Mojo](https://img.shields.io/badge/mojo-0.26.2-orange)](https://docs.modular.com/mojo/manual/)
-[![License](https://img.shields.io/github/license/forfudan/argmojo)](LICENSE)
-[![Stars](https://img.shields.io/github/stars/forfudan/argmojo?style=flat)](https://github.com/forfudan/argmojo/stargazers)
-[![Issues](https://img.shields.io/github/issues/forfudan/argmojo)](https://github.com/forfudan/argmojo/issues)
+[![License](https://img.shields.io/github/license/forfudan/decimo)](LICENSE)
+[![Stars](https://img.shields.io/github/stars/forfudan/decimo?style=flat)](https://github.com/forfudan/decimo/stargazers)
+[![Issues](https://img.shields.io/github/issues/forfudan/decimo)](https://github.com/forfudan/decimo/issues)
 ![Platforms](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey)
 -->
 

--- a/docs/readme_unreleased.md
+++ b/docs/readme_unreleased.md
@@ -73,7 +73,7 @@ Then, you can install Decimo using any of these methods:
 1. In the `mojoproject.toml` file of your project, add the following dependency:
 
     ```toml
-    decimo = "==0.8.0"
+    decimo = "==0.9.0"
     ```
 
     Then run `pixi install` to download and install the package.
@@ -93,7 +93,7 @@ The following table summarizes the package versions and their corresponding Mojo
 | `decimojo` | v0.6.0  | ==0.25.7      | pixi            |
 | `decimojo` | v0.7.0  | ==0.26.1      | pixi            |
 | `decimo`   | v0.8.0  | ==0.26.1      | pixi            |
-| `decimo`   | v0.9.0  | ==0.26.1      | pixi            |
+| `decimo`   | v0.9.0  | ==0.26.2      | pixi            |
 
 ## Quick start
 
@@ -375,7 +375,7 @@ If you find Decimo useful, consider listing it in your citations.
     year         = {2026},
     title        = {Decimo: An arbitrary-precision integer and decimal library for Mojo},
     url          = {https://github.com/forfudan/decimo},
-    version      = {0.8.0},
+    version      = {0.9.0},
     note         = {Computer Software}
 }
 ```

--- a/docs/readme_unreleased.md
+++ b/docs/readme_unreleased.md
@@ -8,7 +8,7 @@ An arbitrary-precision integer and decimal library for [Mojo](https://www.modula
 [![Last Commit](https://img.shields.io/github/last-commit/forfudan/argmojo?color=red)](https://github.com/forfudan/argmojo/commits/main)
 
 <!-- 
-[![Mojo](https://img.shields.io/badge/mojo-0.26.1-orange)](https://docs.modular.com/mojo/manual/)
+[![Mojo](https://img.shields.io/badge/mojo-0.26.2-orange)](https://docs.modular.com/mojo/manual/)
 [![License](https://img.shields.io/github/license/forfudan/argmojo)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/forfudan/argmojo?style=flat)](https://github.com/forfudan/argmojo/stargazers)
 [![Issues](https://img.shields.io/github/issues/forfudan/argmojo)](https://github.com/forfudan/argmojo/issues)

--- a/docs/readme_zht.md
+++ b/docs/readme_zht.md
@@ -59,7 +59,7 @@ channels = ["https://conda.modular.com/max", "https://repo.prefix.dev/modular-co
 1. 在您項目的 `mojoproject.toml` 文件中，添加以下依賴：
 
     ```toml
-    decimo = "==0.8.0"
+    decimo = "==0.9.0"
     ```
 
     然後運行 `pixi install` 來下載並安裝包。
@@ -79,6 +79,7 @@ channels = ["https://conda.modular.com/max", "https://repo.prefix.dev/modular-co
 | `decimojo` | v0.6.0 | ==0.25.7      | pixi     |
 | `decimojo` | v0.7.0 | ==0.26.1      | pixi     |
 | `decimo`   | v0.8.0 | ==0.26.1      | pixi     |
+| `decimo`   | v0.9.0 | ==0.26.2      | pixi     |
 
 ## 快速開始
 
@@ -326,7 +327,7 @@ fn main() raises:
     year         = {2026},
     title        = {Decimo: An arbitrary-precision integer and decimal library for Mojo},
     url          = {https://github.com/forfudan/decimo},
-    version      = {0.8.0},
+    version      = {0.9.0},
     note         = {Computer Software}
 }
 ```

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -114,7 +114,7 @@ pixi add decimo
 Or add it manually to `pixi.toml`:
 
 ```toml
-decimo = "==0.8.0"
+decimo = "==0.9.0"
 ```
 
 Then run `pixi install`.

--- a/pixi.toml
+++ b/pixi.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "decimo"
 platforms = ["osx-arm64", "linux-64"]
 readme = "README.md"
-version = "0.8.0"
+version = "0.9.0"
 
 [dependencies]
 # argmojo = ">=0.4.0" # CLI argument parsing for the Decimo calculator (TODO: waiting for argmojo 0.4.0 compatible with mojo 0.26.2)


### PR DESCRIPTION
This PR updates release-facing metadata and documentation to reflect the v0.9.0 release (including the supported Mojo version), ensuring installation snippets and release notes match the new tag.

**Changes:**
- Bump workspace version in `pixi.toml` from 0.8.0 → 0.9.0.
- Update documentation install snippets/tables/citation blocks to reference `decimo==0.9.0` and Mojo `0.26.2`.
- Add a v0.9.0 release entry to the changelog and refresh README badges/version references.