### PR TITLE
[docstring][error] Fixes `raises:` sections in docstrings across codebase to show correct error types

### DIFF
--- a/src/decimo/bigdecimal/arithmetics.mojo
+++ b/src/decimo/bigdecimal/arithmetics.mojo
@@ -308,6 +308,9 @@ def true_divide(
         The quotient of x and y, with precision up to `precision`
         significant digits.
 
+    Raises:
+        ZeroDivisionError: If the divisor is zero.
+
     Notes:
 
     - If the coefficients can be divided exactly, the number of digits after
@@ -692,6 +695,9 @@ def true_divide_inexact(
 
     Returns:
         The quotient of x1 and x2.
+
+    Raises:
+        ZeroDivisionError: If the divisor is zero.
     """
 
     # Check for division by zero
@@ -904,7 +910,7 @@ def truncate_divide(x1: BigDecimal, x2: BigDecimal) raises -> BigDecimal:
         The quotient of x1 and x2, truncated to zeros.
 
     Raises:
-        Error: If division by zero is attempted.
+        ZeroDivisionError: If division by zero is attempted.
 
     Notes:
         This function performs integer division that truncates toward zero.
@@ -951,7 +957,7 @@ def truncate_modulo(
         The truncated modulo of x1 and x2.
 
     Raises:
-        Error: If division by zero is attempted.
+        ZeroDivisionError: If division by zero is attempted.
     """
     # Check for division by zero
     if x2.coefficient.is_zero():

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -345,6 +345,10 @@ struct BigDecimal(
         Returns:
             The BigDecimal representation of the Scalar value.
 
+        Raises:
+            ValueError: If the value is NaN.
+            ConversionError: If the conversion from scalar to BigDecimal fails.
+
         Notes:
 
         If the value is a floating-point number, it is converted to a string
@@ -430,7 +434,7 @@ struct BigDecimal(
             The BigDecimal representation of the Python Decimal.
 
         Raises:
-            Error: If the conversion from Python Decimal fails, or if
+            ConversionError: If the conversion from Python Decimal fails, or if
                 the as_tuple() method returns invalid data.
 
         Examples:

--- a/src/decimo/bigdecimal/constants.mojo
+++ b/src/decimo/bigdecimal/constants.mojo
@@ -162,6 +162,9 @@ def pi(precision: Int) raises -> BigDecimal:
 
     Returns:
         The value of π to the specified precision.
+
+    Raises:
+        ValueError: If the precision is negative.
     """
 
     if precision < 0:

--- a/src/decimo/bigdecimal/exponential.mojo
+++ b/src/decimo/bigdecimal/exponential.mojo
@@ -222,7 +222,8 @@ def power(
 
     Raises:
         ValueError: If base is negative and exponent is not an integer.
-        ZeroDivisionError: If base is zero and exponent is negative or zero.
+        ValueError: If base is zero and exponent is zero.
+        ZeroDivisionError: If base is zero and exponent is negative.
 
     Notes:
 

--- a/src/decimo/bigdecimal/exponential.mojo
+++ b/src/decimo/bigdecimal/exponential.mojo
@@ -221,8 +221,8 @@ def power(
         The result of base^exponent.
 
     Raises:
-        Error: If base is negative and exponent is not an integer.
-        Error: If base is zero and exponent is negative or zero.
+        ValueError: If base is negative and exponent is not an integer.
+        ZeroDivisionError: If base is zero and exponent is negative or zero.
 
     Notes:
 
@@ -425,8 +425,8 @@ def root(x: BigDecimal, n: BigDecimal, precision: Int) raises -> BigDecimal:
         The nth root of x with the specified precision.
 
     Raises:
-        Error: If x is negative and n is not an odd integer.
-        Error: If n is zero.
+        ValueError: If x is negative and n is not an odd integer.
+        ValueError: If n is zero.
 
     Notes:
         Uses the identity x^(1/n) = exp(ln(|x|)/n) for calculation.
@@ -552,9 +552,9 @@ def integer_root(
         The nth root of x with the specified precision.
 
     Raises:
-        Error: If x is negative and n is even.
-        Error: If n is not a positive integer.
-        Error: If n is zero.
+        ValueError: If x is negative and n is even.
+        ValueError: If n is not a positive integer.
+        ValueError: If n is zero.
     """
     comptime BUFFER_DIGITS = 9
     var working_precision = precision + BUFFER_DIGITS
@@ -1016,7 +1016,7 @@ def sqrt(x: BigDecimal, precision: Int) raises -> BigDecimal:
         The square root of x with the specified precision.
 
     Raises:
-        Error: If x is negative.
+        ValueError: If x is negative.
     """
     return sqrt_exact(x, precision)
 
@@ -1199,7 +1199,7 @@ def sqrt_exact(x: BigDecimal, precision: Int) raises -> BigDecimal:
         The square root of x with the specified precision.
 
     Raises:
-        Error: If x is negative.
+        ValueError: If x is negative.
     """
 
     # Handle special cases
@@ -1333,7 +1333,7 @@ def sqrt_reciprocal(x: BigDecimal, precision: Int) raises -> BigDecimal:
         The square root of x with the specified precision.
 
     Raises:
-        Error: If x is negative.
+        ValueError: If x is negative.
     """
 
     # Handle special cases
@@ -1496,7 +1496,7 @@ def sqrt_newton(x: BigDecimal, precision: Int) raises -> BigDecimal:
         The square root of x with the specified precision.
 
     Raises:
-        Error: If x is negative.
+        ValueError: If x is negative.
 
     Notes:
 
@@ -1593,7 +1593,7 @@ def sqrt_decimal_approach(x: BigDecimal, precision: Int) raises -> BigDecimal:
         The square root of x with the specified precision.
 
     Raises:
-        Error: If x is negative.
+        ValueError: If x is negative.
 
     Notes:
 
@@ -1746,9 +1746,6 @@ def cbrt(x: BigDecimal, precision: Int) raises -> BigDecimal:
 
     Returns:
         The cube root of x with the specified precision.
-
-    Raises:
-        Error: If x is negative.
     """
 
     result = integer_root(
@@ -1773,6 +1770,9 @@ def exp(x: BigDecimal, precision: Int) raises -> BigDecimal:
 
     Returns:
         The natural exponential of x (e^x) to the specified precision.
+
+    Raises:
+        OverflowError: If the result is too large to represent.
 
     Notes:
         Uses aggressive range reduction for optimal performance:
@@ -1970,7 +1970,7 @@ def ln(x: BigDecimal, precision: Int) raises -> BigDecimal:
         The natural logarithm of x to the specified precision.
 
     Raises:
-        Error: If x is negative or zero.
+        ValueError: If x is negative or zero.
     """
     var cache = MathCache()
     return ln(x, precision, cache)
@@ -1993,7 +1993,7 @@ def ln(
         The natural logarithm of x to the specified precision.
 
     Raises:
-        Error: If x is negative or zero.
+        ValueError: If x is negative or zero.
     """
     comptime BUFFER_DIGITS = 9  # word-length, easy to append and trim
     var working_precision = precision + BUFFER_DIGITS
@@ -2088,8 +2088,8 @@ def log(x: BigDecimal, base: BigDecimal, precision: Int) raises -> BigDecimal:
         The logarithm of x with respect to base.
 
     Raises:
-        Error: If x is negative or zero.
-        Error: If base is negative, zero, or one.
+        ValueError: If x is negative or zero.
+        ValueError: If base is negative, zero, or one.
     """
     comptime BUFFER_DIGITS = 9  # word-length, easy to append and trim
     var working_precision = precision + BUFFER_DIGITS
@@ -2157,7 +2157,7 @@ def log10(x: BigDecimal, precision: Int) raises -> BigDecimal:
         The base-10 logarithm of x.
 
     Raises:
-        Error: If x is negative or zero.
+        ValueError: If x is negative or zero.
     """
     comptime BUFFER_DIGITS = 9  # word-length, easy to append and trim
     var working_precision = precision + BUFFER_DIGITS

--- a/src/decimo/bigdecimal/trigonometric.mojo
+++ b/src/decimo/bigdecimal/trigonometric.mojo
@@ -346,6 +346,9 @@ def tan_cot(x: BigDecimal, precision: Int, is_tan: Bool) raises -> BigDecimal:
     Returns:
         The cotangent of x with the specified precision.
 
+    Raises:
+        ValueError: If computing cot(nπ) which is undefined.
+
     Notes:
 
     This function calculates tan(x) = cos(x) / sin(x) or
@@ -424,6 +427,9 @@ def csc(x: BigDecimal, precision: Int) raises -> BigDecimal:
 
     Returns:
         The cosecant of x with the specified precision.
+
+    Raises:
+        ValueError: If x is zero (csc(nπ) is undefined).
 
     Notes:
 

--- a/src/decimo/bigfloat/bigfloat.mojo
+++ b/src/decimo/bigfloat/bigfloat.mojo
@@ -144,6 +144,10 @@ struct BigFloat(Comparable, Movable, Writable):
         Args:
             value: A decimal number string (e.g. "3.14159", "-1.5e10").
             precision: Number of significant decimal digits.
+
+        Raises:
+            RuntimeError: If MPFR is not available or handle pool is exhausted.
+            ConversionError: If the string is not a valid number.
         """
         if not mpfrw_available():
             raise RuntimeError(
@@ -235,6 +239,9 @@ struct BigFloat(Comparable, Movable, Writable):
 
         Returns:
             A decimal string representation.
+
+        Raises:
+            ConversionError: If string export fails.
         """
         var d = digits if digits > 0 else self.precision
         var address = mpfrw_get_str(self.handle, Int32(d))
@@ -308,6 +315,9 @@ struct BigFloat(Comparable, Movable, Writable):
 
         Returns:
             A BigDecimal with the requested number of significant digits.
+
+        Raises:
+            ConversionError: If raw digit export fails.
         """
         var d = precision if precision > 0 else self.precision
 
@@ -456,6 +466,9 @@ struct BigFloat(Comparable, Movable, Writable):
 
         Returns:
             The negated value.
+
+        Raises:
+            RuntimeError: If MPFR handle allocation fails.
         """
         var h = mpfrw_init(_dps_to_bits(self.precision))
         if h < 0:
@@ -471,6 +484,9 @@ struct BigFloat(Comparable, Movable, Writable):
 
         Returns:
             The absolute value.
+
+        Raises:
+            RuntimeError: If MPFR handle allocation fails.
         """
         var h = mpfrw_init(_dps_to_bits(self.precision))
         if h < 0:
@@ -493,6 +509,9 @@ struct BigFloat(Comparable, Movable, Writable):
 
         Returns:
             The sum.
+
+        Raises:
+            RuntimeError: If MPFR handle allocation fails.
         """
         var prec = max(self.precision, other.precision)
         var h = mpfrw_init(_dps_to_bits(prec))
@@ -512,6 +531,9 @@ struct BigFloat(Comparable, Movable, Writable):
 
         Returns:
             The difference.
+
+        Raises:
+            RuntimeError: If MPFR handle allocation fails.
         """
         var prec = max(self.precision, other.precision)
         var h = mpfrw_init(_dps_to_bits(prec))
@@ -531,6 +553,9 @@ struct BigFloat(Comparable, Movable, Writable):
 
         Returns:
             The product.
+
+        Raises:
+            RuntimeError: If MPFR handle allocation fails.
         """
         var prec = max(self.precision, other.precision)
         var h = mpfrw_init(_dps_to_bits(prec))
@@ -550,6 +575,9 @@ struct BigFloat(Comparable, Movable, Writable):
 
         Returns:
             The quotient.
+
+        Raises:
+            RuntimeError: If MPFR handle allocation fails.
         """
         var prec = max(self.precision, other.precision)
         var h = mpfrw_init(_dps_to_bits(prec))
@@ -581,6 +609,9 @@ struct BigFloat(Comparable, Movable, Writable):
 
         Returns:
             The square root of this value.
+
+        Raises:
+            RuntimeError: If MPFR handle allocation fails.
         """
         var h = mpfrw_init(_dps_to_bits(self.precision))
         if h < 0:
@@ -596,6 +627,9 @@ struct BigFloat(Comparable, Movable, Writable):
 
         Returns:
             The exponential of this value.
+
+        Raises:
+            RuntimeError: If MPFR handle allocation fails.
         """
         var h = mpfrw_init(_dps_to_bits(self.precision))
         if h < 0:
@@ -611,6 +645,9 @@ struct BigFloat(Comparable, Movable, Writable):
 
         Returns:
             The natural logarithm of this value.
+
+        Raises:
+            RuntimeError: If MPFR handle allocation fails.
         """
         var h = mpfrw_init(_dps_to_bits(self.precision))
         if h < 0:
@@ -626,6 +663,9 @@ struct BigFloat(Comparable, Movable, Writable):
 
         Returns:
             The sine of this value.
+
+        Raises:
+            RuntimeError: If MPFR handle allocation fails.
         """
         var h = mpfrw_init(_dps_to_bits(self.precision))
         if h < 0:
@@ -641,6 +681,9 @@ struct BigFloat(Comparable, Movable, Writable):
 
         Returns:
             The cosine of this value.
+
+        Raises:
+            RuntimeError: If MPFR handle allocation fails.
         """
         var h = mpfrw_init(_dps_to_bits(self.precision))
         if h < 0:
@@ -656,6 +699,9 @@ struct BigFloat(Comparable, Movable, Writable):
 
         Returns:
             The tangent of this value.
+
+        Raises:
+            RuntimeError: If MPFR handle allocation fails.
         """
         var h = mpfrw_init(_dps_to_bits(self.precision))
         if h < 0:
@@ -674,6 +720,9 @@ struct BigFloat(Comparable, Movable, Writable):
 
         Returns:
             The result of `self` raised to `exponent`.
+
+        Raises:
+            RuntimeError: If MPFR handle allocation fails.
         """
         var prec = max(self.precision, exponent.precision)
         var h = mpfrw_init(_dps_to_bits(prec))
@@ -693,6 +742,9 @@ struct BigFloat(Comparable, Movable, Writable):
 
         Returns:
             The n-th root of this value.
+
+        Raises:
+            RuntimeError: If MPFR handle allocation fails.
         """
         var h = mpfrw_init(_dps_to_bits(self.precision))
         if h < 0:
@@ -712,6 +764,9 @@ struct BigFloat(Comparable, Movable, Writable):
 
         Returns:
             A `BigFloat` containing π at the requested precision.
+
+        Raises:
+            RuntimeError: If MPFR is not available or handle allocation fails.
         """
         if not mpfrw_available():
             raise RuntimeError(

--- a/src/decimo/bigint/arithmetics.mojo
+++ b/src/decimo/bigint/arithmetics.mojo
@@ -2032,6 +2032,9 @@ def floor_divide_inplace(mut x: BigInt, read other: BigInt) raises:
     Args:
         x: The dividend (modified in-place to hold the quotient).
         other: The divisor.
+
+    Raises:
+        ZeroDivisionError: If the divisor is zero.
     """
     var result = _divmod_magnitudes(x.words, other.words)
     var q_words = result[0].copy()
@@ -2075,6 +2078,9 @@ def floor_modulo_inplace(mut x: BigInt, read other: BigInt) raises:
     Args:
         x: The dividend (modified in-place to hold the remainder).
         other: The divisor.
+
+    Raises:
+        ZeroDivisionError: If the divisor is zero.
     """
     var result = _divmod_magnitudes(x.words, other.words)
     _ = result[0]
@@ -2124,7 +2130,7 @@ def floor_divide(x1: BigInt, x2: BigInt) raises -> BigInt:
         The quotient of x1 / x2, rounded toward negative infinity.
 
     Raises:
-        Error: If x2 is zero.
+        ZeroDivisionError: If the divisor is zero.
     """
     var result = _divmod_magnitudes(x1.words, x2.words)
     var q_words = result[0].copy()
@@ -2171,7 +2177,7 @@ def truncate_divide(x1: BigInt, x2: BigInt) raises -> BigInt:
         The quotient of x1 / x2, truncated toward zero.
 
     Raises:
-        Error: If x2 is zero.
+        ZeroDivisionError: If the divisor is zero.
     """
     var result = _divmod_magnitudes(x1.words, x2.words)
     var q_words = result[0].copy()
@@ -2203,7 +2209,7 @@ def floor_modulo(x1: BigInt, x2: BigInt) raises -> BigInt:
         The remainder with the same sign as x2.
 
     Raises:
-        Error: If x2 is zero.
+        ZeroDivisionError: If the divisor is zero.
     """
     var result = _divmod_magnitudes(x1.words, x2.words)
     _ = result[0]
@@ -2243,7 +2249,7 @@ def truncate_modulo(x1: BigInt, x2: BigInt) raises -> BigInt:
         The remainder with the same sign as x1.
 
     Raises:
-        Error: If x2 is zero.
+        ZeroDivisionError: If the divisor is zero.
     """
     var result = _divmod_magnitudes(x1.words, x2.words)
     _ = result[0]
@@ -2276,7 +2282,7 @@ def floor_divmod(x1: BigInt, x2: BigInt) raises -> Tuple[BigInt, BigInt]:
         A tuple of (quotient, remainder).
 
     Raises:
-        Error: If x2 is zero.
+        ZeroDivisionError: If the divisor is zero.
     """
     var result = _divmod_magnitudes(x1.words, x2.words)
     var q_words = result[0].copy()
@@ -2329,8 +2335,8 @@ def power(base: BigInt, exponent: Int) raises -> BigInt:
         The result of base raised to the given exponent.
 
     Raises:
-        Error: If the exponent is negative.
-        Error: If the exponent is too large (>= 1_000_000_000).
+        ValueError: If the exponent is negative.
+        ValueError: If the exponent is too large (>= 1_000_000_000).
     """
     if exponent < 0:
         raise ValueError(

--- a/src/decimo/bigint/bigint.mojo
+++ b/src/decimo/bigint/bigint.mojo
@@ -193,6 +193,9 @@ struct BigInt(
 
         Args:
             value: The string representation of the integer.
+
+        Raises:
+            ConversionError: If the string cannot be parsed as an integer.
         """
         self = Self.from_string(value)
 
@@ -451,8 +454,7 @@ struct BigInt(
             The BigInt representation.
 
         Raises:
-            Error: If the string is empty, contains invalid characters,
-                or represents a non-integer value.
+            ConversionError: If the string cannot be parsed as an integer.
         """
         # Use the shared string parser for format handling
         _tuple = decimo.str.parse_numeric_string(value)
@@ -572,6 +574,9 @@ struct BigInt(
 
         Returns:
             The `Int` representation.
+
+        Raises:
+            OverflowError: If the number exceeds the size of Int.
         """
         return self.to_int()
 
@@ -620,7 +625,7 @@ struct BigInt(
             The number as Int.
 
         Raises:
-            Error: If the number is too large or too small to fit in Int.
+            OverflowError: If the number exceeds the size of Int.
         """
         # Int is 64-bit, so we need at most 2 words to represent it.
         # Int.MAX = 9_223_372_036_854_775_807 = 0x7FFF_FFFF_FFFF_FFFF
@@ -970,6 +975,9 @@ struct BigInt(
 
         Returns:
             The quotient, rounded toward negative infinity.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         try:
             return decimo.bigint.arithmetics.floor_divide(self, other)
@@ -989,6 +997,9 @@ struct BigInt(
 
         Returns:
             The floor remainder with the same sign as the divisor.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         try:
             return decimo.bigint.arithmetics.floor_modulo(self, other)
@@ -1008,6 +1019,9 @@ struct BigInt(
 
         Returns:
             A tuple of (quotient, remainder) using floor division.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         try:
             return decimo.bigint.arithmetics.floor_divmod(self, other)
@@ -1027,6 +1041,10 @@ struct BigInt(
 
         Returns:
             The result of raising to the given power.
+
+        Raises:
+            ValueError: If the exponent is negative.
+            OverflowError: If the exponent is too large to fit in Int.
         """
         return self.power(exponent)
 
@@ -1039,6 +1057,9 @@ struct BigInt(
 
         Returns:
             The result of raising to the given power.
+
+        Raises:
+            ValueError: If the exponent is negative or too large.
         """
         return self.power(exponent)
 
@@ -1115,6 +1136,9 @@ struct BigInt(
 
         Returns:
             The quotient, rounded toward negative infinity.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return decimo.bigint.arithmetics.floor_divide(other, self)
 
@@ -1127,6 +1151,9 @@ struct BigInt(
 
         Returns:
             The floor remainder with the same sign as the divisor.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return decimo.bigint.arithmetics.floor_modulo(other, self)
 
@@ -1139,6 +1166,9 @@ struct BigInt(
 
         Returns:
             A tuple of (quotient, remainder) using floor division.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return decimo.bigint.arithmetics.floor_divmod(other, self)
 
@@ -1151,6 +1181,9 @@ struct BigInt(
 
         Returns:
             The result of raising the base to this power.
+
+        Raises:
+            ValueError: If the exponent is negative.
         """
         return base.power(self)
 
@@ -1201,6 +1234,9 @@ struct BigInt(
 
         Args:
             other: The right-hand side operand.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         decimo.bigint.arithmetics.floor_divide_inplace(self, other)
 
@@ -1210,6 +1246,9 @@ struct BigInt(
 
         Args:
             other: The right-hand side operand.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         decimo.bigint.arithmetics.floor_modulo_inplace(self, other)
 
@@ -1435,7 +1474,8 @@ struct BigInt(
             The result of self raised to the given exponent.
 
         Raises:
-            Error: If the exponent is negative.
+            ValueError: If the exponent is negative.
+            ValueError: If the exponent is too large (>= 1_000_000_000).
         """
         return decimo.bigint.arithmetics.power(self, exponent)
 
@@ -1449,7 +1489,8 @@ struct BigInt(
             The result of self raised to the given exponent.
 
         Raises:
-            Error: If the exponent is negative or too large.
+            ValueError: If the exponent is negative.
+            OverflowError: If the exponent is too large to fit in Int.
         """
         if exponent.is_negative():
             raise ValueError(

--- a/src/decimo/bigint/bigint.mojo
+++ b/src/decimo/bigint/bigint.mojo
@@ -195,7 +195,7 @@ struct BigInt(
             value: The string representation of the integer.
 
         Raises:
-            ConversionError: If the string cannot be parsed as an integer.
+            ConversionError: If the string cannot be converted to a BigInt.
         """
         self = Self.from_string(value)
 
@@ -457,7 +457,18 @@ struct BigInt(
             ConversionError: If the string cannot be parsed as an integer.
         """
         # Use the shared string parser for format handling
-        _tuple = decimo.str.parse_numeric_string(value)
+        try:
+            _tuple = decimo.str.parse_numeric_string(value)
+        except e:
+            raise ConversionError(
+                function="BigInt.from_string(value: String)",
+                message=(
+                    'The input value "'
+                    + value
+                    + '" cannot be parsed as an integer.\n'
+                    + String(e)
+                ),
+            )
         var ref coef: List[UInt8] = _tuple[0]
         var scale: Int = _tuple[1]
         var sign: Bool = _tuple[2]

--- a/src/decimo/bigint/exponential.mojo
+++ b/src/decimo/bigint/exponential.mojo
@@ -261,7 +261,7 @@ def sqrt(x: BigInt) raises -> BigInt:
         The integer square root of x.
 
     Raises:
-        Error: If x is negative.
+        ValueError: If x is negative.
 
     Notes:
 
@@ -494,6 +494,6 @@ def isqrt(x: BigInt) raises -> BigInt:
         The integer square root of x.
 
     Raises:
-        Error: If x is negative.
+        ValueError: If x is negative.
     """
     return sqrt(x)

--- a/src/decimo/bigint/number_theory.mojo
+++ b/src/decimo/bigint/number_theory.mojo
@@ -242,7 +242,8 @@ def mod_pow(base: BigInt, exponent: BigInt, modulus: BigInt) raises -> BigInt:
         A BigInt in the range [0, modulus).
 
     Raises:
-        If exponent < 0 or modulus <= 0.
+        ValueError: If the exponent is negative.
+        ValueError: If the modulus is not positive.
     """
     if exponent.is_negative():
         raise ValueError(
@@ -295,6 +296,10 @@ def mod_pow(base: BigInt, exponent: Int, modulus: BigInt) raises -> BigInt:
 
     Returns:
         A BigInt in the range [0, modulus).
+
+    Raises:
+        ValueError: If the exponent is negative.
+        ValueError: If the modulus is not positive.
     """
     return mod_pow(base, BigInt(exponent), modulus)
 
@@ -319,7 +324,8 @@ def mod_inverse(a: BigInt, modulus: BigInt) raises -> BigInt:
         The modular inverse, in [0, modulus).
 
     Raises:
-        If modulus <= 0 or the inverse does not exist (gcd(a, modulus) != 1).
+        ValueError: If the modulus is not positive.
+        ValueError: If the modular inverse does not exist (gcd != 1).
     """
     if not modulus.is_positive():
         raise ValueError(

--- a/src/decimo/bigint10/arithmetics.mojo
+++ b/src/decimo/bigint10/arithmetics.mojo
@@ -208,8 +208,7 @@ def floor_divide(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
         The quotient of x1 / x2, rounded toward negative infinity.
 
     Raises:
-        DecimoError: If `decimo.biguint.arithmetics.floor_divide()` fails.
-        DecimoError: If `decimo.biguint.arithmetics.ceil_divide()` fails.
+        ZeroDivisionError: If the divisor is zero.
     """
 
     # For floor division, the sign rules are:
@@ -260,7 +259,7 @@ def truncate_divide(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
         The quotient of x1 / x2, truncated toward zero.
 
     Raises:
-        DecimoError: If `decimo.biguint.arithmetics.floor_divide()` fails.
+        ZeroDivisionError: If the divisor is zero.
     """
     var magnitude: BigUInt
     try:
@@ -289,8 +288,7 @@ def floor_modulo(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
         The remainder of x1 being divided by x2, with the same sign as x2.
 
     Raises:
-        DecimoError: If `decimo.biguint.arithmetics.floor_modulo()` fails.
-        DecimoError: If `decimo.biguint.arithmetics.ceil_modulo()` fails.
+        ZeroDivisionError: If the divisor is zero.
     """
 
     var magnitude: BigUInt
@@ -337,7 +335,7 @@ def truncate_modulo(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
         The remainder of x1 being divided by x2, with the same sign as x1.
 
     Raises:
-        DecimoError: If `decimo.biguint.arithmetics.floor_modulo()` fails.
+        ZeroDivisionError: If the divisor is zero.
     """
     var magnitude: BigUInt
     try:

--- a/src/decimo/bigint10/bigint10.mojo
+++ b/src/decimo/bigint10/bigint10.mojo
@@ -111,6 +111,9 @@ struct BigInt10(
                 The words are stored in little-endian order.
             sign: The sign of the BigInt10.
 
+        Raises:
+            ConversionError: If any word exceeds 999_999_999.
+
         Notes:
             This is equal to `BigInt10.from_list()`.
         """
@@ -153,6 +156,9 @@ struct BigInt10(
 
         Args:
             value: The string representation of the integer.
+
+        Raises:
+            ConversionError: If the string cannot be parsed.
         """
         try:
             self = Self.from_string(value)
@@ -193,6 +199,9 @@ struct BigInt10(
 
         Args:
             py: The Python integer object to convert from.
+
+        Raises:
+            ConversionError: If the Python object cannot be converted.
         """
         self = Self.from_python_int(py)
 
@@ -218,7 +227,7 @@ struct BigInt10(
             sign: The sign of the BigInt10.
 
         Raises:
-            Error: If any word is larger than `999_999_999`.
+            ConversionError: If any word exceeds 999_999_999.
 
         Returns:
             The BigInt10 representation of the list of UInt32 words.
@@ -250,6 +259,9 @@ struct BigInt10(
 
         Returns:
             A new `BigInt10` from the given words.
+
+        Raises:
+            ValueError: If any word exceeds 999_999_999.
         """
 
         var list_of_words = List[UInt32](capacity=len(words))
@@ -345,6 +357,9 @@ struct BigInt10(
 
         Returns:
             The BigInt10 representation of the string.
+
+        Raises:
+            ConversionError: If the string cannot be parsed.
         """
         _tuple = decimo.str.parse_numeric_string(value)
         var ref coef: List[UInt8] = _tuple[0]
@@ -369,8 +384,7 @@ struct BigInt10(
             The BigInt10 representation of the Python integer.
 
         Raises:
-            Error: If the conversion from Python int to string fails, or if
-                the string cannot be parsed as a valid integer.
+            ConversionError: If the conversion from Python int fails.
 
         Examples:
         ```mojo
@@ -413,6 +427,9 @@ struct BigInt10(
 
         Returns:
             The `Int` representation of this value.
+
+        Raises:
+            OverflowError: If the number exceeds the size of Int.
         """
         return self.to_int()
 
@@ -450,7 +467,7 @@ struct BigInt10(
             The number as Int.
 
         Raises:
-            Error: If the number is too large or too small to fit in Int.
+            OverflowError: If the number exceeds the size of Int.
         """
 
         # 2^63-1 = 9_223_372_036_854_775_807
@@ -615,6 +632,9 @@ struct BigInt10(
 
         Returns:
             The floor division quotient.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         try:
             return decimo.bigint10.arithmetics.floor_divide(self, other)
@@ -634,6 +654,9 @@ struct BigInt10(
 
         Returns:
             The remainder of the floor division.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         try:
             return decimo.bigint10.arithmetics.floor_modulo(self, other)
@@ -653,6 +676,9 @@ struct BigInt10(
 
         Returns:
             The result of raising to the given power.
+
+        Raises:
+            OverflowError: If the exponent is too large.
         """
         return self.power(exponent)
 
@@ -1032,6 +1058,9 @@ struct BigInt10(
 
         Returns:
             The result of raising to the given power.
+
+        Raises:
+            ValueError: If the exponent is negative or too large.
         """
         var magnitude = self.magnitude.power(exponent)
         var sign = False
@@ -1048,6 +1077,10 @@ struct BigInt10(
 
         Returns:
             The result of raising to the given power.
+
+        Raises:
+            OverflowError: If the exponent is too large.
+            ValueError: If the exponent is negative or too large.
         """
         if exponent > Self(BigUInt(raw_words=[0, 1]), sign=False):
             raise OverflowError(

--- a/src/decimo/bigint10/bigint10.mojo
+++ b/src/decimo/bigint10/bigint10.mojo
@@ -361,7 +361,18 @@ struct BigInt10(
         Raises:
             ConversionError: If the string cannot be parsed.
         """
-        _tuple = decimo.str.parse_numeric_string(value)
+        try:
+            _tuple = decimo.str.parse_numeric_string(value)
+        except e:
+            raise ConversionError(
+                function="BigInt10.from_string(value: String)",
+                message=(
+                    'The input value "'
+                    + value
+                    + '" cannot be parsed as an integer.\n'
+                    + String(e)
+                ),
+            )
         var ref coef: List[UInt8] = _tuple[0]
         var sign: Bool = _tuple[2]
 

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -98,7 +98,7 @@ def negative(x: BigUInt) raises -> BigUInt:
         x: The BigUInt value to compute the negative of.
 
     Raises:
-        Error: If x is not zero, as negative of non-zero unsigned integer is undefined.
+        OverflowError: If the number is non-zero.
 
     Returns:
         A new BigUInt containing the negative of x.
@@ -486,7 +486,7 @@ def subtract(x: BigUInt, y: BigUInt) raises -> BigUInt:
         y: The second unsigned integer (subtrahend).
 
     Raises:
-        Error: If y is greater than x, resulting in an underflow.
+        OverflowError: If x < y (result would be negative).
 
     Returns:
         The result of subtracting y from x.
@@ -681,6 +681,9 @@ def subtract_inplace(mut x: BigUInt, y: BigUInt) raises -> None:
     Args:
         x: The `BigUInt` minuend, modified in place.
         y: The `BigUInt` subtrahend.
+
+    Raises:
+        OverflowError: If x < y (result would be negative).
     """
 
     # If the subtrahend is zero, return the minuend
@@ -1938,7 +1941,7 @@ def floor_divide(x: BigUInt, y: BigUInt) raises -> BigUInt:
         The quotient of x / y, truncated toward zero.
 
     Raises:
-        ValueError: If the divisor is zero.
+        ZeroDivisionError: If the divisor is zero.
 
     Notes:
         It is equal to truncated division for positive numbers.
@@ -2059,7 +2062,7 @@ def floor_divide_school(x: BigUInt, y: BigUInt) raises -> BigUInt:
         The quotient of x // y.
 
     Raises:
-        Error: If the y is zero.
+        ZeroDivisionError: If the divisor is zero.
     """
 
     # Because the Burnikel-Ziegler division algorithm will fall back to this
@@ -3123,6 +3126,9 @@ def floor_divide_three_by_two_uint32(
         (2) the most significant word of the remainder (as UInt32)
         (3) the least significant word of the remainder (as UInt32).
 
+    Raises:
+        ValueError: If b1 < 500_000_000.
+
     Notes:
 
     a = a2 * BASE^2 + a1 * BASE + a0.
@@ -3180,6 +3186,9 @@ def floor_divide_four_by_two_uint32(
         (2) the least significant word of the quotient (as UInt32)
         (3) the most significant word of the remainder (as UInt32)
         (4) the least significant word of the remainder (as UInt32).
+
+    Raises:
+        ValueError: If b1 < 500_000_000 or a >= b * 10^18.
     """
 
     if b1 < 500_000_000:
@@ -3228,6 +3237,9 @@ def truncate_divide(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
 
     Returns:
         The quotient of `x1` divided by `x2`.
+
+    Raises:
+        ZeroDivisionError: If the divisor is zero.
     """
     return floor_divide(x1, x2)
 
@@ -3243,7 +3255,7 @@ def ceil_divide(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
         The quotient of x1 / x2, rounded up.
 
     Raises:
-        ValueError: If the divisor is zero.
+        ZeroDivisionError: If the divisor is zero.
     """
 
     # CASE: Division by zero
@@ -3277,8 +3289,6 @@ def floor_modulo(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
 
     Raises:
         ZeroDivisionError: If the divisor is zero.
-        Error: If `floor_divide()` raises an error.
-        Error: If `subtract()` raises an error.
 
     Notes:
         It is equal to floored modulo for positive numbers.
@@ -3422,8 +3432,7 @@ def floor_divide_modulo(
         The quotient of x1 / x2, truncated toward zero and the remainder.
 
     Raises:
-        Error: If `floor_divide()` raises an error.
-        Error: If `subtract()` raises an error.
+        ZeroDivisionError: If the divisor is zero.
 
     Notes:
         It is equal to truncated division for positive numbers.
@@ -3615,7 +3624,7 @@ def power_of_10(n: Int) raises -> BigUInt:
         A BigUInt representing 10 raised to the power of n.
 
     Raises:
-        DecimoError: If n is negative.
+        ValueError: If n is negative.
     """
     if n < 0:
         raise ValueError(

--- a/src/decimo/biguint/biguint.mojo
+++ b/src/decimo/biguint/biguint.mojo
@@ -196,6 +196,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
                 Each UInt32 word represents digits ranging from 0 to 10^9 - 1.
                 The words are stored in little-endian order.
 
+        Raises:
+            ConversionError: If any word exceeds 999_999_999.
+
         Notes:
 
         This is equal to `BigUInt.from_list()`.
@@ -242,7 +245,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             value: The integer to initialize the `BigUInt` from.
 
         Raises:
-            Error: Calling `BigUInt.from_int()`.
+            ConversionError: If the value is negative.
         """
         try:
             self = Self.from_int(value)
@@ -273,7 +276,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
                 If False, the sign is considered.
 
         Raises:
-            Error: If an error occurs in `from_string()`.
+            ConversionError: If the string cannot be parsed.
 
         Notes:
             This is equal to `BigUInt.from_string()`.
@@ -310,7 +313,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
                 The words are stored in little-endian order.
 
         Raises:
-            Error: If any word is larger than `999_999_999`.
+            OverflowError: If any word exceeds 999_999_999.
 
         Returns:
             The BigUInt representation of the list of UInt32 words.
@@ -364,7 +367,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
                 The words are stored in little-endian order.
 
         Raises:
-            Error: If any word is larger than `999_999_999`.
+            OverflowError: If any word exceeds 999_999_999.
 
         Notes:
 
@@ -452,7 +455,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             The BigUInt representation of the integer value.
 
         Raises:
-            Error: If the input value is negative.
+            OverflowError: If the value is negative.
         """
         if value == 0:
             return Self()
@@ -765,7 +768,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             The number as Int.
 
         Raises:
-            Error: If to_int() raises an error.
+            ConversionError: If the number exceeds the size of Int.
         """
         try:
             return self.to_int()
@@ -844,7 +847,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             The number as UInt64.
 
         Raises:
-            Error: If the number exceeds the size of UInt64.
+            OverflowError: If the number exceeds the size of UInt64.
         """
         if self.is_uint64_overflow():
             raise OverflowError(
@@ -1081,6 +1084,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Returns:
             The negated value.
+
+        Raises:
+            OverflowError: If the number is non-zero (negative of unsigned is undefined).
         """
         return decimo.biguint.arithmetics.negative(self)
 
@@ -1126,6 +1132,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Returns:
             The difference.
+
+        Raises:
+            OverflowError: If the result would be negative.
         """
         try:
             return decimo.biguint.arithmetics.subtract(self, other)
@@ -1153,6 +1162,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Returns:
             The quotient.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         try:
             return decimo.biguint.arithmetics.floor_divide(self, other)
@@ -1172,6 +1184,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Returns:
             The quotient rounded up.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         try:
             return decimo.biguint.arithmetics.ceil_divide(self, other)
@@ -1191,6 +1206,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Returns:
             The remainder.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         try:
             return decimo.biguint.arithmetics.floor_modulo(self, other)
@@ -1210,6 +1228,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Returns:
             A tuple of (quotient, remainder).
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         try:
             return decimo.biguint.arithmetics.floor_divide_modulo(self, other)
@@ -1225,6 +1246,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Returns:
             The power `self` raised to `exponent`.
+
+        Raises:
+            ValueError: If the exponent is too large.
         """
         try:
             return self.power(exponent)
@@ -1244,6 +1268,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Returns:
             The power `self` raised to `exponent`.
+
+        Raises:
+            ValueError: If the exponent is negative or too large.
         """
         try:
             return self.power(exponent)
@@ -1281,6 +1308,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Returns:
             The difference.
+
+        Raises:
+            OverflowError: If the result would be negative.
         """
         return decimo.biguint.arithmetics.subtract(other, self)
 
@@ -1305,6 +1335,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Returns:
             The quotient.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return decimo.biguint.arithmetics.floor_divide(other, self)
 
@@ -1317,6 +1350,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Returns:
             The remainder.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return decimo.biguint.arithmetics.floor_modulo(other, self)
 
@@ -1329,6 +1365,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Returns:
             A tuple of (quotient, remainder).
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return decimo.biguint.arithmetics.floor_divide_modulo(other, self)
 
@@ -1341,6 +1380,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Returns:
             The power `base` raised to `self`.
+
+        Raises:
+            ValueError: If the exponent is too large.
         """
         return base.power(self)
 
@@ -1368,6 +1410,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Args:
             other: The operand to subtract.
+
+        Raises:
+            OverflowError: If the result would be negative.
         """
         decimo.biguint.arithmetics.subtract_inplace(self, other)
 
@@ -1386,6 +1431,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Args:
             other: The divisor.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         self = decimo.biguint.arithmetics.floor_divide(self, other)
 
@@ -1395,6 +1443,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Args:
             other: The divisor.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         self = decimo.biguint.arithmetics.floor_modulo(self, other)
 
@@ -1673,8 +1724,8 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             A `BigUInt` representing `self` raised to the power of `exponent`.
 
         Raises:
-            Error: If the exponent is negative.
-            Error: If the exponent is too large, e.g., larger than 1_000_000_000.
+            ValueError: If the exponent is negative.
+            ValueError: If the exponent is too large, e.g., larger than 1_000_000_000.
         """
         if exponent < 0:
             raise ValueError(

--- a/src/decimo/decimal128/arithmetics.mojo
+++ b/src/decimo/decimal128/arithmetics.mojo
@@ -57,7 +57,7 @@ def add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         A new Decimal128 containing the sum of x1 and x2.
 
     Raises:
-        Error: If the operation would overflow.
+        OverflowError: If the result overflows Decimal128 capacity.
     """
     var x1_coef = x1.coefficient()
     var x2_coef = x2.coefficient()
@@ -367,6 +367,9 @@ def subtract(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
     Returns:
         A new Decimal128 containing the difference.
 
+    Raises:
+        OverflowError: If the result overflows Decimal128 capacity.
+
     Notes:
     ------
     This method is implemented using the existing `__add__()` and `__neg__()` methods.
@@ -439,6 +442,9 @@ def multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
     Returns:
         A new Decimal128 containing the product of x1 and x2.
+
+    Raises:
+        OverflowError: If the product overflows Decimal128 capacity.
     """
 
     var x1_coef = x1.coefficient()
@@ -804,7 +810,8 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         A new Decimal128 containing the result of x1 / x2.
 
     Raises:
-        Error: If x2 is zero.
+        ZeroDivisionError: If the divisor is zero.
+        OverflowError: If the result overflows Decimal128 capacity.
     """
 
     # Treatment for special cases
@@ -1272,6 +1279,10 @@ def truncate_divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
     Returns:
         A new Decimal128 containing the integral part of x1 / x2.
+
+    Raises:
+        ZeroDivisionError: If the divisor is zero.
+        OverflowError: If the result overflows.
     """
     try:
         return divide(x1, x2).round(0, RoundingMode.down())
@@ -1289,6 +1300,10 @@ def modulo(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
     Returns:
         A new Decimal128 containing the remainder of x1 / x2.
+
+    Raises:
+        ZeroDivisionError: If the divisor is zero.
+        OverflowError: If the result overflows.
     """
     try:
         return x1 - (truncate_divide(x1, x2) * x2)

--- a/src/decimo/decimal128/constants.mojo
+++ b/src/decimo/decimal128/constants.mojo
@@ -399,7 +399,7 @@ def N_DIVIDE_NEXT(n: Int) raises -> Decimal128:
         A Decimal128 representing the value of n/(n+1).
 
     Raises:
-        Error: If n is outside the range [1, 20].
+        ValueError: If n is not between 1 and 20.
     """
     if n == 1:
         # 1/2 = 0.5

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -291,6 +291,9 @@ struct Decimal128(
             high: The most significant 32 bits of the coefficient.
             scale: The number of decimal places (0-28).
             sign: `True` if the number is negative, `False` otherwise.
+
+        Raises:
+            ConversionError: If the initialization fails.
         """
 
         try:
@@ -318,6 +321,9 @@ struct Decimal128(
         Args:
             value: The integer value to convert.
             scale: The number of decimal places (0-28).
+
+        Raises:
+            ConversionError: If the value cannot be represented.
         """
         try:
             self = Decimal128.from_int(value, scale)
@@ -334,6 +340,9 @@ struct Decimal128(
 
         Args:
             value: The string representation of the decimal number.
+
+        Raises:
+            ConversionError: If the string cannot be parsed.
         """
         try:
             self = Decimal128.from_string(value)
@@ -350,6 +359,9 @@ struct Decimal128(
 
         Args:
             value: The floating-point value to convert.
+
+        Raises:
+            ConversionError: If the float cannot be converted.
         """
 
         try:
@@ -386,7 +398,7 @@ struct Decimal128(
             A Decimal128 instance with the given components.
 
         Raises:
-            Error: If the scale is greater than MAX_SCALE.
+            ValueError: If the scale exceeds 28.
         """
 
         if scale > UInt32(Self.MAX_SCALE):
@@ -494,7 +506,7 @@ struct Decimal128(
             The Decimal128 representation of the integer.
 
         Raises:
-            Error: If the scale is greater than MAX_SCALE.
+            ValueError: If the scale exceeds 28.
 
         Notes:
 
@@ -551,8 +563,8 @@ struct Decimal128(
             The Decimal128 representation of the UInt128 value.
 
         Raises:
-            Error: If the most significant word of the UInt128 is not zero.
-            Error: If the scale is greater than MAX_SCALE.
+            ValueError: If the value does not fit in 96 bits.
+            ValueError: If the scale exceeds 28.
         """
 
         if value >> 96 != 0:
@@ -588,7 +600,8 @@ struct Decimal128(
             The Decimal128 representation of the string.
 
         Raises:
-            Error: If an error occurs during the conversion, forward the error.
+            ValueError: If the string contains invalid characters.
+            OverflowError: If the exponent is too large.
 
         Notes:
 
@@ -890,8 +903,8 @@ struct Decimal128(
             The Decimal128 representation of the floating-point value.
 
         Raises:
-            Error: If the input is too large to be transformed into Decimal128.
-            Error: If the input is infinity or NaN.
+            OverflowError: If the value is too large for Decimal128.
+            ValueError: If the value is infinity or NaN.
 
         Example:
         ```mojo
@@ -1037,6 +1050,9 @@ struct Decimal128(
 
         Returns:
             The `Int` representation.
+
+        Raises:
+            ConversionError: If the conversion fails.
         """
         return self.to_int()
 
@@ -1117,7 +1133,7 @@ struct Decimal128(
             The signed integral part of the Decimal128.
 
         Raises:
-            Error: If the Decimal128 is too large to fit in Int.
+            ConversionError: If the conversion fails.
         """
         try:
             return Int(self.to_int64())
@@ -1136,7 +1152,7 @@ struct Decimal128(
             The signed integral part of the Decimal128.
 
         Raises:
-            Error: If the Decimal128 is too large to fit in Int64.
+            OverflowError: If the value exceeds the Int64 range.
         """
         var result = self.to_int128()
 
@@ -1985,7 +2001,7 @@ struct Decimal128(
             A new Decimal128 with increased precision.
 
         Raises:
-            Error: If the level is less than 0.
+            ValueError: If precision_diff is negative.
 
         Examples:
         ```mojo

--- a/src/decimo/decimal128/exponential.mojo
+++ b/src/decimo/decimal128/exponential.mojo
@@ -44,11 +44,8 @@ def power(base: Decimal128, exponent: Decimal128) raises -> Decimal128:
         A new Decimal128 containing the result of base^exponent.
 
     Raises:
-        Error: If the base is negative or the exponent is negative and not an integer.
-        Error: If an error occurs in calling the power() function with an integer exponent.
-        Error: If an error occurs in calling the sqrt() function with a Decimal128 exponent.
-        Error: If an error occurs in calling the ln() function with a Decimal128 base.
-        Error: If an error occurs in calling the exp() function with a Decimal128 exponent.
+        ValueError: If the base is negative with a non-integer exponent.
+        OverflowError: If the result overflows.
     """
 
     # CASE: If the exponent is integer
@@ -109,6 +106,9 @@ def power(base: Decimal128, exponent: Int) raises -> Decimal128:
 
     Returns:
         A new Decimal128 containing the result.
+
+    Raises:
+        ValueError: If the base is zero and exponent is negative.
     """
 
     # Special cases
@@ -173,8 +173,7 @@ def root(x: Decimal128, n: Int) raises -> Decimal128:
         A new Decimal128 containing the n-th root of x.
 
     Raises:
-        Error: If x is negative and n is even.
-        Error: If n is zero or negative.
+        ValueError: If n is non-positive or the input is invalid.
     """
     # var t0 = time.perf_counter_ns()
 
@@ -352,7 +351,7 @@ def sqrt(x: Decimal128) raises -> Decimal128:
         A new Decimal128 containing the square root of x.
 
     Raises:
-        Error: If x is negative.
+        ValueError: If x is negative.
     """
     # Special cases
     if x.is_negative():
@@ -478,7 +477,7 @@ def exp(x: Decimal128) raises -> Decimal128:
         A Decimal128 approximation of e^x.
 
     Raises:
-        Error: If x is greater than 66.54.
+        OverflowError: If x is too large (> 66.54).
 
     Notes:
         Because ln(2^96-1) ~= 66.54212933375474970405428366,
@@ -688,7 +687,7 @@ def ln(x: Decimal128) raises -> Decimal128:
         A Decimal128 approximation of ln(x).
 
     Raises:
-        Error: If x is less than or equal to zero.
+        ValueError: If x is non-positive.
 
     Notes:
         This implementation uses range reduction to improve accuracy and performance.
@@ -953,8 +952,7 @@ def log(x: Decimal128, base: Decimal128) raises -> Decimal128:
         A Decimal128 approximation of log_base(x).
 
     Raises:
-        Error: If x is less than or equal to zero.
-        Error: If base is less than or equal to zero or equal to 1.
+        ValueError: If x is non-positive, base is non-positive, or base is 1.
 
     Notes:
 
@@ -1012,7 +1010,7 @@ def log10(x: Decimal128) raises -> Decimal128:
         A Decimal128 approximation of log10(x).
 
     Raises:
-        Error: If x is less than or equal to zero.
+        ValueError: If x is non-positive.
 
     Notes:
         This implementation uses the identity log10(x) = ln(x) / ln(10).

--- a/src/decimo/decimal128/exponential.mojo
+++ b/src/decimo/decimal128/exponential.mojo
@@ -45,6 +45,8 @@ def power(base: Decimal128, exponent: Decimal128) raises -> Decimal128:
 
     Raises:
         ValueError: If the base is negative with a non-integer exponent.
+        ZeroDivisionError: If a reciprocal power is undefined, such as
+            when evaluating `0^-0.5`.
         OverflowError: If the result overflows.
     """
 

--- a/src/decimo/decimal128/rounding.mojo
+++ b/src/decimo/decimal128/rounding.mojo
@@ -65,6 +65,9 @@ def round(
 
     Returns:
         A new Decimal128 rounded to the specified number of decimal places.
+
+    Raises:
+        OverflowError: If rounding causes the result to exceed Decimal128 capacity.
     """
 
     # Number of decimal places of the number is equal to the scale of the number

--- a/src/decimo/decimal128/special.mojo
+++ b/src/decimo/decimal128/special.mojo
@@ -32,6 +32,10 @@ def factorial(n: Int) raises -> Decimal128:
     Returns:
         The factorial of n.
 
+    Raises:
+        ValueError: If n is negative.
+        OverflowError: If n > 27.
+
     Notes:
 
     27! is the largest factorial that can be represented by Decimal128.
@@ -137,6 +141,9 @@ def factorial_reciprocal(n: Int) raises -> Decimal128:
 
     Returns:
         The reciprocal of factorial of n (1/n!).
+
+    Raises:
+        ValueError: If n is negative.
 
     Notes:
         This function is optimized for Taylor series calculations.

--- a/src/decimo/str.mojo
+++ b/src/decimo/str.mojo
@@ -105,6 +105,10 @@ def parse_numeric_string(
     parse_numeric_string("-123")            -> ([1,2,3], 0, True)
     ```
     End of examples.
+
+    Raises:
+        ValueError: If the string is empty, contains invalid characters, or
+            has malformed numeric syntax.
     """
 
     # [Mojo Miji]

--- a/src/decimo/tests.mojo
+++ b/src/decimo/tests.mojo
@@ -299,6 +299,9 @@ def parse_file(file_path: String) raises -> TOMLDocument:
 
     Returns:
         A `TOMLDocument` containing the parsed TOML data.
+
+    Raises:
+        ValueError: If the TOML file cannot be parsed.
     """
     try:
         return parse_toml_file(file_path)

--- a/src/decimo/toml/parser.mojo
+++ b/src/decimo/toml/parser.mojo
@@ -460,6 +460,9 @@ def _set_value(
     Navigates through `path` (creating intermediate tables as needed),
     then sets `key = value` in the target table.  Raises on duplicate
     non-table keys.
+
+    Raises:
+        ValueError: If a duplicate key is found or a key exists but is not a table.
     """
     if len(path) == 0:
         # Set directly in root
@@ -522,7 +525,11 @@ def _set_value(
 def _ensure_table_path(
     mut root: Dict[String, TOMLValue], path: List[String]
 ) raises:
-    """Ensure all tables along `path` exist in `root`."""
+    """Ensure all tables along `path` exist in `root`.
+
+    Raises:
+        ValueError: If a key exists but is not a table.
+    """
     if len(path) == 0:
         return
 
@@ -563,7 +570,11 @@ def _ensure_table_path(
 def _append_array_of_tables(
     mut root: Dict[String, TOMLValue], path: List[String]
 ) raises:
-    """Append a new empty table to the array-of-tables at `path`."""
+    """Append a new empty table to the array-of-tables at `path`.
+
+    Raises:
+        ValueError: If the path is empty or a key cannot be redefined as array of tables.
+    """
     if len(path) == 0:
         raise ValueError(
             message="Array of tables path cannot be empty",
@@ -686,6 +697,9 @@ struct TOMLParser:
 
         Returns a list of key parts.  Accepts both KEY and STRING tokens
         as key components.
+
+        Raises:
+            ValueError: If a key token is expected but not found.
         """
         var parts = List[String]()
 
@@ -826,7 +840,11 @@ struct TOMLParser:
     # ---- inline tables ---------------------------------------------------
 
     def _parse_inline_table(mut self) raises -> TOMLValue:
-        """Parse an inline table { key = value, ... } (opening { consumed)."""
+        """Parse an inline table { key = value, ... } (opening { consumed).
+
+        Raises:
+            ValueError: If a syntax error or duplicate key is found.
+        """
         var table = Dict[String, TOMLValue]()
 
         if self._tok().type == TokenType.INLINE_TABLE_END:
@@ -882,7 +900,11 @@ struct TOMLParser:
     # ---- table header parsing --------------------------------------------
 
     def _parse_table_header(mut self) raises -> List[String]:
-        """Parse [a.b.c] and return the path.  Opening [ already consumed."""
+        """Parse [a.b.c] and return the path.  Opening [ already consumed.
+
+        Raises:
+            ValueError: If the closing ']' is missing.
+        """
         var path = self._parse_key_path()
 
         # Expect closing ]
@@ -897,7 +919,11 @@ struct TOMLParser:
         return path^
 
     def _parse_array_of_tables_header(mut self) raises -> List[String]:
-        """Parse [[a.b.c]] and return the path.  Opening [[ already consumed."""
+        """Parse [[a.b.c]] and return the path.  Opening [[ already consumed.
+
+        Raises:
+            ValueError: If the closing ']]' is missing.
+        """
         var path = self._parse_key_path()
 
         # Expect closing ]]


### PR DESCRIPTION
This PR updates docstring `Raises:` sections across Decimo to replace generic `Error` entries with specific error types (e.g., `ValueError`, `OverflowError`, `ZeroDivisionError`, `ConversionError`) so API documentation more accurately reflects runtime behavior.

**Changes:**
- Standardized and expanded docstring `Raises:` sections across TOML parsing, numeric parsing, and multiple numeric types (Decimal128/Big*).
- Replaced generic `Error`/`DecimoError` docstring entries with concrete error types used by the implementation.
- Added missing `Raises:` sections to several functions that previously had none.