### PR TITLE
[cli][repl] Allow passing precision integer directly + `:` for settings, `?` for help, `$` for variables + Colorful help message

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,7 @@ This is a list of changes for the Decimo package (formerly DeciMojo).
 1. Add **REPL info commands**: `:settings` / `:show` displays all current options, `:vars` / `:variables` lists all defined variables and their values, `:help` / `:h` shows a complete command reference, and `:q` / `:quit` / `:exit` exits the session.
 1. Add **case-insensitive input** in the REPL: all input is lowercased before processing, so `PI`, `Sqrt(2)`, `SIN(1)` all work.
 1. Streamline the **REPL welcome banner** to a compact one-liner with a hint to `:help` and `:q`.
+1. Add **standalone integer precision shortcut** in settings: `:100` is equivalent to `:p 100`. Any all-digit token in a settings command is treated as the precision value.
 
 ### 🦋 Changed in v0.10.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,10 +13,11 @@ This is a list of changes for the Decimo package (formerly DeciMojo).
 1. Add **shell completion** documentation for Bash, Zsh, and Fish (`decimo --completions bash|zsh|fish`).
 1. Add **CLI performance benchmarks** (`benches/cli/bench_cli.sh`) comparing correctness and timing against `bc` and `python3` across 47 comparisons — all results match to 15 significant digits; `decimo` is 3–4× faster than `python3 -c`.
 1. Add **interactive REPL**: launch with `decimo` (no arguments, TTY attached). Features coloured `decimo>` prompt on stderr, per-line error recovery with caret diagnostics, comment/blank-line skipping, and graceful exit via `exit`, `quit`, or Ctrl-D. All CLI flags (`-P`, `--scientific`, etc.) apply to the REPL session.
-1. Add **REPL info commands**: `:settings` / `:show` displays all current options, `:vars` / `:variables` lists all defined variables and their values, `:help` / `:h` shows a complete command reference, and `:q` / `:quit` / `:exit` exits the session.
+1. Add **REPL info commands**: `:show` / `:settings` displays all current options, `:vars` / `:variables` lists all defined variables and their values, `:help` / `:h` shows a complete command reference, and `:q` / `:quit` / `:exit` exits the session.
 1. Add **case-insensitive input** in the REPL: all input is lowercased before processing, so `PI`, `Sqrt(2)`, `SIN(1)` all work.
 1. Streamline the **REPL welcome banner** to a compact one-liner with a hint to `:help` and `:q`.
 1. Add **standalone integer precision shortcut** in settings: `:100` is equivalent to `:p 100`. Any all-digit token in a settings command is treated as the precision value.
+1. Print **full settings block** after every settings change (`:...` commands) instead of a one-line summary, so the effect is immediately visible.
 
 ### 🦋 Changed in v0.10.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,9 +13,9 @@ This is a list of changes for the Decimo package (formerly DeciMojo).
 1. Add **shell completion** documentation for Bash, Zsh, and Fish (`decimo --completions bash|zsh|fish`).
 1. Add **CLI performance benchmarks** (`benches/cli/bench_cli.sh`) comparing correctness and timing against `bc` and `python3` across 47 comparisons — all results match to 15 significant digits; `decimo` is 3–4× faster than `python3 -c`.
 1. Add **interactive REPL**: launch with `decimo` (no arguments, TTY attached). Features coloured `decimo>` prompt on stderr, per-line error recovery with caret diagnostics, comment/blank-line skipping, and graceful exit via `exit`, `quit`, or Ctrl-D. All CLI flags (`-P`, `--scientific`, etc.) apply to the REPL session.
-1. Add **REPL info commands**: `:show` / `:settings` displays all current options, `:vars` / `:variables` lists all defined variables and their values, `:help` / `:h` shows a complete command reference, and `:q` / `:quit` / `:exit` exits the session.
+1. Add **REPL info commands**: `:` shows current settings, `?` shows help, `$` / `:v` / `:vars` lists all defined variables, `:q` / `:quit` / `:exit` exits the session.
 1. Add **case-insensitive input** in the REPL: all input is lowercased before processing, so `PI`, `Sqrt(2)`, `SIN(1)` all work.
-1. Streamline the **REPL welcome banner** to a compact one-liner with a hint to `:help` and `:q`.
+1. Streamline the **REPL welcome banner** to a compact one-liner with a hint to `?`, `:`, and `:q`.
 1. Add **standalone integer precision shortcut** in settings: `:100` is equivalent to `:p 100`. Any all-digit token in a settings command is treated as the precision value.
 1. Print **full settings block** after every settings change (`:...` commands) instead of a one-line summary, so the effect is immediately visible.
 

--- a/docs/plans/cli_calculator.md
+++ b/docs/plans/cli_calculator.md
@@ -379,10 +379,10 @@ decimo> exit
 | 4.6  | Meta-commands (`:precision N`, etc.)       |   ✓    | `:` prefix avoids collision; settings names + aliases (`:vars` not yet)     |
 | 4.7  | One-line quick setting                     |   ✓    | `:p 100 s r down` sets precision, scientific, and rounding in one line      |
 | 4.8  | Same-line temp precision setting           |   ✓    | `2*sqrt(1.23):p 100 s r down` — temp override via `:` separator             |
