### PR TITLE
[error] Make `message` and `function` fields mandatory for `DecimoError` type

### DIFF
--- a/src/decimo/bigfloat/bigfloat.mojo
+++ b/src/decimo/bigfloat/bigfloat.mojo
@@ -151,7 +151,8 @@ struct BigFloat(Comparable, Movable, Writable):
                     message=(
                         "BigFloat requires MPFR (brew install mpfr / apt"
                         " install libmpfr-dev)"
-                    )
+                    ),
+                    function="BigFloat.__init__()",
                 )
             )
         var bits = _dps_to_bits(precision)
@@ -468,7 +469,12 @@ struct BigFloat(Comparable, Movable, Writable):
         """
         var h = mpfrw_init(_dps_to_bits(self.precision))
         if h < 0:
-            raise Error(DecimoError(message="Handle allocation failed"))
+            raise Error(
+                DecimoError(
+                    message="Handle allocation failed.",
+                    function="BigFloat.__neg__()",
+                )
+            )
         mpfrw_neg(h, self.handle)
         return Self(_handle=h, _precision=self.precision)
 
@@ -480,7 +486,12 @@ struct BigFloat(Comparable, Movable, Writable):
         """
         var h = mpfrw_init(_dps_to_bits(self.precision))
         if h < 0:
-            raise Error(DecimoError(message="Handle allocation failed"))
+            raise Error(
+                DecimoError(
+                    message="Handle allocation failed.",
+                    function="BigFloat.__abs__()",
+                )
+            )
         mpfrw_abs(h, self.handle)
         return Self(_handle=h, _precision=self.precision)
 
@@ -500,7 +511,12 @@ struct BigFloat(Comparable, Movable, Writable):
         var prec = max(self.precision, other.precision)
         var h = mpfrw_init(_dps_to_bits(prec))
         if h < 0:
-            raise Error(DecimoError(message="Handle allocation failed"))
+            raise Error(
+                DecimoError(
+                    message="Handle allocation failed.",
+                    function="BigFloat.__add__()",
+                )
+            )
         mpfrw_add(h, self.handle, other.handle)
         return Self(_handle=h, _precision=prec)
 
@@ -516,7 +532,12 @@ struct BigFloat(Comparable, Movable, Writable):
         var prec = max(self.precision, other.precision)
         var h = mpfrw_init(_dps_to_bits(prec))
         if h < 0:
-            raise Error(DecimoError(message="Handle allocation failed"))
+            raise Error(
+                DecimoError(
+                    message="Handle allocation failed.",
+                    function="BigFloat.__sub__()",
+                )
+            )
         mpfrw_sub(h, self.handle, other.handle)
         return Self(_handle=h, _precision=prec)
 
@@ -532,7 +553,12 @@ struct BigFloat(Comparable, Movable, Writable):
         var prec = max(self.precision, other.precision)
         var h = mpfrw_init(_dps_to_bits(prec))
         if h < 0:
-            raise Error(DecimoError(message="Handle allocation failed"))
+            raise Error(
+                DecimoError(
+                    message="Handle allocation failed.",
+                    function="BigFloat.__mul__()",
+                )
+            )
         mpfrw_mul(h, self.handle, other.handle)
         return Self(_handle=h, _precision=prec)
 
@@ -548,7 +574,12 @@ struct BigFloat(Comparable, Movable, Writable):
         var prec = max(self.precision, other.precision)
         var h = mpfrw_init(_dps_to_bits(prec))
         if h < 0:
-            raise Error(DecimoError(message="Handle allocation failed"))
+            raise Error(
+                DecimoError(
+                    message="Handle allocation failed.",
+                    function="BigFloat.__truediv__()",
+                )
+            )
         mpfrw_div(h, self.handle, other.handle)
         return Self(_handle=h, _precision=prec)
 
