### PR TITLE
[dec128] Add `fit_to_max_coefficient()` and `round_coefficient()` to replace old functions

### DIFF
--- a/docs/plans/decimal128_enhancement.md
+++ b/docs/plans/decimal128_enhancement.md
@@ -399,26 +399,26 @@ Some test cases worth adding:
 
 ## 6. Priority Summary
 
-| #   | Issue                                   | Severity    | Effort                        | Priority |
-| --- | --------------------------------------- | ----------- | ----------------------------- | -------- |
-| 3.1 | NaN/Inf broken (fix or remove)          | Critical    | Small (remove) / Medium (fix) | P0       |
-| 3.2 | `from_words` uses `testing.assert_true` | Medium      | Small                         | P1       |
-| 4.2 | `power_of_10` not fully precomputed     | High        | Small                         | P1       |
-| 4.3 | `truncate_to_max` lacks .NET tricks     | High        | Medium                        | P1       |
-| 3.4 | `compare_absolute` overflow             | Medium      | Small                         | P2       |
-| 4.1 | `number_of_bits` loop                   | Medium      | Small                         | P2       |
-| 4.8 | Separate `//` and `%` in division       | Medium      | Small                         | P2       |
-| 4.7 | `from_string` digit-by-digit            | Medium      | Medium                        | P2       |
-| 4.4 | `ln()` range reduction loops            | Medium      | Medium                        | P2       |
-| 5.4 | `min/max/clamp`                         | Enhancement | Trivial                       | P3       |
-| 5.5 | `normalize()`                           | Enhancement | Small                         | P3       |
-| 5.1 | `__hash__`                              | Enhancement | Small                         | P3       |
-| 5.6 | Edge case tests                         | Enhancement | Medium                        | P3       |
-| 4.5 | `subtract` temporary                    | Low         | Trivial                       | P4       |
-| 4.6 | Series convergence tolerance            | Low         | Small                         | P4       |
-| 3.3 | Division rounding mode (configurable)   | Low         | Medium                        | P4       |
-| 5.3 | Better `from_float`                     | Enhancement | Medium                        | P4       |
-| 5.2 | `Stringable` conformance                | Enhancement | Trivial                       | P4       |
+| #   | Issue                                   | Severity    | Effort         | Priority | Status |
+| --- | --------------------------------------- | ----------- | -------------- | -------- | ------ |
+| 3.1 | NaN/Inf broken (fix or remove)          | Critical    | Small (remove) | P0       | Done   |
+| 3.2 | `from_words` uses `testing.assert_true` | Medium      | Small          | P1       | Done   |
+| 4.2 | `power_of_10` not fully precomputed     | High        | Small          | P1       | Done   |
+| 4.3 | `truncate_to_max` lacks .NET tricks     | High        | Medium         | P1       | -      |
+| 3.4 | `compare_absolute` overflow             | Medium      | Small          | P2       | -      |
+| 4.1 | `number_of_bits` loop                   | Medium      | Small          | P2       | -      |
+| 4.8 | Separate `//` and `%` in division       | Medium      | Small          | P2       | -      |
+| 4.7 | `from_string` digit-by-digit            | Medium      | Medium         | P2       | -      |
+| 4.4 | `ln()` range reduction loops            | Medium      | Medium         | P2       | -      |
+| 5.4 | `min/max/clamp`                         | Enhancement | Trivial        | P3       | -      |
+| 5.5 | `normalize()`                           | Enhancement | Small          | P3       | -      |
+| 5.1 | `__hash__`                              | Enhancement | Small          | P3       | -      |
+| 5.6 | Edge case tests                         | Enhancement | Medium         | P3       | -      |
+| 4.5 | `subtract` temporary                    | Low         | Trivial        | P4       | -      |
+| 4.6 | Series convergence tolerance            | Low         | Small          | P4       | -      |
+| 3.3 | Division rounding mode (configurable)   | Low         | Medium         | P4       | -      |
+| 5.3 | Better `from_float`                     | Enhancement | Medium         | P4       | -      |
+| 5.2 | `Stringable` conformance                | Enhancement | Trivial        | P4       | -      |
 
 ## 7. Execution Order
 

--- a/docs/plans/decimal128_enhancement.md
+++ b/docs/plans/decimal128_enhancement.md
@@ -32,15 +32,15 @@ Decimo, C#, and Rust share the same layout — a proven design. Arrow and govalu
 
 ### 1.2 Special Values
 
-| Feature       | Decimo                | C#         | Rust | Arrow | Go govalues |
-| ------------- | --------------------- | ---------- | ---- | ----- | ----------- |
-| +Infinity     | ✓ (broken — see §3.1) | ✗ (throws) | ✗    | ✗     | ✗           |
-| −Infinity     | ✓ (broken)            | ✗          | ✗    | ✗     | ✗           |
-| NaN           | ✓ (broken — see §3.1) | ✗          | ✗    | ✗     | ✗           |
-| Negative zero | ✗                     | ✗          | ✗    | ✗     | ✗           |
-| Subnormals    | ✗                     | ✗          | ✗    | ✗     | ✗           |
+| Feature       | Decimo             | C#         | Rust | Arrow | Go govalues |
+| ------------- | ------------------ | ---------- | ---- | ----- | ----------- |
+| +Infinity     | ✗ (removed — §3.1) | ✗ (throws) | ✗    | ✗     | ✗           |
+| −Infinity     | ✗ (removed)        | ✗          | ✗    | ✗     | ✗           |
+| NaN           | ✗ (removed — §3.1) | ✗          | ✗    | ✗     | ✗           |
+| Negative zero | ✗                  | ✗          | ✗    | ✗     | ✗           |
+| Subnormals    | ✗                  | ✗          | ✗    | ✗     | ✗           |
 
-None of the comparable 128-bit fixed-precision libraries support NaN or Infinity. We are the only one, and our implementation is broken (§3.1). Maybe consider removing NaN/Infinity support to match the established paradigm — all four comparable libraries simply throw or return an error for undefined operations. If we keep them, the bugs must be fixed and full arithmetic propagation must be added, which is a lot of effort for a feature no peer library provides.
+None of the comparable 128-bit fixed-precision libraries support NaN or Infinity. We removed our broken NaN/Infinity support (§3.1) to match the established paradigm — all four comparable libraries simply raise errors for undefined operations.
 
 ### 1.3 Rounding Modes
 
@@ -91,7 +91,7 @@ This is probably the biggest architectural concern I found. It affects performan
 
 Our max coefficient is 2^96 − 1 = 79,228,162,514,264,337,593,543,950,335. This is a 29-digit number, but the leading digit can only be 0–7. The number 80,000,000,000,000,000,000,000,000,000 (which has only 2 significant digits) is out of range. Meanwhile, all 28-digit numbers fit.
 
-This creates a messy boundary: after every arithmetic operation that might produce a wide result (multiplication, addition with carry, etc.), I need to check whether the coefficient exceeds 2^96 − 1 and, if so, round it down. The rounding itself is non-trivial because the boundary is not at a clean decimal digit — I cannot just drop the last digit. The `truncate_to_max` function in `utility.mojo` handles this, and it is one of the most complex functions in the codebase.
+This creates a messy boundary: after every arithmetic operation that might produce a wide result (multiplication, addition with carry, etc.), I need to check whether the coefficient exceeds 2^96 − 1 and, if so, round it down. The rounding itself is non-trivial because the boundary is not at a clean decimal digit — I cannot just drop the last digit. The `fit_to_max_coefficient` + `round_coefficient` pair in `utility.mojo` handles this (replacing the old `truncate_to_max` / `round_to_keep_first_n_digits`).
 
 ### 2.2 How Other Libraries Handle This
 
@@ -146,9 +146,9 @@ Since the bound IS a power of 10, the rounding is clean: just count digits, divi
 
 ### 2.4 Implications for Decimo
 
-Since we follow the C#/Rust paradigm (binary bound, 2^96 − 1), the `truncate_to_max` complexity is inherent. There are a few things I can do:
+Since we follow the C#/Rust paradigm (binary bound, 2^96 − 1), the coefficient-fitting complexity is inherent. What we have done so far:
 
-1. Adopt .NET's optimization tricks. Specifically: the `log10(2) ≈ 77/256` estimation for scale-down amount, precomputed `POWER_OVERFLOW_VALUES` table for safe scale-up, and the `Unscale()` trailing-zero removal with quick-reject bit checks. These would make our existing `truncate_to_max` and `round_to_keep_first_n_digits` much faster.
+1. (Done) Adopted three .NET `ScaleResult` optimisations in the new `round_coefficient()` function: single-division remainder, `2×remainder` vs `divisor` half-comparison, and caller-supplied digit-removal count. The old `truncate_to_max` and `round_to_keep_first_n_digits` are replaced by `fit_to_max_coefficient` + `round_coefficient`. Possible future work: CLZ-based digit estimation (`LeadingZeroCount × 77/256`), precomputed `POWER_OVERFLOW_VALUES` table for safe scale-up, and `Unscale()` trailing-zero removal with quick-reject bit checks.
 
 2. Consider decimal bound for a future Decimal256. If I ever widen to full 128-bit coefficient, using 10^38 − 1 as the max (matching Arrow and SQL Server) would eliminate this problem entirely and give us interoperability with Arrow wire format and SQL `decimal(38)`.
 
@@ -158,7 +158,7 @@ Since we follow the C#/Rust paradigm (binary bound, 2^96 − 1), the `truncate_t
 
 Mojo now has native `UInt128` and `UInt256` types (via `Scalar[DType.uint128]` and `Scalar[DType.uint256]`). The codebase already uses them — `coefficient()` bitcasts the three UInt32 words to UInt128, and `multiply()` uses UInt256 for intermediate products. But there are more opportunities:
 
-- In `truncate_to_max` and `round_to_keep_first_n_digits`, the divmod operations on UInt128/UInt256 could exploit the fact that Mojo compiles to LLVM IR, where UInt128 division on 64-bit targets translates to two hardware `div` instructions (high and low halves). This is much faster than manually managing three 32-bit limbs. We are already partially doing this, but some code paths still work with individual UInt32 words when they could just operate on the UInt128 directly.
+- In `round_coefficient` and `fit_to_max_coefficient`, the divmod operations on UInt128/UInt256 exploit the fact that Mojo compiles to LLVM IR, where UInt128 division on 64-bit targets translates to two hardware `div` instructions (high and low halves). The new `round_coefficient` already avoids the second division by computing `remainder = value - truncated * divisor`.
 - The `number_of_bits` loop (§4.1) could be replaced by casting UInt128 to two UInt64s and using `count_leading_zeros` on the high word — this gives O(1) bit width instead of a 96-iteration loop.
 - Arrow's approach of promoting to 256-bit for multiply is directly applicable since we already have UInt256. Instead of the current 3×UInt32 partial-product approach in some code paths, we could do: `UInt256(x_coef) * UInt256(y_coef)`, then scale/truncate the result. This is simpler and likely just as fast since LLVM will optimize the wide multiply.
 - For the `compare_absolute` overflow bug (§3.4), using UInt256 instead of UInt128 for the fractional scaling is a one-line fix thanks to the type already being available.
@@ -167,64 +167,26 @@ In short: we already depend on UInt128/UInt256 for the core paths. The opportuni
 
 ## 3. Correctness Bugs
 
-### 3.1 NaN/Infinity Implementation Is Broken
+### 3.1 NaN/Infinity Implementation Was Broken (Removed)
 
 File: `decimal128.mojo`
 
-There are multiple compounding bugs in the NaN/Infinity support:
+The NaN/Infinity support had multiple compounding bugs (mask mismatch, `is_zero()` returning True,
+no arithmetic propagation). Since no comparable 128-bit fixed-precision library supports NaN or
+Infinity (§1.2), we removed NaN/Infinity support entirely. Operations that would produce
+undefined results now raise errors, matching C#, Rust, Arrow, and govalues.
 
-Bug A — NaN mask mismatch:
+Status: **Done** (removed `NAN()`, `NEGATIVE_NAN()`, `INFINITY()`, `NEGATIVE_INFINITY()`,
+`NAN_MASK`, `INFINITY_MASK`, `is_nan()`, `is_infinity()` and their callers).
 
