### PR TITLE
[cli][repl] Add info/about section in decimo CLI and REPL

### DIFF
--- a/docs/plans/cli_calculator.md
+++ b/docs/plans/cli_calculator.md
@@ -387,7 +387,7 @@ decimo> exit
 | 4.14 | Graceful exit (`exit`, `quit`, Ctrl-D)     |   ✓    |                                                                             |
 | 4.15 | Error recovery (don't crash session)       |   ✓    | Catch exceptions per-line, display error, continue loop                     |
 | 4.16 | `:100` in REPL settings to set precision   |   ✓    | Shortcut of `:p 100`. Any all-digit token is treated as precision           |
-| 4.17 | Add `--about`/`--info` flag and in REPL    |   ✗    | Display version, build info, links to docs/repo, etc, for both CLI and REPL |
+| 4.17 | Add `--about`/`--info` flag and in REPL    |   ✓    | Display version, build info, links to docs/repo, etc, for both CLI and REPL |
 | 4.18 | Line editing (left/right, backspace, del)  |   ✓    | Implemented via `limo` package; see `docs/plans/line_editor.md`             |
 | 4.19 | Input history (up/down arrow navigation)   |   ✓    | Implemented via `limo` package; see `docs/plans/line_editor.md`             |
 

--- a/docs/user_manual_limo.md
+++ b/docs/user_manual_limo.md
@@ -429,7 +429,7 @@ of 18 named actions. This separates "what key was pressed" from "what should
 happen" — for example, both the Left arrow key (ESC `[` `D`) and Ctrl+B (`0x02`)
 map to the same `_ACT_LEFT` action.
 
-```
+```txt
 _ACT_INSERT          = 0    # Printable character — insert into buffer
 _ACT_ACCEPT          = 1    # Enter — accept the line
 _ACT_EOF             = 2    # Ctrl-D on empty line — end of file
@@ -484,7 +484,7 @@ This is the core function. Here's the step-by-step flow:
    - `history_index: Int = -1` — `-1` means "not browsing history right now."
    - `saved_line: String = ""` — saves the in-progress line when the user
      starts browsing history (so pressing Down all the way restores it).
-3. **Draw the initial prompt** — writes `decimo> ` in bold green to stderr.
+3. **Draw the initial prompt** — writes `decimo>` in bold green to stderr.
 4. **Main loop — repeat until done:**
    1. Call `read_byte()` to get one byte from the keyboard.
    2. **Classify** the byte into an action (see the action table above). If the

--- a/src/cli/calculator/__init__.mojo
+++ b/src/cli/calculator/__init__.mojo
@@ -54,6 +54,7 @@ from .engine import (
 from .display import print_error, print_warning, print_hint, write_prompt
 from .io import (
     stdin_is_tty,
+    stdout_is_tty,
     read_line,
     read_stdin,
     split_into_lines,

--- a/src/cli/calculator/display.mojo
+++ b/src/cli/calculator/display.mojo
@@ -171,40 +171,42 @@ def write_prompt(prompt: String):
 # === About / Info ============================================================
 
 
-def format_about() -> String:
-    """Returns a formatted about/info string with ANSI colours.
+def format_about(use_color: Bool = True) -> String:
+    """Returns a formatted about/info string.
 
     Used by both ``--about`` (CLI, printed to stdout) and ``:about``
-    (REPL, printed to stderr).
+    (REPL, printed to stderr).  When *use_color* is False the output
+    contains no ANSI escape codes, suitable for piped/redirected output.
+
+    Args:
+        use_color: Whether to include ANSI colour codes.  Defaults to True.
     """
-    # Colour aliases.
-    comptime TITLE_COLOR = BOLD + ORANGE  # Title/label colour (orange theme)
-    comptime LABEL_COLOR = BOLD + MAGENTA  # Field label colour (magenta theme)
-    # Values use the terminal's default foreground (after RESET) so they
-    # remain readable on both dark and light terminal backgrounds.
+    var title_color = BOLD + ORANGE if use_color else ""
+    var label_color = BOLD + MAGENTA if use_color else ""
+    var reset = RESET if use_color else ""
     return (
-        TITLE_COLOR
+        title_color
         + "Decimo — arbitrary-precision calculator 🔥"
-        + RESET
+        + reset
         + "\n"
-        + LABEL_COLOR
+        + label_color
         + "  Version       "
-        + RESET
+        + reset
         + DECIMO_VERSION
         + "\n"
-        + LABEL_COLOR
+        + label_color
         + "  Author        "
-        + RESET
+        + reset
         + "ZHU Yuhao (朱宇浩) <dr.yuhao.zhu@outlook.com>"
         + "\n"
-        + LABEL_COLOR
+        + label_color
         + "  License       "
-        + RESET
+        + reset
         + "Apache-2.0"
         + "\n"
-        + LABEL_COLOR
+        + label_color
         + "  Mojo          "
-        + RESET
+        + reset
         + "v"
         + String(MOJO_VERSION.major)
         + "."
@@ -212,14 +214,14 @@ def format_about() -> String:
         + "."
         + String(MOJO_VERSION.patch)
         + "\n"
-        + LABEL_COLOR
+        + label_color
         + "  GitHub        "
-        + RESET
+        + reset
         + "https://github.com/forfudan/decimo"
         + "\n"
-        + LABEL_COLOR
+        + label_color
         + "  Documentation "
-        + RESET
+        + reset
         + "https://github.com/forfudan/decimo/blob/main/docs/user_manual.md"
     )
 

--- a/src/cli/calculator/display.mojo
+++ b/src/cli/calculator/display.mojo
@@ -180,7 +180,8 @@ def format_about() -> String:
     # Colour aliases.
     comptime TITLE_COLOR = BOLD + ORANGE  # Title/label colour (orange theme)
     comptime LABEL_COLOR = BOLD + MAGENTA  # Field label colour (magenta theme)
-    comptime VALUE_COLOR = WHITE  # Value colour
+    # Values use the terminal's default foreground (after RESET) so they
+    # remain readable on both dark and light terminal backgrounds.
     return (
         TITLE_COLOR
         + "Decimo — arbitrary-precision calculator 🔥"
@@ -189,49 +190,37 @@ def format_about() -> String:
         + LABEL_COLOR
         + "  Version       "
         + RESET
-        + VALUE_COLOR
         + DECIMO_VERSION
-        + RESET
         + "\n"
         + LABEL_COLOR
         + "  Author        "
         + RESET
-        + VALUE_COLOR
         + "ZHU Yuhao (朱宇浩) <dr.yuhao.zhu@outlook.com>"
-        + RESET
         + "\n"
         + LABEL_COLOR
         + "  License       "
         + RESET
-        + VALUE_COLOR
         + "Apache-2.0"
-        + RESET
         + "\n"
         + LABEL_COLOR
         + "  Mojo          "
         + RESET
-        + VALUE_COLOR
         + "v"
         + String(MOJO_VERSION.major)
         + "."
         + String(MOJO_VERSION.minor)
         + "."
         + String(MOJO_VERSION.patch)
-        + RESET
         + "\n"
         + LABEL_COLOR
         + "  GitHub        "
         + RESET
-        + VALUE_COLOR
         + "https://github.com/forfudan/decimo"
-        + RESET
         + "\n"
         + LABEL_COLOR
         + "  Documentation "
         + RESET
-        + VALUE_COLOR
         + "https://github.com/forfudan/decimo/blob/main/docs/user_manual.md"
-        + RESET
     )
 
 

--- a/src/cli/calculator/display.mojo
+++ b/src/cli/calculator/display.mojo
@@ -30,6 +30,8 @@ in an expression.  Modelled after ArgMojo's colour system.
 """
 
 from std.sys import stderr
+from std.sys.defines import MOJO_VERSION
+from decimo import DECIMO_VERSION
 
 # == ANSI colour codes ========================================================
 
@@ -164,6 +166,73 @@ def write_prompt(prompt: String):
     """
     var styled = BOLD + GREEN + prompt + RESET
     print(styled, end="", file=stderr, flush=True)
+
+
+# === About / Info ============================================================
+
+
+def format_about() -> String:
+    """Returns a formatted about/info string with ANSI colours.
+
+    Used by both ``--about`` (CLI, printed to stdout) and ``:about``
+    (REPL, printed to stderr).
+    """
+    # Colour aliases.
+    comptime TITLE_COLOR = BOLD + ORANGE  # Title/label colour (orange theme)
+    comptime LABEL_COLOR = BOLD + MAGENTA  # Field label colour (magenta theme)
+    comptime VALUE_COLOR = WHITE  # Value colour
+    return (
+        TITLE_COLOR
+        + "Decimo — arbitrary-precision calculator 🔥"
+        + RESET
+        + "\n"
+        + LABEL_COLOR
+        + "  Version       "
+        + RESET
+        + VALUE_COLOR
+        + DECIMO_VERSION
+        + RESET
+        + "\n"
+        + LABEL_COLOR
+        + "  Author        "
+        + RESET
+        + VALUE_COLOR
+        + "ZHU Yuhao (朱宇浩) <dr.yuhao.zhu@outlook.com>"
+        + RESET
+        + "\n"
+        + LABEL_COLOR
+        + "  License       "
+        + RESET
+        + VALUE_COLOR
+        + "Apache-2.0"
+        + RESET
+        + "\n"
+        + LABEL_COLOR
+        + "  Mojo          "
+        + RESET
+        + VALUE_COLOR
+        + "v"
+        + String(MOJO_VERSION.major)
+        + "."
+        + String(MOJO_VERSION.minor)
+        + "."
+        + String(MOJO_VERSION.patch)
+        + RESET
+        + "\n"
+        + LABEL_COLOR
+        + "  GitHub        "
+        + RESET
+        + VALUE_COLOR
+        + "https://github.com/forfudan/decimo"
+        + RESET
+        + "\n"
+        + LABEL_COLOR
+        + "  Documentation "
+        + RESET
+        + VALUE_COLOR
+        + "https://github.com/forfudan/decimo/blob/main/docs/user_manual.md"
+        + RESET
+    )
 
 
 # == Internal helpers =========================================================

--- a/src/cli/calculator/io.mojo
+++ b/src/cli/calculator/io.mojo
@@ -44,6 +44,16 @@ def stdin_is_tty() -> Bool:
     return external_call["isatty", Int32](Int32(0)) != 0
 
 
+def stdout_is_tty() -> Bool:
+    """Returns True if stdout is connected to a terminal (TTY),
+    False if it is a pipe or redirected file.
+
+    Returns:
+        True if stdout is a TTY, False otherwise.
+    """
+    return external_call["isatty", Int32](Int32(1)) != 0
+
+
 # ===----------------------------------------------------------------------=== #
 # stdin reading
 # ===----------------------------------------------------------------------=== #

--- a/src/cli/calculator/repl.mojo
+++ b/src/cli/calculator/repl.mojo
@@ -464,402 +464,437 @@ def _print_help():
     (2-char indent + 28-char command column).
     """
     # Colour aliases — zero visible width, used for styling only.
-    comptime H = BOLD + CYAN  # section Heading
-    comptime L = BOLD + GREEN  # Long name / command
-    comptime S = BOLD + YELLOW  # Short name / alias
-    comptime V = MAGENTA  # Value placeholder
-    comptime R = RESET  # Reset
-    comptime B = BOLD  # Bold
+    comptime HEADING_COLOR = BOLD + CYAN  # section Heading
+    comptime LONG_NAME_COLOR = BOLD + GREEN  # Long name / command
+    comptime SHORT_NAME_COLOR = BOLD + YELLOW  # Short name / alias
+    comptime VALUE_NAME_COLOR = MAGENTA  # Value placeholder
 
     var w = stderr
 
     # --- title ---
-    print(H + "Decimo REPL help" + R + B + ":" + R + "\n", file=w)
+    print(
+        SHORT_NAME_COLOR
+        + "Decimo REPL help"
+        + RESET
+        + BOLD
+        + ":"
+        + RESET
+        + "\n",
+        file=w,
+    )
 
     # --- expressions ---
-    print(H + "Expressions" + R + B + ":" + R, file=w)
+    print(HEADING_COLOR + "Expressions" + RESET + BOLD + ":" + RESET, file=w)
     print("  Type any math expression to evaluate it.", file=w)
     print(
-        "  Example: " + S + "pi + sin(-ln(1.23)) * sqrt(e^2)" + R + "\n", file=w
+        "  Example: "
+        + SHORT_NAME_COLOR
+        + "pi + sin(-ln(1.23)) * sqrt(e^2)"
+        + RESET
+        + "\n",
+        file=w,
     )
 
     # --- variables (col 28) ---
-    print(H + "Variables" + R + B + ":" + R, file=w)
+    print(HEADING_COLOR + "Variables" + RESET + BOLD + ":" + RESET, file=w)
     #     |name = expr       |                 <- 11 + 17 = 28
     print(
         "  "
-        + V
+        + VALUE_NAME_COLOR
         + "name"
-        + R
+        + RESET
         + " = "
-        + V
+        + VALUE_NAME_COLOR
         + "expr"
-        + R
+        + RESET
         + "                 Assign a value:  x = 1.023^365",
         file=w,
     )
     #     |ans               |                 <- 3 + 25 = 28
     print(
         "  "
-        + L
+        + LONG_NAME_COLOR
         + "ans"
-        + R
+        + RESET
         + "                         Refers to the last result.\n",
         file=w,
     )
 
     # --- functions ---
-    print(H + "Functions" + R + B + ":" + R, file=w)
+    print(HEADING_COLOR + "Functions" + RESET + BOLD + ":" + RESET, file=w)
     print(
         "  "
-        + L
+        + LONG_NAME_COLOR
         + "sqrt"
-        + R
+        + RESET
         + "  "
-        + L
+        + LONG_NAME_COLOR
         + "cbrt"
-        + R
+        + RESET
         + "  "
-        + L
+        + LONG_NAME_COLOR
         + "root"
-        + R
+        + RESET
         + "("
-        + V
+        + VALUE_NAME_COLOR
         + "x"
-        + R
+        + RESET
         + ","
-        + V
+        + VALUE_NAME_COLOR
         + "n"
-        + R
+        + RESET
         + ")  "
-        + L
+        + LONG_NAME_COLOR
         + "abs"
-        + R
+        + RESET
         + "  "
-        + L
+        + LONG_NAME_COLOR
         + "exp"
-        + R
+        + RESET
         + "  "
-        + L
+        + LONG_NAME_COLOR
         + "ln"
-        + R
+        + RESET
         + "  "
-        + L
+        + LONG_NAME_COLOR
         + "log10"
-        + R
+        + RESET
         + "  "
-        + L
+        + LONG_NAME_COLOR
         + "log"
-        + R
+        + RESET
         + "("
-        + V
+        + VALUE_NAME_COLOR
         + "x"
-        + R
+        + RESET
         + ","
-        + V
+        + VALUE_NAME_COLOR
         + "base"
-        + R
+        + RESET
         + ")",
         file=w,
     )
     print(
         "  "
-        + L
+        + LONG_NAME_COLOR
         + "sin"
-        + R
+        + RESET
         + "  "
-        + L
+        + LONG_NAME_COLOR
         + "cos"
-        + R
+        + RESET
         + "  "
-        + L
+        + LONG_NAME_COLOR
         + "tan"
-        + R
+        + RESET
         + "  "
-        + L
+        + LONG_NAME_COLOR
         + "cot"
-        + R
+        + RESET
         + "  "
-        + L
+        + LONG_NAME_COLOR
         + "csc"
-        + R
+        + RESET
         + "\n",
         file=w,
     )
 
     # --- constants ---
-    print(H + "Constants" + R + B + ":" + R, file=w)
-    print("  " + L + "pi" + R + "  " + L + "e" + R + "\n", file=w)
+    print(HEADING_COLOR + "Constants" + RESET + BOLD + ":" + RESET, file=w)
+    print(
+        "  "
+        + LONG_NAME_COLOR
+        + "pi"
+        + RESET
+        + "  "
+        + LONG_NAME_COLOR
+        + "e"
+        + RESET
+        + "\n",
+        file=w,
+    )
 
     # --- settings commands (col 28) ---
-    print(H + "Settings commands" + R + B + ":" + R, file=w)
+    print(
+        HEADING_COLOR + "Settings commands" + RESET + BOLD + ":" + RESET, file=w
+    )
     #     |:p, :precision N  |            <- 16 + 12 = 28
     print(
         "  "
-        + S
+        + SHORT_NAME_COLOR
         + ":p"
-        + R
+        + RESET
         + ", "
-        + L
+        + LONG_NAME_COLOR
         + ":precision"
-        + R
+        + RESET
         + " "
-        + V
+        + VALUE_NAME_COLOR
         + "N"
-        + R
+        + RESET
         + "            Set precision to "
-        + V
+        + VALUE_NAME_COLOR
         + "N"
-        + R
+        + RESET
         + " digits.",
         file=w,
     )
     #     |:N                |            <- 2 + 26 = 28
     print(
         "  "
-        + S
+        + SHORT_NAME_COLOR
         + ":"
-        + R
-        + V
+        + RESET
+        + VALUE_NAME_COLOR
         + "N"
-        + R
+        + RESET
         + "                          Shortcut for :p "
-        + V
+        + VALUE_NAME_COLOR
         + "N"
-        + R
+        + RESET
         + " (e.g. "
-        + S
+        + SHORT_NAME_COLOR
         + ":100"
-        + R
+        + RESET
         + ").",
         file=w,
     )
     #     |:s, :scientific, :sci|         <- 21 + 7 = 28
     print(
         "  "
-        + S
+        + SHORT_NAME_COLOR
         + ":s"
-        + R
+        + RESET
         + ", "
-        + L
+        + LONG_NAME_COLOR
         + ":scientific"
-        + R
+        + RESET
         + ", "
-        + L
+        + LONG_NAME_COLOR
         + ":sci"
-        + R
+        + RESET
         + "       Toggle scientific notation.",
         file=w,
     )
     #     |:e, :engineering, :eng|        <- 22 + 6 = 28
     print(
         "  "
-        + S
+        + SHORT_NAME_COLOR
         + ":e"
-        + R
+        + RESET
         + ", "
-        + L
+        + LONG_NAME_COLOR
         + ":engineering"
-        + R
+        + RESET
         + ", "
-        + L
+        + LONG_NAME_COLOR
         + ":eng"
-        + R
+        + RESET
         + "      Toggle engineering notation.",
         file=w,
     )
     #     |:pad              |            <- 4 + 24 = 28
     print(
-        "  " + S + ":pad" + R + "                        Toggle zero-padding.",
+        "  "
+        + SHORT_NAME_COLOR
+        + ":pad"
+        + RESET
+        + "                        Toggle zero-padding.",
         file=w,
     )
     #     |:r, :round, :rm MODE|          <- 20 + 8 = 28
     print(
         "  "
-        + S
+        + SHORT_NAME_COLOR
         + ":r"
-        + R
+        + RESET
         + ", "
-        + L
+        + LONG_NAME_COLOR
         + ":round"
-        + R
+        + RESET
         + ", "
-        + L
+        + LONG_NAME_COLOR
         + ":rm"
-        + R
+        + RESET
         + " "
-        + V
+        + VALUE_NAME_COLOR
         + "MODE"
-        + R
+        + RESET
         + "        Set rounding mode ("
-        + S
+        + SHORT_NAME_COLOR
         + "he"
-        + R
+        + RESET
         + "/"
-        + S
+        + SHORT_NAME_COLOR
         + "hu"
-        + R
+        + RESET
         + "/"
-        + S
+        + SHORT_NAME_COLOR
         + "hd"
-        + R
+        + RESET
         + "/"
-        + S
+        + SHORT_NAME_COLOR
         + "u"
-        + R
+        + RESET
         + "/"
-        + S
+        + SHORT_NAME_COLOR
         + "d"
-        + R
+        + RESET
         + "/"
-        + S
+        + SHORT_NAME_COLOR
         + "c"
-        + R
+        + RESET
         + "/"
-        + S
+        + SHORT_NAME_COLOR
         + "f"
-        + R
+        + RESET
         + "/"
-        + S
+        + SHORT_NAME_COLOR
         + "b"
-        + R
+        + RESET
         + ").",
         file=w,
     )
     #     |:delimiter C      |            <- 12 + 16 = 28
     print(
         "  "
-        + L
+        + LONG_NAME_COLOR
         + ":delimiter"
-        + R
+        + RESET
         + " "
-        + V
+        + VALUE_NAME_COLOR
         + "C"
-        + R
+        + RESET
         + "                Set digit-group delimiter.",
         file=w,
     )
     #     |:p 100 s r d      |            <- 12 + 16 = 28
     print(
         "  "
-        + S
+        + SHORT_NAME_COLOR
         + ":p 100 s r d"
-        + R
+        + RESET
         + "                Combine multiple settings in one line.\n",
         file=w,
     )
 
     # --- inline temp settings (col 28) ---
-    print(H + "Inline temp settings" + R + B + ":" + R, file=w)
+    print(
+        HEADING_COLOR + "Inline temp settings" + RESET + BOLD + ":" + RESET,
+        file=w,
+    )
     #     |expr:settings     |            <- 13 + 15 = 28
     print(
         "  "
-        + V
+        + VALUE_NAME_COLOR
         + "expr"
-        + R
+        + RESET
         + ":"
-        + V
+        + VALUE_NAME_COLOR
         + "settings"
-        + R
+        + RESET
         + "               Override settings for one expression only.",
         file=w,
     )
-    print("  Example: " + S + "sqrt(2):p 100" + R + "\n", file=w)
+    print(
+        "  Example: " + SHORT_NAME_COLOR + "sqrt(2):p 100" + RESET + "\n",
+        file=w,
+    )
 
     # --- info commands (col 28) ---
-    print(H + "Info commands" + R + B + ":" + R, file=w)
+    print(HEADING_COLOR + "Info commands" + RESET + BOLD + ":" + RESET, file=w)
     #     |:                 |            <- 1 + 27 = 28
     print(
         "  "
-        + S
+        + SHORT_NAME_COLOR
         + ":"
-        + R
+        + RESET
         + "                           Show current settings.",
         file=w,
     )
     #     |?, :help, :h, :?  |            <- 16 + 12 = 28
     print(
         "  "
-        + S
+        + SHORT_NAME_COLOR
         + "?"
-        + R
+        + RESET
         + ", "
-        + L
+        + LONG_NAME_COLOR
         + ":help"
-        + R
+        + RESET
         + ", "
-        + S
+        + SHORT_NAME_COLOR
         + ":h"
-        + R
+        + RESET
         + ", "
-        + S
+        + SHORT_NAME_COLOR
         + ":?"
-        + R
+        + RESET
         + "            Show this help.",
         file=w,
     )
     #     |$, :vars          |            <- 8 + 20 = 28
     print(
         "  "
-        + S
+        + SHORT_NAME_COLOR
         + "$"
-        + R
+        + RESET
         + ", "
-        + L
+        + LONG_NAME_COLOR
         + ":vars"
-        + R
+        + RESET
         + "                    List all variables.",
         file=w,
     )
     #     |:about, :a, :info |            <- 18 + 10 = 28
     print(
         "  "
-        + L
+        + LONG_NAME_COLOR
         + ":about"
-        + R
+        + RESET
         + ", "
-        + S
+        + SHORT_NAME_COLOR
         + ":a"
-        + R
+        + RESET
         + ", "
-        + L
+        + LONG_NAME_COLOR
         + ":info"
-        + R
-        + "          Show version, author, license, and links.",
+        + RESET
+        + "           Show version, author, license, and links.",
         file=w,
     )
     #     |:version, :v      |            <- 12 + 16 = 28
     print(
         "  "
-        + L
+        + LONG_NAME_COLOR
         + ":version"
-        + R
+        + RESET
         + ", "
-        + S
+        + SHORT_NAME_COLOR
         + ":v"
-        + R
-        + "              Show version number.\n",
+        + RESET
+        + "                Show version number.\n",
         file=w,
     )
 
     # --- quit ---
-    print(H + "Quit" + R + B + ":" + R, file=w)
+    print(HEADING_COLOR + "Quit" + RESET + BOLD + ":" + RESET, file=w)
     print(
         "  "
-        + S
+        + SHORT_NAME_COLOR
         + ":q"
-        + R
+        + RESET
         + "  "
-        + L
+        + LONG_NAME_COLOR
         + "exit"
-        + R
+        + RESET
         + "  "
-        + L
+        + LONG_NAME_COLOR
         + "quit"
-        + R
+        + RESET
         + "  "
-        + S
+        + SHORT_NAME_COLOR
         + "Ctrl-D"
-        + R,
+        + RESET,
         file=w,
     )

--- a/src/cli/calculator/repl.mojo
+++ b/src/cli/calculator/repl.mojo
@@ -37,8 +37,9 @@ from std.collections import Dict
 from decimo import Decimal
 from decimo.rounding_mode import RoundingMode
 from limo import LineEditor
+from decimo import DECIMO_VERSION
 from .display import BOLD, RESET, YELLOW, CYAN, GREEN, MAGENTA
-from .display import print_error, format_about, DECIMO_VERSION
+from .display import print_error, format_about
 from .engine import evaluate_and_return
 from .io import strip, is_comment_or_blank
 from .settings import Settings, parse_settings, split_inline_settings, to_lower
@@ -464,6 +465,7 @@ def _print_help():
     (2-char indent + 28-char command column).
     """
     # Colour aliases — zero visible width, used for styling only.
+    comptime TITLE_COLOR = BOLD + YELLOW  # Title and important highlights
     comptime HEADING_COLOR = BOLD + CYAN  # section Heading
     comptime LONG_NAME_COLOR = BOLD + GREEN  # Long name / command
     comptime SHORT_NAME_COLOR = BOLD + YELLOW  # Short name / alias
@@ -473,13 +475,7 @@ def _print_help():
 
     # --- title ---
     print(
-        SHORT_NAME_COLOR
-        + "Decimo REPL help"
-        + RESET
-        + BOLD
-        + ":"
-        + RESET
-        + "\n",
+        TITLE_COLOR + "Decimo REPL help" + RESET + BOLD + ":" + RESET + "\n",
         file=w,
     )
 

--- a/src/cli/calculator/repl.mojo
+++ b/src/cli/calculator/repl.mojo
@@ -464,12 +464,12 @@ def _print_help():
     (2-char indent + 28-char command column).
     """
     # Colour aliases — zero visible width, used for styling only.
-    comptime B = BOLD
-    comptime R = RESET
     comptime H = BOLD + CYAN  # section Heading
     comptime L = BOLD + GREEN  # Long name / command
     comptime S = BOLD + YELLOW  # Short name / alias
     comptime V = MAGENTA  # Value placeholder
+    comptime R = RESET  # Reset
+    comptime B = BOLD  # Bold
 
     var w = stderr
 

--- a/src/cli/calculator/repl.mojo
+++ b/src/cli/calculator/repl.mojo
@@ -38,7 +38,7 @@ from decimo import Decimal
 from decimo.rounding_mode import RoundingMode
 from limo import LineEditor
 from .display import BOLD, RESET, YELLOW, CYAN, GREEN, MAGENTA
-from .display import print_error
+from .display import print_error, format_about, DECIMO_VERSION
 from .engine import evaluate_and_return
 from .io import strip, is_comment_or_blank
 from .settings import Settings, parse_settings, split_inline_settings, to_lower
@@ -142,7 +142,17 @@ def run_repl(
                 _print_help()
                 continue
 
-            # `:v` / `:vars`
+            # `:about` / `:a` / `:info` — show about/info
+            if _is_about_command(cmd_str):
+                print(format_about(), file=stderr)
+                continue
+
+            # `:version` / `:v` — show version
+            if _is_version_command(cmd_str):
+                print("decimo " + DECIMO_VERSION, file=stderr)
+                continue
+
+            # `:vars`
             # This displays all user-defined variables and their current values,
             # including `ans`.
             if _is_vars_command(cmd_str):
@@ -368,8 +378,18 @@ def _is_help_command(cmd: String) -> Bool:
 
 
 def _is_vars_command(cmd: String) -> Bool:
-    """Match: v, vars."""
-    return cmd == "v" or cmd == "vars"
+    """Match: vars."""
+    return cmd == "vars"
+
+
+def _is_about_command(cmd: String) -> Bool:
+    """Match: about, a, info."""
+    return cmd == "about" or cmd == "a" or cmd == "info"
+
+
+def _is_version_command(cmd: String) -> Bool:
+    """Match: version, v."""
+    return cmd == "version" or cmd == "v"
 
 
 def _is_quit_command(cmd: String) -> Bool:
@@ -778,21 +798,47 @@ def _print_help():
         + "            Show this help.",
         file=w,
     )
-    #     |$, :v, :vars      |            <- 12 + 16 = 28
+    #     |$, :vars          |            <- 8 + 20 = 28
     print(
         "  "
         + S
         + "$"
         + R
         + ", "
-        + S
-        + ":v"
-        + R
-        + ", "
         + L
         + ":vars"
         + R
-        + "                List all variables.\n",
+        + "                    List all variables.",
+        file=w,
+    )
+    #     |:about, :a, :info |            <- 18 + 10 = 28
+    print(
+        "  "
+        + L
+        + ":about"
+        + R
+        + ", "
+        + S
+        + ":a"
+        + R
+        + ", "
+        + L
+        + ":info"
+        + R
+        + "          Show version, author, license, and links.",
+        file=w,
+    )
+    #     |:version, :v      |            <- 12 + 16 = 28
+    print(
+        "  "
+        + L
+        + ":version"
+        + R
+        + ", "
+        + S
+        + ":v"
+        + R
+        + "              Show version number.\n",
         file=w,
     )
 

--- a/src/cli/limo/line_editor.mojo
+++ b/src/cli/limo/line_editor.mojo
@@ -191,8 +191,7 @@ struct LineEditor(Movable):
                 done = True
 
             elif action == _ACT_CANCEL:
-                write_stderr("^C")
-                write_stdout("\r\n")
+                write_stderr("^C\r\n")
                 result = String("")
                 done = True
 

--- a/src/cli/limo/line_editor.mojo
+++ b/src/cli/limo/line_editor.mojo
@@ -191,6 +191,7 @@ struct LineEditor(Movable):
                 done = True
 
             elif action == _ACT_CANCEL:
+                write_stderr("^C")
                 write_stdout("\r\n")
                 result = String("")
                 done = True

--- a/src/cli/main.mojo
+++ b/src/cli/main.mojo
@@ -14,8 +14,9 @@
 from std.sys import exit
 
 from argmojo import Parsable, Option, Flag, Positional, Command
+from decimo import DECIMO_VERSION
 from decimo.rounding_mode import RoundingMode
-from calculator.display import print_error
+from calculator.display import print_error, format_about
 from calculator.engine import evaluate_and_print
 from calculator.io import (
     stdin_is_tty,
@@ -89,6 +90,17 @@ struct DecimoArgs(Parsable):
         value_name="MODE",
         group="Computation",
     ]
+    var about: Flag[
+        long="about",
+        short="A",
+        help="Display version, author, license, and links",
+        group="Info",
+    ]
+    var info: Flag[
+        long="info",
+        help="Same as --about",
+        group="Info",
+    ]
 
     @staticmethod
     def description() -> String:
@@ -96,7 +108,7 @@ struct DecimoArgs(Parsable):
 
     @staticmethod
     def version() -> String:
-        return "0.1.0"
+        return DECIMO_VERSION
 
     @staticmethod
     def name() -> String:
@@ -138,6 +150,11 @@ def _run() raises:
     var pad = args.pad.value
     var delimiter = args.delimiter.value
     var rounding_mode = _parse_rounding_mode(args.rounding_mode.value)
+
+    # ── About / Info ───────────────────────────────────────────────────────
+    if args.about.value or args.info.value:
+        print(format_about())
+        return
 
     # ── Mode detection ─────────────────────────────────────────────────────
     # 1. --file flag provided        → file mode

--- a/src/cli/main.mojo
+++ b/src/cli/main.mojo
@@ -20,6 +20,7 @@ from calculator.display import print_error, format_about
 from calculator.engine import evaluate_and_print
 from calculator.io import (
     stdin_is_tty,
+    stdout_is_tty,
     read_stdin,
     split_into_lines,
     filter_expression_lines,
@@ -153,7 +154,7 @@ def _run() raises:
 
     # ── About / Info ───────────────────────────────────────────────────────
     if args.about.value or args.info.value:
-        print(format_about())
+        print(format_about(use_color=stdout_is_tty()))
         return
 
     # ── Mode detection ─────────────────────────────────────────────────────

--- a/src/decimo/__init__.mojo
+++ b/src/decimo/__init__.mojo
@@ -24,6 +24,9 @@ from decimo import Decimal, BInt, RoundingMode
 ```
 """
 
+comptime DECIMO_VERSION = "v0.10.0"
+"""Version of the Decimo library."""
+
 # Core types
 from .decimal128.decimal128 import Decimal128, Dec128
 from .bigint.bigint import BigInt, BInt, Integer

--- a/tests/cli/test_repl.mojo
+++ b/tests/cli/test_repl.mojo
@@ -1,6 +1,7 @@
 """Test REPL helpers: _parse_assignment, _validate_variable_name,
 _is_meta_command, _strip_colon_prefix, _is_help_command,
-_is_vars_command, _is_quit_command."""
+_is_vars_command, _is_about_command, _is_version_command,
+_is_quit_command."""
 
 from std import testing
 
@@ -11,6 +12,8 @@ from calculator.repl import (
     _strip_colon_prefix,
     _is_help_command,
     _is_vars_command,
+    _is_about_command,
+    _is_version_command,
     _is_quit_command,
 )
 
@@ -228,8 +231,8 @@ def test_help_command_no_match() raises:
 
 
 def test_vars_command_v() raises:
-    """`v` matches."""
-    testing.assert_true(_is_vars_command("v"), "v")
+    """`v` no longer matches vars (now used for :version)."""
+    testing.assert_false(_is_vars_command("v"), "v")
 
 
 def test_vars_command_vars() raises:
@@ -275,6 +278,51 @@ def test_quit_command_exit() raises:
 def test_quit_command_no_match() raises:
     """`bye` does not match."""
     testing.assert_false(_is_quit_command("bye"), "bye")
+
+
+# ===----------------------------------------------------------------------=== #
+# Tests: _is_about_command
+# ===----------------------------------------------------------------------=== #
+
+
+def test_about_command_about() raises:
+    """`about` matches."""
+    testing.assert_true(_is_about_command("about"), "about")
+
+
+def test_about_command_a() raises:
+    """`a` matches."""
+    testing.assert_true(_is_about_command("a"), "a")
+
+
+def test_about_command_info() raises:
+    """`info` matches."""
+    testing.assert_true(_is_about_command("info"), "info")
+
+
+def test_about_command_no_match() raises:
+    """`information` does not match."""
+    testing.assert_false(_is_about_command("information"), "information")
+
+
+# ===----------------------------------------------------------------------=== #
+# Tests: _is_version_command
+# ===----------------------------------------------------------------------=== #
+
+
+def test_version_command_version() raises:
+    """`version` matches."""
+    testing.assert_true(_is_version_command("version"), "version")
+
+
+def test_version_command_v() raises:
+    """`v` matches."""
+    testing.assert_true(_is_version_command("v"), "v")
+
+
+def test_version_command_no_match() raises:
+    """`ver` does not match."""
+    testing.assert_false(_is_version_command("ver"), "ver")
 
 
 # ===----------------------------------------------------------------------=== #


### PR DESCRIPTION
This PR adds an “about/info” surface to the Decimo CLI and REPL, plus a centralized version constant, to make it easy to discover version/authorship/license/links from both interactive and non-interactive entry points.

**Changes:**
- Introduce `DECIMO_VERSION` in `decimo` and wire it into CLI `--version`, REPL `:version/:v`, and about output.
- Add CLI flags `--about/--info` and REPL meta-commands `:about/:a/:info`.
- Update REPL help/tests and related docs/plans to reflect the new commands.