@@ -575,7 +606,12 @@ struct BigFloat(Comparable, Movable, Writable):
         """
         var h = mpfrw_init(_dps_to_bits(self.precision))
         if h < 0:
-            raise Error(DecimoError(message="Handle allocation failed"))
+            raise Error(
+                DecimoError(
+                    message="Handle allocation failed.",
+                    function="BigFloat.sqrt()",
+                )
+            )
         mpfrw_sqrt(h, self.handle)
         return Self(_handle=h, _precision=self.precision)
 
@@ -587,7 +623,12 @@ struct BigFloat(Comparable, Movable, Writable):
         """
         var h = mpfrw_init(_dps_to_bits(self.precision))
         if h < 0:
-            raise Error(DecimoError(message="Handle allocation failed"))
+            raise Error(
+                DecimoError(
+                    message="Handle allocation failed.",
+                    function="BigFloat.exp()",
+                )
+            )
         mpfrw_exp(h, self.handle)
         return Self(_handle=h, _precision=self.precision)
 
@@ -599,7 +640,12 @@ struct BigFloat(Comparable, Movable, Writable):
         """
         var h = mpfrw_init(_dps_to_bits(self.precision))
         if h < 0:
-            raise Error(DecimoError(message="Handle allocation failed"))
+            raise Error(
+                DecimoError(
+                    message="Handle allocation failed.",
+                    function="BigFloat.ln()",
+                )
+            )
         mpfrw_log(h, self.handle)
         return Self(_handle=h, _precision=self.precision)
 
@@ -611,7 +657,12 @@ struct BigFloat(Comparable, Movable, Writable):
         """
         var h = mpfrw_init(_dps_to_bits(self.precision))
         if h < 0:
-            raise Error(DecimoError(message="Handle allocation failed"))
+            raise Error(
+                DecimoError(
+                    message="Handle allocation failed.",
+                    function="BigFloat.sin()",
+                )
+            )
         mpfrw_sin(h, self.handle)
         return Self(_handle=h, _precision=self.precision)
 
@@ -623,7 +674,12 @@ struct BigFloat(Comparable, Movable, Writable):
         """
         var h = mpfrw_init(_dps_to_bits(self.precision))
         if h < 0:
-            raise Error(DecimoError(message="Handle allocation failed"))
+            raise Error(
+                DecimoError(
+                    message="Handle allocation failed.",
+                    function="BigFloat.cos()",
+                )
+            )
         mpfrw_cos(h, self.handle)
         return Self(_handle=h, _precision=self.precision)
 
@@ -635,7 +691,12 @@ struct BigFloat(Comparable, Movable, Writable):
         """
         var h = mpfrw_init(_dps_to_bits(self.precision))
         if h < 0:
-            raise Error(DecimoError(message="Handle allocation failed"))
+            raise Error(
+                DecimoError(
+                    message="Handle allocation failed.",
+                    function="BigFloat.tan()",
+                )
+            )
         mpfrw_tan(h, self.handle)
         return Self(_handle=h, _precision=self.precision)
 
@@ -651,7 +712,12 @@ struct BigFloat(Comparable, Movable, Writable):
         var prec = max(self.precision, exponent.precision)
         var h = mpfrw_init(_dps_to_bits(prec))
         if h < 0:
-            raise Error(DecimoError(message="Handle allocation failed"))
+            raise Error(
+                DecimoError(
+                    message="Handle allocation failed.",
+                    function="BigFloat.power()",
+                )
+            )
         mpfrw_pow(h, self.handle, exponent.handle)
         return Self(_handle=h, _precision=prec)
 