-| 4.9  | Print settings (`:show`)                   |   ✓    | `:show` / `:settings` displays all current options in a labelled list       |
-| 4.10 | Variable listing (`:vars` and `:variable`) |   ✓    | `:vars` / `:variables` / `:var` lists `ans` first, then user variables      |
-| 4.11 | Help command (`:help`)                     |   ✓    | `:help` / `:h` / `:?` shows expressions, variables, functions, commands     |
-| 4.12 | Better header banner                       |   ✓    | Compact: title + "Type :help for help, :q to quit." + current settings      |
+| 4.9  | Print settings (`:`)                       |   ✓    | Bare `:` displays full settings block; shown after every `:...` change      |
+| 4.10 | Variable listing (`:v`, `:vars`, `$`)      |   ✓    | `:v` / `:vars` or bare `$` lists `ans` first, then user variables           |
+| 4.11 | Help command (`?`)                         |   ✓    | Bare `?` or `:help` / `:h` shows expressions, variables, functions, cmds    |
+| 4.12 | Better header banner                       |   ✓    | Compact: title + "Type ? for help, : for settings, :q to quit."             |
 | 4.13 | Everything in the REPL is case-insensitive |   ✓    | `to_lower()` applied to all input before processing (pre-tokenizer stage)   |
 | 4.14 | Graceful exit (`exit`, `quit`, Ctrl-D)     |   ✓    |                                                                             |
 | 4.15 | Error recovery (don't crash session)       |   ✓    | Catch exceptions per-line, display error, continue loop                     |

--- a/docs/plans/cli_calculator.md
+++ b/docs/plans/cli_calculator.md
@@ -379,7 +379,7 @@ decimo> exit
 | 4.6  | Meta-commands (`:precision N`, etc.)       |   ✓    | `:` prefix avoids collision; settings names + aliases (`:vars` not yet)     |
 | 4.7  | One-line quick setting                     |   ✓    | `:p 100 s r down` sets precision, scientific, and rounding in one line      |
 | 4.8  | Same-line temp precision setting           |   ✓    | `2*sqrt(1.23):p 100 s r down` — temp override via `:` separator             |
-| 4.9  | Print settings (`:settings`)               |   ✓    | `:settings` / `:show` displays all current options in a labelled list       |
+| 4.9  | Print settings (`:show`)                   |   ✓    | `:show` / `:settings` displays all current options in a labelled list       |
 | 4.10 | Variable listing (`:vars` and `:variable`) |   ✓    | `:vars` / `:variables` / `:var` lists `ans` first, then user variables      |
 | 4.11 | Help command (`:help`)                     |   ✓    | `:help` / `:h` / `:?` shows expressions, variables, functions, commands     |
 | 4.12 | Better header banner                       |   ✓    | Compact: title + "Type :help for help, :q to quit." + current settings      |

--- a/docs/plans/cli_calculator.md
+++ b/docs/plans/cli_calculator.md
@@ -386,7 +386,7 @@ decimo> exit
 | 4.13 | Everything in the REPL is case-insensitive |   ✓    | `to_lower()` applied to all input before processing (pre-tokenizer stage)   |
 | 4.14 | Graceful exit (`exit`, `quit`, Ctrl-D)     |   ✓    |                                                                             |
 | 4.15 | Error recovery (don't crash session)       |   ✓    | Catch exceptions per-line, display error, continue loop                     |
-| 4.16 | `:100` in REPL settings to set precision   |   ✗    | Shortcut of `:p 100`. If `token[0]` is 0-9, it means precision              |
+| 4.16 | `:100` in REPL settings to set precision   |   ✓    | Shortcut of `:p 100`. Any all-digit token is treated as precision           |
 | 4.17 | Add `--about`/`--info` flag and in REPL    |   ✗    | Display version, build info, links to docs/repo, etc, for both CLI and REPL |
 | 4.18 | Line editing (left/right, backspace, del)  |   ✗    | Implemented via `limo` package; see `docs/plans/line_editor.md`             |
 | 4.19 | Input history (up/down arrow navigation)   |   ✗    | Implemented via `limo` package; see `docs/plans/line_editor.md`             |

--- a/docs/plans/cli_calculator.md
+++ b/docs/plans/cli_calculator.md
@@ -381,7 +381,7 @@ decimo> exit
 | 4.8  | Same-line temp precision setting           |   ✓    | `2*sqrt(1.23):p 100 s r down` — temp override via `:` separator             |
 | 4.9  | Print settings (`:`)                       |   ✓    | Bare `:` displays full settings block; shown after every `:...` change      |
 | 4.10 | Variable listing (`:v`, `:vars`, `$`)      |   ✓    | `:v` / `:vars` or bare `$` lists `ans` first, then user variables           |
-| 4.11 | Help command (`?`)                         |   ✓    | Bare `?` or `:help` / `:h` shows expressions, variables, functions, cmds    |
+| 4.11 | Help command (`?`)                         |   ✓    | `?` / `:help` / `:h` / `:?`; colourful output with section headings         |
 | 4.12 | Better header banner                       |   ✓    | Compact: title + "Type ? for help, : for settings, :q to quit."             |
 | 4.13 | Everything in the REPL is case-insensitive |   ✓    | `to_lower()` applied to all input before processing (pre-tokenizer stage)   |
 | 4.14 | Graceful exit (`exit`, `quit`, Ctrl-D)     |   ✓    |                                                                             |

--- a/docs/user_manual_cli.md
+++ b/docs/user_manual_cli.md
@@ -383,11 +383,11 @@ decimo> sqrt(2):p 100
 
 #### Info commands (prefix with `:`)
 
-| Command     | Effect                      |
-| ----------- | --------------------------- |
-| `:show`     | Show all current settings.  |
-| `:vars`     | List all defined variables. |
-| `:help`     | Show REPL help.             |
+| Command | Effect                      |
+| ------- | --------------------------- |
+| `:show` | Show all current settings.  |
+| `:vars` | List all defined variables. |
+| `:help` | Show REPL help.             |
 
 #### Quitting
 

--- a/docs/user_manual_cli.md
+++ b/docs/user_manual_cli.md
@@ -337,7 +337,7 @@ When invoked with no expression and stdin is a TTY, `decimo` launches an interac
 
 ```sh
 $ decimo
-Decimo — arbitrary-precision calculator, written in Mojo 🔥
+Decimo — arbitrary-precision calculator 🔥
 Type :h for help, :show for settings, :q to quit.
 Precision: 50.
 decimo> 100 * 12 - 23/17
@@ -364,6 +364,7 @@ decimo> :q
 | Command        | Effect                                                  |
 | -------------- | ------------------------------------------------------- |
 | `:p N`         | Set precision to `N` digits.                            |
+| `:N`           | Shortcut for `:p N` (e.g. `:100`).                      |
 | `:s`           | Toggle scientific notation.                             |
 | `:e`           | Toggle engineering notation.                            |
 | `:pad`         | Toggle zero-padding.                                    |

--- a/docs/user_manual_cli.md
+++ b/docs/user_manual_cli.md
@@ -385,7 +385,7 @@ decimo> sqrt(2):p 100
 
 | Command     | Effect                      |
 | ----------- | --------------------------- |
-| `:settings` | Show all current settings.  |
+| `:show`     | Show all current settings.  |
 | `:vars`     | List all defined variables. |
 | `:help`     | Show REPL help.             |
 

--- a/docs/user_manual_cli.md
+++ b/docs/user_manual_cli.md
@@ -361,17 +361,17 @@ decimo> :q
 
 #### Settings commands (prefix with `:`)
 
-| Command        | Effect                                                  |
-| -------------- | ------------------------------------------------------- |
-| `:p N`         | Set precision to `N` digits.                            |
-| `:N`           | Shortcut for `:p N` (e.g. `:100`).                      |
-| `:s`           | Toggle scientific notation.                             |
-| `:e`           | Toggle engineering notation.                            |
-| `:pad`         | Toggle zero-padding.                                    |
-| `:r MODE`      | Set rounding mode (`he`/`hu`/`hd`/`u`/`d`/`c`/`f`/`b`). |
-| `:MODE`        | Set rounding mode (`he`/`hu`/`hd`/`u`/`d`/`c`/`f`/`b`). |
-| `:delimiter C` | Set digit-group delimiter.                              |
-| `:p 100 s r d` | Combine multiple settings in one line.                  |
+| Command                      | Effect                                                  |
+| ---------------------------- | ------------------------------------------------------- |
+| `:p N`, `:precision N`       | Set precision to `N` digits.                            |
+| `:N`                         | Shortcut for `:p N` (e.g. `:100`).                      |
+| `:s`, `:scientific`, `:sci`  | Toggle scientific notation.                             |
+| `:e`, `:engineering`, `:eng` | Toggle engineering notation.                            |
+| `:pad`                       | Toggle zero-padding.                                    |
+| `:r MODE`, `:round`, `:rm`   | Set rounding mode (`he`/`hu`/`hd`/`u`/`d`/`c`/`f`/`b`). |
+| `:MODE`                      | Set rounding mode (`he`/`hu`/`hd`/`u`/`d`/`c`/`f`/`b`). |
+| `:delimiter C`               | Set digit-group delimiter.                              |
+| `:p 100 s r d`               | Combine multiple settings in one line.                  |
 
 #### Inline temp settings
 
@@ -383,13 +383,11 @@ decimo> sqrt(2):p 100
 
 #### Info commands
 
-| Command | Effect                      |
-| ------- | --------------------------- |
-| `:`     | Show all current settings.  |
-| `?`     | Show REPL help.             |
-| `$`     | List all defined variables. |
-| `:v`    | List all defined variables. |
-| `:vars` | List all defined variables. |
+| Command                  | Effect                      |
+| ------------------------ | --------------------------- |
+| `:`                      | Show all current settings.  |
+| `?`, `:help`, `:h`, `:?` | Show REPL help.             |
+| `$`, `:v`, `:vars`       | List all defined variables. |
 
 #### Quitting
 

--- a/docs/user_manual_cli.md
+++ b/docs/user_manual_cli.md
@@ -26,7 +26,7 @@
     - [Variables](#variables)
     - [Settings commands (prefix with `:`)](#settings-commands-prefix-with-)
     - [Inline temp settings](#inline-temp-settings)
-    - [Info commands (prefix with `:`)](#info-commands-prefix-with-)
+    - [Info commands](#info-commands)
     - [Quitting](#quitting)
 - [Shell Integration](#shell-integration)
   - [Quoting Expressions](#quoting-expressions)
@@ -338,8 +338,8 @@ When invoked with no expression and stdin is a TTY, `decimo` launches an interac
 ```sh
 $ decimo
 Decimo — arbitrary-precision calculator 🔥
-Type :h for help, :show for settings, :q to quit.
-Precision: 50.
+Type ? for help, : for settings, :q to quit.
+Precision: 50. Rounding: ROUND_HALF_EVEN.
 decimo> 100 * 12 - 23/17
 1198.6470588235294117647058823529411764705882352941
 decimo> ans + 1
@@ -381,13 +381,15 @@ Append `:<settings>` to an expression to override settings for that single evalu
 decimo> sqrt(2):p 100
 ```
 
-#### Info commands (prefix with `:`)
+#### Info commands
 
 | Command | Effect                      |
 | ------- | --------------------------- |
-| `:show` | Show all current settings.  |
+| `:`     | Show all current settings.  |
+| `?`     | Show REPL help.             |
+| `$`     | List all defined variables. |
+| `:v`    | List all defined variables. |
 | `:vars` | List all defined variables. |
-| `:help` | Show REPL help.             |
 
 #### Quitting
 

--- a/src/cli/calculator/repl.mojo
+++ b/src/cli/calculator/repl.mojo
@@ -342,10 +342,7 @@ def _validate_variable_name(name: String) -> Optional[String]:
 def _print_banner(settings: Settings):
     """Prints the REPL welcome banner to stderr."""
     comptime title = (
-        BOLD
-        + YELLOW
-        + "Decimo — arbitrary-precision calculator, written in Mojo 🔥\n"
-        + RESET
+        BOLD + YELLOW + "Decimo — arbitrary-precision calculator 🔥\n" + RESET
     )
     comptime hints = "Type :h for help, :show for settings, :q to quit."
     print(title + hints, file=stderr)
@@ -478,6 +475,7 @@ def _print_help():
         + RESET
         + " (prefix with :):\n"
         "  :p N          Set precision to N digits.\n"
+        "  :N            Shortcut for :p N (e.g. :100).\n"
         "  :s            Toggle scientific notation.\n"
         "  :e            Toggle engineering notation.\n"
         "  :pad          Toggle zero-padding.\n"

--- a/src/cli/calculator/repl.mojo
+++ b/src/cli/calculator/repl.mojo
@@ -116,24 +116,32 @@ def run_repl(
         if line == "exit" or line == "quit":
             break
 
+        # == Bare commands (no `:` prefix) ================================
+        # `?` — show help
+        if line == "?":
+            _print_help()
+            continue
+
+        # `$` — show variables
+        if line == "$":
+            _print_variables(variables)
+            continue
+
         # == Meta-command: line starts with `:` ===========================
         if _is_meta_command(line):
             var cmd_str = _strip_colon_prefix(line)
 
-            # `:help` / `:h`
-            # This displays a complete command reference for REPL features
+            # Bare `:` — show current settings
+            if cmd_str == "":
+                _print_settings(settings)
+                continue
+
+            # `:help` / `:h` — also show help (`:?` removed; use bare `?`)
             if _is_help_command(cmd_str):
                 _print_help()
                 continue
 
-            # `:show` / `:settings`
-            # This displays all current settings and their values
-            # (precision, sci/eng, pad, delimiter, rounding mode)
-            if _is_settings_command(cmd_str):
-                _print_settings(settings)
-                continue
-
-            # `:vars` / `:variables`
+            # `:v` / `:vars`
             # This displays all user-defined variables and their current values,
             # including `ans`.
             if _is_vars_command(cmd_str):
@@ -343,7 +351,7 @@ def _print_banner(settings: Settings):
     comptime title = (
         BOLD + YELLOW + "Decimo — arbitrary-precision calculator 🔥\n" + RESET
     )
-    comptime hints = "Type :h for help, :show for settings, :q to quit."
+    comptime hints = "Type ? for help, : for settings, :q to quit."
     print(title + hints, file=stderr)
     print(String(settings), file=stderr)
 
@@ -354,18 +362,13 @@ def _print_banner(settings: Settings):
 
 
 fn _is_help_command(cmd: String) -> Bool:
-    """Match: help, h, ?."""
-    return cmd == "help" or cmd == "h" or cmd == "?"
-
-
-fn _is_settings_command(cmd: String) -> Bool:
-    """Match: show, settings."""
-    return cmd == "show" or cmd == "settings"
+    """Match: help, h."""
+    return cmd == "help" or cmd == "h"
 
 
 fn _is_vars_command(cmd: String) -> Bool:
-    """Match: vars, variables, var."""
-    return cmd == "vars" or cmd == "variables" or cmd == "var"
+    """Match: v, vars."""
+    return cmd == "v" or cmd == "vars"
 
 
 fn _is_quit_command(cmd: String) -> Bool:
@@ -489,10 +492,11 @@ def _print_help():
         + BOLD
         + "Info commands"
         + RESET
-        + " (prefix with :):\n"
-        "  :show, :settings  Show current settings.\n"
-        "  :vars             List all variables.\n"
-        "  :help, :h, :?     Show this help.\n"
+        + ":\n"
+        "  :             Show current settings.\n"
+        "  ?             Show this help.\n"
+        "  $             List all variables.\n"
+        "  :v, :vars     List all variables.\n"
         "\n"
         + BOLD
         + "Quit"

--- a/src/cli/calculator/repl.mojo
+++ b/src/cli/calculator/repl.mojo
@@ -126,7 +126,7 @@ def run_repl(
                 _print_help()
                 continue
 
-            # `:settings` / `:show`
+            # `:show` / `:settings`
             # This displays all current settings and their values
             # (precision, sci/eng, pad, delimiter, rounding mode)
             if _is_settings_command(cmd_str):
@@ -147,8 +147,7 @@ def run_repl(
 
             try:
                 parse_settings(cmd_str, settings)
-                # Print confirmation to stderr
-                print(String(settings), file=stderr)
+                _print_settings(settings)
             except e:
                 print_error(String(e))
             continue
@@ -360,8 +359,8 @@ fn _is_help_command(cmd: String) -> Bool:
 
 
 fn _is_settings_command(cmd: String) -> Bool:
-    """Match: settings, show."""
-    return cmd == "settings" or cmd == "show"
+    """Match: show, settings."""
+    return cmd == "show" or cmd == "settings"
 
 
 fn _is_vars_command(cmd: String) -> Bool:
@@ -491,9 +490,9 @@ def _print_help():
         + "Info commands"
         + RESET
         + " (prefix with :):\n"
-        "  :settings     Show current settings.\n"
-        "  :vars         List all variables.\n"
-        "  :help, :h, :? Show this help.\n"
+        "  :show, :settings  Show current settings.\n"
+        "  :vars             List all variables.\n"
+        "  :help, :h, :?     Show this help.\n"
         "\n"
         + BOLD
         + "Quit"

--- a/src/cli/calculator/repl.mojo
+++ b/src/cli/calculator/repl.mojo
@@ -36,7 +36,7 @@ from std.collections import Dict
 
 from decimo import Decimal
 from decimo.rounding_mode import RoundingMode
-from .display import BOLD, RESET, YELLOW, CYAN
+from .display import BOLD, RESET, YELLOW, CYAN, GREEN, MAGENTA
 from .display import write_prompt, print_error
 from .engine import evaluate_and_return
 from .io import read_line, strip, is_comment_or_blank
@@ -136,7 +136,7 @@ def run_repl(
                 _print_settings(settings)
                 continue
 
-            # `:help` / `:h` — also show help (`:?` removed; use bare `?`)
+            # `:help` / `:h` / `:?` — show help
             if _is_help_command(cmd_str):
                 _print_help()
                 continue
@@ -362,8 +362,8 @@ def _print_banner(settings: Settings):
 
 
 fn _is_help_command(cmd: String) -> Bool:
-    """Match: help, h."""
-    return cmd == "help" or cmd == "h"
+    """Match: help, h, ?."""
+    return cmd == "help" or cmd == "h" or cmd == "?"
 
 
 fn _is_vars_command(cmd: String) -> Bool:
@@ -437,70 +437,382 @@ def _print_variables(variables: Dict[String, Decimal]) raises:
 
 
 def _print_help():
-    """Display REPL-specific help to stderr (4.11)."""
-    comptime help_text = (
-        BOLD
-        + CYAN
-        + "Decimo REPL help"
-        + RESET
-        + BOLD
-        + ":"
-        + RESET
-        + "\n\n"
-        + BOLD
-        + "Expressions"
-        + RESET
-        + ":\n"
-        "  Type any math expression to evaluate it.\n"
-        "  Example: pi + sin(-ln(1.23)) * sqrt(e^2)\n"
-        "\n"
-        + BOLD
-        + "Variables"
-        + RESET
-        + ":\n"
-        "  name = expr   Assign a value:  x = 1.023^365\n"
-        "  ans           Refers to the last result.\n"
-        "\n"
-        + BOLD
-        + "Functions"
-        + RESET
-        + ":\n"
-        "  sqrt  cbrt  root(x,n)  abs  exp  ln  log10  log(x,base)\n"
-        "  sin  cos  tan  cot  csc\n"
-        "\n"
-        + BOLD
-        + "Constants"
-        + RESET
-        + ":\n  pi  e\n\n"
-        + BOLD
-        + "Settings commands"
-        + RESET
-        + " (prefix with :):\n"
-        "  :p N          Set precision to N digits.\n"
-        "  :N            Shortcut for :p N (e.g. :100).\n"
-        "  :s            Toggle scientific notation.\n"
-        "  :e            Toggle engineering notation.\n"
-        "  :pad          Toggle zero-padding.\n"
-        "  :r MODE       Set rounding mode (he/hu/hd/u/d/c/f/b).\n"
-        "  :delimiter C  Set digit-group delimiter.\n"
-        "  :p 100 s r d  Combine multiple settings in one line.\n"
-        "\n"
-        + BOLD
-        + "Inline temp settings"
-        + RESET
-        + ":\n  expr:p 100    Override settings for one expression only.\n\n"
-        + BOLD
-        + "Info commands"
-        + RESET
-        + ":\n"
-        "  :             Show current settings.\n"
-        "  ?             Show this help.\n"
-        "  $             List all variables.\n"
-        "  :v, :vars     List all variables.\n"
-        "\n"
-        + BOLD
-        + "Quit"
-        + RESET
-        + ":\n  :q  exit  quit  Ctrl-D"
+    """Display REPL-specific help to stderr.
+
+    All description columns are aligned at visible column 30
+    (2-char indent + 28-char command column).
+    """
+    # Colour aliases — zero visible width, used for styling only.
+    comptime B = BOLD
+    comptime R = RESET
+    comptime H = BOLD + CYAN  # section Heading
+    comptime L = BOLD + GREEN  # Long name / command
+    comptime S = BOLD + YELLOW  # Short name / alias
+    comptime V = MAGENTA  # Value placeholder
+
+    var w = stderr
+
+    # --- title ---
+    print(H + "Decimo REPL help" + R + B + ":" + R + "\n", file=w)
+
+    # --- expressions ---
+    print(H + "Expressions" + R + B + ":" + R, file=w)
+    print("  Type any math expression to evaluate it.", file=w)
+    print(
+        "  Example: " + S + "pi + sin(-ln(1.23)) * sqrt(e^2)" + R + "\n", file=w
     )
-    print(help_text, file=stderr)
+
+    # --- variables (col 28) ---
+    print(H + "Variables" + R + B + ":" + R, file=w)
+    #     |name = expr       |                 <- 11 + 17 = 28
+    print(
+        "  "
+        + V
+        + "name"
+        + R
+        + " = "
+        + V
+        + "expr"
+        + R
+        + "                 Assign a value:  x = 1.023^365",
+        file=w,
+    )
+    #     |ans               |                 <- 3 + 25 = 28
+    print(
+        "  "
+        + L
+        + "ans"
+        + R
+        + "                         Refers to the last result.\n",
+        file=w,
+    )
+
+    # --- functions ---
+    print(H + "Functions" + R + B + ":" + R, file=w)
+    print(
+        "  "
+        + L
+        + "sqrt"
+        + R
+        + "  "
+        + L
+        + "cbrt"
+        + R
+        + "  "
+        + L
+        + "root"
+        + R
+        + "("
+        + V
+        + "x"
+        + R
+        + ","
+        + V
+        + "n"
+        + R
+        + ")  "
+        + L
+        + "abs"
+        + R
+        + "  "
+        + L
+        + "exp"
+        + R
+        + "  "
+        + L
+        + "ln"
+        + R
+        + "  "
+        + L
+        + "log10"
+        + R
+        + "  "
+        + L
+        + "log"
+        + R
+        + "("
+        + V
+        + "x"
+        + R
+        + ","
+        + V
+        + "base"
+        + R
+        + ")",
+        file=w,
+    )
+    print(
+        "  "
+        + L
+        + "sin"
+        + R
+        + "  "
+        + L
+        + "cos"
+        + R
+        + "  "
+        + L
+        + "tan"
+        + R
+        + "  "
+        + L
+        + "cot"
+        + R
+        + "  "
+        + L
+        + "csc"
+        + R
+        + "\n",
+        file=w,
+    )
+
+    # --- constants ---
+    print(H + "Constants" + R + B + ":" + R, file=w)
+    print("  " + L + "pi" + R + "  " + L + "e" + R + "\n", file=w)
+
+    # --- settings commands (col 28) ---
+    print(H + "Settings commands" + R + B + ":" + R, file=w)
+    #     |:p, :precision N  |            <- 16 + 12 = 28
+    print(
+        "  "
+        + S
+        + ":p"
+        + R
+        + ", "
+        + L
+        + ":precision"
+        + R
+        + " "
+        + V
+        + "N"
+        + R
+        + "            Set precision to "
+        + V
+        + "N"
+        + R
+        + " digits.",
+        file=w,
+    )
+    #     |:N                |            <- 2 + 26 = 28
+    print(
+        "  "
+        + S
+        + ":"
+        + R
+        + V
+        + "N"
+        + R
+        + "                          Shortcut for :p "
+        + V
+        + "N"
+        + R
+        + " (e.g. "
+        + S
+        + ":100"
+        + R
+        + ").",
+        file=w,
+    )
+    #     |:s, :scientific, :sci|         <- 21 + 7 = 28
+    print(
+        "  "
+        + S
+        + ":s"
+        + R
+        + ", "
+        + L
+        + ":scientific"
+        + R
+        + ", "
+        + L
+        + ":sci"
+        + R
+        + "       Toggle scientific notation.",
+        file=w,
+    )
+    #     |:e, :engineering, :eng|        <- 22 + 6 = 28
+    print(
+        "  "
+        + S
+        + ":e"
+        + R
+        + ", "
+        + L
+        + ":engineering"
+        + R
+        + ", "
+        + L
+        + ":eng"
+        + R
+        + "      Toggle engineering notation.",
+        file=w,
+    )
+    #     |:pad              |            <- 4 + 24 = 28
+    print(
+        "  " + S + ":pad" + R + "                        Toggle zero-padding.",
+        file=w,
+    )
+    #     |:r, :round, :rm MODE|          <- 20 + 8 = 28
+    print(
+        "  "
+        + S
+        + ":r"
+        + R
+        + ", "
+        + L
+        + ":round"
+        + R
+        + ", "
+        + L
+        + ":rm"
+        + R
+        + " "
+        + V
+        + "MODE"
+        + R
+        + "        Set rounding mode ("
+        + S
+        + "he"
+        + R
+        + "/"
+        + S
+        + "hu"
+        + R
+        + "/"
+        + S
+        + "hd"
+        + R
+        + "/"
+        + S
+        + "u"
+        + R
+        + "/"
+        + S
+        + "d"
+        + R
+        + "/"
+        + S
+        + "c"
+        + R
+        + "/"
+        + S
+        + "f"
+        + R
+        + "/"
+        + S
+        + "b"
+        + R
+        + ").",
+        file=w,
+    )
+    #     |:delimiter C      |            <- 12 + 16 = 28
+    print(
+        "  "
+        + L
+        + ":delimiter"
+        + R
+        + " "
+        + V
+        + "C"
+        + R
+        + "                Set digit-group delimiter.",
+        file=w,
+    )
+    #     |:p 100 s r d      |            <- 12 + 16 = 28
+    print(
+        "  "
+        + S
+        + ":p 100 s r d"
+        + R
+        + "                Combine multiple settings in one line.\n",
+        file=w,
+    )
+
+    # --- inline temp settings (col 28) ---
+    print(H + "Inline temp settings" + R + B + ":" + R, file=w)
+    #     |expr:settings     |            <- 13 + 15 = 28
+    print(
+        "  "
+        + V
+        + "expr"
+        + R
+        + ":"
+        + V
+        + "settings"
+        + R
+        + "               Override settings for one expression only.",
+        file=w,
+    )
+    print("  Example: " + S + "sqrt(2):p 100" + R + "\n", file=w)
+
+    # --- info commands (col 28) ---
+    print(H + "Info commands" + R + B + ":" + R, file=w)
+    #     |:                 |            <- 1 + 27 = 28
+    print(
+        "  "
+        + S
+        + ":"
+        + R
+        + "                           Show current settings.",
+        file=w,
+    )
+    #     |?, :help, :h, :?  |            <- 16 + 12 = 28
+    print(
+        "  "
+        + S
+        + "?"
+        + R
+        + ", "
+        + L
+        + ":help"
+        + R
+        + ", "
+        + S
+        + ":h"
+        + R
+        + ", "
+        + S
+        + ":?"
+        + R
+        + "            Show this help.",
+        file=w,
+    )
+    #     |$, :v, :vars      |            <- 12 + 16 = 28
+    print(
+        "  "
+        + S
+        + "$"
+        + R
+        + ", "
+        + S
+        + ":v"
+        + R
+        + ", "
+        + L
+        + ":vars"
+        + R
+        + "                List all variables.\n",
+        file=w,
+    )
+
+    # --- quit ---
+    print(H + "Quit" + R + B + ":" + R, file=w)
+    print(
+        "  "
+        + S
+        + ":q"
+        + R
+        + "  "
+        + L
+        + "exit"
+        + R
+        + "  "
+        + L
+        + "quit"
+        + R
+        + "  "
+        + S
+        + "Ctrl-D"
+        + R,
+        file=w,
+    )

--- a/src/cli/calculator/settings.mojo
+++ b/src/cli/calculator/settings.mojo
@@ -27,6 +27,7 @@ it against known names, and consume a following value for options.  Flags
 (scientific, engineering, pad) toggle on each use — repeat to turn off.
 
     `:p 100 s d`  →  precision=100, scientific=True, rounding=down
+    `50 e hd`     →  precision=50, engineering=True, rounding=half-down
 
 Name mapping (mirrors DecimoArgs, case-insensitive inside the REPL):
 
@@ -43,6 +44,9 @@ Name mapping (mirrors DecimoArgs, case-insensitive inside the REPL):
     Standalone rounding modes (set directly, no `r` prefix needed):
         he  hu  hd  u  d  c  f  b
         half-even  half-up  half-down  up  down  ceiling  floor  bankers
+
+    Standalone precision (set directly, no `p` prefix needed):
+        [\\d]+  (e.g. `100`) — any integer is treated as a precision value
 
 Rounding-mode values (accepted after `r` or standalone):
     half-even  half_even  he  b  bankers  (default, banker's rounding)
@@ -157,6 +161,10 @@ def parse_settings(input: String, mut settings: Settings) raises:
         var token = to_lower(tokens[i])
 
         # == Options (consume next token as value) ========================
+        # TODO: Maybe the improvement is marginal but can try:
+        # Re-order the checks so that more common options are checked first
+        # (e.g. precision > scentific/engineering > rounding mode > delimiter),
+        # to reduce average checks per token.
         if _is_precision_name(token):
             i += 1
             if i >= n:
@@ -205,6 +213,14 @@ def parse_settings(input: String, mut settings: Settings) raises:
         # == Standalone rounding modes (no `r` prefix needed) ============
         elif _is_standalone_rounding_mode(token):
             settings.rounding_mode = _parse_rounding_mode(token)
+
+        # == Standalone precision (no `p` prefix needed) ==================
+        elif _is_integer_name(token):
+            # Standalone precision: any integer token sets the precision.
+            var val = Int(token)
+            if val < 1:
+                raise Error("precision must be >= 1, got " + String(val))
+            settings.precision = val
 
         else:
             raise Error("unknown setting: '" + tokens[i] + "'")
@@ -295,6 +311,20 @@ def split_inline_settings(
 # ===----------------------------------------------------------------------=== #
 # Name matching — mirrors DecimoArgs CLI definitions
 # ===----------------------------------------------------------------------=== #
+
+
+fn _is_integer_name(token: String) -> Bool:
+    """Match standalone integer tokens for precision setting.
+
+    Returns True if the token is a non-empty string of ASCII digits.
+    """
+    var bytes = token.as_bytes()  # No copy
+    if len(bytes) == 0:
+        return False
+    for i in range(len(bytes)):
+        if bytes[i] < 48 or bytes[i] > 57:  # not '0'-'9'
+            return False
+    return True
 
 
 fn _is_precision_name(token: String) -> Bool:

--- a/src/cli/calculator/settings.mojo
+++ b/src/cli/calculator/settings.mojo
@@ -162,7 +162,7 @@ def parse_settings(input: String, mut settings: Settings) raises:
         # == Options (consume next token as value) ========================
         # TODO: Maybe the improvement is marginal but can try:
         # Re-order the checks so that more common options are checked first
-        # (e.g. precision > scentific/engineering > rounding mode > delimiter),
+        # (e.g. precision > scientific/engineering > rounding mode > delimiter),
         # to reduce average checks per token.
         if _is_precision_name(token):
             i += 1
@@ -216,7 +216,7 @@ def parse_settings(input: String, mut settings: Settings) raises:
         # == Standalone precision (no `p` prefix needed) ==================
         elif _is_integer_name(token):
             # Standalone precision: any integer token sets the precision.
-            var val = Int(token)
+            var val = _parse_int(token, "precision")
             if val < 1:
                 raise Error("precision must be >= 1, got " + String(val))
             settings.precision = val

--- a/src/cli/calculator/settings.mojo
+++ b/src/cli/calculator/settings.mojo
@@ -126,8 +126,7 @@ struct Settings(Copyable, Movable, Writable):
             writer.write(" Zero-padded.")
         if self.delimiter:
             writer.write(" Delimiter: '", self.delimiter, "'.")
-        if not (self.rounding_mode == RoundingMode.half_even()):
-            writer.write(" Rounding: ", self.rounding_mode, ".")
+        writer.write(" Rounding: ", self.rounding_mode, ".")
 
 
 # ===----------------------------------------------------------------------=== #

--- a/tests/cli/test_repl.mojo
+++ b/tests/cli/test_repl.mojo
@@ -1,5 +1,5 @@
 """Test REPL helpers: _parse_assignment, _validate_variable_name,
-_is_meta_command, _strip_colon_prefix, _is_help_command, _is_settings_command,
+_is_meta_command, _strip_colon_prefix, _is_help_command,
 _is_vars_command, _is_quit_command."""
 
 from std import testing
@@ -10,7 +10,6 @@ from calculator.repl import (
     _is_meta_command,
     _strip_colon_prefix,
     _is_help_command,
-    _is_settings_command,
     _is_vars_command,
     _is_quit_command,
 )
@@ -214,8 +213,8 @@ def test_help_command_h() raises:
 
 
 def test_help_command_question() raises:
-    """`?` matches."""
-    testing.assert_true(_is_help_command("?"), "?")
+    """`?` no longer matches (bare `?` is handled directly in loop)."""
+    testing.assert_false(_is_help_command("?"), "? not a colon command")
 
 
 def test_help_command_no_match() raises:
@@ -224,28 +223,13 @@ def test_help_command_no_match() raises:
 
 
 # ===----------------------------------------------------------------------=== #
-# Tests: _is_settings_command (4.9)
-# ===----------------------------------------------------------------------=== #
-
-
-def test_settings_command_settings() raises:
-    """`settings` matches."""
-    testing.assert_true(_is_settings_command("settings"), "settings")
-
-
-def test_settings_command_show() raises:
-    """`show` matches."""
-    testing.assert_true(_is_settings_command("show"), "show")
-
-
-def test_settings_command_no_match() raises:
-    """`set` does not match."""
-    testing.assert_false(_is_settings_command("set"), "set")
-
-
-# ===----------------------------------------------------------------------=== #
 # Tests: _is_vars_command (4.10)
 # ===----------------------------------------------------------------------=== #
+
+
+def test_vars_command_v() raises:
+    """`v` matches."""
+    testing.assert_true(_is_vars_command("v"), "v")
 
 
 def test_vars_command_vars() raises:
@@ -253,19 +237,19 @@ def test_vars_command_vars() raises:
     testing.assert_true(_is_vars_command("vars"), "vars")
 
 
-def test_vars_command_variables() raises:
-    """`variables` matches."""
-    testing.assert_true(_is_vars_command("variables"), "variables")
+def test_vars_command_variables_no_match() raises:
+    """`variables` no longer matches."""
+    testing.assert_false(_is_vars_command("variables"), "variables")
 
 
-def test_vars_command_var() raises:
-    """`var` matches."""
-    testing.assert_true(_is_vars_command("var"), "var")
+def test_vars_command_var_no_match() raises:
+    """`var` no longer matches."""
+    testing.assert_false(_is_vars_command("var"), "var")
 
 
 def test_vars_command_no_match() raises:
-    """`v` does not match."""
-    testing.assert_false(_is_vars_command("v"), "v")
+    """`variable` does not match."""
+    testing.assert_false(_is_vars_command("variable"), "variable")
 
 
 # ===----------------------------------------------------------------------=== #

--- a/tests/cli/test_repl.mojo
+++ b/tests/cli/test_repl.mojo
@@ -213,8 +213,8 @@ def test_help_command_h() raises:
 
 
 def test_help_command_question() raises:
-    """`?` no longer matches (bare `?` is handled directly in loop)."""
-    testing.assert_false(_is_help_command("?"), "? not a colon command")
+    """`?` matches."""
+    testing.assert_true(_is_help_command("?"), "?")
 
 
 def test_help_command_no_match() raises:

--- a/tests/cli/test_settings.mojo
+++ b/tests/cli/test_settings.mojo
@@ -376,6 +376,67 @@ def test_standalone_in_one_liner() raises:
 
 
 # ===----------------------------------------------------------------------=== #
+# Tests: parse_settings — standalone integer precision
+# ===----------------------------------------------------------------------=== #
+
+
+def test_standalone_precision_basic() raises:
+    """`100` sets precision to 100."""
+    var s = Settings()
+    parse_settings("100", s)
+    testing.assert_equal(s.precision, 100)
+
+
+def test_standalone_precision_one() raises:
+    """`1` is the minimum valid precision."""
+    var s = Settings()
+    parse_settings("1", s)
+    testing.assert_equal(s.precision, 1)
+
+
+def test_standalone_precision_large() raises:
+    """`5000` sets a large precision."""
+    var s = Settings()
+    parse_settings("5000", s)
+    testing.assert_equal(s.precision, 5000)
+
+
+def test_standalone_precision_with_other_settings() raises:
+    """`100 s` sets precision and toggles scientific."""
+    var s = Settings()
+    parse_settings("100 s", s)
+    testing.assert_equal(s.precision, 100)
+    testing.assert_true(s.scientific, "scientific on")
+
+
+def test_standalone_precision_with_rounding() raises:
+    """`200 d` sets precision and rounding down."""
+    var s = Settings()
+    parse_settings("200 d", s)
+    testing.assert_equal(s.precision, 200)
+    testing.assert_true(s.rounding_mode == RoundingMode.down(), "rounding down")
+
+
+def test_standalone_precision_zero_raises() raises:
+    """`0` is below the minimum and should raise."""
+    var s = Settings()
+    var raised = False
+    try:
+        parse_settings("0", s)
+    except:
+        raised = True
+    testing.assert_true(raised, "expected error for precision 0")
+
+
+def test_standalone_precision_after_flag() raises:
+    """`s 100` toggles scientific then sets precision."""
+    var s = Settings()
+    parse_settings("s 100", s)
+    testing.assert_true(s.scientific, "scientific on")
+    testing.assert_equal(s.precision, 100)
+
+
+# ===----------------------------------------------------------------------=== #
 # Tests: parse_settings — multi-token (4.7 one-liner)
 # ===----------------------------------------------------------------------=== #
 


### PR DESCRIPTION
This pull request introduces several improvements to the Decimo CLI calculator, focusing on streamlining REPL commands, enhancing usability, and adding a new standalone precision shortcut. The REPL command set has been simplified and made more consistent, the settings system now accepts bare integers to set precision, and documentation and tests have been updated to match these changes.

**REPL and Command Usability Improvements:**

- Simplified REPL info commands: The settings, help, and variable-listing commands are now triggered by `:`, `?`, and `/`:v`/`:vars` respectively, replacing previous longer forms like `:settings`, `:help`, and `:variables`. The welcome banner now hints at these new commands.
- The help and variable-listing commands have updated aliases, and the documentation now reflects these changes.

**Settings System Enhancements:**

- Added a standalone integer precision shortcut: Any integer token in a settings command (e.g., `:100` or `50 e hd`) is now treated as a precision value, making it faster to set precision. This is supported in both the REPL and one-liner settings.
- After every settings change, the REPL now prints the full settings block for immediate feedback.

**Testing and Documentation Updates:**

- Added comprehensive tests for the new standalone precision feature and removed tests for deprecated settings/variable command aliases.
- Updated user manual, changelog, and CLI plans to reflect new command syntax, improved banner, and new features.

These changes make the REPL more intuitive and efficient for users, while also improving maintainability and test coverage.