### PR TITLE
[cli] Make all short names upper cases + Enable pipe mode and file mode

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,17 @@
 
 This is a list of changes for the Decimo package (formerly DeciMojo).
 
+## Unreleased - under development
+
+### ⭐️ New in v0.10.0
+
+**CLI Calculator:**
+
+1. Add **pipe/stdin mode**: read expressions from standard input, one per line, when no positional argument is given and stdin is piped (e.g. `echo "1+2" | decimo`, `printf "pi\nsqrt(2)" | decimo -P 100`). Blank lines and comment lines (starting with `#`) are automatically skipped.
+1. Add **file mode**: use `--file` / `-F` flag to evaluate expressions from a file, one per line (e.g. `decimo -F expressions.dm -P 50`). Comments (`#`), inline comments, and blank lines are skipped. All CLI flags (precision, formatting, rounding) apply to every expression.
+
+### 🦋 Changed in v0.10.0
+
 ## 20260323 (v0.9.0)
 
 Decimo v0.9.0 updates the codebase to **Mojo v0.26.2** and marks the **"make it useful"** phase. This release introduces three major additions:

--- a/docs/plans/cli_calculator.md
+++ b/docs/plans/cli_calculator.md
@@ -328,7 +328,7 @@ Format the final `BigDecimal` result based on CLI flags:
 | 3.13 | Documentation (user manual for CLI)                             |   ✗    | `docs/user_manual_cli.md`; include shell completion setup                                  |
 | 3.14 | Build and distribute as single binary                           |   ✗    |                                                                                            |
 | 3.15 | Allow negative expressions                                      |   ✓    | `allow_hyphen=True` on `Positional`; `decimo "-3*pi*(sin(1))"` works                       |
-| 3.16 | Make short names upper cases to avoid expression collisions     |   ✗    | `-sin(1)` clashes with `-s` (scientific), `-e` clashes with `--engineering`                |
+| 3.16 | Make short names upper cases to avoid expression collisions     |   ✓    | `-P`, `-S`, `-E`, `-D`, `-R`; `--pad` has no short name; `-e`, `-pi`, `-sin(1)` all work   |
 | 3.17 | Define `allow_hyphen_values` in declarative API                 |   ✗    | When argmojo supports it                                                                   |
 
 ### Phase 4: Interactive REPL & Subcommands

--- a/docs/plans/cli_calculator.md
+++ b/docs/plans/cli_calculator.md
@@ -95,7 +95,7 @@ cat expressions.txt | decimo
 decimo < expressions.txt
 
 # Evaluate a script file (.dm)
-decimo file.dm
+decimo -F file.dm
 ```
 
 Example `expressions.dm`:
@@ -266,17 +266,17 @@ Format the final `BigDecimal` result based on CLI flags:
 6. Handle unary minus.
 7. Test with basic expressions.
 
-| #   | Task                                             | Status | Notes                         |
-| --- | ------------------------------------------------ | :----: | ----------------------------- |
-| 1.1 | Project structure (src/cli/, calculator module)  |   ✓    |                               |
-| 1.2 | Tokenizer (numbers, `+ - * /`, parens)           |   ✓    |                               |
-| 1.3 | Shunting-yard parser (infix → RPN)               |   ✓    |                               |
-| 1.4 | RPN evaluator using `BigDecimal`                 |   ✓    |                               |
-| 1.5 | ArgMojo wiring (`expr`, `--precision`, `--help`) |   ✓    |                               |
-| 1.6 | Unary minus                                      |   ✓    |                               |
-| 1.7 | Basic expression tests                           |   ✓    | 4 test files, 118 tests total |
-| 1.8 | Pipeline / stdin input (`echo "1+2" \| decimo`)  |   ✗    | Not yet implemented           |
-| 1.9 | File input (`decimo file.dm`)                    |   ✗    | Not yet implemented           |
+| #   | Task                                             | Status | Notes                                                                                        |
+| --- | ------------------------------------------------ | :----: | -------------------------------------------------------------------------------------------- |
+| 1.1 | Project structure (src/cli/, calculator module)  |   ✓    |                                                                                              |
+| 1.2 | Tokenizer (numbers, `+ - * /`, parens)           |   ✓    |                                                                                              |
+| 1.3 | Shunting-yard parser (infix → RPN)               |   ✓    |                                                                                              |
+| 1.4 | RPN evaluator using `BigDecimal`                 |   ✓    |                                                                                              |
+| 1.5 | ArgMojo wiring (`expr`, `--precision`, `--help`) |   ✓    |                                                                                              |
+| 1.6 | Unary minus                                      |   ✓    |                                                                                              |
+| 1.7 | Basic expression tests                           |   ✓    | 4 test files                                                                                 |
+| 1.8 | Pipeline / stdin input (`echo "1+2" \| decimo`)  |   ✓    | Pipe mode: reads stdin when no positional arg and stdin is not a TTY                         |
+| 1.9 | File input (`decimo -F file.dm`)                 |   ✓    | File mode via `-F/--file` flag: reads files line by line, skips comments (#) and blank lines |
 
 ### Phase 2: Power and Functions
 
@@ -408,7 +408,7 @@ This is the natural choice for a calculator: users expect `7 / 2` to be `3.5`, n
 | ------------------------------------- | ------------------------------------- |
 | `decimo "expr"`                       | One-shot: evaluate and exit           |
 | `echo "expr" \| decimo`               | Pipe: read stdin line by line         |
-| `decimo file.dm`                      | File: read and evaluate each line     |
+| `decimo -F file.dm`                   | File: read and evaluate each line     |
 | `decimo` (no args, terminal is a TTY) | REPL: interactive session             |
 | `decimo -i`                           | REPL: force interactive even if piped |
 

--- a/docs/user_manual_cli.md
+++ b/docs/user_manual_cli.md
@@ -253,11 +253,11 @@ decimo "1/6" -P 5 -R up            # 0.16667
 
 `decimo` accepts input in three ways: a single expression on the command line, piped stdin, or a file.
 
-| Mode       | Invocation              | When used                                                       |
-| ---------- | ----------------------- | --------------------------------------------------------------- |
-| Expression | `decimo "EXPR"`         | A positional argument that is not a file path                   |
-| Pipe       | `echo "EXPR" \| decimo` | No positional argument and stdin is not a TTY                   |
-| File       | `decimo FILE.dm`        | Positional argument ends in `.dm` or `.txt` and the file exists |
+| Mode       | Invocation              | When used                                          |
+| ---------- | ----------------------- | -------------------------------------------------- |
+| Expression | `decimo "EXPR"`         | A positional argument is provided as an expression |
+| Pipe       | `echo "EXPR" \| decimo` | No positional argument and stdin is not a TTY      |
+| File       | `decimo -F FILE.dm`     | The `-F`/`--file` option is used                   |
 
 If no expression is given and stdin is a TTY (interactive terminal), `decimo` prints an error and exits.
 
@@ -322,7 +322,7 @@ ln(10)
 
 Comments start with `#`. Inline comments are also supported (e.g. `1+2 # add`). Leading whitespace before `#` is allowed. Blank lines and whitespace-only lines are skipped.
 
-If the specified file does not exist, `decimo` reports a "file not found" error and exits.
+If the specified file does not exist or cannot be read, `decimo` reports an error and exits.
 
 ## Shell Integration
 