@@ -666,7 +732,12 @@ struct BigFloat(Comparable, Movable, Writable):
         """
         var h = mpfrw_init(_dps_to_bits(self.precision))
         if h < 0:
-            raise Error(DecimoError(message="Handle allocation failed"))
+            raise Error(
+                DecimoError(
+                    message="Handle allocation failed.",
+                    function="BigFloat.root()",
+                )
+            )
         mpfrw_rootn_ui(h, self.handle, n)
         return Self(_handle=h, _precision=self.precision)
 
@@ -686,11 +757,17 @@ struct BigFloat(Comparable, Movable, Writable):
                     message=(
                         "BigFloat requires MPFR (brew install mpfr / apt"
                         " install libmpfr-dev)"
-                    )
+                    ),
+                    function="BigFloat.pi()",
                 )
             )
         var h = mpfrw_init(_dps_to_bits(precision))
         if h < 0:
-            raise Error(DecimoError(message="Handle allocation failed"))
+            raise Error(
+                DecimoError(
+                    message="Handle allocation failed.",
+                    function="BigFloat.pi()",
+                )
+            )
         mpfrw_const_pi(h)
         return BigFloat(_handle=h, _precision=precision)

--- a/src/decimo/bigint/bigint.mojo
+++ b/src/decimo/bigint/bigint.mojo
@@ -986,6 +986,7 @@ struct BigInt(
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function="BigInt.__floordiv__()",
                     previous_error=e^,
                 )
@@ -1006,6 +1007,7 @@ struct BigInt(
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function="BigInt.__mod__()",
                     previous_error=e^,
                 )
@@ -1026,6 +1028,7 @@ struct BigInt(
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function="BigInt.__divmod__()",
                     previous_error=e^,
                 )

--- a/src/decimo/bigint10/arithmetics.mojo
+++ b/src/decimo/bigint10/arithmetics.mojo
@@ -227,6 +227,7 @@ def floor_divide(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function="floor_divide()",
                     previous_error=e^,
                 ),
@@ -242,6 +243,7 @@ def floor_divide(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function="floor_divide()",
                     previous_error=e^,
                 ),
@@ -272,6 +274,7 @@ def truncate_divide(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
     except e:
         raise Error(
             DecimoError(
+                message="See the above exception.",
                 function="truncate_divide()",
                 previous_error=e^,
             ),
@@ -307,6 +310,7 @@ def floor_modulo(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function="floor_modulo()",
                     previous_error=e^,
                 ),
@@ -322,6 +326,7 @@ def floor_modulo(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function="floor_modulo()",
                     previous_error=e^,
                 ),
@@ -352,6 +357,7 @@ def truncate_modulo(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
     except e:
         raise Error(
             DecimoError(
+                message="See the above exception.",
                 function="truncate_modulo()",
                 previous_error=e^,
             ),

--- a/src/decimo/bigint10/bigint10.mojo
+++ b/src/decimo/bigint10/bigint10.mojo
@@ -119,6 +119,7 @@ struct BigInt10(
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function=(
                         "BigInt10.__init__(var words: List[UInt32], sign: Bool)"
                     ),
@@ -231,6 +232,7 @@ struct BigInt10(
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function=(
                         "BigInt10.from_list(var words: List[UInt32], sign:"
                         " Bool)"
@@ -636,6 +638,7 @@ struct BigInt10(
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function="BigInt10.__floordiv__()",
                     previous_error=e^,
                 )
@@ -656,6 +659,7 @@ struct BigInt10(
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function="BigInt10.__mod__()",
                     previous_error=e^,
                 )

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -3345,6 +3345,7 @@ def floor_modulo(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
     except e:
         raise Error(
             DecimoError(
+                message="See the above exception.",
                 function="floor_modulo()",
                 previous_error=e^,
             )
@@ -3357,6 +3358,7 @@ def floor_modulo(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
     except e:
         raise Error(
             DecimoError(
+                message="See the above exception.",
                 function="floor_modulo()",
                 previous_error=e^,
             )
@@ -3386,6 +3388,7 @@ def truncate_modulo(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
     except e:
         raise Error(
             DecimoError(
+                message="See the above exception.",
                 function="truncate_modulo()",
                 previous_error=e^,
             )
@@ -3474,6 +3477,7 @@ def floor_divide_modulo(
     except e:
         raise Error(
             DecimoError(
+                message="See the above exception.",
                 function="floor_divide_modulo()",
                 previous_error=e^,
             )

--- a/src/decimo/biguint/biguint.mojo
+++ b/src/decimo/biguint/biguint.mojo
@@ -205,6 +205,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function="BigUInt.__init__(var words: List[UInt32])",
                     previous_error=e^,
                 )
@@ -250,6 +251,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function="BigUInt.__init__(value: Int)",
                     previous_error=e^,
                 )
@@ -285,6 +287,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function="BigUInt.__init__(value: String)",
                     previous_error=e^,
                 )
@@ -788,6 +791,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function="BigUInt.__int__()",
                     previous_error=e^,
                 )
@@ -1150,6 +1154,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function="BigUInt.__sub__(other: Self)",
                     previous_error=e^,
                 )
@@ -1182,6 +1187,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function="BigUInt.__floordiv__(other: Self)",
                     previous_error=e^,
                 )
@@ -1202,6 +1208,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function="BigUInt.__ceildiv__(other: Self)",
                     previous_error=e^,
                 )
@@ -1222,6 +1229,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function="BigUInt.__mod__(other: Self)",
                     previous_error=e^,
                 )
@@ -1242,6 +1250,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function="BigUInt.__divmod__(other: Self)",
                     previous_error=e^,
                 )
@@ -1262,6 +1271,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function="BigUInt.__pow__(exponent: Self)",
                     previous_error=e^,
                 )
@@ -1282,6 +1292,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function="BigUInt.__pow__(exponent: Int)",
                     previous_error=e^,
                 )

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -400,10 +400,12 @@ struct Decimal128(
 
         if scale > UInt32(Self.MAX_SCALE):
             raise Error(
-                String(
-                    "Error in Decimal128 constructor with five components:"
-                    " Scale must be between 0 and 28, but got {}"
-                ).format(scale)
+                ValueError(
+                    message=String(
+                        "Scale must be between 0 and 28, but got {}."
+                    ).format(scale),
+                    function="Decimal128.from_components()",
+                )
             )
 
         var flags: UInt32 = 0
@@ -635,6 +637,7 @@ struct Decimal128(
                         message=String(
                             "Invalid characters in decimal128 string: {}"
                         ).format(value),
+                        function="Decimal128.from_string()",
                     )
                 )
 
@@ -672,6 +675,7 @@ struct Decimal128(
                             message=(
                                 "Minus sign cannot appear twice in exponent."
                             ),
+                            function="Decimal128.from_string()",
                         )
                     )
                 elif exponent_notation_read:
@@ -684,6 +688,7 @@ struct Decimal128(
                                 "Minus sign can only appear once at the"
                                 " beginning."
                             ),
+                            function="Decimal128.from_string()",
                         )
                     )
                 else:
@@ -698,6 +703,7 @@ struct Decimal128(
                             message=(
                                 "Plus sign cannot appear twice in exponent."
                             ),
+                            function="Decimal128.from_string()",
                         )
                     )
                 elif exponent_notation_read:
@@ -709,6 +715,7 @@ struct Decimal128(
                                 "Plus sign can only appear once at the"
                                 " beginning."
                             ),
+                            function="Decimal128.from_string()",
                         )
                     )
                 else:
@@ -720,6 +727,7 @@ struct Decimal128(
                     raise Error(
                         ValueError(
                             message="Decimal point can only appear once.",
+                            function="Decimal128.from_string()",
                         )
                     )
                 else:
@@ -734,6 +742,7 @@ struct Decimal128(
                             message=(
                                 "Exponential notation can only appear once."
                             ),
+                            function="Decimal128.from_string()",
                         )
                     )
                 if not mantissa_start:
@@ -742,6 +751,7 @@ struct Decimal128(
                             message=(
                                 "Exponential notation must follow a number."
                             ),
+                            function="Decimal128.from_string()",
                         )
                     )
                 else:
@@ -789,6 +799,7 @@ struct Decimal128(
                                 message=String(
                                     "Exponent part is too large: {}"
                                 ).format(raw_exponent),
+                                function="Decimal128.from_string()",
                             )
                         )
 
@@ -825,6 +836,7 @@ struct Decimal128(
                         message=String(
                             "Invalid character in decimal128 string: {}"
                         ).format(chr(Int(code))),
+                        function="Decimal128.from_string()",
                     )
                 )
 
@@ -832,6 +844,7 @@ struct Decimal128(
             raise Error(
                 ValueError(
                     message="Unexpected end character in decimal128 string.",
+                    function="Decimal128.from_string()",
                 )
             )
 

--- a/src/decimo/decimal128/exponential.mojo
+++ b/src/decimo/decimal128/exponential.mojo
@@ -84,6 +84,7 @@ def power(base: Decimal128, exponent: Decimal128) raises -> Decimal128:
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function="power()",
                     previous_error=e^,
                 )
@@ -95,6 +96,7 @@ def power(base: Decimal128, exponent: Decimal128) raises -> Decimal128:
         except e:
             raise Error(
                 DecimoError(
+                    message="See the above exception.",
                     function="power()",
                     previous_error=e^,
                 )
@@ -109,6 +111,7 @@ def power(base: Decimal128, exponent: Decimal128) raises -> Decimal128:
     except e:
         raise Error(
             DecimoError(
+                message="See the above exception.",
                 function="power()",
                 previous_error=e^,
             )

--- a/src/decimo/errors.mojo
+++ b/src/decimo/errors.mojo
@@ -26,8 +26,8 @@ ValueError: description of what went wrong
 ```
 
 File name and line number are automatically captured at the raise site using
-`call_location()`. Function name is an optional argument -- Mojo does not have
-a built-in way to get the current function name at runtime.
+`call_location()`. Function name must be provided manually since Mojo does not
+have a built-in way to get the current function name at runtime.
 """
 
 from std.reflection import call_location