-```txt
-NAN_MASK = UInt32(0x00000002)    # bit 1
-```
-
-But the constructors set a different bit:
-
-```txt
-NAN()          → Self(0, 0, 0, 0x00000010)  # bit 4
-NEGATIVE_NAN() → Self(0, 0, 0, 0x80000010)  # bit 4
-```
-
-So `Decimal128.NAN().is_nan()` returns False.
-
-Bug B — `is_zero()` returns True for NaN and Infinity:
-
-```mojo
-def is_zero(self) -> Bool:
-    return self.low == 0 and self.mid == 0 and self.high == 0
-```
-
-NaN and Infinity have zero coefficients, so `INFINITY().is_zero()` → True.
-
-Bug C — No arithmetic propagation: none of the arithmetic operations check for NaN or Infinity inputs. Passing them into `add()`, `multiply()`, etc., produces garbage silently.
-
-Since no comparable 128-bit fixed-precision library supports NaN or Infinity (see §1.2), maybe the cleanest fix is to just remove NaN/Infinity support entirely and raise errors for undefined operations (matching C#, Rust, Arrow, and govalues). If I decide to keep them, all three bugs must be fixed:
-
-- Fix A: Change `NAN()` → `Self(0, 0, 0, 0x00000002)` and `NEGATIVE_NAN()` → `Self(0, 0, 0, 0x80000002)` to match the mask.
-- Fix B: Guard `is_zero()` with `if self.is_nan() or self.is_infinity(): return False`.
-- Fix C: Add early-return NaN/Inf checks to every arithmetic function (significant effort).
-
-### 3.2 `from_words` Uses `testing.assert_true` in Production Code
+### 3.2 `from_words` Uses `testing.assert_true` in Production Code (Fixed)
 
 File: `decimal128.mojo`, lines ~344, 351
 
-```mojo
-from testing import assert_true
-assert_true(scale <= Self.MAX_SCALE, ...)
-assert_true(coefficient <= Self.MAX_AS_UINT128, ...)
-```
+The function used `testing.assert_true` to validate arguments, which panics with a test failure
+message rather than raising a recoverable error.
 
-This imports the test framework into production code. `assert_true` panics with a test failure message rather than raising a recoverable error. Users expect `raise Error(...)`.
-
-Fix:
-
-```mojo
-if scale > Self.MAX_SCALE:
-    raise Error("Error in Decimal128.from_words(): Scale must be <= 28, got " + str(scale))
-if coefficient > Self.MAX_AS_UINT128:
-    raise Error("Error in Decimal128.from_words(): Coefficient exceeds 96-bit max")
-```
+Status: **Done** — replaced with `raise Error(...)` for both scale and coefficient validation.
 
 ### 3.3 Division Hardcodes Rounding Behavior
 
@@ -280,23 +242,30 @@ Fix: split UInt128 into two UInt64s and use `count_leading_zeros` on the high wo
 
 File: `utility.mojo`
 
-The function already has hardcoded return values for n=0 through n=32, but for n=33 through n=56+ it falls back to `ValueType(10) ** n` which computes via loop.
+The function had hardcoded return values for n=0 through n=32, but for n=33 through n=56+ it fell back to `ValueType(10) ** n` which computes via loop.
 
-Since `power_of_10` is called in nearly every arithmetic operation (scale adjustment, `number_of_digits`, comparison, division), the fallback path matters.
+Fix (done): extended the hardcoded constants up to n=58 (the maximum needed for UInt256 products of two 29-digit numbers). The cache layer remains for values beyond the hardcoded range, but in practice n ≤ 58 covers all Decimal128 arithmetic paths.
 
-Fix: extend the hardcoded constants up to n=58 (the maximum needed for UInt256 products of two 29-digit numbers). The pattern is already there for n ≤ 32 — just continue it. For UInt256 values too large for integer literals, use the `@always_inline` constant function pattern from `constants.mojo`.
-
-### 4.3 `truncate_to_max` Could Use .NET Tricks
+### 4.3 `round_to_keep_first_n_digits` Lacked .NET-style Optimisations
 
 File: `utility.mojo`
 
-Our `truncate_to_max` computes `number_of_digits`, then divides by `power_of_10`, then rounds. .NET's [`ScaleResult`](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Decimal.DecCalc.cs) uses:
+The old `round_to_keep_first_n_digits` had three inefficiencies compared to
+.NET's [`ScaleResult`](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Decimal.DecCalc.cs):
 
-- `LeadingZeroCount` × `77/256` to estimate digit count without a full `number_of_digits` call
-- Division by compile-time constants (10^1 through 10^9) using multiply-by-reciprocal
-- `Unscale()` trailing-zero removal with bit-check quick-rejects
+1. **Two wide divisions** — `value // divisor` and `value % divisor` performed
+   two separate UInt128/UInt256 divisions, when the remainder can be derived
+   from a single division plus one multiply: `remainder = value - truncated * divisor`.
+2. **Expensive half-comparison** — the cutoff `5 * power_of_10(n − 1)` required
+   an extra power-of-10 lookup and a wide multiply.  .NET instead compares
+   `2 * remainder` against `divisor`, which is a single left-shift.
+3. **Redundant `number_of_digits` call** — the function always recomputed the
+   digit count even though most callers already knew it.
 
-These tricks could significantly speed up our overflow handling.
+Fix (done): introduced `round_coefficient(value, ndigits_to_remove, sign, rounding_mode)`
+which applies all three .NET-style tricks and takes `ndigits_to_remove` directly
+so callers that already know the digit count skip the redundant computation.
+All production call sites migrated; the old function is kept but deprecated.
 
 ### 4.4 `ln()` Range Reduction Uses Loops
 
@@ -356,6 +325,8 @@ rem = rem % x2_coef
 
 Two separate 128-bit divisions on the same operands. Most hardware produces both quotient and remainder in a single `div` instruction.
 
+Note: the `round_coefficient` function (§4.3) already addresses this for the rounding path by computing `remainder = value - truncated * divisor` instead of a second division. This §4.8 issue remains only in the long-division digit-extraction loop inside `divide()`, which is a different code path.
+
 Fix: use `divmod()` if available in Mojo.
 
 ## 5. Improvement Opportunities
@@ -399,39 +370,39 @@ Some test cases worth adding:
 
 ## 6. Priority Summary
 
-| #   | Issue                                   | Severity    | Effort         | Priority | Status |
-| --- | --------------------------------------- | ----------- | -------------- | -------- | ------ |
-| 3.1 | NaN/Inf broken (fix or remove)          | Critical    | Small (remove) | P0       | Done   |
-| 3.2 | `from_words` uses `testing.assert_true` | Medium      | Small          | P1       | Done   |
-| 4.2 | `power_of_10` not fully precomputed     | High        | Small          | P1       | Done   |
-| 4.3 | `truncate_to_max` lacks .NET tricks     | High        | Medium         | P1       | -      |
-| 3.4 | `compare_absolute` overflow             | Medium      | Small          | P2       | -      |
-| 4.1 | `number_of_bits` loop                   | Medium      | Small          | P2       | -      |
-| 4.8 | Separate `//` and `%` in division       | Medium      | Small          | P2       | -      |
-| 4.7 | `from_string` digit-by-digit            | Medium      | Medium         | P2       | -      |
-| 4.4 | `ln()` range reduction loops            | Medium      | Medium         | P2       | -      |
-| 5.4 | `min/max/clamp`                         | Enhancement | Trivial        | P3       | -      |
-| 5.5 | `normalize()`                           | Enhancement | Small          | P3       | -      |
-| 5.1 | `__hash__`                              | Enhancement | Small          | P3       | -      |
-| 5.6 | Edge case tests                         | Enhancement | Medium         | P3       | -      |
-| 4.5 | `subtract` temporary                    | Low         | Trivial        | P4       | -      |
-| 4.6 | Series convergence tolerance            | Low         | Small          | P4       | -      |
-| 3.3 | Division rounding mode (configurable)   | Low         | Medium         | P4       | -      |
-| 5.3 | Better `from_float`                     | Enhancement | Medium         | P4       | -      |
-| 5.2 | `Stringable` conformance                | Enhancement | Trivial        | P4       | -      |
+| #   | Issue                                            | Severity    | Effort  | Priority | Status |
+| --- | ------------------------------------------------ | ----------- | ------- | -------- | ------ |
+| 3.1 | NaN/Inf removed                                  | Critical    | Small   | P0       | Done   |
+| 3.2 | `from_words` uses `testing.assert_true`          | Medium      | Small   | P1       | Done   |
+| 4.2 | `power_of_10` not fully precomputed              | High        | Small   | P1       | Done   |
+| 4.3 | `round_to_keep_first_n_digits` lacks .NET tricks | High        | Medium  | P1       | Done   |
+| 3.4 | `compare_absolute` overflow                      | Medium      | Small   | P2       | -      |
+| 4.1 | `number_of_bits` loop                            | Medium      | Small   | P2       | -      |
+| 4.8 | Separate `//` and `%` in division loop           | Medium      | Small   | P2       | -      |
+| 4.7 | `from_string` digit-by-digit                     | Medium      | Medium  | P2       | -      |
+| 4.4 | `ln()` range reduction loops                     | Medium      | Medium  | P2       | -      |
+| 5.4 | `min/max/clamp`                                  | Enhancement | Trivial | P3       | -      |
+| 5.5 | `normalize()`                                    | Enhancement | Small   | P3       | -      |
+| 5.1 | `__hash__`                                       | Enhancement | Small   | P3       | -      |
+| 5.6 | Edge case tests                                  | Enhancement | Medium  | P3       | -      |
+| 4.5 | `subtract` temporary                             | Low         | Trivial | P4       | -      |
+| 4.6 | Series convergence tolerance                     | Low         | Small   | P4       | -      |
+| 3.3 | Division rounding mode (configurable)            | Low         | Medium  | P4       | -      |
+| 5.3 | Better `from_float`                              | Enhancement | Medium  | P4       | -      |
+| 5.2 | `Stringable` conformance                         | Enhancement | Trivial | P4       | -      |
 
 ## 7. Execution Order
 
-Phase 1 — correctness:
+Phase 1 — correctness: **(Done)**
 
-1. Decide: remove NaN/Infinity or fix them (§3.1). If removing, delete `NAN()`, `NEGATIVE_NAN()`, `INFINITY()`, `NEGATIVE_INFINITY()`, `NAN_MASK`, `INFINITY_MASK`, `is_nan()`, `is_infinity()` and change callers to raise errors. If fixing, apply fixes A/B/C from §3.1.
-2. Fix `from_words` to use `raise Error` instead of `testing.assert_true` (§3.2).
-3. Add edge case tests (§5.6).
+1. ~~Decide: remove NaN/Infinity or fix them (§3.1).~~ **Done** — removed NaN/Infinity entirely.
+2. ~~Fix `from_words` to use `raise Error` instead of `testing.assert_true` (§3.2).~~ **Done.**
+3. Add edge case tests (§5.6). (Partially done — `test_round_coefficient` added 19 cases.)
 
-Phase 2 — performance (coefficient bound):
+Phase 2 — performance (coefficient bound): **(Mostly done)**
 
-1. Extend `power_of_10` hardcoded constants up to n=58 (§4.2).
-2. Add .NET-style tricks to `truncate_to_max`: CLZ-based digit estimation, divide-by-constant optimization, trailing-zero quick-reject (§4.3).
+1. ~~Extend `power_of_10` hardcoded constants up to n=58 (§4.2).~~ **Done.**
+2. ~~Add .NET-style tricks to rounding: new `round_coefficient` with single-division remainder, cheap half-comparison, and caller-supplied removal count (§4.3).~~ **Done** — all 10 production callers migrated.
 3. Replace `number_of_bits` with hardware CLZ via UInt64 split (§4.1).
 4. Fix `compare_absolute` overflow with UInt256 (§3.4).
 
@@ -645,7 +616,7 @@ For govalues/decimal precision 19:
 
 Decimo follows the C#/Rust approach (binary bound, 2^96 − 1). This means:
 
-1. **The `truncate_to_max` style bound-checking IS a concern:** When multiplying two 29-digit
+1. **The coefficient-fitting logic IS a concern:** When multiplying two 29-digit
    numbers, the intermediate product can have up to 58 digits. If the result after scale adjustment
    still exceeds 2^96 − 1, we must handle it. The current behavior should be documented: do we
    raise an error, or do we round to fit?

--- a/docs/plans/decimal128_enhancement.md
+++ b/docs/plans/decimal128_enhancement.md
@@ -253,19 +253,11 @@ File: `utility.mojo`
 The old `round_to_keep_first_n_digits` had three inefficiencies compared to
 .NET's [`ScaleResult`](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Decimal.DecCalc.cs):
 
-1. **Two wide divisions** — `value // divisor` and `value % divisor` performed
-   two separate UInt128/UInt256 divisions, when the remainder can be derived
-   from a single division plus one multiply: `remainder = value - truncated * divisor`.
-2. **Expensive half-comparison** — the cutoff `5 * power_of_10(n − 1)` required
-   an extra power-of-10 lookup and a wide multiply.  .NET instead compares
-   `2 * remainder` against `divisor`, which is a single left-shift.
-3. **Redundant `number_of_digits` call** — the function always recomputed the
-   digit count even though most callers already knew it.
+1. **Two wide divisions** — `value // divisor` and `value % divisor` performed two separate UInt128/UInt256 divisions, when the remainder can be derived from a single division plus one multiply: `remainder = value - truncated * divisor`.
+2. **Expensive half-comparison** — the cutoff `5 * power_of_10(n − 1)` required an extra power-of-10 lookup and a wide multiply.  .NET instead compares `2 * remainder` against `divisor`, which is a single left-shift.
+3. **Redundant `number_of_digits` call** — the function always recomputed the digit count even though most callers already knew it.
 
-Fix (done): introduced `round_coefficient(value, ndigits_to_remove, sign, rounding_mode)`
-which applies all three .NET-style tricks and takes `ndigits_to_remove` directly
-so callers that already know the digit count skip the redundant computation.
-All production call sites migrated; the old function is kept but deprecated.
+Fix (done): introduced `round_coefficient(value, ndigits_to_remove, sign, rounding_mode)` which applies all three .NET-style tricks and takes `ndigits_to_remove` directly so callers that already know the digit count skip the redundant computation. All production call sites migrated; the old function is kept but deprecated.
 
 ### 4.4 `ln()` Range Reduction Uses Loops
 
@@ -497,13 +489,9 @@ Not truly 128-bit — the struct is **160 bits (20 bytes)**. Layout:
 - `reserved: UInt16`
 - `mantissa: (UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16)` — 8×UInt16 = 128 bits
 
-The 128-bit mantissa can theoretically hold values up to 2^128 − 1, but the `_length` field
-(4 bits, max 15) indicates how many of the 8 UInt16 slots are used, and Apple documents the max as
-38 significant decimal digits (i.e., effectively capped at 10^38 − 1).
+The 128-bit mantissa can theoretically hold values up to 2^128 − 1, but the `_length` field (4 bits, max 15) indicates how many of the 8 UInt16 slots are used, and Apple documents the max as 38 significant decimal digits (i.e., effectively capped at 10^38 − 1).
 
-Unlike C# and Rust, Swift Decimal **supports NaN** (`isNaN` property). It does NOT support Infinity
-in practice — the `isInfinite` property exists (inherited from `FloatingPoint` protocol) but Apple's
-implementation does not produce or handle Infinity values meaningfully.
+Unlike C# and Rust, Swift Decimal **supports NaN** (`isNaN` property). It does NOT support Infinity in practice — the `isInfinite` property exists (inherited from `FloatingPoint` protocol) but Apple's implementation does not produce or handle Infinity values meaningfully.
 
 #### SQL Server decimal / numeric
 
@@ -524,25 +512,17 @@ No NaN, no Infinity. `decimal` and `numeric` are synonyms; both are fixed precis
 
 #### Go govalues/decimal
 
-A high-performance, zero-allocation decimal designed for financial systems. Internally uses a
-`uint64` coefficient (max 10^19 − 1 = 9,999,999,999,999,999,999) with 19-digit precision and
-scale 0–19. The struct fits in 128 bits total (bool sign + uint64 coefficient + int scale, though
-Go struct layout may pad slightly).
+A high-performance, zero-allocation decimal designed for financial systems. Internally uses a `uint64` coefficient (max 10^19 − 1 = 9,999,999,999,999,999,999) with 19-digit precision and scale 0–19. The struct fits in 128 bits total (bool sign + uint64 coefficient + int scale, though Go struct layout may pad slightly).
 
-No NaN, no Infinity, no negative zero, no subnormals. Immutable, panic-free (returns errors).
-Uses half-to-even rounding by default. Falls back to `big.Int` for intermediate calculations to
-maintain correctness, but final results are always rounded to 19 digits.
+No NaN, no Infinity, no negative zero, no subnormals. Immutable, panic-free (returns errors). Uses half-to-even rounding by default. Falls back to `big.Int` for intermediate calculations to maintain correctness, but final results are always rounded to 19 digits.
 
 #### Delphi Currency
 
-Only 64 bits, included for completeness. A 64-bit signed integer scaled by 10^4 (i.e., always
-exactly 4 decimal places). Max value: 922,337,203,685,477.5807. Not truly 128-bit, but it is a
-notable example of a fixed-point decimal type in the wild.
+Only 64 bits, included for completeness. A 64-bit signed integer scaled by 10^4 (i.e., always exactly 4 decimal places). Max value: 922,337,203,685,477.5807. Not truly 128-bit, but it is a notable example of a fixed-point decimal type in the wild.
 
 ### A.3 Eliminated Candidates
 
-The following were investigated but **excluded** because they are arbitrary-precision (not
-fixed-precision within 128 bits):
+The following were investigated but **excluded** because they are arbitrary-precision (not fixed-precision within 128 bits):
 
 | Name                   | Language   | Reason for Exclusion                                                                                                           |
 | ---------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------ |
@@ -553,15 +533,13 @@ fixed-precision within 128 bits):
 
 ### A.4 Critical Analysis: Coefficient Upper Bound Approaches
 
