### PR TITLE
[cli][repl] Enhance REPL with displaying help messages and variables + better banner + case-insensitivity

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,9 @@ This is a list of changes for the Decimo package (formerly DeciMojo).
 1. Add **shell completion** documentation for Bash, Zsh, and Fish (`decimo --completions bash|zsh|fish`).
 1. Add **CLI performance benchmarks** (`benches/cli/bench_cli.sh`) comparing correctness and timing against `bc` and `python3` across 47 comparisons — all results match to 15 significant digits; `decimo` is 3–4× faster than `python3 -c`.
 1. Add **interactive REPL**: launch with `decimo` (no arguments, TTY attached). Features coloured `decimo>` prompt on stderr, per-line error recovery with caret diagnostics, comment/blank-line skipping, and graceful exit via `exit`, `quit`, or Ctrl-D. All CLI flags (`-P`, `--scientific`, etc.) apply to the REPL session.
+1. Add **REPL info commands**: `:settings` / `:show` displays all current options, `:vars` / `:variables` lists all defined variables and their values, `:help` / `:h` shows a complete command reference, and `:q` / `:quit` / `:exit` exits the session.
+1. Add **case-insensitive input** in the REPL: all input is lowercased before processing, so `PI`, `Sqrt(2)`, `SIN(1)` all work.
+1. Streamline the **REPL welcome banner** to a compact one-liner with a hint to `:help` and `:q`.
 
 ### 🦋 Changed in v0.10.0
 

--- a/docs/plans/cli_calculator.md
+++ b/docs/plans/cli_calculator.md
@@ -379,15 +379,17 @@ decimo> exit
 | 4.6  | Meta-commands (`:precision N`, etc.)       |   ✓    | `:` prefix avoids collision; settings names + aliases (`:vars` not yet)     |
 | 4.7  | One-line quick setting                     |   ✓    | `:p 100 s r down` sets precision, scientific, and rounding in one line      |
 | 4.8  | Same-line temp precision setting           |   ✓    | `2*sqrt(1.23):p 100 s r down` — temp override via `:` separator             |