@@ -88,7 +88,7 @@ struct DecimoError[error_type: String = "DecimoError"](Writable):
     ```
 
     File name and line number are automatically captured at the raise site.
-    Function name is an optional argument since Mojo does not yet support
+    Function name must be provided manually since Mojo does not yet support
     runtime introspection of the current function name.
 
     Parameters:
@@ -99,10 +99,10 @@ struct DecimoError[error_type: String = "DecimoError"](Writable):
     """The source file where the error occurred (auto-captured)."""
     var line: Int
     """The line number where the error occurred (auto-captured)."""
-    var function: Optional[String]
-    """An optional function name where the error occurred."""
-    var message: Optional[String]
-    """An optional message describing the error."""
+    var function: String
+    """The function name where the error occurred."""
+    var message: String
+    """A message describing the error."""
     var previous_error: Optional[String]
     """An optional formatted string of a previous error that caused this one."""
 
@@ -110,8 +110,8 @@ struct DecimoError[error_type: String = "DecimoError"](Writable):
     def __init__(
         out self,
         *,
-        message: Optional[String] = None,
-        function: Optional[String] = None,
+        message: String,
+        function: String,
         previous_error: Optional[Error] = None,
     ):
         """Creates a new `DecimoError` with auto-captured file and line.
@@ -119,8 +119,8 @@ struct DecimoError[error_type: String = "DecimoError"](Writable):
         File name and line number are automatically captured from the call site.
 
         Args:
-            message: An optional message describing the error.
-            function: An optional function name where the error occurred.
+            message: A message describing the error.
+            function: The function name where the error occurred.
             previous_error: An optional previous error that caused this one.
         """
         var loc = call_location()
@@ -193,20 +193,18 @@ struct DecimoError[error_type: String = "DecimoError"](Writable):
         writer.write(_CLR_LINE_NUM)
         writer.write(String(self.line))
         writer.write(_RESET)
-        if self.function is not None:
-            writer.write(", in ")
-            writer.write(_CLR_FUNC_NAME)
-            writer.write(self.function.value())
-            writer.write(_RESET)
+        writer.write(", in ")
+        writer.write(_CLR_FUNC_NAME)
+        writer.write(self.function)
+        writer.write(_RESET)
         writer.write("\n")
 
         # "ValueError: description of what went wrong"
         writer.write(_CLR_ERROR_TYPE)
         writer.write(Self.error_type)
         writer.write(_RESET)
-        if self.message is not None:
-            writer.write(": ")
-            writer.write(_CLR_MSG_TEXT)
-            writer.write(self.message.value())
-            writer.write(_RESET)
+        writer.write(": ")
+        writer.write(_CLR_MSG_TEXT)
+        writer.write(self.message)
+        writer.write(_RESET)
         writer.write("\n")

--- a/src/decimo/str.mojo
+++ b/src/decimo/str.mojo
@@ -200,12 +200,14 @@ def parse_numeric_string(
                         message=(
                             "Decimal point cannot appear in the exponent part."
                         ),
+                        function="parse_numeric_string()",
                     )
                 )
             if decimal_point_pos != -1:
                 raise Error(
                     ValueError(
                         message="Decimal point can only appear once.",
+                        function="parse_numeric_string()",
                     )
                 )
             decimal_point_pos = i
@@ -218,12 +220,14 @@ def parse_numeric_string(
                 raise Error(
                     ValueError(
                         message="Exponential notation can only appear once.",
+                        function="parse_numeric_string()",
                     )
                 )
             if total_mantissa_digits == 0:
                 raise Error(
                     ValueError(
                         message="Exponential notation must follow a number.",
+                        function="parse_numeric_string()",
                     )
                 )
             exponent_pos = i
@@ -240,6 +244,7 @@ def parse_numeric_string(
                                 "Exponent sign can only appear once,"
                                 " before exponent digits."
                             ),
+                            function="parse_numeric_string()",
                         )
                     )
                 exponent_sign_read = True
@@ -251,6 +256,7 @@ def parse_numeric_string(
                                 "Minus sign can only appear once at the"
                                 " beginning."
                             ),
+                            function="parse_numeric_string()",
                         )
                     )
                 sign = True
@@ -267,6 +273,7 @@ def parse_numeric_string(
                                 "Exponent sign can only appear once,"
                                 " before exponent digits."
                             ),
+                            function="parse_numeric_string()",
                         )
                     )
                 exponent_sign_read = True
@@ -278,6 +285,7 @@ def parse_numeric_string(
                                 "Plus sign can only appear once at the"
                                 " beginning."
                             ),
+                            function="parse_numeric_string()",
                         )
                     )
                 sign_read = True
@@ -288,6 +296,7 @@ def parse_numeric_string(
                     message=String(
                         "Invalid character in the string of the number: {}"
                     ).format(chr(Int(c))),
+                    function="parse_numeric_string()",
                 )
             )
 
@@ -295,6 +304,7 @@ def parse_numeric_string(
         raise Error(
             ValueError(
                 message="Unexpected end character in the string of the number.",
+                function="parse_numeric_string()",
             )
         )
 
@@ -302,6 +312,7 @@ def parse_numeric_string(
         raise Error(
             ValueError(
                 message="No digits found in the string of the number.",
+                function="parse_numeric_string()",
             )
         )
 

--- a/src/decimo/toml/parser.mojo
+++ b/src/decimo/toml/parser.mojo
@@ -871,7 +871,11 @@ struct TOMLParser:
             if len(key_parts) == 1:
                 if key_parts[0] in table:
                     raise Error(
-                        "Duplicate key in inline table: " + key_parts[0]
+                        ValueError(
+                            message="Duplicate key in inline table: "
+                            + key_parts[0],
+                            function="TOMLParser._parse_inline_table()",
+                        )
                     )
                 table[key_parts[0]] = value^
             else:


### PR DESCRIPTION
This PR updates Decimo’s structured error type so that `DecimoError` always includes a `message` and `function`, ensuring tracebacks consistently show both fields (alongside auto-captured file/line).

**Changes:**
- Make `DecimoError.message` and `DecimoError.function` mandatory (non-optional) and require them in `__init__`.
- Update error construction call sites across parsing, numeric parsing, and numeric types to pass `message` + `function`.
- Convert a couple of previously string-raised errors to structured `ValueError` instances to comply with the new contract.