--- a/docs/user_manual_cli.md
+++ b/docs/user_manual_cli.md
@@ -18,6 +18,10 @@
   - [Pad to Precision (`--pad`)](#pad-to-precision---pad)
   - [Digit Separator (`--delimiter`, `-D`)](#digit-separator---delimiter--d)
   - [Rounding Mode (`--rounding-mode`, `-R`)](#rounding-mode---rounding-mode--r)
+- [Input Modes](#input-modes)
+  - [Expression Mode (Default)](#expression-mode-default)
+  - [Pipe Mode (stdin)](#pipe-mode-stdin)
+  - [File Mode (`-F`)](#file-mode--f)
 - [Shell Integration](#shell-integration)
   - [Quoting Expressions](#quoting-expressions)
   - [Negative Expressions](#negative-expressions)
@@ -245,6 +249,81 @@ decimo "1/6" -P 5 -R down          # 0.16666
 decimo "1/6" -P 5 -R up            # 0.16667
 ```
 
+## Input Modes
+
+`decimo` accepts input in three ways: a single expression on the command line, piped stdin, or a file.
+
+| Mode       | Invocation              | When used                                                       |
+| ---------- | ----------------------- | --------------------------------------------------------------- |
+| Expression | `decimo "EXPR"`         | A positional argument that is not a file path                   |
+| Pipe       | `echo "EXPR" \| decimo` | No positional argument and stdin is not a TTY                   |
+| File       | `decimo FILE.dm`        | Positional argument ends in `.dm` or `.txt` and the file exists |
+
+If no expression is given and stdin is a TTY (interactive terminal), `decimo` prints an error and exits.
+
+### Expression Mode (Default)
+
+Pass a single expression as the positional argument:
+
+```bash
+decimo "1/3" -P 100
+```
+
+This is the most common usage. See [Expression Syntax](#expression-syntax) for what you can write.
+
+### Pipe Mode (stdin)
+
+When no positional argument is provided and stdin is piped, `decimo` reads all of stdin and evaluates each non-empty, non-comment line:
+
+```bash
+# Single expression
+echo "sqrt(2)" | decimo -P 30
+# → 1.41421356237309504880168872421
+
+# Multiple expressions (one per line)
+printf '1/3\nsqrt(2)\npi' | decimo -P 20
+# → 0.33333333333333333333
+# → 1.4142135623730950488
+# → 3.1415926535897932385
+
+# Lines starting with '#' are comments; blank lines are skipped
+printf '# constants\npi\n\ne' | decimo -P 10
+# → 3.141592654
+# → 2.718281828
+```
+
+All CLI options (`-P`, `-S`, `-E`, `-D`, `-R`, `--pad`) apply to every line.
+
+If any expression fails, `decimo` prints the error for that line, continues evaluating the remaining lines, and exits with code 1.
+
+### File Mode (`-F`)
+
+Use the `-F` (or `--file`) flag to evaluate expressions from a file, one per line:
+
+```bash
+decimo -F expressions.dm -P 50
+```
+
+Example file (`expressions.dm`):
+
+```text
+# Basic arithmetic
+1 + 2
+100 * 12 - 23/17
+
+# High-precision constants
+pi
+e
+
+# Functions
+sqrt(2)
+ln(10)
+```
+
+Comments start with `#`. Inline comments are also supported (e.g. `1+2 # add`). Leading whitespace before `#` is allowed. Blank lines and whitespace-only lines are skipped.
+
+If the specified file does not exist, `decimo` reports a "file not found" error and exits.
+
 ## Shell Integration
 
 ### Quoting Expressions
@@ -441,19 +520,19 @@ Error: unmatched '('
 ```txt
 Arbitrary-precision CLI calculator powered by Decimo.
 
-Note: if your expression contains *, ( or ), your shell may
-intercept them before decimo runs. Use quotes or noglob:
-  decimo "2 * (3 + 4)"         # with quotes
-  noglob decimo 2*(3+4)        # with noglob
-  alias decimo='noglob decimo' # add to ~/.zshrc
+Tip: If your expression contains *, ( or ), quote it: decimo "2 * (3 + 4)"
+Tip: Or use noglob: alias decimo='noglob decimo' (add to ~/.zshrc)
+Tip: Pipe expressions: echo '1/3' | decimo -P 100
+Tip: Evaluate a file: decimo -F expressions.dm -P 50
 
-Usage: decimo <expr> [OPTIONS]
+Usage: decimo [OPTIONS] [EXPR]
 
 Arguments:
-  expr    Math expression to evaluate (e.g. 'sqrt(abs(1.1*-12-23/17))')
+  expr    Math expression to evaluate
+          (e.g. 'sqrt(2)')
 
 Options:
-  -P, --precision <precision>
+  -P, --precision <N>
           Number of significant digits (default: 50)
   -S, --scientific
           Output in scientific notation (e.g. 1.23E+10)
@@ -461,10 +540,13 @@ Options:
           Output in engineering notation (exponent multiple of 3)
   --pad
           Pad trailing zeros to the specified precision
-  -D, --delimiter <delimiter>
+  -D, --delimiter <CHAR>
           Digit-group separator inserted every 3 digits (e.g. '_' gives 1_234.567_89)
-  -R, --rounding-mode {half-even,half-up,half-down,up,down,ceiling,floor}
+  -R, --rounding-mode <MODE>
           Rounding mode for the final result (default: half-even)
+          {half-even,half-up,half-down,up,down,ceiling,floor}
+  -F, --file <PATH>
+          Evaluate expressions from a file (one per line)
   -h, --help
           Show this help message
   -V, --version

--- a/docs/user_manual_cli.md
+++ b/docs/user_manual_cli.md
@@ -12,12 +12,12 @@
   - [Functions](#functions)
   - [Constants](#constants)
 - [CLI Options](#cli-options)
-  - [Precision (`--precision`, `-p`)](#precision---precision--p)
-  - [Scientific Notation (`--scientific`, `-s`)](#scientific-notation---scientific--s)
-  - [Engineering Notation (`--engineering`, `-e`)](#engineering-notation---engineering--e)
-  - [Pad to Precision (`--pad`, `-P`)](#pad-to-precision---pad--p)
-  - [Digit Separator (`--delimiter`, `-d`)](#digit-separator---delimiter--d)
-  - [Rounding Mode (`--rounding-mode`, `-r`)](#rounding-mode---rounding-mode--r)
+  - [Precision (`--precision`, `-P`)](#precision---precision--p)
+  - [Scientific Notation (`--scientific`, `-S`)](#scientific-notation---scientific--s)
+  - [Engineering Notation (`--engineering`, `-E`)](#engineering-notation---engineering--e)
+  - [Pad to Precision (`--pad`)](#pad-to-precision---pad)
+  - [Digit Separator (`--delimiter`, `-D`)](#digit-separator---delimiter--d)
+  - [Rounding Mode (`--rounding-mode`, `-R`)](#rounding-mode---rounding-mode--r)
 - [Shell Integration](#shell-integration)
   - [Quoting Expressions](#quoting-expressions)
   - [Negative Expressions](#negative-expressions)
@@ -66,15 +66,15 @@ decimo "1 + 2 * 3"
 # → 7
 
 # High-precision division
-decimo "1/3" -p 100
+decimo "1/3" -P 100
 # → 0.3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333
 
 # Square root of 2 to 50 digits
-decimo "sqrt(2)" -p 50
+decimo "sqrt(2)" -P 50
 # → 1.4142135623730950488016887242096980785696718753770
 
 # 1000 digits of pi
-decimo "pi" -p 1000
+decimo "pi" -P 1000
 
 # Large integer exponentiation
 decimo "2^256"
@@ -91,7 +91,7 @@ decimo "2^256"
 - **Negative expressions:** `-3*pi`, `-3*pi*(sin(1))`
 - **Unary minus:** `2 * -3`, `sqrt(-1 + 2)`
 
-Negative numbers and many expressions starting with `-` can be passed directly as the positional argument. However, if the expression token looks like a CLI flag (e.g., `-e`), use `--` to force positional parsing. See [Negative Expressions](#negative-expressions) for details.
+Negative numbers and many expressions starting with `-` can be passed directly as the positional argument. See [Negative Expressions](#negative-expressions) for details.
 
 ### Operators
 
@@ -122,7 +122,7 @@ Right-associativity of `^` means `2^3^2` = `2^(3^2)` = `2^9` = `512`, not `(2^3)
 
 ### Functions
 
-All functions use the CLI's precision setting (default 50, configurable with `-p`).
+All functions use the CLI's precision setting (default 50, configurable with `-P`).
 
 **Single-argument functions:**
 
@@ -164,67 +164,67 @@ decimo "ln(exp(1))"   # → 1
 Constants are computed to the requested precision:
 
 ```bash
-decimo "pi" -p 100        # 100 digits of π
-decimo "e" -p 500         # 500 digits of e
+decimo "pi" -P 100        # 100 digits of π
+decimo "e" -P 500         # 500 digits of e
 decimo "2 * pi * 6371"    # Circumference using π
 ```
 
 ## CLI Options
 
-### Precision (`--precision`, `-p`)
+### Precision (`--precision`, `-P`)
 
 Number of significant digits in the result. Default: **50**.
 
 ```bash
-decimo "1/7" -p 10       # 0.1428571429
-decimo "1/7" -p 100      # 100 significant digits
-decimo "1/7" -p 200      # 200 significant digits
+decimo "1/7" -P 10       # 0.1428571429
+decimo "1/7" -P 100      # 100 significant digits
+decimo "1/7" -P 200      # 200 significant digits
 ```
 
-### Scientific Notation (`--scientific`, `-s`)
+### Scientific Notation (`--scientific`, `-S`)
 
 Output in scientific notation (e.g., `1.23E+10`).
 
 ```bash
-decimo "123456789 * 987654321" -s
+decimo "123456789 * 987654321" -S
 # → 1.21932631112635269E+17
 ```
 
-### Engineering Notation (`--engineering`, `-e`)
+### Engineering Notation (`--engineering`, `-E`)
 
 Output in engineering notation (exponent is always a multiple of 3).
 
 ```bash
-decimo "123456789 * 987654321" -e
+decimo "123456789 * 987654321" -E
 # → 121.932631112635269E+15
 ```
 
 > `--scientific` and `--engineering` are mutually exclusive.
 
-### Pad to Precision (`--pad`, `-P`)
+### Pad to Precision (`--pad`)
 
 Pad trailing zeros so the fractional part has exactly `precision` digits after the decimal point.
 
 When used together with `--precision`, the `precision` value is treated as the number of fractional digits for padding purposes, not as a strict limit on total significant digits. As a result, the formatted number can have more than `precision` significant digits.
 
 ```bash
-decimo "1.5" -P -p 10
+decimo "1.5" --pad -P 10
 # → 1.5000000000 (10 fractional digits, 11 significant digits)
 ```
 
-### Digit Separator (`--delimiter`, `-d`)
+### Digit Separator (`--delimiter`, `-D`)
 
 Insert a character every 3 digits for readability.
 
 ```bash
-decimo "2^64" -d _
+decimo "2^64" -D _
 # → 18_446_744_073_709_551_616
 
-decimo "pi" -p 30 -d _
+decimo "pi" -P 30 -D _
 # → 3.141_592_653_589_793_238_462_643_383_28
 ```
 
-### Rounding Mode (`--rounding-mode`, `-r`)
+### Rounding Mode (`--rounding-mode`, `-R`)
 
 Choose how the final result is rounded. Default: **half-even** (banker's rounding).
 
@@ -239,10 +239,10 @@ Choose how the final result is rounded. Default: **half-even** (banker's roundin
 | `floor`     | Round toward −∞                     |
 
 ```bash
-decimo "1/6" -p 5 -r half-up       # 0.16667
-decimo "1/6" -p 5 -r half-even     # 0.16667
-decimo "1/6" -p 5 -r down          # 0.16666
-decimo "1/6" -p 5 -r up            # 0.16667
+decimo "1/6" -P 5 -R half-up       # 0.16667
+decimo "1/6" -P 5 -R half-even     # 0.16667
+decimo "1/6" -P 5 -R down          # 0.16666
+decimo "1/6" -P 5 -R up            # 0.16667
 ```
 
 ## Shell Integration
@@ -277,19 +277,31 @@ decimo "-3*pi*(sin(1))"
 # → -7.930677192244368536658197969…
 
 # Options can appear before or after the expression
-decimo -p 10 "-3*pi"
-decimo "-3*pi" -p 10
+decimo -P 10 "-3*pi"
+decimo "-3*pi" -P 10
 ```
 
-**Caveat:** If the expression looks like an existing CLI flag (e.g., `-e` matches `--engineering`), ArgMojo will consume it as an option. Use `--` to force positional parsing in those cases:
+Because all short option names are uppercase (`-P`, `-S`, `-E`, `-D`, `-R`), expressions like `-e`, `-sin(1)`, and `-pi` are never mistaken for flags:
 
 ```bash
-# -e is the engineering flag, so use -- to treat it as an expression
-decimo -- "-e"
+# Euler's number, negated
+decimo "-e"
 # → -2.71828…
+
+# Negative sine
+decimo "-sin(1)"
+# → -0.84147…
+
+# Negative pi
+decimo "-pi"
+# → -3.14159…
 ```
 
-> **Note:** A future release will rename short flags to uppercase (`-S`, `-E`) to eliminate these collisions entirely.
+The `--` separator still works if you prefer explicit positional parsing:
+
+```bash
+decimo -- "-e"
+```
 
 ### Using noglob
 
@@ -328,34 +340,34 @@ decimo "2 ^ 256"
 
 ```bash
 # 200 digits of 1/7
-decimo "1/7" -p 200
+decimo "1/7" -P 200
 
 # π to 1000 digits
-decimo "pi" -p 1000
+decimo "pi" -P 1000
 
 # e to 500 digits
-decimo "e" -p 500
+decimo "e" -P 500
 
 # sqrt(2) to 100 digits
-decimo "sqrt(2)" -p 100
+decimo "sqrt(2)" -P 100
 ```
 
 ### Mathematical Functions
 
 ```bash
 # Trigonometry
-decimo "sin(pi/6)" -p 50       # → 0.5
-decimo "cos(pi/3)" -p 50       # → 0.5
-decimo "tan(pi/4)" -p 50       # → 1
+decimo "sin(pi/6)" -P 50       # → 0.5
+decimo "cos(pi/3)" -P 50       # → 0.5
+decimo "tan(pi/4)" -P 50       # → 1
 
 # Logarithms
-decimo "ln(2)" -p 100
+decimo "ln(2)" -P 100
 decimo "log10(1000)"            # → 3
 decimo "log(256, 2)"            # → 8
 
 # Nested functions
-decimo "sqrt(abs(1.1 * -12 - 23/17))" -p 30
-decimo "exp(ln(100))" -p 30     # → 100
+decimo "sqrt(abs(1.1 * -12 - 23/17))" -P 30
+decimo "exp(ln(100))" -P 30     # → 100
 
 # Cube root
 decimo "cbrt(27)"               # → 3
@@ -366,19 +378,19 @@ decimo "root(1000000, 6)"       # → 10
 
 ```bash
 # Scientific notation
-decimo "123456789.987654321" -s
+decimo "123456789.987654321" -S
 # → 1.23456789987654321E+8
 
 # Engineering notation
-decimo "123456789.987654321" -e
+decimo "123456789.987654321" -E
 # → 123.456789987654321E+6
 
 # Digit separators
-decimo "2^100" -d _
+decimo "2^100" -D _
 # → 1_267_650_600_228_229_401_496_703_205_376
 
 # Pad trailing zeros
-decimo "1/4" -p 20 -P
+decimo "1/4" -P 20 --pad
 # → 0.25000000000000000000
 ```
 
@@ -386,11 +398,11 @@ decimo "1/4" -p 20 -P
 
 ```bash
 # Compare rounding of 2.5 to 0 decimal places:
-decimo "2.5 + 0" -p 1 -r half-even   # → 2 (banker's: round to even)
-decimo "2.5 + 0" -p 1 -r half-up     # → 3 (traditional)
-decimo "2.5 + 0" -p 1 -r down        # → 2 (truncate)
-decimo "2.5 + 0" -p 1 -r ceiling     # → 3 (toward +∞)
-decimo "2.5 + 0" -p 1 -r floor       # → 2 (toward −∞)
+decimo "2.5 + 0" -P 1 -R half-even   # → 2 (banker's: round to even)
+decimo "2.5 + 0" -P 1 -R half-up     # → 3 (traditional)
+decimo "2.5 + 0" -P 1 -R down        # → 2 (truncate)
+decimo "2.5 + 0" -P 1 -R ceiling     # → 3 (toward +∞)
+decimo "2.5 + 0" -P 1 -R floor       # → 2 (toward −∞)
 ```
 
 ## Error Messages
@@ -441,17 +453,17 @@ Arguments:
   expr    Math expression to evaluate (e.g. 'sqrt(abs(1.1*-12-23/17))')
 
 Options:
-  -p, --precision <precision>
+  -P, --precision <precision>
           Number of significant digits (default: 50)
-  -s, --scientific
+  -S, --scientific
           Output in scientific notation (e.g. 1.23E+10)
-  -e, --engineering
+  -E, --engineering
           Output in engineering notation (exponent multiple of 3)
-  -P, --pad
+  --pad
           Pad trailing zeros to the specified precision
-  -d, --delimiter <delimiter>
+  -D, --delimiter <delimiter>
           Digit-group separator inserted every 3 digits (e.g. '_' gives 1_234.567_89)
-  -r, --rounding-mode {half-even,half-up,half-down,up,down,ceiling,floor}
+  -R, --rounding-mode {half-even,half-up,half-down,up,down,ceiling,floor}
           Rounding mode for the final result (default: half-even)
   -h, --help
           Show this help message

--- a/src/cli/calculator/__init__.mojo
+++ b/src/cli/calculator/__init__.mojo
@@ -45,3 +45,15 @@ from .tokenizer import (
 from .parser import parse_to_rpn
 from .evaluator import evaluate_rpn, evaluate
 from .display import print_error, print_warning, print_hint
+from .io import (
+    stdin_is_tty,
+    read_stdin,
+    split_into_lines,
+    strip_comment,
+    is_blank,
+    is_comment_or_blank,
+    strip,
+    filter_expression_lines,
+    read_file_text,
+    file_exists,
+)

--- a/src/cli/calculator/io.mojo
+++ b/src/cli/calculator/io.mojo
@@ -161,9 +161,8 @@ def is_comment_or_blank(line: String) -> Bool:
     """Returns True if the line is blank, whitespace-only, or a comment
     (first non-whitespace character is ``#``).
 
-    Equivalent to ``is_blank(strip_comment(line))`` but implemented as
-    a single pass for efficiency. Kept for backward compatibility with
-    existing callers.
+    Equivalent to ``is_blank(strip_comment(line))``.  Provided as a
+    convenience for callers that do not need the intermediate results.
     """
     return is_blank(strip_comment(line))
 
@@ -221,8 +220,12 @@ def read_file_text(path: String) raises -> String:
     """Reads the entire contents of a file and returns it as a String.
 
     Uses POSIX ``open()`` + ``dup2()`` + ``getchar()`` to read the file
-    by redirecting stdin.  This avoids FFI signature conflicts with
-    Mojo's stdlib and ArgMojo for ``read``/``fclose``.
+    by temporarily redirecting stdin.  This avoids FFI signature conflicts
+    with Mojo's stdlib and ArgMojo for ``read``/``fclose``.
+
+    The original stdin is saved via ``dup()`` before redirection and
+    restored afterwards, so callers (e.g. a future REPL ``:load`` command)
+    can continue reading from the real stdin after this call returns.
 
     Args:
         path: The file path to read.
@@ -232,14 +235,28 @@ def read_file_text(path: String) raises -> String:
     """
     var c_path = _to_cstr(path)
 
+    # Save original stdin so we can restore it after reading.
+    var saved_stdin = external_call["dup", Int32](Int32(0))
+
     # open(path, O_RDONLY=0)
     var fd = external_call["open", Int32](c_path.unsafe_ptr(), Int32(0))
     if fd < 0:
+        # Restore stdin before raising.
+        if saved_stdin >= 0:
+            _ = external_call["dup2", Int32](saved_stdin, Int32(0))
+            _ = external_call["close", Int32](saved_stdin)
         raise Error("cannot open file: " + path)
 
     # Redirect stdin (fd 0) to the file
     var dup_result = external_call["dup2", Int32](fd, Int32(0))
+    # Close the original fd — dup2 made a copy on fd 0.
+    _ = external_call["close", Int32](fd)
+
     if dup_result < 0:
+        # Restore stdin before raising.
+        if saved_stdin >= 0:
+            _ = external_call["dup2", Int32](saved_stdin, Int32(0))
+            _ = external_call["close", Int32](saved_stdin)
         raise Error("cannot redirect stdin to file: " + path)
 
     # Read all bytes via getchar()
@@ -249,6 +266,11 @@ def read_file_text(path: String) raises -> String:
         if c < 0:  # EOF
             break
         chunks.append(UInt8(c))
+
+    # Restore original stdin.
+    if saved_stdin >= 0:
+        _ = external_call["dup2", Int32](saved_stdin, Int32(0))
+        _ = external_call["close", Int32](saved_stdin)
 
     if len(chunks) == 0:
         return String("")

--- a/src/cli/calculator/io.mojo
+++ b/src/cli/calculator/io.mojo
@@ -1,0 +1,281 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright 2025 Yuhao Zhu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""
+I/O utilities for the Decimo CLI calculator.
+
+Provides functions for detecting whether stdin is a pipe or terminal,
+reading lines from stdin, reading expression files, and line-level text
+processing (comment stripping, whitespace handling).
+
+The text-processing primitives (``strip_comment``, ``is_blank``, ``strip``)
+are designed to be composable and reusable across all input modes —
+pipe, file, and future REPL.
+"""
+
+from std.ffi import external_call
+
+
+# ===----------------------------------------------------------------------=== #
+# stdin detection
+# ===----------------------------------------------------------------------=== #
+
+
+def stdin_is_tty() -> Bool:
+    """Returns True if stdin is connected to a terminal (TTY),
+    False if it is a pipe or redirected file."""
+    return external_call["isatty", Int32](Int32(0)) != 0
+
+
+# ===----------------------------------------------------------------------=== #
+# stdin reading
+# ===----------------------------------------------------------------------=== #
+
+
+def read_stdin() -> String:
+    """Reads all data from stdin and return it as a String.
+
+    Uses the C ``getchar()`` function to read one byte at a time until
+    EOF. This avoids FFI conflicts with the POSIX ``read()`` syscall.
+    Returns an empty string if stdin is empty.
+    """
+    var chunks = List[UInt8]()
+
+    while True:
+        var c = external_call["getchar", Int32]()
+        if c < 0:  # EOF is -1
+            break
+        chunks.append(UInt8(c))
+
+    if len(chunks) == 0:
+        return String("")
+
+    # String(unsafe_from_utf8=...) adds its own null terminator.
+    return String(unsafe_from_utf8=chunks^)
+
+
+# ===----------------------------------------------------------------------=== #
+# Line splitting and text processing
+# ===----------------------------------------------------------------------=== #
+
+
+def split_into_lines(text: String) -> List[String]:
+    """Splits a string into individual lines.
+
+    Handles both ``\\n`` and ``\\r\\n`` line endings.
+    Trailing empty lines from a final newline are not included.
+    """
+    var lines = List[String]()
+    var start = 0
+    var text_len = len(text)
+
+    for i in range(text_len):
+        if text[byte=i] == "\n":
+            # Handle \r\n
+            var end = i
+            if end > start and text[byte=end - 1] == "\r":
+                end -= 1
+            lines.append(String(text[byte=start:end]))
+            start = i + 1
+
+    # Handle last line without trailing newline
+    if start < text_len:
+        var last = String(text[byte=start:text_len])
+        # Strip trailing \r if present
+        if len(last) > 0 and last[byte=len(last) - 1] == "\r":
+            last = String(last[byte = 0 : len(last) - 1])
+        if len(last) > 0:
+            lines.append(last)
+
+    return lines^
+
+
+def strip_comment(line: String) -> String:
+    """Removes a ``#``-style comment from a line.
+
+    Returns everything before the first ``#`` character. If there is
+    no ``#``, the line is returned unchanged.
+
+    This is a composable primitive — use it in combination with
+    ``strip()`` and ``is_blank()`` for full line processing.
+
+    Examples::
+
+        strip_comment("1+2 # add")    → "1+2 "
+        strip_comment("# comment")    → ""
+        strip_comment("sqrt(2)")      → "sqrt(2)"
+        strip_comment("")             → ""
+    """
+    var n = len(line)
+    if n == 0:
+        return String("")
+
+    var bytes = StringSlice(line).as_bytes()
+    var ptr = bytes.unsafe_ptr()
+
+    for i in range(n):
+        if ptr[i] == 35:  # '#'
+            if i == 0:
+                return String("")
+            return String(line[byte=0:i])
+
+    return line
+
+
+def is_blank(line: String) -> Bool:
+    """Returns True if the line is empty or contains only whitespace
+    (spaces and tabs).
+
+    This is a composable primitive — combine with ``strip_comment()``
+    to check for comment-or-blank lines.
+    """
+    var n = len(line)
+    if n == 0:
+        return True
+
+    var bytes = StringSlice(line).as_bytes()
+    var ptr = bytes.unsafe_ptr()
+
+    for i in range(n):
+        var c = ptr[i]
+        if c != 32 and c != 9:  # not space, not tab
+            return False
+
+    return True
+
+
+def is_comment_or_blank(line: String) -> Bool:
+    """Returns True if the line is blank, whitespace-only, or a comment
+    (first non-whitespace character is ``#``).
+
+    Equivalent to ``is_blank(strip_comment(line))`` but implemented as
+    a single pass for efficiency. Kept for backward compatibility with
+    existing callers.
+    """
+    return is_blank(strip_comment(line))
+
+
+def strip(s: String) -> String:
+    """Strips leading and trailing whitespace from a string.
+
+    Removes spaces (32), tabs (9), carriage returns (13), and
+    newlines (10).
+    """
+    var bytes = StringSlice(s).as_bytes()
+    var ptr = bytes.unsafe_ptr()
+    var start = 0
+    var end = len(s)
+
+    while start < end:
+        var c = ptr[start]
+        # space=32, tab=9, \r=13, \n=10
+        if c != 32 and c != 9 and c != 13 and c != 10:
+            break
+        start += 1
+
+    while end > start:
+        var c = ptr[end - 1]
+        if c != 32 and c != 9 and c != 13 and c != 10:
+            break
+        end -= 1
+
+    if start >= end:
+        return String("")
+    return String(s[byte=start:end])
+
+
+def filter_expression_lines(lines: List[String]) -> List[String]:
+    """Filters a list of lines to only those that are valid expressions.
+
+    Removes blank lines and comment lines (starting with ``#``).
+    Also strips inline comments and leading/trailing whitespace from
+    each expression line.
+    """
+    var result = List[String]()
+    for i in range(len(lines)):
+        var line = strip(strip_comment(lines[i]))
+        if len(line) > 0:
+            result.append(line)
+    return result^
+
+
+# ===----------------------------------------------------------------------=== #
+# File reading
+# ===----------------------------------------------------------------------=== #
+
+
+def read_file_text(path: String) raises -> String:
+    """Reads the entire contents of a file and returns it as a String.
+
+    Uses POSIX ``open()`` + ``dup2()`` + ``getchar()`` to read the file
+    by redirecting stdin.  This avoids FFI signature conflicts with
+    Mojo's stdlib and ArgMojo for ``read``/``fclose``.
+
+    Args:
+        path: The file path to read.
+
+    Raises:
+        If the file cannot be opened.
+    """
+    var c_path = _to_cstr(path)
+
+    # open(path, O_RDONLY=0)
+    var fd = external_call["open", Int32](c_path.unsafe_ptr(), Int32(0))
+    if fd < 0:
+        raise Error("cannot open file: " + path)
+
+    # Redirect stdin (fd 0) to the file
+    var dup_result = external_call["dup2", Int32](fd, Int32(0))
+    if dup_result < 0:
+        raise Error("cannot redirect stdin to file: " + path)
+
+    # Read all bytes via getchar()
+    var chunks = List[UInt8]()
+    while True:
+        var c = external_call["getchar", Int32]()
+        if c < 0:  # EOF
+            break
+        chunks.append(UInt8(c))
+
+    if len(chunks) == 0:
+        return String("")
+
+    return String(unsafe_from_utf8=chunks^)
+
+
+def file_exists(path: String) -> Bool:
+    """Returns True if the given path exists as a readable file.
+
+    Uses the POSIX ``access()`` syscall with ``R_OK`` (4).
+    """
+    var c_path = _to_cstr(path)
+    # access(path, R_OK=4) returns 0 on success
+    return external_call["access", Int32](c_path.unsafe_ptr(), Int32(4)) == 0
+
+
+# ===----------------------------------------------------------------------=== #
+# Internal helpers
+# ===----------------------------------------------------------------------=== #
+
+
+def _to_cstr(s: String) -> List[UInt8]:
+    """Converts a Mojo String to a null-terminated C string (List[UInt8])."""
+    var bytes = StringSlice(s).as_bytes()
+    var c = List[UInt8](capacity=len(bytes) + 1)
+    for i in range(len(bytes)):
+        c.append(bytes[i])
+    c.append(0)
+    return c^

--- a/src/cli/calculator/io.mojo
+++ b/src/cli/calculator/io.mojo
@@ -237,14 +237,15 @@ def read_file_text(path: String) raises -> String:
 
     # Save original stdin so we can restore it after reading.
     var saved_stdin = external_call["dup", Int32](Int32(0))
+    if saved_stdin < 0:
+        raise Error("cannot save stdin (dup failed)")
 
     # open(path, O_RDONLY=0)
     var fd = external_call["open", Int32](c_path.unsafe_ptr(), Int32(0))
     if fd < 0:
         # Restore stdin before raising.
-        if saved_stdin >= 0:
-            _ = external_call["dup2", Int32](saved_stdin, Int32(0))
-            _ = external_call["close", Int32](saved_stdin)
+        _ = external_call["dup2", Int32](saved_stdin, Int32(0))
+        _ = external_call["close", Int32](saved_stdin)
         raise Error("cannot open file: " + path)
 
     # Redirect stdin (fd 0) to the file
@@ -254,9 +255,8 @@ def read_file_text(path: String) raises -> String:
 
     if dup_result < 0:
         # Restore stdin before raising.
-        if saved_stdin >= 0:
-            _ = external_call["dup2", Int32](saved_stdin, Int32(0))
-            _ = external_call["close", Int32](saved_stdin)
+        _ = external_call["dup2", Int32](saved_stdin, Int32(0))
+        _ = external_call["close", Int32](saved_stdin)
         raise Error("cannot redirect stdin to file: " + path)
 
     # Read all bytes via getchar()
@@ -268,9 +268,8 @@ def read_file_text(path: String) raises -> String:
         chunks.append(UInt8(c))
 
     # Restore original stdin.
-    if saved_stdin >= 0:
-        _ = external_call["dup2", Int32](saved_stdin, Int32(0))
-        _ = external_call["close", Int32](saved_stdin)
+    _ = external_call["dup2", Int32](saved_stdin, Int32(0))
+    _ = external_call["close", Int32](saved_stdin)
 
     if len(chunks) == 0:
         return String("")

--- a/src/cli/main.mojo
+++ b/src/cli/main.mojo
@@ -28,7 +28,7 @@ struct DecimoArgs(Parsable):
     var precision: Option[
         Int,
         long="precision",
-        short="p",
+        short="P",
         help="Number of significant digits",
         default="50",
         value_name="N",
@@ -39,26 +39,25 @@ struct DecimoArgs(Parsable):
     ]
     var scientific: Flag[
         long="scientific",
-        short="s",
+        short="S",
         help="Output in scientific notation (e.g. 1.23E+10)",
         group="Formatting",
     ]
     var engineering: Flag[
         long="engineering",
-        short="e",
+        short="E",
         help="Output in engineering notation (exponent multiple of 3)",
         group="Formatting",
     ]
     var pad: Flag[
         long="pad",
-        short="P",
         help="Pad trailing zeros to the specified precision",
         group="Formatting",
     ]
     var delimiter: Option[
         String,
         long="delimiter",
-        short="d",
+        short="D",
         help="Digit-group separator inserted every 3 digits (e.g. '_' gives 1_234.567_89)",
         default="",
         value_name="CHAR",
@@ -67,7 +66,7 @@ struct DecimoArgs(Parsable):
     var rounding_mode: Option[
         String,
         long="rounding-mode",
-        short="r",
+        short="R",
         help="Rounding mode for the final result",
         default="half-even",
         choices="half-even,half-up,half-down,up,down,ceiling,floor",

--- a/src/cli/main.mojo
+++ b/src/cli/main.mojo
@@ -150,7 +150,11 @@ def _run() raises:
     var has_file = len(args.file.value) > 0
     var has_expr = len(args.expr.value) > 0
 
-    if has_file:
+    if has_file and has_expr:
+        # Ambiguous: both --file and a positional expression were given.
+        print_error("cannot use both -F/--file and a positional expression")
+        exit(1)
+    elif has_file:
         # ── File mode ────────────────────────────────────────────────────
         _run_file_mode(
             args.file.value,
@@ -163,16 +167,19 @@ def _run() raises:
         )
     elif has_expr:
         # ── Expression mode (one-shot) ───────────────────────────────────
-        _evaluate_and_print(
-            args.expr.value,
-            precision,
-            scientific,
-            engineering,
-            pad,
-            delimiter,
-            rounding_mode,
-            show_expr_on_error=True,
-        )
+        try:
+            _evaluate_and_print(
+                args.expr.value,
+                precision,
+                scientific,
+                engineering,
+                pad,
+                delimiter,
+                rounding_mode,
+                show_expr_on_error=True,
+            )
+        except:
+            exit(1)
     elif not stdin_is_tty():
         # ── Pipe mode ────────────────────────────────────────────────────
         _run_pipe_mode(

--- a/src/cli/main.mojo
+++ b/src/cli/main.mojo
@@ -23,11 +23,8 @@ from calculator.io import (
     stdin_is_tty,
     read_stdin,
     split_into_lines,
-    strip_comment,
-    is_blank,
-    strip,
+    filter_expression_lines,
     read_file_text,
-    file_exists,
 )
 
 
@@ -217,19 +214,13 @@ def _run_pipe_mode(
     if len(text) == 0:
         return
 
-    var lines = split_into_lines(text)
+    var expressions = filter_expression_lines(split_into_lines(text))
     var had_error = False
 
-    for i in range(len(lines)):
-        # Strip comments and whitespace
-        var line = strip(strip_comment(lines[i]))
-
-        if is_blank(line):
-            continue
-
+    for i in range(len(expressions)):
         try:
             _evaluate_and_print(
-                line,
+                expressions[i],
                 precision,
                 scientific,
                 engineering,
@@ -256,11 +247,6 @@ def _run_file_mode(
     rounding_mode: RoundingMode,
 ) raises:
     """Reads expressions from a file (one per line) and evaluates each."""
-    if not file_exists(path):
-        print_error("file not found: " + path)
-        exit(1)
-        return  # Unreachable, but keeps the compiler happy
-
     var text: String
     try:
         text = read_file_text(path)
@@ -269,19 +255,13 @@ def _run_file_mode(
         exit(1)
         return  # Unreachable, but keeps the compiler happy
 
-    var lines = split_into_lines(text)
+    var expressions = filter_expression_lines(split_into_lines(text))
     var had_error = False
 
-    for i in range(len(lines)):
-        # Strip comments and whitespace
-        var line = strip(strip_comment(lines[i]))
-
-        if is_blank(line):
-            continue
-
+    for i in range(len(expressions)):
         try:
             _evaluate_and_print(
-                line,
+                expressions[i],
                 precision,
                 scientific,
                 engineering,

--- a/src/cli/main.mojo
+++ b/src/cli/main.mojo
@@ -5,8 +5,10 @@
 # Decimo (BigDecimal) and ArgMojo (CLI parsing).
 #
 # Usage:
-#   mojo run -I src -I src/cli src/cli/main.mojo "100 * 12 - 23/17" -p 50
-#   ./decimo "100 * 12 - 23/17" -p 50
+#   mojo run -I src -I src/cli src/cli/main.mojo "100 * 12 - 23/17" -P 50
+#   ./decimo "100 * 12 - 23/17" -P 50
+#   echo "1+2" | mojo run -I src -I src/cli src/cli/main.mojo
+#   mojo run -I src -I src/cli src/cli/main.mojo -F expressions.dm -P 100
 # ===----------------------------------------------------------------------=== #
 
 from std.sys import exit
@@ -17,13 +19,32 @@ from calculator.tokenizer import tokenize
 from calculator.parser import parse_to_rpn
 from calculator.evaluator import evaluate_rpn, final_round
 from calculator.display import print_error
+from calculator.io import (
+    stdin_is_tty,
+    read_stdin,
+    split_into_lines,
+    strip_comment,
+    is_blank,
+    strip,
+    read_file_text,
+    file_exists,
+)
 
 
 struct DecimoArgs(Parsable):
     var expr: Positional[
         String,
-        help="Math expression to evaluate (e.g. 'sqrt(abs(1.1*-12-23/17))')",
-        required=True,
+        help="Math expression to evaluate (e.g. 'sqrt(2)', '1/3 + pi')",
+        required=False,
+    ]
+    var file: Option[
+        String,
+        long="file",
+        short="F",
+        help="Evaluate expressions from a file (one per line)",
+        default="",
+        value_name="PATH",
+        group="Input",
     ]
     var precision: Option[
         Int,
@@ -100,7 +121,7 @@ def main():
 
 def _run() raises:
     var cmd = DecimoArgs.to_command()
-    cmd.usage("decimo [OPTIONS] <EXPR>")
+    cmd.usage("decimo [OPTIONS] [EXPR]")
     cmd.mutually_exclusive(["scientific", "engineering"])
     # Allow expressions starting with '-' (e.g. "-3*pi*(sin(1))") to be
     # treated as positional values rather than option flags.
@@ -112,9 +133,10 @@ def _run() raises:
         'If your expression contains *, ( or ), quote it: decimo "2 * (3 + 4)"'
     )
     cmd.add_tip("Or use noglob: alias decimo='noglob decimo' (add to ~/.zshrc)")
+    cmd.add_tip("Pipe expressions: echo '1/3' | decimo -P 100")
+    cmd.add_tip("Evaluate a file: decimo -F expressions.dm -P 50")
     var args = DecimoArgs.parse_from_command(cmd^)
 
-    var expr = args.expr.value
     var precision = args.precision.value
     var scientific = args.scientific.value
     var engineering = args.engineering.value
@@ -122,14 +144,184 @@ def _run() raises:
     var delimiter = args.delimiter.value
     var rounding_mode = _parse_rounding_mode(args.rounding_mode.value)
 
-    # ── Phase 1: Tokenize & parse ──────────────────────────────────────────
+    # ── Mode detection ─────────────────────────────────────────────────────
+    # 1. --file flag provided        → file mode
+    # 2. Positional expr provided    → expression mode (one-shot)
+    # 3. No expr, stdin is piped     → pipe mode
+    # 4. No expr, stdin is a TTY     → error (no input)
+
+    var has_file = len(args.file.value) > 0
+    var has_expr = len(args.expr.value) > 0
+
+    if has_file:
+        # ── File mode ────────────────────────────────────────────────────
+        _run_file_mode(
+            args.file.value,
+            precision,
+            scientific,
+            engineering,
+            pad,
+            delimiter,
+            rounding_mode,
+        )
+    elif has_expr:
+        # ── Expression mode (one-shot) ───────────────────────────────────
+        _evaluate_and_print(
+            args.expr.value,
+            precision,
+            scientific,
+            engineering,
+            pad,
+            delimiter,
+            rounding_mode,
+            show_expr_on_error=True,
+        )
+    elif not stdin_is_tty():
+        # ── Pipe mode ────────────────────────────────────────────────────
+        _run_pipe_mode(
+            precision,
+            scientific,
+            engineering,
+            pad,
+            delimiter,
+            rounding_mode,
+        )
+    else:
+        # No expression, no file, no pipe — show help.
+        print_error("no expression provided")
+        print(
+            "Usage: decimo [OPTIONS] [EXPR]\n"
+            "       echo 'EXPR' | decimo [OPTIONS]\n"
+            "       decimo -F FILE [OPTIONS]\n"
+            "\n"
+            "Run 'decimo --help' for more information."
+        )
+        exit(1)
+
+
+# ===----------------------------------------------------------------------=== #
+# Mode implementations
+# ===----------------------------------------------------------------------=== #
+
+
+def _run_pipe_mode(
+    precision: Int,
+    scientific: Bool,
+    engineering: Bool,
+    pad: Bool,
+    delimiter: String,
+    rounding_mode: RoundingMode,
+) raises:
+    """Read expressions from stdin (one per line) and evaluate each."""
+    var text = read_stdin()
+    if len(text) == 0:
+        return
+
+    var lines = split_into_lines(text)
+    var had_error = False
+
+    for i in range(len(lines)):
+        # Strip comments and whitespace
+        var line = strip(strip_comment(lines[i]))
+
+        if is_blank(line):
+            continue
+
+        try:
+            _evaluate_and_print(
+                line,
+                precision,
+                scientific,
+                engineering,
+                pad,
+                delimiter,
+                rounding_mode,
+                show_expr_on_error=True,
+            )
+        except:
+            had_error = True
+            # Continue processing remaining lines
+
+    if had_error:
+        exit(1)
+
+
+def _run_file_mode(
+    path: String,
+    precision: Int,
+    scientific: Bool,
+    engineering: Bool,
+    pad: Bool,
+    delimiter: String,
+    rounding_mode: RoundingMode,
+) raises:
+    """Reads expressions from a file (one per line) and evaluates each."""
+    if not file_exists(path):
+        print_error("file not found: " + path)
+        exit(1)
+        return  # Unreachable, but keeps the compiler happy
+
+    var text: String
+    try:
+        text = read_file_text(path)
+    except e:
+        print_error("cannot read file '" + path + "': " + String(e))
+        exit(1)
+        return  # Unreachable, but keeps the compiler happy
+
+    var lines = split_into_lines(text)
+    var had_error = False
+
+    for i in range(len(lines)):
+        # Strip comments and whitespace
+        var line = strip(strip_comment(lines[i]))
+
+        if is_blank(line):
+            continue
+
+        try:
+            _evaluate_and_print(
+                line,
+                precision,
+                scientific,
+                engineering,
+                pad,
+                delimiter,
+                rounding_mode,
+                show_expr_on_error=True,
+            )
+        except:
+            had_error = True
+            # Continue processing remaining lines
+
+    if had_error:
+        exit(1)
+
+
+# ===----------------------------------------------------------------------=== #
+# Core evaluation and formatting
+# ===----------------------------------------------------------------------=== #
+
+
+def _evaluate_and_print(
+    expr: String,
+    precision: Int,
+    scientific: Bool,
+    engineering: Bool,
+    pad: Bool,
+    delimiter: String,
+    rounding_mode: RoundingMode,
+    show_expr_on_error: Bool = False,
+) raises:
+    """Tokenize, parse, evaluate, and print one expression.
+
+    On error, displays a coloured diagnostic and raises to signal failure
+    to the caller.
+    """
     try:
         var tokens = tokenize(expr)
         var rpn = parse_to_rpn(tokens^)
 
-        # ── Phase 2: Evaluate ────────────────────────────────────────────
-        # Syntax was fine — any error here is a math error (division by
-        # zero, negative sqrt, …).  No glob hint needed.
         try:
             var value = final_round(
                 evaluate_rpn(rpn^, precision), precision, rounding_mode
@@ -148,16 +340,22 @@ def _run() raises:
             else:
                 print(value.to_string(delimiter=delimiter))
         except eval_err:
-            _display_calc_error(String(eval_err), expr)
-            exit(1)
+            if show_expr_on_error:
+                _display_calc_error(String(eval_err), expr)
+            else:
+                print_error(String(eval_err))
+            raise eval_err^
 
     except parse_err:
-        _display_calc_error(String(parse_err), expr)
-        exit(1)
+        if show_expr_on_error:
+            _display_calc_error(String(parse_err), expr)
+        else:
+            print_error(String(parse_err))
+        raise parse_err^
 
 
 def _display_calc_error(error_msg: String, expr: String):
-    """Parse a calculator error message and display it with colours
+    """Parses a calculator error message and displays it with colours
     and a caret indicator.
 
     The calculator engine produces errors in two forms:
@@ -200,7 +398,7 @@ def _display_calc_error(error_msg: String, expr: String):
 
 
 def _pad_to_precision(plain: String, precision: Int) -> String:
-    """Pad (or add) trailing zeros so the fractional part has exactly
+    """Pads (or adds) trailing zeros so the fractional part has exactly
     `precision` digits.
     """
     if precision <= 0:
@@ -224,7 +422,8 @@ def _pad_to_precision(plain: String, precision: Int) -> String:
 
 
 def _parse_rounding_mode(name: String) -> RoundingMode:
-    """Convert a CLI rounding-mode name (hyphenated) to a RoundingMode value."""
+    """Converts a CLI rounding-mode name (hyphenated) to a RoundingMode value.
+    """
     if name == "half-even":
         return RoundingMode.half_even()
     elif name == "half-up":

--- a/tests/cli/test_io.mojo
+++ b/tests/cli/test_io.mojo
@@ -186,8 +186,9 @@ def test_filter_basic() raises:
 
 
 def test_file_exists_nonexistent() raises:
+    # Use a path with enough entropy to avoid false positives on any machine.
     testing.assert_false(
-        file_exists(String("/tmp/nonexistent_decimo_test_12345.dm"))
+        file_exists(String("/tmp/_decimo_no_such_file_a1b2c3d4e5f6_.dm"))
     )
 
 

--- a/tests/cli/test_io.mojo
+++ b/tests/cli/test_io.mojo
@@ -1,0 +1,251 @@
+"""Test the I/O utilities: line splitting, comment handling, text processing."""
+
+from std import testing
+
+from calculator.io import (
+    split_into_lines,
+    strip_comment,
+    is_blank,
+    is_comment_or_blank,
+    strip,
+    filter_expression_lines,
+    file_exists,
+    _to_cstr,
+)
+
+
+# ===----------------------------------------------------------------------=== #
+# split_into_lines
+# ===----------------------------------------------------------------------=== #
+
+
+def test_split_empty() raises:
+    var lines = split_into_lines(String(""))
+    testing.assert_equal(len(lines), 0)
+
+
+def test_split_single_line() raises:
+    var lines = split_into_lines(String("hello"))
+    testing.assert_equal(len(lines), 1)
+    testing.assert_equal(lines[0], "hello")
+
+
+def test_split_multiple_lines() raises:
+    var lines = split_into_lines(String("a\nb\nc"))
+    testing.assert_equal(len(lines), 3)
+    testing.assert_equal(lines[0], "a")
+    testing.assert_equal(lines[1], "b")
+    testing.assert_equal(lines[2], "c")
+
+
+def test_split_trailing_newline() raises:
+    var lines = split_into_lines(String("a\nb\n"))
+    testing.assert_equal(len(lines), 2)
+    testing.assert_equal(lines[0], "a")
+    testing.assert_equal(lines[1], "b")
+
+
+def test_split_blank_lines() raises:
+    var lines = split_into_lines(String("a\n\nb\n\n"))
+    testing.assert_equal(len(lines), 4)
+    testing.assert_equal(lines[0], "a")
+    testing.assert_equal(lines[1], "")
+    testing.assert_equal(lines[2], "b")
+    testing.assert_equal(lines[3], "")
+
+
+def test_split_crlf() raises:
+    var lines = split_into_lines(String("a\r\nb\r\n"))
+    testing.assert_equal(len(lines), 2)
+    testing.assert_equal(lines[0], "a")
+    testing.assert_equal(lines[1], "b")
+
+
+# ===----------------------------------------------------------------------=== #
+# strip_comment
+# ===----------------------------------------------------------------------=== #
+
+
+def test_strip_comment_empty() raises:
+    testing.assert_equal(strip_comment(String("")), "")
+
+
+def test_strip_comment_no_hash() raises:
+    testing.assert_equal(strip_comment(String("1+2")), "1+2")
+    testing.assert_equal(strip_comment(String("sqrt(2)")), "sqrt(2)")
+
+
+def test_strip_comment_full_line_comment() raises:
+    testing.assert_equal(strip_comment(String("# comment")), "")
+    testing.assert_equal(strip_comment(String("#")), "")
+
+
+def test_strip_comment_inline_comment() raises:
+    testing.assert_equal(strip_comment(String("1+2 # add")), "1+2 ")
+    testing.assert_equal(strip_comment(String("pi # constant")), "pi ")
+    testing.assert_equal(strip_comment(String("sqrt(2)#no space")), "sqrt(2)")
+
+
+def test_strip_comment_indented_comment() raises:
+    testing.assert_equal(strip_comment(String("  # indented")), "  ")
+
+
+# ===----------------------------------------------------------------------=== #
+# is_blank
+# ===----------------------------------------------------------------------=== #
+
+
+def test_is_blank_empty() raises:
+    testing.assert_true(is_blank(String("")))
+
+
+def test_is_blank_whitespace() raises:
+    testing.assert_true(is_blank(String("   ")))
+    testing.assert_true(is_blank(String("\t\t")))
+    testing.assert_true(is_blank(String("  \t ")))
+
+
+def test_is_blank_not_blank() raises:
+    testing.assert_false(is_blank(String("1+2")))
+    testing.assert_false(is_blank(String("  x")))
+    testing.assert_false(is_blank(String("#")))
+
+
+# ===----------------------------------------------------------------------=== #
+# strip
+# ===----------------------------------------------------------------------=== #
+
+
+def test_strip_basic() raises:
+    testing.assert_equal(strip(String("  hello  ")), "hello")
+    testing.assert_equal(strip(String("\thello\t")), "hello")
+    testing.assert_equal(strip(String("  hello")), "hello")
+    testing.assert_equal(strip(String("hello  ")), "hello")
+
+
+def test_strip_empty() raises:
+    testing.assert_equal(strip(String("")), "")
+    testing.assert_equal(strip(String("   ")), "")
+
+
+def test_strip_no_change() raises:
+    testing.assert_equal(strip(String("hello")), "hello")
+
+
+# ===----------------------------------------------------------------------=== #
+# is_comment_or_blank (backward compat / composition)
+# ===----------------------------------------------------------------------=== #
+
+
+def test_blank_line() raises:
+    testing.assert_true(is_comment_or_blank(String("")))
+
+
+def test_whitespace_only() raises:
+    testing.assert_true(is_comment_or_blank(String("   ")))
+    testing.assert_true(is_comment_or_blank(String("\t\t")))
+    testing.assert_true(is_comment_or_blank(String("  \t ")))
+
+
+def test_comment_line() raises:
+    testing.assert_true(is_comment_or_blank(String("# comment")))
+    testing.assert_true(is_comment_or_blank(String("  # indented comment")))
+    testing.assert_true(is_comment_or_blank(String("\t# tab comment")))
+
+
+def test_expression_line() raises:
+    testing.assert_false(is_comment_or_blank(String("1+2")))
+    testing.assert_false(is_comment_or_blank(String("  sqrt(2)")))
+    testing.assert_false(is_comment_or_blank(String("pi")))
+
+
+# ===----------------------------------------------------------------------=== #
+# filter_expression_lines
+# ===----------------------------------------------------------------------=== #
+
+
+def test_filter_basic() raises:
+    var lines = List[String]()
+    lines.append(String("# comment"))
+    lines.append(String(""))
+    lines.append(String("1+2"))
+    lines.append(String("  sqrt(2)  "))
+    lines.append(String(""))
+    lines.append(String("# another comment"))
+    lines.append(String("pi"))
+    var filtered = filter_expression_lines(lines)
+    testing.assert_equal(len(filtered), 3)
+    testing.assert_equal(filtered[0], "1+2")
+    testing.assert_equal(filtered[1], "sqrt(2)")
+    testing.assert_equal(filtered[2], "pi")
+
+
+# ===----------------------------------------------------------------------=== #
+# file_exists
+# ===----------------------------------------------------------------------=== #
+
+
+def test_file_exists_nonexistent() raises:
+    testing.assert_false(
+        file_exists(String("/tmp/nonexistent_decimo_test_12345.dm"))
+    )
+
+
+# ===----------------------------------------------------------------------=== #
+# _to_cstr
+# ===----------------------------------------------------------------------=== #
+
+
+def test_to_cstr() raises:
+    var result = _to_cstr(String("hello"))
+    testing.assert_equal(len(result), 6)  # 5 chars + null terminator
+    testing.assert_equal(result[5], UInt8(0))
+
+
+# ===----------------------------------------------------------------------=== #
+# main
+# ===----------------------------------------------------------------------=== #
+
+
+def main() raises:
+    # split_into_lines
+    test_split_empty()
+    test_split_single_line()
+    test_split_multiple_lines()
+    test_split_trailing_newline()
+    test_split_blank_lines()
+    test_split_crlf()
+
+    # strip_comment
+    test_strip_comment_empty()
+    test_strip_comment_no_hash()
+    test_strip_comment_full_line_comment()
+    test_strip_comment_inline_comment()
+    test_strip_comment_indented_comment()
+
+    # is_blank
+    test_is_blank_empty()
+    test_is_blank_whitespace()
+    test_is_blank_not_blank()
+
+    # strip
+    test_strip_basic()
+    test_strip_empty()
+    test_strip_no_change()
+
+    # is_comment_or_blank (backward compat)
+    test_blank_line()
+    test_whitespace_only()
+    test_comment_line()
+    test_expression_line()
+
+    # filter_expression_lines
+    test_filter_basic()
+
+    # file_exists
+    test_file_exists_nonexistent()
+
+    # _to_cstr
+    test_to_cstr()
+
+    print("All io tests passed!")

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -167,6 +167,16 @@ else
     FAIL=$((FAIL + 1))
 fi
 
+# File mode + positional expr should be rejected
+BOTH_OUTPUT=$("$BINARY" -F "nonexistent_file.dm" "1+2" 2>&1 || true)
+if echo "$BOTH_OUTPUT" | grep -qi "cannot use both"; then
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: -F + positional expr should be rejected"
+    echo "  actual: $BOTH_OUTPUT"
+    FAIL=$((FAIL + 1))
+fi
+
 echo ""
 echo "CLI integration tests: $PASS passed, $FAIL failed"
 

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -37,32 +37,32 @@ assert_output() {
 # Basic expression
 assert_output "basic addition" "5" "$BINARY" "2+3"
 
-# Precision flag (-p)
-assert_output "precision -p 10" "0.3333333333" "$BINARY" "1/3" -p 10
+# Precision flag (-P)
+assert_output "precision -P 10" "0.3333333333" "$BINARY" "1/3" -P 10
 
-# Scientific notation (--scientific / -s)
+# Scientific notation (--scientific / -S)
 assert_output "scientific notation" "1.2345678E+4" "$BINARY" "12345.678" --scientific
 
-# Engineering notation (--engineering / -e)
+# Engineering notation (--engineering / -E)
 assert_output "engineering notation" "12.345678E+3" "$BINARY" "12345.678" --engineering
 
-# Delimiter flag (-d)
-assert_output "delimiter underscore" "1_234_567.89" "$BINARY" "1234567.89" -d "_"
+# Delimiter flag (-D)
+assert_output "delimiter underscore" "1_234_567.89" "$BINARY" "1234567.89" -D "_"
 
-# Rounding mode (--rounding-mode / -r)
-assert_output "rounding mode ceiling" "0.33334" "$BINARY" "1/3" -p 5 -r ceiling
+# Rounding mode (--rounding-mode / -R)
+assert_output "rounding mode ceiling" "0.33334" "$BINARY" "1/3" -P 5 -R ceiling
 
-# Pad flag (--pad / -P)
-assert_output "pad trailing zeros" "0.33333" "$BINARY" "1/3" -p 5 --pad
+# Pad flag (--pad)
+assert_output "pad trailing zeros" "0.33333" "$BINARY" "1/3" -P 5 --pad
 
 # ── Negative expressions (allow_hyphen) ───────────────────────────────────
 assert_output "negative number" "-3.14" "$BINARY" "-3.14"
 assert_output "negative integer" "-42" "$BINARY" "-42"
 assert_output "negative expression" "-6" "$BINARY" "-3*2"
-assert_output "negative expression with pi" "-9.424777961" "$BINARY" "-3*pi" -p 10
-assert_output "negative expr with abs()" "-3" "$BINARY" "-abs(3)" -p 10
-assert_output "negative expression complex" "17.32428719" "$BINARY" "-3*pi/sin(10)" -p 10
-assert_output "negative expression with parens" "-7.9306771922443685366581979690091558499739419154171" "$BINARY" "-3*pi*(sin(1))" -p 50
+assert_output "negative expression with pi" "-9.424777961" "$BINARY" "-3*pi" -P 10
+assert_output "negative expr with abs()" "-3" "$BINARY" "-abs(3)" -P 10
+assert_output "negative expression complex" "17.32428719" "$BINARY" "-3*pi/sin(10)" -P 10
+assert_output "negative expression with parens" "-7.9306771922443685366581979690091558499739419154171" "$BINARY" "-3*pi*(sin(1))" -P 50
 assert_output "negative zero" "-0" "$BINARY" "-0"
 assert_output "negative minus negative" "1" "$BINARY" "-1*-1"
 assert_output "negative power" "-8" "$BINARY" "-2^3"
@@ -70,23 +70,28 @@ assert_output "negative cancel out" "0" "$BINARY" "-1+1"
 assert_output "negative subtraction" "-50" "$BINARY" "-100+50"
 
 # ── Option/positional ordering ────────────────────────────────────────────
-assert_output "options before expr" "0.3333333333" "$BINARY" -p 10 "1/3"
-assert_output "options after expr" "0.3333333333" "$BINARY" "1/3" -p 10
-assert_output "multiple options before expr" "1.732428719E+1" "$BINARY" -s -p 10 "-3*pi/sin(10)"
-assert_output "mixed order: flag expr option" "1.732428719E+1" "$BINARY" -s "-3*pi/sin(10)" -p 10
-assert_output "mixed order: option expr flag" "1.732428719E+1" "$BINARY" -p 10 "-3*pi/sin(10)" -s
-assert_output "engineering before expr" "-12.345678E+3" "$BINARY" -e "-12345.678"
-assert_output "engineering after expr" "-12.345678E+3" "$BINARY" "-12345.678" -e
-assert_output "delimiter before expr" "3.141_592_654" "$BINARY" -d _ -p 10 "pi"
-assert_output "delimiter after expr" "3.141_592_654" "$BINARY" "pi" -p 10 -d _
-assert_output "rounding before expr" "0.33334" "$BINARY" -p 5 -r ceiling "1/3"
-assert_output "all options before expr" "0.33334" "$BINARY" -p 5 -r ceiling --pad "1/3"
-assert_output "all options after expr" "0.33334" "$BINARY" "1/3" -p 5 -r ceiling --pad
+assert_output "options before expr" "0.3333333333" "$BINARY" -P 10 "1/3"
+assert_output "options after expr" "0.3333333333" "$BINARY" "1/3" -P 10
+assert_output "multiple options before expr" "1.732428719E+1" "$BINARY" -S -P 10 "-3*pi/sin(10)"
+assert_output "mixed order: flag expr option" "1.732428719E+1" "$BINARY" -S "-3*pi/sin(10)" -P 10
+assert_output "mixed order: option expr flag" "1.732428719E+1" "$BINARY" -P 10 "-3*pi/sin(10)" -S
+assert_output "engineering before expr" "-12.345678E+3" "$BINARY" -E "-12345.678"
+assert_output "engineering after expr" "-12.345678E+3" "$BINARY" "-12345.678" -E
+assert_output "delimiter before expr" "3.141_592_654" "$BINARY" -D _ -P 10 "pi"
+assert_output "delimiter after expr" "3.141_592_654" "$BINARY" "pi" -P 10 -D _
+assert_output "rounding before expr" "0.33334" "$BINARY" -P 5 -R ceiling "1/3"
+assert_output "all options before expr" "0.33334" "$BINARY" -P 5 -R ceiling --pad "1/3"
+assert_output "all options after expr" "0.33334" "$BINARY" "1/3" -P 5 -R ceiling --pad
 
 # ── Double-dash separator ─────────────────────────────────────────────────
 assert_output "-- with negative expr" "-6" "$BINARY" -- "-3*2"
 assert_output "-- with negative number" "-3.14" "$BINARY" -- "-3.14"
 assert_output "-- with -e as expr" "-2.7182818284590452353602874713526624977572470937000" "$BINARY" -- "-e"
+
+# ── Expressions that previously collided with short flags ─────────────────
+assert_output "-e as expr (no --)" "-2.7182818284590452353602874713526624977572470937000" "$BINARY" "-e"
+assert_output "-pi as expr" "-3.1415926535897932384626433832795028841971693993751" "$BINARY" "-pi"
+assert_output "-sin(1) as expr" "-0.84147098480789650665250232163029899962256306079837" "$BINARY" "-sin(1)"
 
 # ── Bare hyphen rejection ─────────────────────────────────────────────────
 if "$BINARY" -- - >/dev/null 2>&1; then

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -101,6 +101,72 @@ else
     PASS=$((PASS + 1))
 fi
 
+# ── Pipe mode (stdin) ────────────────────────────────────────────────────
+assert_pipe_output() {
+    local description="$1"
+    local input="$2"
+    local expected="$3"
+    shift 3
+    local actual
+    actual=$(printf '%s' "$input" | "$BINARY" "$@" 2>&1)
+    if [[ "$actual" == "$expected" ]]; then
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description"
+        echo "  expected: $expected"
+        echo "  actual:   $actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_pipe_output "pipe single expression" "1+2" "3"
+assert_pipe_output "pipe sqrt" "sqrt(2)" "1.4142135623730950488016887242096980785696718753769"
+assert_pipe_output "pipe with precision" "1/3" "0.3333333333" -P 10
+assert_pipe_output "pipe multiple lines" \
+    "$(printf '1+2\nsqrt(4)\npi')" \
+    "$(printf '3\n2\n3.1415926535897932384626433832795028841971693993751')"
+assert_pipe_output "pipe skip comments" \
+    "$(printf '# comment\n1+2\n\n# another\nsqrt(4)')" \
+    "$(printf '3\n2')"
+assert_pipe_output "pipe skip blank lines" \
+    "$(printf '\n\n1+2\n\n')" \
+    "3"
+assert_pipe_output "pipe with scientific" "12345.678" "1.2345678E+4" -S
+assert_pipe_output "pipe with engineering" "12345.678" "12.345678E+3" -E
+assert_pipe_output "pipe with delimiter" "1234567.89" "1_234_567.89" -D "_"
+
+# ── File mode (-F/--file flag) ────────────────────────────────────────────
+TMPFILE=$(mktemp /tmp/decimo_test_XXXXXX.dm)
+cat > "$TMPFILE" << 'FILE_EOF'
+# Test expression file
+pi
+e
+sqrt(2)
+
+# Arithmetic
+100 * 12 - 23/17
+FILE_EOF
+
+assert_output "file mode basic" \
+    "$(printf '3.1415926535897932384626433832795028841971693993751\n2.7182818284590452353602874713526624977572470937000\n1.4142135623730950488016887242096980785696718753769\n1198.6470588235294117647058823529411764705882352941')" \
+    "$BINARY" -F "$TMPFILE"
+
+assert_output "file mode with precision" \
+    "$(printf '3.141592654\n2.718281828\n1.414213562\n1198.647059')" \
+    "$BINARY" -F "$TMPFILE" -P 10
+
+rm -f "$TMPFILE"
+
+# File mode: nonexistent file gives a clear error
+NONEXIST_OUTPUT=$("$BINARY" -F "nonexistent_file.dm" 2>&1 || true)
+if echo "$NONEXIST_OUTPUT" | grep -qi "file not found"; then
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: file mode nonexistent should report 'file not found'"
+    echo "  actual: $NONEXIST_OUTPUT"
+    FAIL=$((FAIL + 1))
+fi
+
 echo ""
 echo "CLI integration tests: $PASS passed, $FAIL failed"
 

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -159,10 +159,10 @@ rm -f "$TMPFILE"
 
 # File mode: nonexistent file gives a clear error
 NONEXIST_OUTPUT=$("$BINARY" -F "nonexistent_file.dm" 2>&1 || true)
-if echo "$NONEXIST_OUTPUT" | grep -qi "file not found"; then
+if echo "$NONEXIST_OUTPUT" | grep -qi "cannot read file"; then
     PASS=$((PASS + 1))
 else
-    echo "FAIL: file mode nonexistent should report 'file not found'"
+    echo "FAIL: file mode nonexistent should report 'cannot read file'"
     echo "  actual: $NONEXIST_OUTPUT"
     FAIL=$((FAIL + 1))
 fi


### PR DESCRIPTION
This PR updates the Decimo CLI to avoid short-flag collisions with negative expressions by uppercasing short options, and adds new stdin (pipe) + file-based input modes for evaluating multiple expressions.

**Changes:**
- Uppercase short flags for formatting/computation options (`-P/-S/-E/-D/-R`) and remove the `--pad` short flag to prevent collisions with expressions like `-e`, `-pi`, `-sin(1)`.
- Add pipe mode (read/evaluate expressions from stdin, one per non-empty non-comment line) and file mode (`-F/--file`).
- Extend integration/unit tests and update docs/changelog/plans for the new CLI UX.