### PR TITLE
[dec128] Remove `nan` an `inf` + Update `from_words()` + Improve `power_of_10()`

### DIFF
--- a/docs/readme_unreleased.md
+++ b/docs/readme_unreleased.md
@@ -36,7 +36,7 @@ The core types are[^auxiliary]:
 - An arbitrary-precision decimal implementation (`Decimal`) allowing for calculations with unlimited digits and decimal places[^arbitrary], which is a Mojo-native equivalent of Python's `decimal.Decimal`.
 - A 128-bit fixed-point decimal implementation (`Dec128`) supporting up to 29 significant digits with a maximum of 28 decimal places[^fixed].
 - An arbitrary-precision floating-point implementation (`Float`) backed by the GNU MPFR library, supporting computations with configurable precision and a wide exponent range. Unlike `Decimal`, which uses base-10 arithmetic, `Float` uses binary floating-point internally. This type is optional and requires MPFR/GMP to be installed on the user's system.
-- An arbitray-precision exact rational number type (`Rational`) represented as a reduced fraction of two `BInt`s (numerator and denominator). It supports exact arithmetic and comparisons without any loss of precision, making it ideal for applications that require precise fractional calculations.
+- An arbitrary-precision exact rational number type (`Rational`) represented as a reduced fraction of two `BInt`s (numerator and denominator). It supports exact arithmetic and comparisons without any loss of precision, making it ideal for applications that require precise fractional calculations.
 
 | Type       | Alternative names    | Information                              | Internal representation |
 | ---------- | -------------------- | ---------------------------------------- | ----------------------- |

--- a/docs/readme_unreleased.md
+++ b/docs/readme_unreleased.md
@@ -36,13 +36,15 @@ The core types are[^auxiliary]:
 - An arbitrary-precision decimal implementation (`Decimal`) allowing for calculations with unlimited digits and decimal places[^arbitrary], which is a Mojo-native equivalent of Python's `decimal.Decimal`.
 - A 128-bit fixed-point decimal implementation (`Dec128`) supporting up to 29 significant digits with a maximum of 28 decimal places[^fixed].
 - An arbitrary-precision floating-point implementation (`Float`) backed by the GNU MPFR library, supporting computations with configurable precision and a wide exponent range. Unlike `Decimal`, which uses base-10 arithmetic, `Float` uses binary floating-point internally. This type is optional and requires MPFR/GMP to be installed on the user's system.
+- An arbitray-precision exact rational number type (`Rational`) represented as a reduced fraction of two `BInt`s (numerator and denominator). It supports exact arithmetic and comparisons without any loss of precision, making it ideal for applications that require precise fractional calculations.
 
-| Type      | Alternative names    | Information                              | Internal representation |
-| --------- | -------------------- | ---------------------------------------- | ----------------------- |
-| `BInt`    | `BigInt`, `Integer`  | Equivalent to Python's `int`             | Base-2^32               |
-| `Decimal` | `BigDecimal`, `BDec` | Equivalent to Python's `decimal.Decimal` | Base-10^9               |
-| `Dec128`  | `Decimal128`         | 128-bit fixed-precision decimal type     | Triple 32-bit words     |
-| `Float`   | `BigFloat`           | Arbitrary-precision floating-point type  | MPFR/GMP                |
+| Type       | Alternative names    | Information                              | Internal representation |
+| ---------- | -------------------- | ---------------------------------------- | ----------------------- |
+| `BInt`     | `BigInt`, `Integer`  | Equivalent to Python's `int`             | Base-2^32               |
+| `Decimal`  | `BigDecimal`, `BDec` | Equivalent to Python's `decimal.Decimal` | Base-10^9               |
+| `Dec128`   | `Decimal128`         | 128-bit fixed-precision decimal type     | Triple 32-bit words     |
+| `Float`    | `BigFloat`           | Arbitrary-precision floating-point type  | MPFR/GMP                |
+| `Rational` | N/A                  | Exact rational number type               | Two `BInt`s             |
 
 **Decimo** combines "**Deci**mal" and "**Mo**jo" - reflecting its purpose and implementation language. "Decimo" is also a Latin word meaning "tenth" and is the root of the word "decimal".
 