-There are **two fundamentally different approaches** to bounding the coefficient in fixed-precision
-decimal types:
+There are **two fundamentally different approaches** to bounding the coefficient in fixed-precision decimal types:
 
 #### Approach 1: Binary Bound (2^N − 1)
 
 **Used by:** C# System.Decimal, Rust rust_decimal, Decimo Decimal128
 
-The coefficient is an N-bit unsigned integer, and the maximum value is the full binary range
-2^N − 1. For 96-bit coefficients:
+The coefficient is an N-bit unsigned integer, and the maximum value is the full binary range 2^N − 1. For 96-bit coefficients:
 
 - Max = 2^96 − 1 = **79,228,162,514,264,337,593,543,950,335**
 - This is a 29-digit number, but the leading digit can only be 0–7 (since 10^29 − 1 > 2^96 − 1)
@@ -576,18 +554,14 @@ The coefficient is an N-bit unsigned integer, and the maximum value is the full 
 
 **Cons:**
 
-- The "truncate-to-max" problem: when an operation produces a coefficient > 2^96 − 1, you must
-  either raise an error or round. The boundary is not at a clean decimal digit boundary, which
-  makes rounding semantics awkward. E.g., 80,000,000,000,000,000,000,000,000,000 (8×10^28) is
-  out of range, even though it only needs 2 significant digits.
+- The "truncate-to-max" problem: when an operation produces a coefficient > 2^96 − 1, you must either raise an error or round. The boundary is not at a clean decimal digit boundary, which makes rounding semantics awkward. E.g., 80,000,000,000,000,000,000,000,000,000 (8×10^28) is out of range, even though it only needs 2 significant digits.
 - Non-uniform digit range: the 29th digit has range 0–7, not 0–9. This is confusing for users.
 
 #### Approach 2: Decimal Bound (10^p − 1)
 
 **Used by:** Apache Arrow Decimal128, SQL Server decimal(38), Swift Decimal, govalues/decimal
 
-The coefficient is bounded by 10^p − 1, where p is the declared precision. Even if the underlying
-storage has more bits available, values above 10^p − 1 are not representable.
+The coefficient is bounded by 10^p − 1, where p is the declared precision. Even if the underlying storage has more bits available, values above 10^p − 1 are not representable.
 
 For Arrow/SQL precision 38:
 
@@ -616,19 +590,8 @@ For govalues/decimal precision 19:
 
 Decimo follows the C#/Rust approach (binary bound, 2^96 − 1). This means:
 
-1. **The coefficient-fitting logic IS a concern:** When multiplying two 29-digit
-   numbers, the intermediate product can have up to 58 digits. If the result after scale adjustment
-   still exceeds 2^96 − 1, we must handle it. The current behavior should be documented: do we
-   raise an error, or do we round to fit?
+1. **The coefficient-fitting logic IS a concern:** When multiplying two 29-digit numbers, the intermediate product can have up to 58 digits. If the result after scale adjustment still exceeds 2^96 − 1, we must handle it. The current behavior should be documented: do we raise an error, or do we round to fit?
 
-2. **The non-uniform 29th digit** should be documented. Users may expect that "29 digits of
-   precision" means they can represent any 29-digit number, but
-   `99,999,999,999,999,999,999,999,999,999` (29 nines) = ~10^29 is > 2^96 and therefore
-   out of range. The actual guarantee is "28 full digits plus a leading digit 0–7".
+2. **The non-uniform 29th digit** should be documented. Users may expect that "29 digits of precision" means they can represent any 29-digit number, but `99,999,999,999,999,999,999,999,999,999` (29 nines) = ~10^29 is > 2^96 and therefore out of range. The actual guarantee is "28 full digits plus a leading digit 0–7".
 
-3. **If we ever consider a Decimal256 or widen to full 128-bit coefficient:** We should evaluate
-   whether to switch to the decimal-bounded approach (10^38 − 1 with 128-bit storage, matching
-   Arrow/SQL) vs. staying with binary bound (2^128 − 1, giving ~38.5 digits with non-uniform
-   leading digit). The Arrow/SQL approach would give us exact compatibility with SQL Server
-   `decimal(38)` and Arrow `Decimal128` wire format, which is a significant interoperability
-   advantage.
+3. **If we ever consider a Decimal256 or widen to full 128-bit coefficient:** We should evaluate whether to switch to the decimal-bounded approach (10^38 − 1 with 128-bit storage, matching Arrow/SQL) vs. staying with binary bound (2^128 − 1, giving ~38.5 digits with non-uniform leading digit). The Arrow/SQL approach would give us exact compatibility with SQL Server `decimal(38)` and Arrow `Decimal128` wire format, which is a significant interoperability advantage.

--- a/docs/plans/decimal128_enhancement.md
+++ b/docs/plans/decimal128_enhancement.md
@@ -294,7 +294,9 @@ Both `exp_series` and `ln_series` loop up to 500 with convergence check `term.is
 
 Fix: break early if the term is smaller than 10^(−29) — it cannot change the result at our precision.
 
-### 4.7 `from_string` Processes Digits One at a Time
+### 4.7 `from_string` optimization
+
+`from_string` processes Digits One at a Time
 
 File: `decimal128.mojo`
 
@@ -305,6 +307,12 @@ coef = coef * 10 + digit
 Each iteration does a UInt128 multiply-by-10 and add.
 
 Fix: batch up to 9 digits into a UInt64, then multiply `coef` by the appropriate power of 10 and add the batch. Reduces 128-bit multiplications from ~29 to ~4 for a max-length number.
+
+---
+
+`Decimal128.from_string()` has its own parsing code, which seems to be highly overlapping with `str.parse_numeric_string()` that is currently used for `BigDecimal.from_string()`.
+
+Consider using `str.parse_numeric_string()` for `Decimal128.from_string()`.
 
 ### 4.8 Division Loop: Separate `//` and `%` Operations
 
@@ -371,7 +379,7 @@ Some test cases worth adding:
 | 3.4 | `compare_absolute` overflow                      | Medium      | Small   | P2       | -      |
 | 4.1 | `number_of_bits` loop                            | Medium      | Small   | P2       | -      |
 | 4.8 | Separate `//` and `%` in division loop           | Medium      | Small   | P2       | -      |
-| 4.7 | `from_string` digit-by-digit                     | Medium      | Medium  | P2       | -      |
+| 4.7 | `from_string` optimization                       | Medium      | Medium  | P2       | -      |
 | 4.4 | `ln()` range reduction loops                     | Medium      | Medium  | P2       | -      |
 | 5.4 | `min/max/clamp`                                  | Enhancement | Trivial | P3       | -      |
 | 5.5 | `normalize()`                                    | Enhancement | Small   | P3       | -      |

--- a/src/decimo/decimal128/arithmetics.mojo
+++ b/src/decimo/decimal128/arithmetics.mojo
@@ -239,30 +239,12 @@ def add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         # Otherwise, it is >= 29 digits
         # we need to truncate the summation to fit in 96 bits
         else:
-            var ndigits_summation = decimo.decimal128.utility.number_of_digits(
+            var fitted = decimo.decimal128.utility.fit_to_max_coefficient(
                 summation
             )
-            var ndigits_int_summation = UInt32(ndigits_summation) - UInt32(
-                x1_scale
-            )
-            var final_scale = Decimal128.MAX_NUM_DIGITS - ndigits_int_summation
+            var final_scale = UInt32(x1_scale) - UInt32(fitted[1])
 
-            var truncated_summation = (
-                decimo.decimal128.utility.round_to_keep_first_n_digits(
-                    summation, False, Decimal128.MAX_NUM_DIGITS
-                )
-            )
-            if truncated_summation > Decimal128.MAX_AS_UINT128:
-                truncated_summation = (
-                    decimo.decimal128.utility.round_to_keep_first_n_digits(
-                        summation, False, Decimal128.MAX_NUM_DIGITS - 1
-                    )
-                )
-                final_scale -= 1
-
-            return Decimal128.from_uint128(
-                truncated_summation, final_scale, is_negative
-            )
+            return Decimal128.from_uint128(fitted[0], final_scale, is_negative)
 
     # CASE: Float addition which with different scales
     else:  # x1_scale != x2_scale
@@ -324,33 +306,15 @@ def add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         # Otherwise, it is >= 29 digits
         # Otherwise, we need to truncate the summation to fit in 96 bits
         else:
-            var ndigits_summation = decimo.decimal128.utility.number_of_digits(
+            var fitted = decimo.decimal128.utility.fit_to_max_coefficient(
                 summation
             )
-            var ndigits_int_summation = UInt32(ndigits_summation) - UInt32(
-                max(x1_scale, x2_scale)
+            var final_scale = UInt32(max(x1_scale, x2_scale)) - UInt32(
+                fitted[1]
             )
-            var final_scale = (
-                UInt32(Decimal128.MAX_NUM_DIGITS) - ndigits_int_summation
-            )
-
-            truncated_summation = (
-                decimo.decimal128.utility.round_to_keep_first_n_digits(
-                    summation, False, Decimal128.MAX_NUM_DIGITS
-                )
-            )
-            if truncated_summation > Decimal128.MAX_AS_UINT256:
-                truncated_summation = (
-                    decimo.decimal128.utility.round_to_keep_first_n_digits(
-                        summation, False, Decimal128.MAX_NUM_DIGITS - 1
-                    )
-                )
-                final_scale -= 1
 
             return Decimal128.from_uint128(
-                UInt128(
-                    truncated_summation & 0x00000000_FFFFFFFF_FFFFFFFF_FFFFFFFF
-                ),
+                UInt128(fitted[0] & 0x00000000_FFFFFFFF_FFFFFFFF_FFFFFFFF),
                 final_scale,
                 is_negative,
             )
@@ -676,47 +640,22 @@ def multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
     if combined_num_bits <= 128:
         var prod: UInt128 = x1_coef * x2_coef
-        # Truncated first 29 digits
-        var truncated_prod_at_max_length = (
-            decimo.decimal128.utility.round_to_keep_first_n_digits(
-                prod, False, Decimal128.MAX_NUM_DIGITS
-            )
-        )
 
-        # Check outflow
-        # The number of digits of the integral part
-        var num_digits_of_integral_part = (
-            decimo.decimal128.utility.number_of_digits(prod) - combined_scale
-        )
-        if (num_digits_of_integral_part >= Decimal128.MAX_NUM_DIGITS) & (
-            truncated_prod_at_max_length > Decimal128.MAX_AS_UINT128
-        ):
+        # Use fit_to_max_coefficient to handle the try-29/try-28 pattern.
+        # digits_removed tells us how many least-significant digits were
+        # rounded away. If digits_removed > combined_scale, we've lost
+        # integral digits → overflow.
+        var fitted = decimo.decimal128.utility.fit_to_max_coefficient(prod)
+        var digits_removed = fitted[1]
+
+        if digits_removed > combined_scale:
             raise OverflowError(
                 message="Decimal128 overflow in multiplication.",
                 function="multiply()",
             )
 
-        # Otherwise, the value will not overflow even after rounding
-        # Determine the final scale after rounding
-        # If the first 29 digits does not exceed the limit,
-        # the final coefficient can be of 29 digits.
-        # The final scale can be 29 - num_digits_of_integral_part.
-        var num_digits_of_decimal_part = (
-            Decimal128.MAX_NUM_DIGITS - num_digits_of_integral_part
-        )
-        # If the first 29 digits exceed the limit,
-        # we need to adjust the num_digits_of_decimal_part by -1
-        # so that the final coefficient will be of 28 digits.
-        if truncated_prod_at_max_length > Decimal128.MAX_AS_UINT128:
-            num_digits_of_decimal_part -= 1
-            prod = decimo.decimal128.utility.round_to_keep_first_n_digits(
-                prod, False, Decimal128.MAX_NUM_DIGITS - 1
-            )
-        else:
-            prod = truncated_prod_at_max_length
-
-        # Yuhao's notes: I think combined_scale should always be smaller
-        var final_scale = min(num_digits_of_decimal_part, combined_scale)
+        prod = fitted[0]
+        var final_scale = combined_scale - digits_removed
 
         if final_scale > Decimal128.MAX_SCALE:
             var ndigits_prod = decimo.decimal128.utility.number_of_digits(prod)
@@ -738,49 +677,18 @@ def multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
     var prod: UInt256 = UInt256(x1_coef) * UInt256(x2_coef)
 
-    # Truncated first 29 digits
-    var truncated_prod_at_max_length = (
-        decimo.decimal128.utility.round_to_keep_first_n_digits(
-            prod, False, Decimal128.MAX_NUM_DIGITS
-        )
-    )
+    # Use fit_to_max_coefficient to handle the try-29/try-28 pattern.
+    var fitted = decimo.decimal128.utility.fit_to_max_coefficient(prod)
+    var digits_removed = fitted[1]
 
-    # Check outflow
-    # The number of digits of the integral part
-    var num_digits_of_integral_part = (
-        decimo.decimal128.utility.number_of_digits(prod) - combined_scale
-    )
-
-    # Check for overflow of the integral part after rounding
-    if (num_digits_of_integral_part >= Decimal128.MAX_NUM_DIGITS) & (
-        truncated_prod_at_max_length > Decimal128.MAX_AS_UINT256
-    ):
+    if digits_removed > combined_scale:
         raise OverflowError(
             message="Decimal128 overflow in multiplication.",
             function="multiply()",
         )
 
-    # Otherwise, the value will not overflow even after rounding
-    # Determine the final scale after rounding
-    # If the first 29 digits does not exceed the limit,
-    # the final coefficient can be of 29 digits.
-    # The final scale can be 29 - num_digits_of_integral_part.
-    var num_digits_of_decimal_part = (
-        Decimal128.MAX_NUM_DIGITS - num_digits_of_integral_part
-    )
-    # If the first 29 digits exceed the limit,
-    # we need to adjust the num_digits_of_decimal_part by -1
-    # so that the final coefficient will be of 28 digits.
-    if truncated_prod_at_max_length > Decimal128.MAX_AS_UINT256:
-        num_digits_of_decimal_part -= 1
-        prod = decimo.decimal128.utility.round_to_keep_first_n_digits(
-            prod, False, Decimal128.MAX_NUM_DIGITS - 1
-        )
-    else:
-        prod = truncated_prod_at_max_length
-
-    # I think combined_scale should always be smaller
-    var final_scale = min(num_digits_of_decimal_part, combined_scale)
+    prod = fitted[0]
+    var final_scale = combined_scale - digits_removed
 
     if final_scale > Decimal128.MAX_SCALE:
         var ndigits_prod = decimo.decimal128.utility.number_of_digits(prod)
@@ -1080,7 +988,6 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             quot = quot * UInt128(10) ** (-scale_of_quot)
             scale_of_quot = 0
         var ndigits_quot = decimo.decimal128.utility.number_of_digits(quot)
-        var ndigits_quot_int_part = ndigits_quot - scale_of_quot
 
         # print(
         #     String(
@@ -1106,22 +1013,9 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
         # Otherwise, we need to truncate the first 29 or 28 digits
         else:
-            var truncated_quot = (
-                decimo.decimal128.utility.round_to_keep_first_n_digits(
-                    quot, False, Decimal128.MAX_NUM_DIGITS
-                )
-            )
-            var scale_of_truncated_quot = (
-                Decimal128.MAX_NUM_DIGITS - ndigits_quot_int_part
-            )
-
-            if truncated_quot > Decimal128.MAX_AS_UINT128:
-                truncated_quot = (
-                    decimo.decimal128.utility.round_to_keep_first_n_digits(
-                        quot, False, Decimal128.MAX_NUM_DIGITS - 1
-                    )
-                )
-                scale_of_truncated_quot -= 1
+            var fitted = decimo.decimal128.utility.fit_to_max_coefficient(quot)
+            var truncated_quot = fitted[0]
+            var scale_of_truncated_quot = scale_of_quot - fitted[1]
 
             if scale_of_truncated_quot > Decimal128.MAX_SCALE:
                 var num_digits_truncated_quot = (
@@ -1194,7 +1088,6 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             quot256 = quot256 * UInt256(10) ** (-scale_of_quot)
             scale_of_quot = 0
         var ndigits_quot = decimo.decimal128.utility.number_of_digits(quot256)
-        var ndigits_quot_int_part = ndigits_quot - scale_of_quot
 
         # If quot is within MAX, return the result
         if quot256 <= Decimal128.MAX_AS_UINT256:
@@ -1218,33 +1111,20 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
         # Otherwise, we need to truncate the first 29 or 28 digits
         else:
-            var truncated_quot = (
-                decimo.decimal128.utility.round_to_keep_first_n_digits(
-                    quot256, False, Decimal128.MAX_NUM_DIGITS
-                )
+            var fitted = decimo.decimal128.utility.fit_to_max_coefficient(
+                quot256
             )
+            var truncated_quot = fitted[0]
+            var digits_removed = fitted[1]
 
-            # If integer part of quot is more than max, raise error
-            if (ndigits_quot_int_part > Decimal128.MAX_NUM_DIGITS) or (
-                (ndigits_quot_int_part == Decimal128.MAX_NUM_DIGITS)
-                and (truncated_quot > Decimal128.MAX_AS_UINT256)
-            ):
+            # If digits_removed > scale_of_quot, we've lost integral digits
+            if digits_removed > scale_of_quot:
                 raise OverflowError(
                     message="Decimal128 overflow in division.",
                     function="divide()",
                 )
 
-            var scale_of_truncated_quot = (
-                Decimal128.MAX_NUM_DIGITS - ndigits_quot_int_part
-            )
-
-            if truncated_quot > Decimal128.MAX_AS_UINT256:
-                truncated_quot = (
-                    decimo.decimal128.utility.round_to_keep_first_n_digits(
-                        quot256, False, Decimal128.MAX_NUM_DIGITS - 1
-                    )
-                )
-                scale_of_truncated_quot -= 1
+            var scale_of_truncated_quot = scale_of_quot - digits_removed
 
             if scale_of_truncated_quot > Decimal128.MAX_SCALE:
                 var num_digits_truncated_quot = (

--- a/src/decimo/decimal128/arithmetics.mojo
+++ b/src/decimo/decimal128/arithmetics.mojo
@@ -242,6 +242,14 @@ def add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             var fitted = decimo.decimal128.utility.fit_to_max_coefficient(
                 summation
             )
+            # Guard against integral-digit overflow: if the coefficient-fitting
+            # had to remove more digits than the current scale provides, the
+            # result no longer fits Decimal128's range.
+            if UInt32(fitted[1]) > UInt32(x1_scale):
+                raise OverflowError(
+                    message="Addition result exceeds Decimal128 precision.",
+                    function="add()",
+                )
             var final_scale = UInt32(x1_scale) - UInt32(fitted[1])
 
             return Decimal128.from_uint128(fitted[0], final_scale, is_negative)
@@ -309,9 +317,16 @@ def add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             var fitted = decimo.decimal128.utility.fit_to_max_coefficient(
                 summation
             )
-            var final_scale = UInt32(max(x1_scale, x2_scale)) - UInt32(
-                fitted[1]
-            )
+            var working_scale = UInt32(max(x1_scale, x2_scale))
+            # Guard against integral-digit overflow: if the coefficient-fitting
+            # had to remove more digits than the working scale provides, the
+            # result no longer fits Decimal128's range.
+            if UInt32(fitted[1]) > working_scale:
+                raise OverflowError(
+                    message="Addition result exceeds Decimal128 precision.",
+                    function="add()",
+                )
+            var final_scale = working_scale - UInt32(fitted[1])
 
             return Decimal128.from_uint128(
                 UInt128(fitted[0] & 0x00000000_FFFFFFFF_FFFFFFFF_FFFFFFFF),

--- a/src/decimo/decimal128/arithmetics.mojo
+++ b/src/decimo/decimal128/arithmetics.mojo
@@ -464,16 +464,9 @@ def multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         else:
             var prod = x2_coef
             # Rounding may be needed.
-            var num_digits_prod = decimo.decimal128.utility.number_of_digits(
-                prod
-            )
-            var num_digits_to_keep = num_digits_prod - (
-                combined_scale - Decimal128.MAX_SCALE
-            )
-            var truncated_prod = (
-                decimo.decimal128.utility.round_to_keep_first_n_digits(
-                    prod, False, num_digits_to_keep
-                )
+            var truncated_prod = decimo.decimal128.utility.round_coefficient(
+                prod,
+                ndigits_to_remove=combined_scale - Decimal128.MAX_SCALE,
             )
             var final_scale = UInt32(min(Decimal128.MAX_SCALE, combined_scale))
             return Decimal128.from_uint128(
@@ -492,16 +485,9 @@ def multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         else:
             var prod = x1_coef
             # Rounding may be needed.
-            var num_digits_prod = decimo.decimal128.utility.number_of_digits(
-                prod
-            )
-            var num_digits_to_keep = num_digits_prod - (
-                combined_scale - Decimal128.MAX_SCALE
-            )
-            var truncated_prod = (
-                decimo.decimal128.utility.round_to_keep_first_n_digits(
-                    prod, False, num_digits_to_keep
-                )
+            var truncated_prod = decimo.decimal128.utility.round_coefficient(
+                prod,
+                ndigits_to_remove=combined_scale - Decimal128.MAX_SCALE,
             )
             var final_scale = UInt32(min(Decimal128.MAX_SCALE, combined_scale))
             return Decimal128.from_uint128(
@@ -607,23 +593,16 @@ def multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
         # Combined scale no more than max precision, truncate with rounding
         else:
-            var num_digits = decimo.decimal128.utility.number_of_digits(prod)
-            var num_digits_to_keep = num_digits - (
-                combined_scale - Decimal128.MAX_SCALE
-            )
-            prod = decimo.decimal128.utility.round_to_keep_first_n_digits(
-                prod, False, num_digits_to_keep
+            prod = decimo.decimal128.utility.round_coefficient(
+                prod,
+                ndigits_to_remove=combined_scale - Decimal128.MAX_SCALE,
             )
             var final_scale = min(Decimal128.MAX_SCALE, combined_scale)
 
             if final_scale > Decimal128.MAX_SCALE:
-                var ndigits_prod = decimo.decimal128.utility.number_of_digits(
-                    prod
-                )
-                prod = decimo.decimal128.utility.round_to_keep_first_n_digits(
+                prod = decimo.decimal128.utility.round_coefficient(
                     prod,
-                    False,
-                    ndigits_prod - (final_scale - Decimal128.MAX_SCALE),
+                    ndigits_to_remove=final_scale - Decimal128.MAX_SCALE,
                 )
                 final_scale = Decimal128.MAX_SCALE
 
@@ -658,11 +637,9 @@ def multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         var final_scale = combined_scale - digits_removed
 
         if final_scale > Decimal128.MAX_SCALE:
-            var ndigits_prod = decimo.decimal128.utility.number_of_digits(prod)
-            prod = decimo.decimal128.utility.round_to_keep_first_n_digits(
+            prod = decimo.decimal128.utility.round_coefficient(
                 prod,
-                False,
-                ndigits_prod - (final_scale - Decimal128.MAX_SCALE),
+                ndigits_to_remove=final_scale - Decimal128.MAX_SCALE,
             )
             final_scale = Decimal128.MAX_SCALE
 
@@ -691,9 +668,9 @@ def multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
     var final_scale = combined_scale - digits_removed
 
     if final_scale > Decimal128.MAX_SCALE:
-        var ndigits_prod = decimo.decimal128.utility.number_of_digits(prod)
-        prod = decimo.decimal128.utility.round_to_keep_first_n_digits(
-            prod, False, ndigits_prod - (final_scale - Decimal128.MAX_SCALE)
+        prod = decimo.decimal128.utility.round_coefficient(
+            prod,
+            ndigits_to_remove=final_scale - Decimal128.MAX_SCALE,
         )
         final_scale = Decimal128.MAX_SCALE
 
@@ -987,7 +964,6 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         if scale_of_quot < 0:
             quot = quot * UInt128(10) ** (-scale_of_quot)
             scale_of_quot = 0
-        var ndigits_quot = decimo.decimal128.utility.number_of_digits(quot)
 
         # print(
         #     String(
@@ -1000,10 +976,9 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         # If quot is within MAX, return the result
         if quot <= Decimal128.MAX_AS_UINT128:
             if scale_of_quot > Decimal128.MAX_SCALE:
-                quot = decimo.decimal128.utility.round_to_keep_first_n_digits(
+                quot = decimo.decimal128.utility.round_coefficient(
                     quot,
-                    False,
-                    ndigits_quot - (scale_of_quot - Decimal128.MAX_SCALE),
+                    ndigits_to_remove=scale_of_quot - Decimal128.MAX_SCALE,
                 )
                 scale_of_quot = Decimal128.MAX_SCALE
 
@@ -1018,16 +993,10 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             var scale_of_truncated_quot = scale_of_quot - fitted[1]
 
             if scale_of_truncated_quot > Decimal128.MAX_SCALE:
-                var num_digits_truncated_quot = (
-                    decimo.decimal128.utility.number_of_digits(truncated_quot)
-                )
-                truncated_quot = (
-                    decimo.decimal128.utility.round_to_keep_first_n_digits(
-                        truncated_quot,
-                        False,
-                        num_digits_truncated_quot
-                        - (scale_of_truncated_quot - Decimal128.MAX_SCALE),
-                    )
+                truncated_quot = decimo.decimal128.utility.round_coefficient(
+                    truncated_quot,
+                    ndigits_to_remove=scale_of_truncated_quot
+                    - Decimal128.MAX_SCALE,
                 )
                 scale_of_truncated_quot = Decimal128.MAX_SCALE
 
@@ -1087,17 +1056,13 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         if scale_of_quot < 0:
             quot256 = quot256 * UInt256(10) ** (-scale_of_quot)
             scale_of_quot = 0
-        var ndigits_quot = decimo.decimal128.utility.number_of_digits(quot256)
 
         # If quot is within MAX, return the result
         if quot256 <= Decimal128.MAX_AS_UINT256:
             if scale_of_quot > Decimal128.MAX_SCALE:
-                quot256 = (
-                    decimo.decimal128.utility.round_to_keep_first_n_digits(
-                        quot256,
-                        False,
-                        ndigits_quot - (scale_of_quot - Decimal128.MAX_SCALE),
-                    )
+                quot256 = decimo.decimal128.utility.round_coefficient(
+                    quot256,
+                    ndigits_to_remove=scale_of_quot - Decimal128.MAX_SCALE,
                 )
                 scale_of_quot = Decimal128.MAX_SCALE
 
@@ -1127,16 +1092,10 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             var scale_of_truncated_quot = scale_of_quot - digits_removed
 
             if scale_of_truncated_quot > Decimal128.MAX_SCALE:
-                var num_digits_truncated_quot = (
-                    decimo.decimal128.utility.number_of_digits(truncated_quot)
-                )
-                truncated_quot = (
-                    decimo.decimal128.utility.round_to_keep_first_n_digits(
-                        truncated_quot,
-                        False,
-                        num_digits_truncated_quot
-                        - (scale_of_truncated_quot - Decimal128.MAX_SCALE),
-                    )
+                truncated_quot = decimo.decimal128.utility.round_coefficient(
+                    truncated_quot,
+                    ndigits_to_remove=scale_of_truncated_quot
+                    - Decimal128.MAX_SCALE,
                 )
                 scale_of_truncated_quot = Decimal128.MAX_SCALE
 

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -798,7 +798,19 @@ struct Decimal128(
         else:
             var fitted = decimo.decimal128.utility.fit_to_max_coefficient(coef)
             var truncated_coef = fitted[0]
-            var scale_of_truncated_coef = scale - UInt32(fitted[1])
+            var truncated_digits = UInt32(fitted[1])
+            # Guard against integral-digit overflow: if more digits were removed
+            # than the current scale provides, integral digits were lost and
+            # the value no longer fits Decimal128.
+            if truncated_digits > scale:
+                raise OverflowError(
+                    message=(
+                        "Cannot fit Decimal128 coefficient without removing"
+                        " integral digits."
+                    ),
+                    function="Decimal128.from_string()",
+                )
+            var scale_of_truncated_coef = scale - truncated_digits
 
             if scale_of_truncated_coef > UInt32(Decimal128.MAX_SCALE):
                 truncated_coef = decimo.decimal128.utility.round_coefficient(

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -798,25 +798,9 @@ struct Decimal128(
             return Decimal128.from_uint128(coef, scale, mantissa_sign)
 
         else:
-            var ndigits_coef = decimo.decimal128.utility.number_of_digits(coef)
-            var ndigits_quot_int_part = UInt32(ndigits_coef) - scale
-
-            var truncated_coef = (
-                decimo.decimal128.utility.round_to_keep_first_n_digits(
-                    coef, False, Decimal128.MAX_NUM_DIGITS
-                )
-            )
-            var scale_of_truncated_coef = (
-                UInt32(Decimal128.MAX_NUM_DIGITS) - ndigits_quot_int_part
-            )
-
-            if truncated_coef > Decimal128.MAX_AS_UINT128:
-                truncated_coef = (
-                    decimo.decimal128.utility.round_to_keep_first_n_digits(
-                        coef, False, Decimal128.MAX_NUM_DIGITS - 1
-                    )
-                )
-                scale_of_truncated_coef -= 1
+            var fitted = decimo.decimal128.utility.fit_to_max_coefficient(coef)
+            var truncated_coef = fitted[0]
+            var scale_of_truncated_coef = scale - UInt32(fitted[1])
 
             if scale_of_truncated_coef > UInt32(Decimal128.MAX_SCALE):
                 var num_digits_truncated_coef = (

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -787,11 +787,9 @@ struct Decimal128(
         # because it is used in many cases
         if coef <= Decimal128.MAX_AS_UINT128:
             if scale > UInt32(Decimal128.MAX_SCALE):
-                coef = decimo.decimal128.utility.round_to_keep_first_n_digits(
+                coef = decimo.decimal128.utility.round_coefficient(
                     coef,
-                    False,
-                    Int(num_mantissa_digits)
-                    - Int(scale - UInt32(Decimal128.MAX_SCALE)),
+                    ndigits_to_remove=Int(scale - UInt32(Decimal128.MAX_SCALE)),
                 )
                 scale = UInt32(Decimal128.MAX_SCALE)
 
@@ -803,19 +801,11 @@ struct Decimal128(
             var scale_of_truncated_coef = scale - UInt32(fitted[1])
 
             if scale_of_truncated_coef > UInt32(Decimal128.MAX_SCALE):
-                var num_digits_truncated_coef = (
-                    decimo.decimal128.utility.number_of_digits(truncated_coef)
-                )
-                truncated_coef = (
-                    decimo.decimal128.utility.round_to_keep_first_n_digits(
-                        truncated_coef,
-                        False,
-                        num_digits_truncated_coef
-                        - Int(
-                            scale_of_truncated_coef
-                            - UInt32(Decimal128.MAX_SCALE)
-                        ),
-                    )
+                truncated_coef = decimo.decimal128.utility.round_coefficient(
+                    truncated_coef,
+                    ndigits_to_remove=Int(
+                        scale_of_truncated_coef - UInt32(Decimal128.MAX_SCALE)
+                    ),
                 )
                 scale_of_truncated_coef = UInt32(Decimal128.MAX_SCALE)
 

--- a/src/decimo/decimal128/rounding.mojo
+++ b/src/decimo/decimal128/rounding.mojo
@@ -149,6 +149,17 @@ def round(
         # Calculate the number of digits to remove
         var ndigits_to_remove = -scale_diff
 
+        # Also compute ndigits_to_keep for the zero-check below
+        var ndigits_to_keep = ndigits_of_x + scale_diff
+
+        # Fast path: when the requested rounding would discard every digit of
+        # the coefficient and `ndigits` is negative, the final result is 0.
+        # Returning early avoids invoking `round_coefficient` with an
+        # `ndigits_to_remove` that may be very large (e.g. for strongly
+        # negative `ndigits`).
+        if ndigits_to_keep < 0 and ndigits < 0:
+            return Decimal128.ZERO()
+
         # Round coefficient by removing trailing digits
         var res_coef = decimo.decimal128.utility.round_coefficient(
             x_coef,
@@ -156,9 +167,6 @@ def round(
             rounding_mode=rounding_mode,
             sign=number.is_negative(),
         )
-
-        # Also compute ndigits_to_keep for the zero-check below
-        var ndigits_to_keep = ndigits_of_x + scale_diff
 
         if ndigits >= 0:
             return Decimal128.from_uint128(

--- a/src/decimo/decimal128/rounding.mojo
+++ b/src/decimo/decimal128/rounding.mojo
@@ -146,16 +146,19 @@ def round(
 
     else:
         # scale_diff < 0
-        # Calculate the number of digits to keep
-        var ndigits_to_keep = ndigits_of_x + scale_diff
+        # Calculate the number of digits to remove
+        var ndigits_to_remove = -scale_diff
 
-        # Keep the first `ndigits_to_keep` digits with specified rounding mode
-        var res_coef = decimo.decimal128.utility.round_to_keep_first_n_digits(
+        # Round coefficient by removing trailing digits
+        var res_coef = decimo.decimal128.utility.round_coefficient(
             x_coef,
-            ndigits=ndigits_to_keep,
+            ndigits_to_remove=ndigits_to_remove,
             rounding_mode=rounding_mode,
             sign=number.is_negative(),
         )
+
+        # Also compute ndigits_to_keep for the zero-check below
+        var ndigits_to_keep = ndigits_of_x + scale_diff
 
         if ndigits >= 0:
             return Decimal128.from_uint128(

--- a/src/decimo/decimal128/utility.mojo
+++ b/src/decimo/decimal128/utility.mojo
@@ -26,6 +26,9 @@ from std import time
 from decimo.decimal128.decimal128 import Decimal128
 
 
+# ===----------------------------------------------------------------------=== #
+# System-level utilities for Decimal128
+# ===----------------------------------------------------------------------=== #
 # UNSAFE
 def bitcast[dtype: DType](dec: Decimal128) -> Scalar[dtype]:
     """
@@ -57,6 +60,35 @@ def bitcast[dtype: DType](dec: Decimal128) -> Scalar[dtype]:
     # Mask out the bits in flags
     result &= Scalar[dtype](0xFFFFFFFF_FFFFFFFF_FFFFFFFF)
     return result
+
+
+# TODO: At the time when this function was implemented, Mojo's built-in
+# sqrt() function only supports integral types up to 64 bits.
+# Once Mojo supports sqrt() for UInt128, this function can be removed.
+def sqrt(x: UInt128) -> UInt128:
+    """
+    Returns the square root of a UInt128 value.
+
+    Args:
+        x: The UInt128 value to calculate the square root for.
+
+    Returns:
+        The square root of the UInt128 value.
+    """
+
+    if x < 0:
+        return 0
+
+    var r: UInt128 = 0
+
+    for p in range(sys.bit_width_of[UInt128]() // 2 - 1, -1, -1):
+        var new_bit = UInt128(1) << UInt128(p)
+        var would_be = r | new_bit
+        var squared = would_be * would_be
+        if squared <= x:
+            r = would_be
+
+    return r
 
 
 def fit_to_max_coefficient[
@@ -127,47 +159,148 @@ def fit_to_max_coefficient[
     var digits_to_remove = ndigits - Decimal128.MAX_NUM_DIGITS
 
     # First attempt: keep MAX_NUM_DIGITS (29) digits.
-    var result = round_to_keep_first_n_digits(
-        value, sign, Decimal128.MAX_NUM_DIGITS, rounding_mode
-    )
+    var result = round_coefficient(value, digits_to_remove, sign, rounding_mode)
 
     # Because 2^96 − 1 is not at a clean decimal boundary, the 29-digit
     # rounded result may still exceed the maximum. Retry with 28 digits.
     if result > ValueType(Decimal128.MAX_AS_UINT128):
-        result = round_to_keep_first_n_digits(
-            value, sign, Decimal128.MAX_NUM_DIGITS - 1, rounding_mode
+        result = round_coefficient(
+            value, digits_to_remove + 1, sign, rounding_mode
         )
         digits_to_remove += 1
 
     return (result, digits_to_remove)
 
 
-def sqrt(x: UInt128) -> UInt128:
-    """
-    Returns the square root of a UInt128 value.
+# [Mojo Miji]
+# This function replaces `round_to_keep_first_n_digits` with three
+# optimisations borrowed from .NET's `DecCalc.ScaleResult`:
+# 1. **Single division** — the remainder is computed as
+#   `value - truncated * divisor` (one multiply) instead of a second
+#   wide-integer division (`value % divisor`).
+# 2. **Cheap half-comparison** — for HALF_UP / HALF_DOWN / HALF_EVEN,
+#   `2 * remainder` is compared against `divisor` instead of computing
+#   the separate cutoff `5 * 10^(n-1)` (saves one power-of-10 lookup
+#   and one wide multiply).
+# 3. **Caller supplies digit-removal count** — avoids a redundant
+#   `number_of_digits` call when the caller already knows the value's
+#   digit count.
+@always_inline
+def round_coefficient[
+    dtype: DType, //
+](
+    value: Scalar[dtype],
+    ndigits_to_remove: Int,
+    sign: Bool = False,
+    rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,
+) -> Scalar[dtype] where (dtype == DType.uint128 or dtype == DType.uint256):
+    """Rounds an integer coefficient by removing its last `ndigits_to_remove`
+    decimal digits with the specified rounding mode.
+
+    Parameters:
+        dtype: Must be either `DType.uint128` or `DType.uint256`.
 
     Args:
-        x: The UInt128 value to calculate the square root for.
+        value: The coefficient to round.
+        ndigits_to_remove: How many trailing decimal digits to discard.
+            Must be ≥ 0.  If 0 the value is returned unchanged.
+        sign: The sign of the logical number (needed for CEILING / FLOOR
+            translation).
+        rounding_mode: The rounding strategy.  Defaults to banker's
+            rounding (`ROUND_HALF_EVEN`).
 
     Returns:
-        The square root of the UInt128 value.
+        The rounded coefficient with `ndigits_to_remove` fewer decimal
+        digits.
+
+    Examples:
+
+        Remove 3 digits from 123456 with half-even rounding:
+
+        >>> round_coefficient(UInt128(123456), ndigits_to_remove=3)
+        123
+
+        Remove 1 digit from 125 with half-even rounding (rounds to even):
+
+        >>> round_coefficient(UInt128(125), ndigits_to_remove=1)
+        12
+
+        Remove 1 digit from 135 with half-even rounding (rounds to even):
+
+        >>> round_coefficient(UInt128(135), ndigits_to_remove=1)
+        14
+
+        End of examples.
     """
 
-    if x < 0:
-        return 0
+    comptime ValueType = Scalar[dtype]
 
-    var r: UInt128 = 0
+    # Nothing to remove.
+    if ndigits_to_remove <= 0:
+        return value
 
-    for p in range(sys.bit_width_of[UInt128]() // 2 - 1, -1, -1):
-        var new_bit = UInt128(1) << UInt128(p)
-        var would_be = r | new_bit
-        var squared = would_be * would_be
-        if squared <= x:
-            r = would_be
+    # Divide once; derive remainder from a single multiply.
+    var divisor = power_of_10[dtype](ndigits_to_remove)
+    var truncated = value // divisor
+    var remainder = value - truncated * divisor
 
-    return r
+    # Translate directed modes into sign-independent UP / DOWN.
+    var effective_mode = rounding_mode
+    if rounding_mode == RoundingMode.ceiling():
+        effective_mode = RoundingMode.up() if not sign else RoundingMode.down()
+    elif rounding_mode == RoundingMode.floor():
+        effective_mode = RoundingMode.down() if not sign else RoundingMode.up()
+
+    # DOWN — just truncate.
+    if effective_mode == RoundingMode.down():
+        pass
+
+    # UP — round away from zero when anything was discarded.
+    elif effective_mode == RoundingMode.up():
+        if remainder > 0:
+            truncated += 1
+
+    # HALF_UP — round up when remainder ≥ half the divisor.
+    # Equivalent to the classic `remainder >= 5 * 10^(n-1)` but uses
+    # `2 * remainder >= divisor` (.NET trick #2) to avoid an extra
+    # power-of-10 lookup and wide multiply.
+    elif effective_mode == RoundingMode.half_up():
+        var double_remainder = remainder << 1  # 2 * remainder
+        if double_remainder >= divisor:
+            truncated += 1
+
+    # HALF_DOWN — round up only when remainder > half the divisor.
+    elif effective_mode == RoundingMode.half_down():
+        var double_remainder = remainder << 1
+        if double_remainder > divisor:
+            truncated += 1
+
+    # HALF_EVEN — banker's rounding: round to nearest; if exactly half,
+    # round to even.  `2 * remainder` vs `divisor` decides >, <, or ==.
+    elif effective_mode == RoundingMode.half_even():
+        var double_remainder = remainder << 1
+        if double_remainder > divisor:
+            truncated += 1
+        elif double_remainder == divisor:
+            # Exactly half — round to even.
+            truncated += truncated % 2
+
+    else:
+        debug_assert(
+            False,
+            "Unknown rounding mode in round_coefficient: "
+            + String(rounding_mode),
+        )
+
+    return truncated
 
 
+# DEPRECATED: Use `round_coefficient` instead.
+# This function is kept for backward compatibility but is no longer used
+# in production code.  `round_coefficient` is faster because it:
+#   (1) takes ndigits_to_remove (avoids redundant number_of_digits call),
+#   (2) computes remainder via multiply instead of a second division, and
+#   (3) uses 2*remainder vs divisor instead of 5*power_of_10(n-1) cutoff.
 def round_to_keep_first_n_digits[
     dtype: DType, //
 ](

--- a/src/decimo/decimal128/utility.mojo
+++ b/src/decimo/decimal128/utility.mojo
@@ -24,6 +24,7 @@ from std import sys
 from std import time
 
 from decimo.decimal128.decimal128 import Decimal128
+from decimo.rounding_mode import RoundingMode
 
 
 # ===----------------------------------------------------------------------=== #

--- a/src/decimo/decimal128/utility.mojo
+++ b/src/decimo/decimal128/utility.mojo
@@ -76,9 +76,6 @@ def sqrt(x: UInt128) -> UInt128:
         The square root of the UInt128 value.
     """
 
-    if x < 0:
-        return 0
-
     var r: UInt128 = 0
 
     for p in range(sys.bit_width_of[UInt128]() // 2 - 1, -1, -1):
@@ -135,16 +132,17 @@ def fit_to_max_coefficient[
         >>> fit_to_max_coefficient(UInt128(123456))
         (123456, 0)
 
-        If the value is too large, it is rounded to fit:
+        If the value is too large, it is rounded to fit. The 29-digit
+        rounded result may itself exceed `2^96 - 1`, in which case the
+        function automatically retries with 28 digits:
 
         >>> fit_to_max_coefficient(UInt256(792281625142643375935439503560))
-        (79228162514264337593543950356, 1)
+        (7922816251426433759354395036, 2)
 
-        If rounding 29 digits still overflows (because the 29-digit rounded
-        value > 2^96 - 1), the function automatically retries with 28 digits:
+        Another example where the all-nines case forces the retry:
 
         >>> fit_to_max_coefficient(UInt256(99999999999999999999999999999999))
-        (10000000000000000000000000000, 4).
+        (10000000000000000000000000000, 4)
 
         The returned value is always ≤ 2^96 - 1.
     """
@@ -238,6 +236,26 @@ def round_coefficient[
     # Nothing to remove.
     if ndigits_to_remove <= 0:
         return value
+
+    # Fast path: if more digits would be removed than the value has, the
+    # truncated quotient is 0 and the remainder is the whole value, which is
+    # strictly less than `divisor / 10`. Therefore `2 * remainder < divisor`,
+    # so every HALF_* and DOWN-equivalent mode rounds to 0, while UP-equivalent
+    # modes round to 1 (when the value is non-zero). Handling this here avoids
+    # invoking `power_of_10` with an exponent that may overflow `Scalar[dtype]`
+    # when the caller passes a very large `ndigits_to_remove` (e.g. via
+    # `Decimal128.round()` with a strongly negative `ndigits`).
+    if ndigits_to_remove > number_of_digits(value):
+        if value == 0:
+            return ValueType(0)
+        var fast_mode = rounding_mode
+        if rounding_mode == RoundingMode.ceiling():
+            fast_mode = RoundingMode.up() if not sign else RoundingMode.down()
+        elif rounding_mode == RoundingMode.floor():
+            fast_mode = RoundingMode.down() if not sign else RoundingMode.up()
+        if fast_mode == RoundingMode.up():
+            return ValueType(1)
+        return ValueType(0)
 
     # Divide once; derive remainder from a single multiply.
     var divisor = power_of_10[dtype](ndigits_to_remove)

--- a/src/decimo/decimal128/utility.mojo
+++ b/src/decimo/decimal128/utility.mojo
@@ -59,135 +59,87 @@ def bitcast[dtype: DType](dec: Decimal128) -> Scalar[dtype]:
     return result
 
 
-def truncate_to_max[dtype: DType, //](value: Scalar[dtype]) -> Scalar[dtype]:
-    """
-    Truncates a UInt256 or UInt128 value to be as closer to the max value of
-    Decimal128 coefficient (`2^96 - 1`) as possible with rounding.
-    Uses banker's rounding (ROUND_HALF_EVEN) for any truncated digits.
-    `792281625142643375935439503356` will be truncated to
-    `7922816251426433759354395034`.
-    `792281625142643375935439503353` will be truncated to
-    `79228162514264337593543950345`.
+def fit_to_max_coefficient[
+    dtype: DType, //
+](
+    value: Scalar[dtype],
+    sign: Bool = False,
+    rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,
+) -> Tuple[Scalar[dtype], Int] where (
+    dtype == DType.uint128 or dtype == DType.uint256
+):
+    """Rounds a coefficient to fit within Decimal128's 96-bit maximum (2^96 − 1).
+
+    Because 2^96 − 1 = 79_228_162_514_264_337_593_543_950_335 has 29 decimal
+    digits but not every 29-digit number fits (e.g. 9.9…9 × 10^28 > 2^96 − 1),
+    the function first tries keeping 29 digits. If the rounded result still
+    exceeds the maximum, it retries with 28 digits.
 
     Parameters:
-        dtype: Must be either uint128 or uint256.
+        dtype: Must be either `DType.uint128` or `DType.uint256`.
 
     Args:
-        value: The UInt256 value to truncate.
+        value: The coefficient to fit.
+        sign: The sign of the original number (needed for CEILING/FLOOR modes).
+        rounding_mode: The rounding strategy for discarded digits.
+            Defaults to banker's rounding (ROUND_HALF_EVEN).
 
     Constraints:
         `dtype` must be either `DType.uint128` or `DType.uint256`.
 
     Returns:
-        The truncated UInt256 value, guaranteed to fit within 96 bits.
+        A tuple of:
+        - The rounded coefficient, guaranteed ≤ `Decimal128.MAX_AS_UINT128`.
+        - The number of digits removed from the original value.
+
+        The caller can compute the new scale as:
+        `new_scale = original_scale - digits_removed`.
+
+    Examples:
+
+        If the value already fits (≤ 2^96 - 1), it is returned unchanged
+        with `digits_removed = 0`.
+
+        >>> fit_to_max_coefficient(UInt128(123456))
+        (123456, 0)
+
+        If the value is too large, it is rounded to fit:
+
+        >>> fit_to_max_coefficient(UInt256(792281625142643375935439503560))
+        (79228162514264337593543950356, 1)
+
+        If rounding 29 digits still overflows (because the 29-digit rounded
+        value > 2^96 - 1), the function automatically retries with 28 digits:
+
+        >>> fit_to_max_coefficient(UInt256(99999999999999999999999999999999))
+        (10000000000000000000000000000, 4).
+
+        The returned value is always ≤ 2^96 - 1.
     """
 
     comptime ValueType = Scalar[dtype]
 
-    comptime assert (
-        dtype == DType.uint128 or dtype == DType.uint256
-    ), "must be uint128 or uint256"
-
-    # If the value is already less than the maximum possible value, return it
+    # If the value already fits, no truncation needed.
     if value <= ValueType(Decimal128.MAX_AS_UINT128):
-        return value
+        return (value, 0)
 
-    else:
-        # Calculate how many digits we need to truncate
-        # Calculate how many digits to keep (MAX_NUM_DIGITS = 29)
-        var ndigits = number_of_digits(value)
-        var digits_to_remove = ndigits - Decimal128.MAX_NUM_DIGITS
+    var ndigits = number_of_digits(value)
+    var digits_to_remove = ndigits - Decimal128.MAX_NUM_DIGITS
 
-        # Collect digits for rounding decision
-        var divisor = power_of_10[dtype](digits_to_remove)
-        var truncated_value = value // divisor
+    # First attempt: keep MAX_NUM_DIGITS (29) digits.
+    var result = round_to_keep_first_n_digits(
+        value, sign, Decimal128.MAX_NUM_DIGITS, rounding_mode
+    )
 
-        if truncated_value == ValueType(Decimal128.MAX_AS_UINT128):
-            # Case 1:
-            # Truncated_value == MAX_AS_UINT128
-            # Rounding may not cause overflow depending on rounding digit
-            # If removed digits do not caue rounding up. Return truncated value.
-            # If removed digits cause rounding up, return MAX // 10 - 1
-            # 79228162514264337593543950335[removed part] -> 7922816251426433759354395034
+    # Because 2^96 − 1 is not at a clean decimal boundary, the 29-digit
+    # rounded result may still exceed the maximum. Retry with 28 digits.
+    if result > ValueType(Decimal128.MAX_AS_UINT128):
+        result = round_to_keep_first_n_digits(
+            value, sign, Decimal128.MAX_NUM_DIGITS - 1, rounding_mode
+        )
+        digits_to_remove += 1
 
-            var remainder = value % divisor
-
-            # Get the most significant digit of the remainder for rounding
-            var rounding_digit = remainder // power_of_10[dtype](
-                digits_to_remove - 1
-            )
-
-            # Check if we need to round up based on banker's rounding (ROUND_HALF_EVEN)
-            var round_up = False
-
-            # If rounding digit is > 5, round up
-            if rounding_digit > 5:
-                round_up = True
-            # If rounding digit is 5, check if there are any non-zero digits after it
-            elif rounding_digit == 5:
-                var has_nonzero_after = remainder > 5 * power_of_10[dtype](
-                    digits_to_remove - 1
-                )
-                # If there are non-zero digits after, round up
-                if has_nonzero_after:
-                    round_up = True
-                # Otherwise, round to even (round up if last kept digit is odd)
-                else:
-                    round_up = (truncated_value % 2) == 1
-
-            # Apply rounding if needed
-            if round_up:
-                truncated_value = (
-                    truncated_value // 10 + 1
-                )  # 7922816251426433759354395034
-
-            return truncated_value
-
-        else:
-            # Case 3:
-            # Truncated_value > MAX_AS_UINT128
-            # Always overflow, increase the digits_to_remove by 1
-
-            # Case 2:
-            # Trucated_value < MAX_AS_UINT128
-            # Rounding will not case overflow
-
-            if truncated_value > ValueType(Decimal128.MAX_AS_UINT128):
-                digits_to_remove += 1
-
-            # Collect digits for rounding decision
-            divisor = power_of_10[dtype](digits_to_remove)
-            truncated_value = value // divisor
-            var remainder = value % divisor
-
-            # Get the most significant digit of the remainder for rounding
-            var rounding_digit = remainder // power_of_10[dtype](
-                digits_to_remove - 1
-            )
-
-            # Check if we need to round up based on banker's rounding (ROUND_HALF_EVEN)
-            var round_up = False
-
-            # If rounding digit is > 5, round up
-            if rounding_digit > 5:
-                round_up = True
-            # If rounding digit is 5, check if there are any non-zero digits after it
-            elif rounding_digit == 5:
-                var has_nonzero_after = remainder > 5 * power_of_10[dtype](
-                    digits_to_remove - 1
-                )
-                # If there are non-zero digits after, round up
-                if has_nonzero_after:
-                    round_up = True
-                # Otherwise, round to even (round up if last kept digit is odd)
-                else:
-                    round_up = (truncated_value % 2) == 1
-
-            # Apply rounding if needed
-            if round_up:
-                truncated_value += 1
-
-            return truncated_value
+    return (result, digits_to_remove)
 
 
 def sqrt(x: UInt128) -> UInt128:
@@ -216,7 +168,6 @@ def sqrt(x: UInt128) -> UInt128:
     return r
 
 
-# TODO: Evaluate whether this can replace truncate_to_max in some cases.
 def round_to_keep_first_n_digits[
     dtype: DType, //
 ](

--- a/tests/decimal128/test_decimal128_utility.mojo
+++ b/tests/decimal128/test_decimal128_utility.mojo
@@ -84,7 +84,7 @@ def test_fit_to_max_above() raises:
     assert_true(r4[0] <= UInt256(Decimal128.MAX_AS_UINT128))
     assert_equal(r4[1], 4)
 
-    # Banker's rounding: MAX + 20 (trailing 5, preceding digit even → round up)
+    # Banker's rounding: MAX + 20 (trailing 5, kept last digit odd → round up)
     var r5 = fit_to_max_coefficient(
         UInt256(Decimal128.MAX_AS_UINT128) + UInt256(20)
     )
@@ -169,19 +169,9 @@ def test_fit_to_max_cascade_rounding() raises:
     assert_equal(r4[0], UInt256(10000000000000000000000000000))  # 10^28
     assert_equal(r4[1], 12)
 
-    # Exactly MAX + 1 with all-nines flavor: 79228162514264337593543950336
-    # try-29 → ndigits=29, digits_to_remove=0, keep 29 digits → unchanged →
-    # still > MAX → retry-28: remove 1 digit, truncated = 7922816251426433759354395034,
-    # remainder = 6, rounding digit 6 > 5 → round up → 7922816251426433759354395034.
-    # Wait, let me reconsider. value = MAX+1 = 79228162514264337593543950336.
-    # ndigits = 29, digits_to_remove = 0.
-    # try-29: round_to_keep_first_n_digits(value, 29) → ndigits_of_x=29, ndigits=29,
-    # so ndigits >= ndigits_of_x → return value unchanged = MAX+1.
-    # MAX+1 > MAX → retry.
-    # try-28: round_to_keep_first_n_digits(value, 28) → remove 1 digit.
-    # truncated = 7922816251426433759354395033, remainder = 6.
-    # 6 > 5 → round up → 7922816251426433759354395034.
-    # digits_to_remove = 0 + 1 = 1.
+    # MAX + 1: keeping 29 digits leaves the value unchanged and still above MAX,
+    # so the helper retries with 28 digits, rounds once, and reports one digit
+    # removed.
     var r5 = fit_to_max_coefficient(
         UInt256(79228162514264337593543950336)  # MAX + 1
     )

--- a/tests/decimal128/test_decimal128_utility.mojo
+++ b/tests/decimal128/test_decimal128_utility.mojo
@@ -1,6 +1,6 @@
 """
 Tests for utility functions: number_of_digits, fit_to_max_coefficient,
-round_to_keep_first_n_digits, and bitcast.
+round_coefficient, round_to_keep_first_n_digits, and bitcast.
 """
 
 from std import testing
@@ -11,6 +11,7 @@ from decimo.rounding_mode import RoundingMode
 from decimo.decimal128.utility import (
     fit_to_max_coefficient,
     number_of_digits,
+    round_coefficient,
     round_to_keep_first_n_digits,
     bitcast,
 )
@@ -194,6 +195,154 @@ def test_fit_to_max_cascade_rounding() raises:
     )
     assert_true(r6[0] <= UInt128(Decimal128.MAX_AS_UINT128))
     assert_equal(r6[1], 1)
+
+
+def test_round_coefficient() raises:
+    """Tests for round_coefficient (the optimized replacement)."""
+
+    # Remove 0 digits → unchanged
+    assert_equal(
+        round_coefficient(UInt128(12345), ndigits_to_remove=0), UInt128(12345)
+    )
+
+    # Remove 1 digit, half-even: 12345 → remove 5, preceding 4 is even → 1234
+    assert_equal(
+        round_coefficient(UInt128(12345), ndigits_to_remove=1), UInt128(1234)
+    )
+
+    # Remove 1 digit, half-even: 12355 → remove 5, preceding 5 is odd → 1236
+    assert_equal(
+        round_coefficient(UInt128(12355), ndigits_to_remove=1), UInt128(1236)
+    )
+
+    # Remove 1 digit, round down (< 5): 12342 → 1234
+    assert_equal(
+        round_coefficient(UInt128(12342), ndigits_to_remove=1), UInt128(1234)
+    )
+
+    # Remove 1 digit, round up (> 5): 12347 → 1235
+    assert_equal(
+        round_coefficient(UInt128(12347), ndigits_to_remove=1), UInt128(1235)
+    )
+
+    # Remove 3 digits from 123456: 123|456, half is 500, 456 < 500 → 123
+    assert_equal(
+        round_coefficient(UInt128(123456), ndigits_to_remove=3), UInt128(123)
+    )
+
+    # Remove 3 digits from 123556: 123|556, 556 > 500 → 124
+    assert_equal(
+        round_coefficient(UInt128(123556), ndigits_to_remove=3), UInt128(124)
+    )
+
+    # Remove 3 digits from 123500: exactly half, 123 is odd → round up to 124
+    assert_equal(
+        round_coefficient(UInt128(123500), ndigits_to_remove=3), UInt128(124)
+    )
+
+    # Remove 3 digits from 124500: exactly half, 124 is even → 124
+    assert_equal(
+        round_coefficient(UInt128(124500), ndigits_to_remove=3), UInt128(124)
+    )
+
+    # Rounding mode: UP (non-negative)
+    assert_equal(
+        round_coefficient(
+            UInt128(12301), ndigits_to_remove=2, rounding_mode=RoundingMode.up()
+        ),
+        UInt128(124),
+    )
+
+    # Rounding mode: DOWN
+    assert_equal(
+        round_coefficient(
+            UInt128(12399),
+            ndigits_to_remove=2,
+            rounding_mode=RoundingMode.down(),
+        ),
+        UInt128(123),
+    )
+
+    # Rounding mode: HALF_UP (>= 0.5 rounds away from zero)
+    assert_equal(
+        round_coefficient(
+            UInt128(12350),
+            ndigits_to_remove=2,
+            rounding_mode=RoundingMode.half_up(),
+        ),
+        UInt128(124),
+    )
+
+    # Rounding mode: HALF_DOWN (> 0.5 rounds away from zero)
+    assert_equal(
+        round_coefficient(
+            UInt128(12350),
+            ndigits_to_remove=2,
+            rounding_mode=RoundingMode.half_down(),
+        ),
+        UInt128(123),
+    )
+
+    # Remove all digits from 997: 997 / 1000 = 0, remainder 997, 2*997=1994 > 1000 → 1
+    assert_equal(
+        round_coefficient(UInt128(997), ndigits_to_remove=3), UInt128(1)
+    )
+
+    # Zero input
+    assert_equal(round_coefficient(UInt128(0), ndigits_to_remove=5), UInt128(0))
+
+    # Single digit, remove 1: 7 / 10 = 0, remainder 7, 2*7=14 > 10 → 1
+    assert_equal(round_coefficient(UInt128(7), ndigits_to_remove=1), UInt128(1))
+
+    # UInt256 path
+    assert_equal(
+        round_coefficient(UInt256(9876543210987654321), ndigits_to_remove=1),
+        UInt256(987654321098765432),
+    )
+
+    # CEILING mode: positive → acts like UP
+    assert_equal(
+        round_coefficient(
+            UInt128(12301),
+            ndigits_to_remove=2,
+            sign=False,
+            rounding_mode=RoundingMode.ceiling(),
+        ),
+        UInt128(124),
+    )
+
+    # CEILING mode: negative → acts like DOWN
+    assert_equal(
+        round_coefficient(
+            UInt128(12399),
+            ndigits_to_remove=2,
+            sign=True,
+            rounding_mode=RoundingMode.ceiling(),
+        ),
+        UInt128(123),
+    )
+
+    # FLOOR mode: positive → acts like DOWN
+    assert_equal(
+        round_coefficient(
+            UInt128(12399),
+            ndigits_to_remove=2,
+            sign=False,
+            rounding_mode=RoundingMode.floor(),
+        ),
+        UInt128(123),
+    )
+
+    # FLOOR mode: negative → acts like UP
+    assert_equal(
+        round_coefficient(
+            UInt128(12301),
+            ndigits_to_remove=2,
+            sign=True,
+            rounding_mode=RoundingMode.floor(),
+        ),
+        UInt128(124),
+    )
 
 
 def test_round_to_keep_first_n_digits() raises:

--- a/tests/decimal128/test_decimal128_utility.mojo
+++ b/tests/decimal128/test_decimal128_utility.mojo
@@ -1,5 +1,5 @@
 """
-Tests for utility functions: number_of_digits, truncate_to_max,
+Tests for utility functions: number_of_digits, fit_to_max_coefficient,
 round_to_keep_first_n_digits, and bitcast.
 """
 
@@ -9,7 +9,7 @@ from std.testing import assert_equal, assert_true
 from decimo.decimal128.decimal128 import Decimal128
 from decimo.rounding_mode import RoundingMode
 from decimo.decimal128.utility import (
-    truncate_to_max,
+    fit_to_max_coefficient,
     number_of_digits,
     round_to_keep_first_n_digits,
     bitcast,
@@ -38,97 +38,162 @@ def test_number_of_digits() raises:
     )
 
 
-def test_truncate_to_max_below() raises:
-    """Truncate_to_max with values at or below MAX — should be unchanged."""
-    assert_equal(truncate_to_max(UInt128(123456)), UInt128(123456))
-    assert_equal(truncate_to_max(UInt256(7654321)), UInt256(7654321))
-    assert_equal(
-        truncate_to_max(UInt128(Decimal128.MAX_AS_UINT128)),
-        UInt128(Decimal128.MAX_AS_UINT128),
-    )
-    assert_equal(
-        truncate_to_max(UInt256(Decimal128.MAX_AS_UINT128)),
-        UInt256(Decimal128.MAX_AS_UINT128),
-    )
+def test_fit_to_max_below() raises:
+    """Fit_to_max_coefficient with values at or below MAX — no truncation."""
+    var r1 = fit_to_max_coefficient(UInt128(123456))
+    assert_equal(r1[0], UInt128(123456))
+    assert_equal(r1[1], 0)
+
+    var r2 = fit_to_max_coefficient(UInt256(7654321))
+    assert_equal(r2[0], UInt256(7654321))
+    assert_equal(r2[1], 0)
+
+    var r3 = fit_to_max_coefficient(UInt128(Decimal128.MAX_AS_UINT128))
+    assert_equal(r3[0], UInt128(Decimal128.MAX_AS_UINT128))
+    assert_equal(r3[1], 0)
+
+    var r4 = fit_to_max_coefficient(UInt256(Decimal128.MAX_AS_UINT128))
+    assert_equal(r4[0], UInt256(Decimal128.MAX_AS_UINT128))
+    assert_equal(r4[1], 0)
 
 
-def test_truncate_to_max_above() raises:
-    """Truncate_to_max with values above MAX — should be truncated."""
-    # MAX + 1
+def test_fit_to_max_above() raises:
+    """Fit_to_max_coefficient with values above MAX — should be truncated."""
+    # MAX + 1: 30 digits → needs 1 digit removed
     var max_plus_1 = UInt256(Decimal128.MAX_AS_UINT128) + UInt256(1)
-    assert_true(
-        truncate_to_max(max_plus_1) <= UInt256(Decimal128.MAX_AS_UINT128)
-    )
+    var r1 = fit_to_max_coefficient(max_plus_1)
+    assert_true(r1[0] <= UInt256(Decimal128.MAX_AS_UINT128))
+    assert_equal(r1[1], 1)
 
-    # Round down (last truncated digit < 5)
-    assert_equal(
-        truncate_to_max(UInt256(79228162514264337593543950354)),
-        UInt256(7922816251426433759354395035),
-    )
+    # Round down (last truncated digit < 5): digits_removed = 1
+    var r2 = fit_to_max_coefficient(UInt256(79228162514264337593543950354))
+    assert_equal(r2[0], UInt256(7922816251426433759354395035))
+    assert_equal(r2[1], 1)
 
-    # Round up (last truncated digit >= 6)
-    assert_equal(
-        truncate_to_max(UInt256(79228162514264337593543950356)),
-        UInt256(7922816251426433759354395036),
-    )
+    # Round up (last truncated digit >= 6): digits_removed = 1
+    var r3 = fit_to_max_coefficient(UInt256(79228162514264337593543950356))
+    assert_equal(r3[0], UInt256(7922816251426433759354395036))
+    assert_equal(r3[1], 1)
+
+    # Much larger value: truncate multiple digits, digits_removed = 4
+    var much_larger = UInt256(Decimal128.MAX_AS_UINT128) * UInt256(
+        1000
+    ) + UInt256(555)
+    var r4 = fit_to_max_coefficient(much_larger)
+    assert_true(r4[0] <= UInt256(Decimal128.MAX_AS_UINT128))
+    assert_equal(r4[1], 4)
 
     # Banker's rounding: MAX + 20 (trailing 5, preceding digit even → round up)
-    assert_equal(
-        truncate_to_max(UInt256(Decimal128.MAX_AS_UINT128) + UInt256(20)),
-        UInt256(7922816251426433759354395036),
+    var r5 = fit_to_max_coefficient(
+        UInt256(Decimal128.MAX_AS_UINT128) + UInt256(20)
     )
+    assert_equal(r5[0], UInt256(7922816251426433759354395036))
+    assert_equal(r5[1], 1)
 
     # Banker's rounding: constructed trailing 5 with preceding even
     var base = UInt256(79228162514264337593543950330)
     var banker = base * UInt256(10) + UInt256(5)
-    assert_equal(truncate_to_max(banker), base + UInt256(0))
-
-    # Much larger value (truncate multiple digits)
-    var much_larger = UInt256(Decimal128.MAX_AS_UINT128) * UInt256(
-        1000
-    ) + UInt256(555)
-    assert_true(
-        truncate_to_max(much_larger) <= UInt256(Decimal128.MAX_AS_UINT128)
-    )
+    var r6 = fit_to_max_coefficient(banker)
+    assert_equal(r6[0], base + UInt256(0))
+    assert_equal(r6[1], 1)
 
 
-def test_truncate_banker_rounding() raises:
-    """Banker's rounding edge cases in truncate_to_max."""
+def test_fit_to_max_banker_rounding() raises:
+    """Banker's rounding edge cases in fit_to_max_coefficient."""
     # Round down to even (5 as rounding digit, preceding even)
-    assert_equal(
-        truncate_to_max(UInt256(7922816251426433759354395033250)),
-        UInt256(79228162514264337593543950332),
-    )
+    var r1 = fit_to_max_coefficient(UInt256(7922816251426433759354395033250))
+    assert_equal(r1[0], UInt256(79228162514264337593543950332))
+    assert_equal(r1[1], 2)
 
     # Round up to even (5 as rounding digit, preceding odd)
-    assert_equal(
-        truncate_to_max(UInt256(7922816251426433759354395033150)),
-        UInt256(79228162514264337593543950332),
-    )
+    var r2 = fit_to_max_coefficient(UInt256(7922816251426433759354395033150))
+    assert_equal(r2[0], UInt256(79228162514264337593543950332))
+    assert_equal(r2[1], 2)
 
     # Round up: 5 followed by non-zero (preceding even)
-    assert_equal(
-        truncate_to_max(UInt256(79228162514264337593543950332501)),
-        UInt256(79228162514264337593543950333),
-    )
+    var r3 = fit_to_max_coefficient(UInt256(79228162514264337593543950332501))
+    assert_equal(r3[0], UInt256(79228162514264337593543950333))
+    assert_equal(r3[1], 3)
 
     # Round up: 5 followed by non-zero (preceding odd)
-    assert_equal(
-        truncate_to_max(UInt256(79228162514264337593543950331501)),
-        UInt256(79228162514264337593543950332),
-    )
+    var r4 = fit_to_max_coefficient(UInt256(79228162514264337593543950331501))
+    assert_equal(r4[0], UInt256(79228162514264337593543950332))
+    assert_equal(r4[1], 3)
 
     # Rounding digit > 5
-    assert_equal(
-        truncate_to_max(UInt256(7922816251426433759354395033207)),
-        UInt256(79228162514264337593543950332),
-    )
+    var r5 = fit_to_max_coefficient(UInt256(7922816251426433759354395033207))
+    assert_equal(r5[0], UInt256(79228162514264337593543950332))
+    assert_equal(r5[1], 2)
 
     # Rounding digit < 5
-    assert_equal(
-        truncate_to_max(UInt256(7922816251426433759354395033204)),
-        UInt256(79228162514264337593543950332),
+    var r6 = fit_to_max_coefficient(UInt256(7922816251426433759354395033204))
+    assert_equal(r6[0], UInt256(79228162514264337593543950332))
+    assert_equal(r6[1], 2)
+
+
+def test_fit_to_max_cascade_rounding() raises:
+    """Edge cases where rounding cascades (all-nines overflow both tries)."""
+
+    # 32 nines: try-29 rounds 29 nines up to 10^29 > MAX, retry-28 rounds
+    # 28 nines up to 10^28 ≤ MAX. digits_removed = 3 + 1 = 4.
+    var r1 = fit_to_max_coefficient(
+        UInt256(99999999999999999999999999999999)  # 32 nines
     )
+    assert_equal(r1[0], UInt256(10000000000000000000000000000))  # 10^28
+    assert_equal(r1[1], 4)
+    assert_true(r1[0] <= UInt256(Decimal128.MAX_AS_UINT128))
+
+    # 30 nines: try-29 rounds 29 nines up to 10^29 > MAX, retry-28 rounds
+    # 28 nines up to 10^28 ≤ MAX. digits_removed = 1 + 1 = 2.
+    var r2 = fit_to_max_coefficient(
+        UInt256(999999999999999999999999999999)  # 30 nines
+    )
+    assert_equal(r2[0], UInt256(10000000000000000000000000000))  # 10^28
+    assert_equal(r2[1], 2)
+
+    # 29 nines: exactly 29 digits of all nines. 29 nines > MAX (since
+    # MAX = 7922...335 < 9999...999). try-29 keeps all 29 digits unchanged
+    # (no rounding needed), but 29 nines > MAX → retry-28 rounds away 1 digit:
+    # 28 nines + round up → 10^28. digits_removed = 0 + 1 = 1.
+    var r3 = fit_to_max_coefficient(
+        UInt256(99999999999999999999999999999)  # 29 nines
+    )
+    assert_equal(r3[0], UInt256(10000000000000000000000000000))  # 10^28
+    assert_equal(r3[1], 1)
+
+    # 40 nines: very large, digits_removed = 40 - 29 + 1 = 12.
+    var r4 = fit_to_max_coefficient(
+        UInt256(9999999999999999999999999999999999999999)  # 40 nines
+    )
+    assert_equal(r4[0], UInt256(10000000000000000000000000000))  # 10^28
+    assert_equal(r4[1], 12)
+
+    # Exactly MAX + 1 with all-nines flavor: 79228162514264337593543950336
+    # try-29 → ndigits=29, digits_to_remove=0, keep 29 digits → unchanged →
+    # still > MAX → retry-28: remove 1 digit, truncated = 7922816251426433759354395034,
+    # remainder = 6, rounding digit 6 > 5 → round up → 7922816251426433759354395034.
+    # Wait, let me reconsider. value = MAX+1 = 79228162514264337593543950336.
+    # ndigits = 29, digits_to_remove = 0.
+    # try-29: round_to_keep_first_n_digits(value, 29) → ndigits_of_x=29, ndigits=29,
+    # so ndigits >= ndigits_of_x → return value unchanged = MAX+1.
+    # MAX+1 > MAX → retry.
+    # try-28: round_to_keep_first_n_digits(value, 28) → remove 1 digit.
+    # truncated = 7922816251426433759354395033, remainder = 6.
+    # 6 > 5 → round up → 7922816251426433759354395034.
+    # digits_to_remove = 0 + 1 = 1.
+    var r5 = fit_to_max_coefficient(
+        UInt256(79228162514264337593543950336)  # MAX + 1
+    )
+    assert_equal(r5[0], UInt256(7922816251426433759354395034))
+    assert_equal(r5[1], 1)
+    assert_true(r5[0] <= UInt256(Decimal128.MAX_AS_UINT128))
+
+    # UInt128 path: a value just barely above MAX
+    var r6 = fit_to_max_coefficient(
+        UInt128(79228162514264337593543950340)  # MAX + 5
+    )
+    assert_true(r6[0] <= UInt128(Decimal128.MAX_AS_UINT128))
+    assert_equal(r6[1], 1)
 
 
 def test_round_to_keep_first_n_digits() raises:


### PR DESCRIPTION
This PR introduces new Decimal128 coefficient-fitting and rounding helpers (`fit_to_max_coefficient()` and `round_coefficient()`) and migrates core arithmetic/rounding code paths away from the older truncation helpers.

**Changes:**
- Added `fit_to_max_coefficient()` (try-29 then retry-28) and an optimized `round_coefficient()` implementation in `utility.mojo`.
- Migrated call sites in arithmetic operations and `Decimal128.round()`/`from_string()` to use the new helpers.
- Expanded/updated utility tests and updated the Decimal128 enhancement plan doc to reflect the new approach.