-| 4.9  | Print settings (`:settings`)               |   ✗    | Display current precision, formatting options, etc.                         |
-| 4.10 | Variable listing (`:vars` and `:variable`) |   ✗    | List all user-defined variables and their values                            |
-| 4.11 | Help command (`:help`)                     |   ✗    | REPL-specific help with available commands and usage examples               |
-| 4.12 | Better header banner                       |   ✗    | Show title, settings, how to display help `:help`, how to quit `:q`         |
-| 4.13 | Everything in the REPL is case-insensitive |   ✗    | Map all input chars to lower case at pre-tokenizer stage                    |
+| 4.9  | Print settings (`:settings`)               |   ✓    | `:settings` / `:show` displays all current options in a labelled list       |
+| 4.10 | Variable listing (`:vars` and `:variable`) |   ✓    | `:vars` / `:variables` / `:var` lists `ans` first, then user variables      |
+| 4.11 | Help command (`:help`)                     |   ✓    | `:help` / `:h` / `:?` shows expressions, variables, functions, commands     |
+| 4.12 | Better header banner                       |   ✓    | Compact: title + "Type :help for help, :q to quit." + current settings      |
+| 4.13 | Everything in the REPL is case-insensitive |   ✓    | `to_lower()` applied to all input before processing (pre-tokenizer stage)   |
 | 4.14 | Graceful exit (`exit`, `quit`, Ctrl-D)     |   ✓    |                                                                             |
 | 4.15 | Error recovery (don't crash session)       |   ✓    | Catch exceptions per-line, display error, continue loop                     |
-| 4.16 | Line editing (left/right, backspace, del)  |   ✗    | Implemented via `limo` package; see `docs/plans/line_editor.md`             |
-| 4.17 | Input history (up/down arrow navigation)   |   ✗    | Implemented via `limo` package; see `docs/plans/line_editor.md`             |
+| 4.16 | `:100` in REPL settings to set precision   |   ✗    | Shortcut of `:p 100`. If `token[0]` is 0-9, it means precision              |
+| 4.17 | Add `--about`/`--info` flag and in REPL    |   ✗    | Display version, build info, links to docs/repo, etc, for both CLI and REPL |
+| 4.18 | Line editing (left/right, backspace, del)  |   ✗    | Implemented via `limo` package; see `docs/plans/line_editor.md`             |
+| 4.19 | Input history (up/down arrow navigation)   |   ✗    | Implemented via `limo` package; see `docs/plans/line_editor.md`             |
 
 將所有的設定放在一行，這個靈感主要來自於 argmojo，其實就是把 CLI 的選項直接放到了 REPL 的表達式行中。這個想法我個人是很喜歡的，因為它簡潔明瞭，避免了多行設定的冗長。
 

--- a/docs/user_manual_cli.md
+++ b/docs/user_manual_cli.md
@@ -338,7 +338,7 @@ When invoked with no expression and stdin is a TTY, `decimo` launches an interac
 ```sh
 $ decimo
 Decimo — arbitrary-precision calculator, written in Mojo 🔥
-Type :help for help, :q to quit.
+Type :h for help, :show for settings, :q to quit.
 Precision: 50.
 decimo> 100 * 12 - 23/17
 1198.6470588235294117647058823529411764705882352941
@@ -374,7 +374,7 @@ decimo> :q
 
 #### Inline temp settings
 
-Append `:settings` to an expression to override settings for that single evaluation:
+Append `:<settings>` to an expression to override settings for that single evaluation:
 
 ```sh
 decimo> sqrt(2):p 100

--- a/docs/user_manual_cli.md
+++ b/docs/user_manual_cli.md
@@ -22,6 +22,12 @@
   - [Expression Mode (Default)](#expression-mode-default)
   - [Pipe Mode (stdin)](#pipe-mode-stdin)
   - [File Mode (`-F`)](#file-mode--f)
+  - [Interactive REPL](#interactive-repl)
+    - [Variables](#variables)
+    - [Settings commands (prefix with `:`)](#settings-commands-prefix-with-)
+    - [Inline temp settings](#inline-temp-settings)
+    - [Info commands (prefix with `:`)](#info-commands-prefix-with-)
+    - [Quitting](#quitting)
 - [Shell Integration](#shell-integration)
   - [Quoting Expressions](#quoting-expressions)
   - [Negative Expressions](#negative-expressions)
@@ -253,15 +259,14 @@ decimo "1/6" -P 5 -R up            # 0.16667
 
 ## Input Modes
 
-`decimo` accepts input in three ways: a single expression on the command line, piped stdin, or a file.
+`decimo` accepts input in four ways: a single expression on the command line, piped stdin, a file, or an interactive REPL session.
 
 | Mode       | Invocation              | When used                                          |
 | ---------- | ----------------------- | -------------------------------------------------- |
 | Expression | `decimo "EXPR"`         | A positional argument is provided as an expression |
 | Pipe       | `echo "EXPR" \| decimo` | No positional argument and stdin is not a TTY      |
 | File       | `decimo -F FILE.dm`     | The `-F`/`--file` option is used                   |
-
-If no expression is given and stdin is a TTY (interactive terminal), `decimo` prints an error and exits.
+| REPL       | `decimo`                | No positional argument and stdin is a TTY          |
 
 ### Expression Mode (Default)
 
@@ -325,6 +330,67 @@ ln(10)
 Comments start with `#`. Inline comments are also supported (e.g. `1+2 # add`). Leading whitespace before `#` is allowed. Blank lines and whitespace-only lines are skipped.
 
 If the specified file does not exist or cannot be read, `decimo` reports an error and exits.
+
+### Interactive REPL
+
+When invoked with no expression and stdin is a TTY, `decimo` launches an interactive session:
+
+```sh
+$ decimo
+Decimo — arbitrary-precision calculator, written in Mojo 🔥
+Type :help for help, :q to quit.
+Precision: 50.
+decimo> 100 * 12 - 23/17
+1198.6470588235294117647058823529411764705882352941
+decimo> ans + 1
+1199.6470588235294117647058823529411764705882352941
+decimo> x = sqrt(2)
+1.4142135623730950488016887242096980785696718753769
+decimo> x ^ 2
+2
+decimo> :q
+```
+
+**All input is case-insensitive** — `PI`, `Sqrt`, `SIN` are equivalent to `pi`, `sqrt`, `sin`.
+
+#### Variables
+
+- `ans` — automatically holds the result of the last successful evaluation.
+- `name = expr` — assigns the result of `expr` to a user-defined variable.
+- Protected names (`pi`, `e`, `ans`, function names) cannot be used as variable names.
+
+#### Settings commands (prefix with `:`)
+
+| Command        | Effect                                                  |
+| -------------- | ------------------------------------------------------- |
+| `:p N`         | Set precision to `N` digits.                            |
+| `:s`           | Toggle scientific notation.                             |
+| `:e`           | Toggle engineering notation.                            |
+| `:pad`         | Toggle zero-padding.                                    |
+| `:r MODE`      | Set rounding mode (`he`/`hu`/`hd`/`u`/`d`/`c`/`f`/`b`). |
+| `:MODE`        | Set rounding mode (`he`/`hu`/`hd`/`u`/`d`/`c`/`f`/`b`). |
+| `:delimiter C` | Set digit-group delimiter.                              |
+| `:p 100 s r d` | Combine multiple settings in one line.                  |
+
+#### Inline temp settings
+
+Append `:settings` to an expression to override settings for that single evaluation:
+
+```sh
+decimo> sqrt(2):p 100
+```
+
+#### Info commands (prefix with `:`)
+
+| Command     | Effect                      |
+| ----------- | --------------------------- |
+| `:settings` | Show all current settings.  |
+| `:vars`     | List all defined variables. |
+| `:help`     | Show REPL help.             |
+
+#### Quitting
+
+Type `:q`, `exit`, `quit`, or press Ctrl-D.
 
 ## Shell Integration
 

--- a/src/cli/calculator/repl.mojo
+++ b/src/cli/calculator/repl.mojo
@@ -36,11 +36,11 @@ from std.collections import Dict
 
 from decimo import Decimal
 from decimo.rounding_mode import RoundingMode
-from .display import BOLD, RESET, YELLOW
+from .display import BOLD, RESET, YELLOW, CYAN, GREEN
 from .display import write_prompt, print_error
 from .engine import evaluate_and_return
 from .io import read_line, strip, is_comment_or_blank
-from .settings import Settings, parse_settings, split_inline_settings
+from .settings import Settings, parse_settings, split_inline_settings, to_lower
 from .tokenizer import (
     is_alpha_or_underscore,
     is_alnum_or_underscore,
@@ -103,7 +103,10 @@ def run_repl(
             print(file=stderr)  # newline after the prompt
             break
 
-        var line = strip(maybe_line.value())
+        # Case-insensitive — lowercase all input before processing
+        # By doing this early, we ensure that meta-commands, variable names, and
+        # function names are all case-insensitive in a consistent way.
+        var line = to_lower(strip(maybe_line.value()))
 
         # Skip blank lines and comments
         if is_comment_or_blank(line):
@@ -116,6 +119,32 @@ def run_repl(
         # == Meta-command: line starts with `:` ===========================
         if _is_meta_command(line):
             var cmd_str = _strip_colon_prefix(line)
+
+            # `:help` / `:h`
+            # This displays a complete command reference for REPL features
+            if _is_help_command(cmd_str):
+                _print_help()
+                continue
+
+            # `:settings` / `:show`
+            # This displays all current settings and their values
+            # (precision, sci/eng, pad, delimiter, rounding mode)
+            if _is_settings_command(cmd_str):
+                _print_settings(settings)
+                continue
+
+            # `:vars` / `:variables`
+            # This displays all user-defined variables and their current values,
+            # including `ans`.
+            if _is_vars_command(cmd_str):
+                _print_variables(variables)
+                continue
+
+            # `:q` / `:quit` / `:exit`
+            # This exits the REPL session gracefully (same as Ctrl-D).
+            if _is_quit_command(cmd_str):
+                break
+
             try:
                 parse_settings(cmd_str, settings)
                 # Print confirmation to stderr
@@ -312,16 +341,165 @@ def _validate_variable_name(name: String) -> Optional[String]:
 
 def _print_banner(settings: Settings):
     """Prints the REPL welcome banner to stderr."""
-    comptime message = (
+    comptime title = (
         BOLD
         + YELLOW
-        + "Decimo — arbitrary-precision calculator, written in pure Mojo 🔥\n"
+        + "Decimo — arbitrary-precision calculator, written in Mojo 🔥\n"
         + RESET
-        + """Type an expression to evaluate, e.g., `pi + sin(-ln(1.23)) * sqrt(e^2)`.
-You can assign variables with `name = expression`, e.g., `x = 1.023^365`.
-You can use `ans` to refer to the last result.
-Use `:` to change settings, e.g., `:p 100 s r down`.
-Type 'exit' or 'quit', or press Ctrl-D, to quit."""
     )
-    print(message, file=stderr)
+    comptime hints = "Type :h for help, :show for settings, :q to quit."
+    print(title + hints, file=stderr)
     print(String(settings), file=stderr)
+
+
+# ===----------------------------------------------------------------------=== #
+# Meta-command detection helpers
+# ===----------------------------------------------------------------------=== #
+
+
+fn _is_help_command(cmd: String) -> Bool:
+    """Match: help, h, ?."""
+    return cmd == "help" or cmd == "h" or cmd == "?"
+
+
+fn _is_settings_command(cmd: String) -> Bool:
+    """Match: settings, show."""
+    return cmd == "settings" or cmd == "show"
+
+
+fn _is_vars_command(cmd: String) -> Bool:
+    """Match: vars, variables, var."""
+    return cmd == "vars" or cmd == "variables" or cmd == "var"
+
+
+fn _is_quit_command(cmd: String) -> Bool:
+    """Match: q, quit, exit."""
+    return cmd == "q" or cmd == "quit" or cmd == "exit"
+
+
+# ===----------------------------------------------------------------------=== #
+# Meta-command display helpers (4.9, 4.10, 4.11)
+# ===----------------------------------------------------------------------=== #
+
+
+def _print_settings(settings: Settings):
+    """Display all current settings to stderr (4.9)."""
+    print(
+        BOLD + CYAN + "Current settings" + RESET + BOLD + ":" + RESET,
+        file=stderr,
+    )
+    print("  Precision     : " + String(settings.precision), file=stderr)
+    print(
+        "  Scientific    : " + ("on" if settings.scientific else "off"),
+        file=stderr,
+    )
+    print(
+        "  Engineering   : " + ("on" if settings.engineering else "off"),
+        file=stderr,
+    )
+    print(
+        "  Pad           : " + ("on" if settings.pad else "off"),
+        file=stderr,
+    )
+    print(
+        "  Delimiter     : "
+        + ("'" + settings.delimiter + "'" if settings.delimiter else "(none)"),
+        file=stderr,
+    )
+    print("  Rounding mode : " + String(settings.rounding_mode), file=stderr)
+
+
+def _print_variables(variables: Dict[String, Decimal]) raises:
+    """Display all user-defined variables and their values to stderr (4.10)."""
+    var count = len(variables)
+    if count == 0:
+        print("No variables defined.", file=stderr)
+        return
+
+    print(
+        BOLD + CYAN + "Variables" + RESET + BOLD + ":" + RESET,
+        file=stderr,
+    )
+
+    # Always show `ans` first if present
+    if "ans" in variables:
+        print(
+            "  ans = " + variables["ans"].to_string(),
+            file=stderr,
+        )
+
+    # Show user-defined variables
+    for entry in variables.items():
+        if entry.key != "ans":
+            print(
+                "  " + entry.key + " = " + entry.value.to_string(),
+                file=stderr,
+            )
+
+
+def _print_help():
+    """Display REPL-specific help to stderr (4.11)."""
+    comptime help_text = (
+        BOLD
+        + CYAN
+        + "Decimo REPL help"
+        + RESET
+        + BOLD
+        + ":"
+        + RESET
+        + "\n\n"
+        + BOLD
+        + "Expressions"
+        + RESET
+        + ":\n"
+        "  Type any math expression to evaluate it.\n"
+        "  Example: pi + sin(-ln(1.23)) * sqrt(e^2)\n"
+        "\n"
+        + BOLD
+        + "Variables"
+        + RESET
+        + ":\n"
+        "  name = expr   Assign a value:  x = 1.023^365\n"
+        "  ans           Refers to the last result.\n"
+        "\n"
+        + BOLD
+        + "Functions"
+        + RESET
+        + ":\n"
+        "  sqrt  cbrt  root(x,n)  abs  exp  ln  log10  log(x,base)\n"
+        "  sin  cos  tan  cot  csc\n"
+        "\n"
+        + BOLD
+        + "Constants"
+        + RESET
+        + ":\n  pi  e\n\n"
+        + BOLD
+        + "Settings commands"
+        + RESET
+        + " (prefix with :):\n"
+        "  :p N          Set precision to N digits.\n"
+        "  :s            Toggle scientific notation.\n"
+        "  :e            Toggle engineering notation.\n"
+        "  :pad          Toggle zero-padding.\n"
+        "  :r MODE       Set rounding mode (he/hu/hd/u/d/c/f/b).\n"
+        "  :delimiter C  Set digit-group delimiter.\n"
+        "  :p 100 s r d  Combine multiple settings in one line.\n"
+        "\n"
+        + BOLD
+        + "Inline temp settings"
+        + RESET
+        + ":\n  expr:p 100    Override settings for one expression only.\n\n"
+        + BOLD
+        + "Info commands"
+        + RESET
+        + " (prefix with :):\n"
+        "  :settings     Show current settings.\n"
+        "  :vars         List all variables.\n"
+        "  :help         Show this help.\n"
+        "\n"
+        + BOLD
+        + "Quit"
+        + RESET
+        + ":\n  :q  exit  quit  Ctrl-D"
+    )
+    print(help_text, file=stderr)

--- a/src/cli/calculator/repl.mojo
+++ b/src/cli/calculator/repl.mojo
@@ -36,7 +36,7 @@ from std.collections import Dict
 
 from decimo import Decimal
 from decimo.rounding_mode import RoundingMode
-from .display import BOLD, RESET, YELLOW, CYAN, GREEN
+from .display import BOLD, RESET, YELLOW, CYAN
 from .display import write_prompt, print_error
 from .engine import evaluate_and_return
 from .io import read_line, strip, is_comment_or_blank
@@ -495,7 +495,7 @@ def _print_help():
         + " (prefix with :):\n"
         "  :settings     Show current settings.\n"
         "  :vars         List all variables.\n"
-        "  :help         Show this help.\n"
+        "  :help, :h, :? Show this help.\n"
         "\n"
         + BOLD
         + "Quit"

--- a/src/cli/calculator/settings.mojo
+++ b/src/cli/calculator/settings.mojo
@@ -154,7 +154,7 @@ def parse_settings(input: String, mut settings: Settings) raises:
 
     var i = 0
     while i < n:
-        var token = _to_lower(tokens[i])
+        var token = to_lower(tokens[i])
 
         # == Options (consume next token as value) ========================
         if _is_precision_name(token):
@@ -170,7 +170,7 @@ def parse_settings(input: String, mut settings: Settings) raises:
             i += 1
             if i >= n:
                 raise Error("expected a value after '" + tokens[i - 1] + "'")
-            var dval = _to_lower(tokens[i])
+            var dval = to_lower(tokens[i])
             if dval == "off" or dval == "none" or dval == '""' or dval == "''":
                 settings.delimiter = ""
             else:
@@ -182,7 +182,7 @@ def parse_settings(input: String, mut settings: Settings) raises:
                 raise Error(
                     "expected a rounding mode after '" + tokens[i - 1] + "'"
                 )
-            settings.rounding_mode = _parse_rounding_mode(_to_lower(tokens[i]))
+            settings.rounding_mode = _parse_rounding_mode(to_lower(tokens[i]))
 
         # == Flags (toggle; enforce mutual exclusion) =====================
         elif _is_scientific_name(token):
@@ -204,7 +204,7 @@ def parse_settings(input: String, mut settings: Settings) raises:
 
         # == Standalone rounding modes (no `r` prefix needed) ============
         elif _is_standalone_rounding_mode(token):
-            settings.rounding_mode = _parse_rounding_mode(token)
+            settings.rounding_mode = _parse_rounding_mode(to_lower(token))
 
         else:
             raise Error("unknown setting: '" + tokens[i] + "'")
@@ -447,8 +447,15 @@ fn _split_whitespace(s: String) -> List[String]:
     return result^
 
 
-fn _to_lower(s: String) -> String:
-    """Convert a string to lowercase (ASCII only)."""
+fn to_lower(s: String) -> String:
+    """Convert a string to lowercase (ASCII only).
+
+    Args:
+        s: The input string.
+
+    Returns:
+        A new string with all ASCII uppercase letters converted to lowercase.
+    """
     var bytes = StringSlice(s).as_bytes()
     var n = len(bytes)
     var result = List[UInt8](capacity=n)

--- a/src/cli/calculator/settings.mojo
+++ b/src/cli/calculator/settings.mojo
@@ -204,7 +204,7 @@ def parse_settings(input: String, mut settings: Settings) raises:
 
         # == Standalone rounding modes (no `r` prefix needed) ============
         elif _is_standalone_rounding_mode(token):
-            settings.rounding_mode = _parse_rounding_mode(to_lower(token))
+            settings.rounding_mode = _parse_rounding_mode(token)
 
         else:
             raise Error("unknown setting: '" + tokens[i] + "'")

--- a/tests/cli/test_repl.mojo
+++ b/tests/cli/test_repl.mojo
@@ -1,5 +1,6 @@
 """Test REPL helpers: _parse_assignment, _validate_variable_name,
-_is_meta_command, _strip_colon_prefix."""
+_is_meta_command, _strip_colon_prefix, _is_help_command, _is_settings_command,
+_is_vars_command, _is_quit_command."""
 
 from std import testing
 
@@ -8,6 +9,10 @@ from calculator.repl import (
     _validate_variable_name,
     _is_meta_command,
     _strip_colon_prefix,
+    _is_help_command,
+    _is_settings_command,
+    _is_vars_command,
+    _is_quit_command,
 )
 
 
@@ -191,6 +196,101 @@ def test_strip_colon_only() raises:
 def test_strip_colon_with_tab() raises:
     """Tab before `:` is stripped."""
     testing.assert_equal(_strip_colon_prefix("\t:p 50"), "p 50")
+
+
+# ===----------------------------------------------------------------------=== #
+# Tests: _is_help_command (4.11)
+# ===----------------------------------------------------------------------=== #
+
+
+def test_help_command_help() raises:
+    """`help` matches."""
+    testing.assert_true(_is_help_command("help"), "help")
+
+
+def test_help_command_h() raises:
+    """`h` matches."""
+    testing.assert_true(_is_help_command("h"), "h")
+
+
+def test_help_command_question() raises:
+    """`?` matches."""
+    testing.assert_true(_is_help_command("?"), "?")
+
+
+def test_help_command_no_match() raises:
+    """`hello` does not match."""
+    testing.assert_false(_is_help_command("hello"), "hello")
+
+
+# ===----------------------------------------------------------------------=== #
+# Tests: _is_settings_command (4.9)
+# ===----------------------------------------------------------------------=== #
+
+
+def test_settings_command_settings() raises:
+    """`settings` matches."""
+    testing.assert_true(_is_settings_command("settings"), "settings")
+
+
+def test_settings_command_show() raises:
+    """`show` matches."""
+    testing.assert_true(_is_settings_command("show"), "show")
+
+
+def test_settings_command_no_match() raises:
+    """`set` does not match."""
+    testing.assert_false(_is_settings_command("set"), "set")
+
+
+# ===----------------------------------------------------------------------=== #
+# Tests: _is_vars_command (4.10)
+# ===----------------------------------------------------------------------=== #
+
+
+def test_vars_command_vars() raises:
+    """`vars` matches."""
+    testing.assert_true(_is_vars_command("vars"), "vars")
+
+
+def test_vars_command_variables() raises:
+    """`variables` matches."""
+    testing.assert_true(_is_vars_command("variables"), "variables")
+
+
+def test_vars_command_var() raises:
+    """`var` matches."""
+    testing.assert_true(_is_vars_command("var"), "var")
+
+
+def test_vars_command_no_match() raises:
+    """`v` does not match."""
+    testing.assert_false(_is_vars_command("v"), "v")
+
+
+# ===----------------------------------------------------------------------=== #
+# Tests: _is_quit_command
+# ===----------------------------------------------------------------------=== #
+
+
+def test_quit_command_q() raises:
+    """`q` matches."""
+    testing.assert_true(_is_quit_command("q"), "q")
+
+
+def test_quit_command_quit() raises:
+    """`quit` matches."""
+    testing.assert_true(_is_quit_command("quit"), "quit")
+
+
+def test_quit_command_exit() raises:
+    """`exit` matches."""
+    testing.assert_true(_is_quit_command("exit"), "exit")
+
+
+def test_quit_command_no_match() raises:
+    """`bye` does not match."""
+    testing.assert_false(_is_quit_command("bye"), "bye")
 
 
 # ===----------------------------------------------------------------------=== #

--- a/tests/cli/test_settings.mojo
+++ b/tests/cli/test_settings.mojo
@@ -8,6 +8,7 @@ from calculator.settings import (
     Settings,
     parse_settings,
     split_inline_settings,
+    to_lower,
 )
 
 
@@ -487,6 +488,36 @@ def test_inline_colon_inside_parens_ignored() raises:
     var result = split_inline_settings("sqrt(2):p 100")
     testing.assert_true(Bool(result), "colon after paren")
     testing.assert_equal(result.value()[0], "sqrt(2)")
+
+
+# ===----------------------------------------------------------------------=== #
+# Tests: to_lower (4.13)
+# ===----------------------------------------------------------------------=== #
+
+
+def test_to_lower_basic() raises:
+    """Uppercase letters are lowered."""
+    testing.assert_equal(to_lower("ABC"), "abc")
+
+
+def test_to_lower_mixed() raises:
+    """Mixed case is fully lowered."""
+    testing.assert_equal(to_lower("Hello World"), "hello world")
+
+
+def test_to_lower_already_lower() raises:
+    """Lowercase stays unchanged."""
+    testing.assert_equal(to_lower("abc"), "abc")
+
+
+def test_to_lower_with_digits() raises:
+    """Digits and special chars are preserved."""
+    testing.assert_equal(to_lower("PI + SIN(1.23)"), "pi + sin(1.23)")
+
+
+def test_to_lower_empty() raises:
+    """Empty string stays empty."""
+    testing.assert_equal(to_lower(""), "")
 
 
 # ===----------------------------------------------------------------------=== #


### PR DESCRIPTION
This PR enhances the Decimo CLI REPL with additional user-facing meta-commands, improved startup messaging, and case-insensitive input handling, plus corresponding tests and documentation updates.

**Changes:**
- Add REPL info meta-commands for help (`:help`/`:h`/`:?`), settings display (`:settings`/`:show`), variable listing (`:vars`/`:variables`/`:var`), and quitting (`:q`/`:quit`/`:exit`).
- Implement case-insensitive REPL input via an ASCII `to_lower()` helper (now exposed from `calculator.settings`), and streamline the REPL banner.
- Expand tests for the new command-detection helpers and `to_lower()`, and update user docs/changelog/plan tracking.