--- a/src/cli/calculator/display.mojo
+++ b/src/cli/calculator/display.mojo
@@ -180,6 +180,9 @@ def format_about(use_color: Bool = True) -> String:
 
     Args:
         use_color: Whether to include ANSI colour codes.  Defaults to True.
+
+    Returns:
+        A formatted multi-line string containing information about Decimo.
     """
     var title_color = BOLD + ORANGE if use_color else ""
     var label_color = BOLD + MAGENTA if use_color else ""

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -24,7 +24,6 @@ mathematical methods that do not implement a trait.
 """
 
 from std.memory import UnsafePointer
-from std import testing
 
 import decimo.decimal128.arithmetics
 import decimo.decimal128.comparison
@@ -65,9 +64,7 @@ struct Decimal128(
         - Bit 32 to 63 are stored in the mid field: middle bits.
         - Bit 64 to 95 are stored in the high field: most significant bits.
     - 32 bits for the flags, which contain the sign and scale information.
-        - Bit 0 contains the infinity flag: 1 means infinity, 0 means finite.
-        - Bit 1 contains the NaN flag: 1 means NaN, 0 means not NaN.
-        - Bits 2 to 15 are unused and must be zero.
+        - Bits 0 to 15 are unused and must be zero.
         - Bits 16 to 23 must contain an scale (exponent) between 0 and 28.
         - Bits 24 to 30 are unused and must be zero.
         - Bit 31 contains the sign: 0 mean positive, and 1 means negative.
@@ -128,59 +125,10 @@ struct Decimal128(
     Bits 16 to 23 must contain an scale between 0 and 28."""
     comptime SCALE_SHIFT = UInt32(16)
     """Bits 16 to 23 must contain an scale between 0 and 28."""
-    comptime INFINITY_MASK = UInt32(0x00000001)
-    """Infinity mask. `0b0000_0000_0000_0000_0000_0000_0000_0001`."""
-    comptime NAN_MASK = UInt32(0x00000002)
-    """Not a Number mask. `0b0000_0000_0000_0000_0000_0000_0000_0010`."""
-
     # TODO: Move these special values to top of the module
     # when Mojo support global variables in the future.
 
     # Special values
-    @always_inline
-    @staticmethod
-    def INFINITY() -> Self:
-        """Returns a Decimal representing positive infinity.
-        Internal representation: `0b0000_0000_0000_0000_0000_0000_0001`.
-
-        Returns:
-            A `Decimal128` representing positive infinity.
-        """
-        return Self(0, 0, 0, 0x00000001)
-
-    @always_inline
-    @staticmethod
-    def NEGATIVE_INFINITY() -> Self:
-        """Returns a Decimal128 representing negative infinity.
-        Internal representation: `0b1000_0000_0000_0000_0000_0000_0001`.
-
-        Returns:
-            A `Decimal128` representing negative infinity.
-        """
-        return Self(0, 0, 0, 0x80000001)
-
-    @always_inline
-    @staticmethod
-    def NAN() -> Self:
-        """Returns a Decimal128 representing Not a Number (NaN).
-        Internal representation: `0b0000_0000_0000_0000_0000_0000_0010`.
-
-        Returns:
-            A `Decimal128` representing NaN.
-        """
-        return Self(0, 0, 0, 0x00000010)
-
-    @always_inline
-    @staticmethod
-    def NEGATIVE_NAN() -> Self:
-        """Returns a Decimal128 representing negative Not a Number.
-        Internal representation: `0b1000_0000_0000_0000_0000_0000_0010`.
-
-        Returns:
-            A `Decimal128` representing negative NaN.
-        """
-        return Self(0, 0, 0, 0x80000010)
-
     @always_inline
     @staticmethod
     def ZERO() -> Decimal128:
@@ -432,26 +380,28 @@ struct Decimal128(
             A Decimal128 instance with the given words.
 
         Raises:
-            Error: If the `flags` word is invalid.
-            Error: If the scale is greater than MAX_SCALE.
+            ValueError: If the `flags` word has invalid bits set.
+            ValueError: If the scale is greater than MAX_SCALE.
         """
 
         # Check whether the `flags` word is valid.
-        testing.assert_true(
-            (flags & 0b0111_1111_0000_0000_1111_1111_1111_1111) == 0,
-            String(
-                "Error in Decimal128 constructor with four words: Flags must"
-                " have bits 0-15 and 24-30 set to zero, but got {}"
-            ).format(flags),
-        )
-        testing.assert_true(
-            ((flags & 0x00FF0000) >> Self.SCALE_SHIFT)
-            <= UInt32(Self.MAX_SCALE),
-            String(
-                "Error in Decimal128 constructor with four words: Scale must"
-                " be between 0 and 28, but got {}"
-            ).format((flags & 0x00FF0000) >> Self.SCALE_SHIFT),
-        )
+        if (flags & 0b0111_1111_0000_0000_1111_1111_1111_1111) != 0:
+            raise ValueError(
+                message=String(
+                    "Flags must have bits 0-15 and 24-30 set to zero,"
+                    " but got {}"
+                ).format(flags),
+                function="Decimal128.from_words()",
+            )
+
+        var scale = (flags & 0x00FF0000) >> Self.SCALE_SHIFT
+        if scale > UInt32(Self.MAX_SCALE):
+            raise ValueError(
+                message=String(
+                    "Scale must be between 0 and 28, but got {}"
+                ).format(scale),
+                function="Decimal128.from_words()",
+            )
 
         return Self(low, mid, high, flags)
 
@@ -904,7 +854,7 @@ struct Decimal128(
 
         Raises:
             OverflowError: If the value is too large for Decimal128.
-            ValueError: If the value is infinity or NaN.
+            ValueError: If the value is infinity or NaN (IEEE 754 special values).
 
         Example:
         ```mojo
@@ -949,10 +899,12 @@ struct Decimal128(
         if biased_exponent == 0:
             return Self(0, 0, 0, UInt32(Decimal128.MAX_SCALE), is_negative)
 
-        # CASE: Infinity or NaN
+        # CASE: IEEE 754 Infinity or NaN — Decimal128 does not support these
         if biased_exponent == 0x7FF:
             raise ValueError(
-                message="Cannot convert infinity or NaN to Decimal128.",
+                message=(
+                    "Cannot convert IEEE 754 infinity or NaN to Decimal128."
+                ),
                 function="Decimal128.from_float()",
             )
 
@@ -2195,24 +2147,6 @@ struct Decimal128(
             `True` if this value is zero, `False` otherwise.
         """
         return self.low == 0 and self.mid == 0 and self.high == 0
-
-    @always_inline
-    def is_infinity(self) -> Bool:
-        """Returns True if this Decimal128 is positive or negative infinity.
-
-        Returns:
-            `True` if infinity, `False` otherwise.
-        """
-        return (self.flags & Self.INFINITY_MASK) != 0
-
-    @always_inline
-    def is_nan(self) -> Bool:
-        """Returns True if this Decimal128 is NaN (Not a Number).
-
-        Returns:
-            `True` if NaN, `False` otherwise.
-        """
-        return (self.flags & Self.NAN_MASK) != 0
 
     @always_inline
     def scale(self) -> Int:

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -65,7 +65,7 @@ struct Decimal128(
         - Bit 64 to 95 are stored in the high field: most significant bits.
     - 32 bits for the flags, which contain the sign and scale information.
         - Bits 0 to 15 are unused and must be zero.
-        - Bits 16 to 23 must contain an scale (exponent) between 0 and 28.
+        - Bits 16 to 23 must contain a scale (exponent) between 0 and 28.
         - Bits 24 to 30 are unused and must be zero.
         - Bit 31 contains the sign: 0 mean positive, and 1 means negative.
 
@@ -122,9 +122,9 @@ struct Decimal128(
     1 bit for sign (0 is positive and 1 is negative)."""
     comptime SCALE_MASK = UInt32(0x00FF0000)
     """Scale mask. `0b0000_0000_1111_1111_0000_0000_0000_0000`.
-    Bits 16 to 23 must contain an scale between 0 and 28."""
+    Bits 16 to 23 must contain a scale between 0 and 28."""
     comptime SCALE_SHIFT = UInt32(16)
-    """Bits 16 to 23 must contain an scale between 0 and 28."""
+    """Bits 16 to 23 must contain a scale between 0 and 28."""
     # TODO: Move these special values to top of the module
     # when Mojo support global variables in the future.
 

--- a/src/decimo/decimal128/utility.mojo
+++ b/src/decimo/decimal128/utility.mojo
@@ -678,8 +678,6 @@ def power_of_10[
 ):
     """
     Returns 10^n using cached values when available.
-    **WARNING**: The overflow is not checked in this function.
-    Make sure that the n is less than 29 for UInt128 and 77 for UInt256.
 
     Parameters:
         dtype: The Mojo scalar type to calculate the power of 10 for.
@@ -694,11 +692,30 @@ def power_of_10[
         The value of 10^n as a Mojo scalar.
 
     Notes:
+
+        **WARNING**: The overflow is only checked when debug mode is enabled.
+        Make sure that the n is less than 29 for UInt128 and 77 for UInt256.
+
         The powers of 10 are hardcoded up to 10^58. This covers all values
         needed for Decimal128 arithmetic (max scale 28 × 2 = 56 for products
         of two max-scale numbers, plus 2 for rounding headroom). For larger
         values, the function falls back to the `**` operator.
     """
+
+    comptime if dtype == DType.uint128:
+        debug_assert(
+            n <= 29,
+            "power_of_10() for uint128 only supports n up to 29, got {}".format(
+                n
+            ),
+        )
+    else:
+        debug_assert(
+            n <= 77,
+            "power_of_10() for uint256 only supports n up to 77, got {}".format(
+                n
+            ),
+        )
 
     comptime ValueType = Scalar[dtype]
 

--- a/src/decimo/decimal128/utility.mojo
+++ b/src/decimo/decimal128/utility.mojo
@@ -671,7 +671,11 @@ def number_of_bits[dtype: DType, //](var value: Scalar[dtype]) -> Int:
 
 
 @always_inline
-def power_of_10[dtype: DType](n: Int) -> Scalar[dtype]:
+def power_of_10[
+    dtype: DType
+](n: Int) -> Scalar[dtype] where (
+    dtype == DType.uint128 or dtype == DType.uint256
+):
     """
     Returns 10^n using cached values when available.
     **WARNING**: The overflow is not checked in this function.
@@ -690,16 +694,13 @@ def power_of_10[dtype: DType](n: Int) -> Scalar[dtype]:
         The value of 10^n as a Mojo scalar.
 
     Notes:
-        The powers of 10 is hard-coded up to 10^56 since it is twice the maximum
-        scale of Decimal128 (28). For larger values, the function calculates the
-        power of 10 using the built-in `**` operator.
+        The powers of 10 are hardcoded up to 10^58. This covers all values
+        needed for Decimal128 arithmetic (max scale 28 × 2 = 56 for products
+        of two max-scale numbers, plus 2 for rounding headroom). For larger
+        values, the function falls back to the `**` operator.
     """
 
     comptime ValueType = Scalar[dtype]
-
-    comptime assert (
-        dtype == DType.uint128 or dtype == DType.uint256
-    ), "must be uint128 or uint256"
 
     if n == 0:
         return ValueType(1)
@@ -768,52 +769,66 @@ def power_of_10[dtype: DType](n: Int) -> Scalar[dtype]:
     if n == 32:
         return ValueType(100000000000000000000000000000000)
     if n == 33:
-        return ValueType(10) ** 33
+        return ValueType(1000000000000000000000000000000000)
     if n == 34:
-        return ValueType(10) ** 34
+        return ValueType(10000000000000000000000000000000000)
     if n == 35:
-        return ValueType(10) ** 35
+        return ValueType(100000000000000000000000000000000000)
     if n == 36:
-        return ValueType(10) ** 36
+        return ValueType(1000000000000000000000000000000000000)
     if n == 37:
-        return ValueType(10) ** 37
+        return ValueType(10000000000000000000000000000000000000)
     if n == 38:
-        return ValueType(10) ** 38
+        return ValueType(100000000000000000000000000000000000000)
     if n == 39:
-        return ValueType(10) ** 39
+        return ValueType(1000000000000000000000000000000000000000)
     if n == 40:
-        return ValueType(10) ** 40
+        return ValueType(10000000000000000000000000000000000000000)
     if n == 41:
-        return ValueType(10) ** 41
+        return ValueType(100000000000000000000000000000000000000000)
     if n == 42:
-        return ValueType(10) ** 42
+        return ValueType(1000000000000000000000000000000000000000000)
     if n == 43:
-        return ValueType(10) ** 43
+        return ValueType(10000000000000000000000000000000000000000000)
     if n == 44:
-        return ValueType(10) ** 44
+        return ValueType(100000000000000000000000000000000000000000000)
     if n == 45:
-        return ValueType(10) ** 45
+        return ValueType(1000000000000000000000000000000000000000000000)
     if n == 46:
-        return ValueType(10) ** 46
+        return ValueType(10000000000000000000000000000000000000000000000)
     if n == 47:
-        return ValueType(10) ** 47
+        return ValueType(100000000000000000000000000000000000000000000000)
     if n == 48:
-        return ValueType(10) ** 48
+        return ValueType(1000000000000000000000000000000000000000000000000)
     if n == 49:
-        return ValueType(10) ** 49
+        return ValueType(10000000000000000000000000000000000000000000000000)
     if n == 50:
-        return ValueType(10) ** 50
+        return ValueType(100000000000000000000000000000000000000000000000000)
     if n == 51:
-        return ValueType(10) ** 51
+        return ValueType(1000000000000000000000000000000000000000000000000000)
     if n == 52:
-        return ValueType(10) ** 52
+        return ValueType(10000000000000000000000000000000000000000000000000000)
     if n == 53:
-        return ValueType(10) ** 53
+        return ValueType(100000000000000000000000000000000000000000000000000000)
     if n == 54:
-        return ValueType(10) ** 54
+        return ValueType(
+            1000000000000000000000000000000000000000000000000000000
+        )
     if n == 55:
-        return ValueType(10) ** 55
+        return ValueType(
+            10000000000000000000000000000000000000000000000000000000
+        )
     if n == 56:
-        return ValueType(10) ** 56
+        return ValueType(
+            100000000000000000000000000000000000000000000000000000000
+        )
+    if n == 57:
+        return ValueType(
+            1000000000000000000000000000000000000000000000000000000000
+        )
+    if n == 58:
+        return ValueType(
+            10000000000000000000000000000000000000000000000000000000000
+        )
 
     return ValueType(10) ** n


### PR DESCRIPTION
This PR removes Decimal128’s internal NaN/Infinity representation, improves `Decimal128.from_words()` validation by raising runtime errors instead of using test assertions, and expands `power_of_10()`’s hardcoded table to cover more exponents needed by Decimal128 arithmetic.

**Changes:**
- Restrict `power_of_10()` to uint128/uint256 and hardcode additional powers up to 10^58.
- Remove Decimal128 NaN/Infinity flags and related helpers; update `from_words()` to raise `ValueError` for invalid flags/scale.
- Minor documentation updates in CLI about text formatting and unreleased README (adds `Rational`).