### PR TITLE
[dec128] Optimize division using school book calculations to avoid slow `UInt256 // UInt256`

### DIFF
--- a/docs/plans/decimal128_enhancement.md
+++ b/docs/plans/decimal128_enhancement.md
@@ -518,6 +518,8 @@ loop with `black_box`/optimiser barriers). The two columns reported per op are t
 | 20260422 | `dec128_report_20260422_085601.md` |    5 |    7 |    9 |    9 | 2.10 |    28.20 | 134.60 | After removing `format` from `debug_assert` + bisect if/else LUT |
 | 20260422 | `dec128_report_20260422_124242.md` |    5 |    6 |    5 |    8 | 2.10 |    22.65 | 136.00 | After Granlund-Möller UInt256 / 10^k                             |
 | 20260422 | `dec128_report_20260422_200239.md` |    4 |    4 |    — |    — |    — |        — |      — | After H#11 hot-path-first single-function `add`/`sub`            |
+| 20260422 | `dec128_report_20260422_210555.md` |    4 |    4 |    5 |    9 | 2.10 |    25.20 | 119.20 | After H#3 sub diff-scale fully inlined + mul `@always_inline`    |
+| 20260422 | `dec128_report_20260422_212851.md` |    4 |    4 |    4 |    8 | 2.10 |    26.00 |  82.70 | After H#5 divide two-phase: probe + UInt256/u64 schoolbook       |
 
 **Worst-case (max across cases) decimo ns/iter (lower = faster):**
 
@@ -530,6 +532,8 @@ loop with `black_box`/optimiser barriers). The two columns reported per op are t
 | 20260422 | `dec128_report_20260422_085601.md` |   17 |   16 |  262 |  307 | 19.80 |    68.40 | 577.90 | After removing `format` from `debug_assert` + bisect if/else LUT |
 | 20260422 | `dec128_report_20260422_124242.md` |   14 |   15 |   22 |  257 | 17.40 |    65.30 | 554.50 | After Granlund-Möller UInt256 / 10^k                             |
 | 20260422 | `dec128_report_20260422_200239.md` |   14 |   14 |    — |    — |     — |        — |      — | After H#11 hot-path-first `add`/`sub`                            |
+| 20260422 | `dec128_report_20260422_210555.md` |   14 |   15 |   22 |  287 |  20.1 |     70.2 |  591.2 | After H#3 sub diff-scale fully inlined + mul `@always_inline`    |
+| 20260422 | `dec128_report_20260422_212851.md` |   16 |   17 |   27 |   56 |  19.2 |     74.7 |  608.3 | After H#5 divide two-phase: probe + UInt256/u64 schoolbook       |
 
 The mul max barely moves (339 → 335 ns) because the worst case is now
 `High precision multiplication` / `e * e^0.5` / `Product overflows`, all of
@@ -542,36 +546,44 @@ column reveals what the median hides.
 
 **Decimo / competitor ratio (>1 = decimo slower; <1 = decimo faster):**
 
-| date     | op       | dm/rust | dm/csharp | dm/vbnet | notes                                                |
-| -------- | -------- | ------: | --------: | -------: | ---------------------------------------------------- |
-| 20260421 | add      |   21.2x |     43.1x |    59.2x | Before any optimizations                             |
-| 20260421 | sub      |   61.5x |     59.0x |    68.7x | Before any optimizations                             |
-| 20260421 | mul      |    1.6x |      2.9x |     4.4x | Before any optimizations                             |
-| 20260421 | div      |    1.4x |      0.5x |     1.5x | Before any optimizations                             |
-| 20260421 | cmp      |    0.0x |      0.0x |     0.0x | Before any optimizations                             |
-| 20260421 | from_str |    2.6x |      0.7x |     0.7x | Before any optimizations                             |
-| 20260421 | to_str   |    3.6x |      4.2x |     4.3x | Before any optimizations                             |
-| 20260421 | add      |    2.2x |      2.0x |     2.7x | After H#3.1 `add()` reorder                          |
-| 20260421 | sub      |    2.1x |      3.1x |     3.1x | After H#3.1 `add()` reorder                          |
-| 20260421 | mul      |    1.8x |      2.6x |     3.6x | After H#3.1 `add()` reorder                          |
-| 20260421 | div      |    1.4x |      0.6x |     1.4x | After H#3.1 `add()` reorder                          |
-| 20260421 | cmp      |    0.8x |      1.4x |     1.1x | After H#3.1 `add()` reorder                          |
-| 20260421 | from_str |    2.4x |      0.7x |     0.7x | After H#3.1 `add()` reorder                          |
-| 20260421 | to_str   |    3.5x |      4.3x |     4.1x | After H#3.1 `add()` reorder                          |
-| 20260421 | add      |    2.2x |      2.0x |     2.8x | After H#3.1 `is_integer()` pre-check                 |
-| 20260421 | sub      |    2.9x |      2.8x |     2.7x | After H#3.1 `is_integer()` pre-check                 |
-| 20260421 | mul      |    1.9x |      3.0x |     4.6x | After H#3.1 `is_integer()` pre-check                 |
-| 20260421 | div      |    1.5x |      0.6x |     1.3x | After H#3.1 `is_integer()` pre-check                 |
-| 20260421 | cmp      |    0.8x |      1.4x |     1.1x | After H#3.1 `is_integer()` pre-check                 |
-| 20260421 | from_str |    2.4x |      0.6x |     0.6x | After H#3.1 `is_integer()` pre-check                 |
-| 20260421 | to_str   |    3.5x |      4.4x |     4.3x | After H#3.1 `is_integer()` pre-check                 |
-| 20260421 | add      |    1.5x |      2.2x |     1.9x | After H#3.1 `is_integer` branch removed from `add()` |
-| 20260421 | sub      |    3.3x |      3.6x |     2.9x | After H#3.1 `is_integer` branch removed from `add()` |
-| 20260422 | mul      |    2.3x |      3.7x |     4.4x | After H#4.1 `is_integer` branch removed from `mul()` |
-| 20260422 | div      |    1.6x |      0.6x |     1.5x | After H#4.1 `is_integer` branch removed from `mul()` |
-| 20260422 | mul      |    1.8x |      3.8x |     4.4x | After G-M UInt256 / 10^k                             |
-| 20260422 | add      |    1.3x |      1.7x |     1.5x | After H#11 hot-path-first `add`/`sub`                |
-| 20260422 | sub      |    2.0x |      1.9x |     1.7x | After H#11 hot-path-first `add`/`sub`                |
+| date     | op       | dm/rust | dm/csharp | dm/vbnet | notes                                                         |
+| -------- | -------- | ------: | --------: | -------: | ------------------------------------------------------------- |
+| 20260421 | add      |   21.2x |     43.1x |    59.2x | Before any optimizations                                      |
+| 20260421 | sub      |   61.5x |     59.0x |    68.7x | Before any optimizations                                      |
+| 20260421 | mul      |    1.6x |      2.9x |     4.4x | Before any optimizations                                      |
+| 20260421 | div      |    1.4x |      0.5x |     1.5x | Before any optimizations                                      |
+| 20260421 | cmp      |    0.0x |      0.0x |     0.0x | Before any optimizations                                      |
+| 20260421 | from_str |    2.6x |      0.7x |     0.7x | Before any optimizations                                      |
+| 20260421 | to_str   |    3.6x |      4.2x |     4.3x | Before any optimizations                                      |
+| 20260421 | add      |    2.2x |      2.0x |     2.7x | After H#3.1 `add()` reorder                                   |
+| 20260421 | sub      |    2.1x |      3.1x |     3.1x | After H#3.1 `add()` reorder                                   |
+| 20260421 | mul      |    1.8x |      2.6x |     3.6x | After H#3.1 `add()` reorder                                   |
+| 20260421 | div      |    1.4x |      0.6x |     1.4x | After H#3.1 `add()` reorder                                   |
+| 20260421 | cmp      |    0.8x |      1.4x |     1.1x | After H#3.1 `add()` reorder                                   |
+| 20260421 | from_str |    2.4x |      0.7x |     0.7x | After H#3.1 `add()` reorder                                   |
+| 20260421 | to_str   |    3.5x |      4.3x |     4.1x | After H#3.1 `add()` reorder                                   |
+| 20260421 | add      |    2.2x |      2.0x |     2.8x | After H#3.1 `is_integer()` pre-check                          |
+| 20260421 | sub      |    2.9x |      2.8x |     2.7x | After H#3.1 `is_integer()` pre-check                          |
+| 20260421 | mul      |    1.9x |      3.0x |     4.6x | After H#3.1 `is_integer()` pre-check                          |
+| 20260421 | div      |    1.5x |      0.6x |     1.3x | After H#3.1 `is_integer()` pre-check                          |
+| 20260421 | cmp      |    0.8x |      1.4x |     1.1x | After H#3.1 `is_integer()` pre-check                          |
+| 20260421 | from_str |    2.4x |      0.6x |     0.6x | After H#3.1 `is_integer()` pre-check                          |
+| 20260421 | to_str   |    3.5x |      4.4x |     4.3x | After H#3.1 `is_integer()` pre-check                          |
+| 20260421 | add      |    1.5x |      2.2x |     1.9x | After H#3.1 `is_integer` branch removed from `add()`          |
+| 20260421 | sub      |    3.3x |      3.6x |     2.9x | After H#3.1 `is_integer` branch removed from `add()`          |
+| 20260422 | mul      |    2.3x |      3.7x |     4.4x | After H#4.1 `is_integer` branch removed from `mul()`          |
+| 20260422 | div      |    1.6x |      0.6x |     1.5x | After H#4.1 `is_integer` branch removed from `mul()`          |
+| 20260422 | mul      |    1.8x |      3.8x |     4.4x | After G-M UInt256 / 10^k                                      |
+| 20260422 | add      |    1.3x |      1.7x |     1.5x | After H#11 hot-path-first `add`/`sub`                         |
+| 20260422 | sub      |    2.0x |      1.9x |     1.7x | After H#11 hot-path-first `add`/`sub`                         |
+| 20260422 | add      |    1.1x |      1.5x |     1.3x | After H#3 sub diff-scale fully inlined + mul `@always_inline` |
+| 20260422 | sub      |    1.7x |      1.6x |     1.5x | After H#3 sub diff-scale fully inlined + mul `@always_inline` |
+| 20260422 | mul      |    1.9x |      4.6x |     4.2x | After H#3 sub diff-scale fully inlined + mul `@always_inline` |
+| 20260422 | div      |    1.6x |      0.7x |     1.7x | After H#3 sub diff-scale fully inlined + mul `@always_inline` |
+| 20260422 | add      |    1.2x |      2.0x |     2.0x | After H#5 divide two-phase: probe + UInt256/u64 schoolbook    |
+| 20260422 | sub      |    1.7x |      2.2x |     2.0x | After H#5 divide two-phase: probe + UInt256/u64 schoolbook    |
+| 20260422 | mul      |    1.7x |      3.0x |     3.5x | After H#5 divide two-phase: probe + UInt256/u64 schoolbook    |
+| 20260422 | div      |    2.2x |      1.3x |     1.3x | After H#5 divide two-phase: probe + UInt256/u64 schoolbook    |
 
 Observations from the 20260421 baseline:
 
@@ -696,6 +708,65 @@ End-to-end impact in the `dec128_report_20260422_200239.md` cross-language repor
 - *Helper-function decomposition costs ~1 ns over a well-ordered monolith.* An exploratory four-helper split measured 3/4 ns vs the monolith's 4/4 ns, but the readability penalty (six new private symbols for arms that are each called from exactly one place) wasn't worth the 1 ns. Helpers should be reserved for genuinely shared code paths, not for rhetorical "decomposition".
 
 **Files touched:** [src/decimo/decimal128/arithmetics.mojo](../../src/decimo/decimal128/arithmetics.mojo) (the entire `add` / `subtract` neighbourhood, lines ~46–340).
+
+**Notes for #12 — Subtract diff-scale fully inlined + multiply `@always_inline` (20260422_210555):**
+
+H#11 left `subtract()`'s diff-scale arm calling `add(x1, negative(x2))` on the assumption that the negate was free and UInt256 work dominated. The `200239` report showed otherwise: subtract `Decimals with different scales` ran 12 ns vs rust 2.33 (5.1×), and the three `Both integer, different scale` cases sat at 9–19 ns (3.9–4.3×). The detour cost ~3 ns — a `def raises` call into `add()`, a non-inlined `negative()`, and the `try/except` rethrow that fixed up the error message. Against ~5 ns of UInt256 promotion that's a 50% tax.
+
+Fix: inline the whole diff-scale block into `subtract()`. It mirrors `add()` line-for-line with two algebraic substitutions for `x1 − x2 = x1 + (−x2)`:
+
+- The "same effective sign" branch (which adds magnitudes) tests `is_negative() != is_negative()` instead of `==`.
+- Sign assignments that would read `x2.is_negative()` read `not x2.is_negative()`.
+
+The one-operand-zero case is also inlined; `0.0 - -0.00 == 0.00` still holds. The overflow message reads `"Subtraction result exceeds Decimal128 precision."` directly, no rethrow.
+
+Companion: `@always_inline` on `multiply()`. The body had no annotation; adding it lets the integer fast path (`combined_num_bits ≤ 96`) lose its call frame.
+
+Numbers from `dec128_report_20260422_210555.md`:
+
+- `subtract` median 4 ns (flat), dm/rs 2.0× → 1.7×.
+- `subtract` `Decimals with different scales` 12 → 10 ns; `Both integer, different scale (small/medium/wide gap)` 9/12/19 → 6/5/15 ns. The wide-gap case stays at 3.4× rust because rust uses a 32-bit fast path that decimo's unconditional 96→256 promotion can't replicate.
+- `multiply` median 5 ns (flat); the 22-24 ns worst case is unchanged because it's bound by the GM-divider, not the call site.
+- `add` dm/rs 1.3× → 1.1× (re-measurement; body untouched).
+- Result equivalence: add 14/14, sub 14/14, mul 15/16 (unchanged), div 9/11 (unchanged), cmp 30/30, from_str 16/16, to_str 9/9.
+- Tests: `test_decimal128_arithmetics.mojo` 5/5 PASS in 41.7 s under `-D ASSERT=all`.
+
+Still open and out of scope here:
+
+- `multiply` `High precision` 24 ns vs rust 6.6 (3.6×) and `Product overflows` 22 vs 8.75 (2.5×) — both on the UInt256 + GM path. Closing the gap needs either a 128-bit fast path that detects when the product fits in `UInt128` despite `combined_num_bits > 96`, or a different rounding strategy.
+- `divide` `Repeating decimal` 287 vs rust 12.5 (22.9×), `High precision` 248 vs 24.3 (10.2×), `Coprime` 175 vs 21 (8.2×) — the single-digit-per-step long-division loop. The fix is to multiply numerator by `10^k` once and hardware-divide once, but that's a major refactor of `divide()` and is left for a follow-up.
+
+**Files touched:** [src/decimo/decimal128/arithmetics.mojo](../../src/decimo/decimal128/arithmetics.mojo) (`subtract()` diff-scale arm rewritten ~lines 289–410; `@always_inline` on `multiply()` at ~line 472).
+
+**Notes for #13 — Divide two-phase: probe loop + UInt256/u64 schoolbook (20260422_212851):**
+
+H#12 left the divide tail open: `Repeating decimal` 287 ns vs rust 12.5 (22.9×), `High precision` 248 vs 24.3 (10.2×), `Coprime` 175 vs 21 (8.2×). All three sat on the same per-digit long-division loop — `rem *= 10; digit = rem // x2_coef; rem %= x2_coef` — running 25-28 iterations. Each iteration is one UInt128 div + one UInt128 mod + a multiply, ~10 ns apiece on M4 (UInt128 division goes through `__udivti3`).
+
+The first instinct — "do it in one big divide" — does not work. A single `UInt256 / UInt256` divide costs ~236 ns through the software fallback, only marginally better than the 280 ns loop. What does work is splitting the dividend into u64 limbs:
+
+- Add `udiv_u256_by_u64(n: UInt256, d: UInt64)` to [utility.mojo](../../src/decimo/decimal128/utility.mojo). Four-step schoolbook over the 64-bit limbs of `n`, each step one `UInt128 / UInt128` divide where the divisor is `< 2^64`. Hardware-fast: ~12 ns end-to-end vs 236 ns for the symmetric divide. Tested 0/2000 mismatches against `n // d` over random UInt256/UInt64 pairs.
+- Every `Decimal128` divisor fits in `UInt128 ≤ 2^96`, and the bench cases all happen to fit in `UInt64`, so the u64-divisor path covers them. The 96-bit-divisor fallback (rare) keeps the original `UInt256 // UInt256`.
+
+Naive replacement (rip the loop out, scale by `10^max_steps` once, divide once) regressed `Simple decimal division` 19 → 154 ns. Two reasons: (1) we always padded out to `max_steps = 29` digits even when the result terminated in 1, then needed a 28-iteration trim loop to strip trailing zeros; (2) the trim itself was per-digit `quot %= 10; quot //= 10`, which is two UInt128 ops × 28 iterations.
+
+Two-phase fix:
+
+- *Phase 1: probe.* Run the original per-digit loop, but cap it at `PROBE_STEPS = 2`. Catches the common "terminates in ≤ 2 digits" cases (`10.5 / 2.5`, `123.45 / -2`) for ~10 ns total. The probe constant is a sweet spot — 1 missed `1/8`-shaped cases, 4 added 20 ns to the bulk-finish path.
+- *Phase 2: bulk finish.* If the remainder is still non-zero, scale the *remaining* `bulk_steps = max_steps - 2` digits with one `power_of_10[uint128]` lookup, run `udiv_u256_by_u64`, fold the result back into `quot`. Trim trailing zeros bisect-style (16/8/4/2/1 chunks of `pow_of_10`) so the worst case is ~5 UInt128 div-mods instead of 28.
+
+Numbers from `dec128_report_20260422_212851.md`:
+
+- `divide` median 9 → 8 ns, dm/rs 1.6× → 2.2× (median rises because the cheap cases got cheaper relative to the slow cases — see worst-case column).
+- `divide` worst-case max **287 → 56 ns**, the headline win. Per-case: `Repeating decimal` 287 → 57 (22.9× → 3.6×), `High precision` 248 → 59 (10.2× → 2.4×), `Coprime` 175 → 52 (8.2× → 2.4×). All three sit at ~3× rust now — still above the 2× target, bound by the `udiv_u256_by_u64` itself plus the 2-step probe overhead.
+- `divide` `Simple decimal` 19 → 26 ns and `Negative` 21 → 26 ns — small regression versus the pure per-digit loop. The `PROBE_STEPS = 2` cap means these terminate in phase 1 (1 digit needed) but pay a couple of extra branch evals before exiting. Acceptable trade for 3.6× → 2.4× on the slow cases.
+- Result equivalence and tests: `test_decimal128_divide.mojo` 11/11 PASS in 24.0 s under `-D ASSERT=all`; `test_decimal128_arithmetics.mojo` 5/5 PASS in 76.0 s.
+
+Still open:
+
+- The 96-bit-divisor fallback is untouched (no bench case exercises it). If a workload appears with a 7-digit-plus divisor, `udiv_u256_by_u96` would slot in next to `udiv_u256_by_u64`.
+- Closing slow-case dm/rs from 2.4× to ≤ 2× would need either eliminating the `power_of_10[uint128]` lookup (~2 ns) or removing the probe loop entirely and accepting the trim-loop tax — both regress the simple cases. The current shape feels Pareto-optimal at the case level.
+
+**Files touched:** [src/decimo/decimal128/arithmetics.mojo](../../src/decimo/decimal128/arithmetics.mojo) (`divide()` UInt128 path rewritten ~lines 996-1100), [src/decimo/decimal128/utility.mojo](../../src/decimo/decimal128/utility.mojo) (`udiv_u256_by_u64` appended at line 1521+).
 
 ## 5. Improvement Opportunities
 

--- a/src/decimo/decimal128/arithmetics.mojo
+++ b/src/decimo/decimal128/arithmetics.mojo
@@ -259,7 +259,7 @@ def subtract(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
     """
     var x1_coef = x1.coefficient()
     var x2_coef = x2.coefficient()
-    var x_scale = x1.scale()
+    var x1_scale = x1.scale()
 
     # CASE: Same scale (UInt128 fast path)
     #
@@ -267,7 +267,7 @@ def subtract(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
     # coefficients) is reached when x1.is_negative() *differs* from
     # x2.is_negative(). Inlined here so the common case avoids both the
     # `negative()` allocation and the dispatch through `add()` below.
-    if x_scale == x2.scale():
+    if x1_scale == x2.scale():
         var summation: UInt128
         var is_negative: Bool
 
@@ -284,37 +284,150 @@ def subtract(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
                 is_negative = not x2.is_negative()
             else:
                 return Decimal128.from_uint128(
-                    UInt128(0), UInt32(x_scale), False
+                    UInt128(0), UInt32(x1_scale), False
                 )
 
         if summation < Decimal128.MAX_AS_UINT128:
             # Canonicalize -0 - +0 (or any all-zero result) to +0.
             return Decimal128.from_uint128(
                 summation,
-                UInt32(x_scale),
+                UInt32(x1_scale),
                 False if summation == 0 else is_negative,
             )
 
         var fitted = decimo.decimal128.utility.fit_to_max_coefficient(summation)
-        if UInt32(fitted[1]) > UInt32(x_scale):
+        if UInt32(fitted[1]) > UInt32(x1_scale):
             raise OverflowError(
                 message="Decimal128 overflow in subtraction.",
                 function="subtract()",
             )
-        var final_scale = UInt32(x_scale) - UInt32(fitted[1])
+        var final_scale = UInt32(x1_scale) - UInt32(fitted[1])
         return Decimal128.from_uint128(fitted[0], final_scale, is_negative)
 
-    # CASE: Different scales — delegate to add(x1, -x2). The negate is a
-    # single sign-bit flip and the UInt256 work in add() dominates anyway.
-    # Catch and rethrow so callers see `subtract()` as the failing function.
-    try:
-        return add(x1, negative(x2))
-    except e:
-        raise OverflowError(
-            message="Decimal128 overflow in subtraction.",
-            function="subtract()",
-            previous_error=e^,
+    # CASE: One operand is zero (different scales)
+    #
+    # Same as the corresponding case in add() but with x2's sign flipped
+    # since x1 - x2 = x1 + (-x2). Both-zero returns positive zero at the
+    # higher scale (so `0.0 - -0.00 == 0.00`).
+    if x1_coef == 0 and x2_coef == 0:
+        return Decimal128(0, 0, 0, UInt32(max(x1_scale, x2.scale())), False)
+
+    var x2_scale = x2.scale()
+
+    if x1_coef == 0:
+        if x1_scale <= x2_scale:
+            return negative(x2)
+        var sum_coef = x2_coef
+        var scale = min(
+            max(x1_scale, x2_scale),
+            Decimal128.MAX_NUM_DIGITS
+            - decimo.decimal128.utility.number_of_digits(x2.to_uint128()),
         )
+        ## If x2_coef > 7922816251426433759354395033
+        if (
+            (x2_coef > Decimal128.MAX_AS_UINT128 // 10)
+            and (scale > 0)
+            and (scale > x2_scale)
+        ):
+            scale -= 1
+        sum_coef *= UInt128(10) ** (scale - x2_scale)
+        # Sign of result is sign of -x2.
+        return Decimal128.from_uint128(
+            sum_coef, UInt32(scale), not x2.is_negative()
+        )
+
+    if x2_coef == 0:
+        if x2_scale <= x1_scale:
+            return x1
+        var sum_coef = x1_coef
+        var scale = min(
+            max(x1_scale, x2_scale),
+            Decimal128.MAX_NUM_DIGITS
+            - decimo.decimal128.utility.number_of_digits(x1.to_uint128()),
+        )
+        ## If x1_coef > 7922816251426433759354395033
+        if (
+            (x1_coef > Decimal128.MAX_AS_UINT128 // 10)
+            and (scale > 0)
+            and (scale > x1_scale)
+        ):
+            scale -= 1
+        sum_coef *= UInt128(10) ** (scale - x1_scale)
+        return Decimal128.from_uint128(
+            sum_coef, UInt32(scale), x1.is_negative()
+        )
+
+    # CASE: Different scales, both non-zero (UInt256 path)
+    #
+    # Same as add() with x2's effective sign flipped: the "same effective
+    # sign" branch (which adds the coefficients) fires when x1 and x2 have
+    # *different* original signs (because then x1 and -x2 agree).
+    var diff: UInt256
+    var is_negative: Bool
+
+    if x1_scale > x2_scale:
+        var x1_coef_scaled: UInt256 = UInt256(x1_coef)
+        var x2_coef_scaled: UInt256 = UInt256(x2_coef) * UInt256(10) ** (
+            x1_scale - x2_scale
+        )
+
+        if x1.is_negative() != x2.is_negative():
+            is_negative = x1.is_negative()
+            diff = x1_coef_scaled + x2_coef_scaled
+        else:  # Same original signs -> different effective signs
+            if x1_coef_scaled > x2_coef_scaled:
+                diff = x1_coef_scaled - x2_coef_scaled
+                is_negative = x1.is_negative()
+            elif x1_coef_scaled < x2_coef_scaled:
+                diff = x2_coef_scaled - x1_coef_scaled
+                # Sign of -x2.
+                is_negative = not x2.is_negative()
+            else:
+                return Decimal128.from_uint128(
+                    UInt128(0), UInt32(x1_scale), False
+                )
+
+    else:  # x1_scale < x2_scale
+        var x1_coef_scaled: UInt256 = UInt256(x1_coef) * UInt256(10) ** (
+            x2_scale - x1_scale
+        )
+        var x2_coef_scaled: UInt256 = UInt256(x2_coef)
+
+        if x1.is_negative() != x2.is_negative():
+            is_negative = x1.is_negative()
+            diff = x2_coef_scaled + x1_coef_scaled
+        else:
+            if x1_coef_scaled > x2_coef_scaled:
+                diff = x1_coef_scaled - x2_coef_scaled
+                is_negative = x1.is_negative()
+            elif x1_coef_scaled < x2_coef_scaled:
+                diff = x2_coef_scaled - x1_coef_scaled
+                is_negative = not x2.is_negative()
+            else:
+                return Decimal128.from_uint128(
+                    UInt128(0), UInt32(x2_scale), False
+                )
+
+    if diff < Decimal128.MAX_AS_UINT256:
+        return Decimal128.from_uint128(
+            UInt128(diff & 0x00000000_FFFFFFFF_FFFFFFFF_FFFFFFFF),
+            UInt32(max(x1_scale, x2_scale)),
+            is_negative,
+        )
+
+    var fitted = decimo.decimal128.utility.fit_to_max_coefficient(diff)
+    var working_scale = UInt32(max(x1_scale, x2_scale))
+    if UInt32(fitted[1]) > working_scale:
+        raise OverflowError(
+            message="Subtraction result exceeds Decimal128 precision.",
+            function="subtract()",
+        )
+    var final_scale = working_scale - UInt32(fitted[1])
+    return Decimal128.from_uint128(
+        UInt128(fitted[0] & 0x00000000_FFFFFFFF_FFFFFFFF_FFFFFFFF),
+        final_scale,
+        is_negative,
+    )
 
 
 def negative(x: Decimal128) -> Decimal128:
@@ -355,6 +468,7 @@ def absolute(x: Decimal128) -> Decimal128:
     return x
 
 
+@always_inline
 def multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
     """
     Multiplies two Decimal128 values and returns a new Decimal128 containing the product.
@@ -877,27 +991,103 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         var ndigits_initial_quot = decimo.decimal128.utility.number_of_digits(
             quot
         )
+        # Two-phase long division.
+        #
+        # Phase 1: a short probe loop (up to PROBE_STEPS digits) catches
+        # fast-terminating cases like `10.5 / 2.5 = 4.2` or `123.45 / -2
+        # = -61.725` in 1-3 cheap UInt128 div-mod iterations.
+        #
+        # Phase 2: if the remainder is still non-zero after the probe, we
+        # know the result either does not terminate or terminates only
+        # after many more digits. Scale the remaining work up by a single
+        # `10^k` factor and finish with one big `UInt256 / UInt128`
+        # divide (~12 ns for u64 divisors via schoolbook, ~236 ns for
+        # full UInt256/UInt256 software fallback). This collapses ~25
+        # iterations of the per-digit loop into one division.
+        comptime PROBE_STEPS = 2
+        var max_steps = min(
+            Decimal128.MAX_NUM_DIGITS - ndigits_initial_quot + 1,
+            Decimal128.MAX_SCALE - diff_scale - adjusted_scale + 1,
+        )
         while (
             (rem != 0)
-            and (
-                step_counter
-                < (Decimal128.MAX_NUM_DIGITS - ndigits_initial_quot + 1)
-            )
-            and (
-                step_counter
-                < Decimal128.MAX_SCALE - diff_scale - adjusted_scale + 1
-            )
+            and (step_counter < PROBE_STEPS)
+            and (step_counter < max_steps)
         ):
-            # Multiply remainder by 10
             rem *= 10
-            # Calculate next quotient digit
             digit = rem // x2_coef
             quot = quot * 10 + digit
-            # Calculate new remainder
             rem = rem % x2_coef
-            # Increment step counter
             step_counter += 1
-            # Check if division is exact
+
+        if (rem != 0) and (step_counter < max_steps):
+            var bulk_steps = max_steps - step_counter
+            var scale_factor = decimo.decimal128.utility.power_of_10[
+                DType.uint128
+            ](bulk_steps)
+            var scale_factor_256 = UInt256(scale_factor)
+            # `rem * 10^bulk_steps` always fits in UInt256: rem < x2_coef
+            # ≤ 2^96, and bulk_steps ≤ 29 so 10^bulk_steps < 2^97.
+            var rem_scaled: UInt256 = UInt256(rem) * scale_factor_256
+            var x2_256 = UInt256(x2_coef)
+
+            var quot_added: UInt256
+            var rem_after: UInt256
+            if x2_coef <= UInt128(0xFFFF_FFFF_FFFF_FFFF):
+                # Fast path: 4-step schoolbook over u64 limbs.
+                var pair = decimo.decimal128.utility.udiv_u256_by_u64(
+                    rem_scaled, UInt64(x2_coef)
+                )
+                quot_added = pair[0]
+                rem_after = UInt256(pair[1])
+            else:
+                # Rare 96-bit-divisor fallback: software UInt256 divide.
+                quot_added = rem_scaled // x2_256
+                rem_after = rem_scaled - quot_added * x2_256
+
+            var combined: UInt256 = (
+                UInt256(quot) * scale_factor_256
+            ) + quot_added
+            # `combined` fits in UInt128: total decimal digits is at
+            # most `ndigits_initial_quot + step_counter + bulk_steps =
+            # ndigits_initial_quot + max_steps ≤ MAX_NUM_DIGITS + 1 = 30`.
+            quot = UInt128(
+                combined & UInt256(0xFFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF)
+            )
+            step_counter = max_steps
+
+            if rem_after == 0:
+                # Exact division. The per-digit loop would have stopped
+                # at the first zero remainder, so its `quot` carries no
+                # trailing zeros from beyond that point. Bisect-strip
+                # the equivalent zeros so the final scale matches.
+                digit = 0
+                rem = 0
+                var pow16 = UInt128(10000000000000000)
+                while (step_counter >= 16) and (quot % pow16 == 0):
+                    quot = quot // pow16
+                    step_counter -= 16
+                var pow8 = UInt128(100000000)
+                while (step_counter >= 8) and (quot % pow8 == 0):
+                    quot = quot // pow8
+                    step_counter -= 8
+                var pow4 = UInt128(10000)
+                while (step_counter >= 4) and (quot % pow4 == 0):
+                    quot = quot // pow4
+                    step_counter -= 4
+                var pow2 = UInt128(100)
+                while (step_counter >= 2) and (quot % pow2 == 0):
+                    quot = quot // pow2
+                    step_counter -= 2
+                while (step_counter >= 1) and (quot % 10 == 0):
+                    quot = quot // 10
+                    step_counter -= 1
+            else:
+                # Inexact: the bottom digit of `quot` is the +1 extra
+                # rounding digit (`max_steps` includes it by construction).
+                # The `digit == 5 and rem != 0` patch below uses it.
+                digit = quot % 10
+                rem = UInt128(1)
 
         # Yuhao's notes: When the remainder is non-zero at the end and the the digit to round is 5
         # we always round up, even if the rounding mode is round half to even

--- a/src/decimo/decimal128/utility.mojo
+++ b/src/decimo/decimal128/utility.mojo
@@ -1519,3 +1519,61 @@ fn udiv_u256_by_pow10_gm(value: UInt256, k: Int) -> UInt256:
     var t1 = _mulhi_u256(mp, value)
     var t = ((value - t1) >> 1) + t1
     return t >> UInt256(shift)
+
+
+@always_inline
+fn udiv_u256_by_u64(n: UInt256, d: UInt64) -> Tuple[UInt256, UInt64]:
+    """Schoolbook UInt256 / UInt64 division, hardware-fast on aarch64.
+
+    Args:
+        n: The 256-bit dividend.
+        d: The 64-bit divisor. Must be non-zero.
+
+    Returns:
+        A tuple `(quotient, remainder)` with the 256-bit quotient and
+        the 64-bit remainder (`r < d`).
+
+    Notes:
+        Splits `n` into four 64-bit limbs (high to low) and processes one
+        limb per step:
+
+            temp = (rem << 64) | limb_i
+            q_i  = temp // d
+            rem  = temp - q_i * d
+
+        Each step is a 128-bit / 64-bit divide (hardware-supported via
+        `__udivti3`/`udiv` on M-series). Standalone cost ~12 ns vs ~236
+        ns for the generic `UInt256 // UInt256` software loop.
+
+        Used by `arithmetics.divide()` to replace the per-digit long
+        division loop with one big scaled divide whenever the divisor
+        coefficient fits in 64 bits (which covers all currently-tracked
+        bench cases — `Decimal128` divisors above 2^64 are rare).
+    """
+    var l3 = UInt128((n >> 192) & UInt256(0xFFFF_FFFF_FFFF_FFFF))
+    var l2 = UInt128((n >> 128) & UInt256(0xFFFF_FFFF_FFFF_FFFF))
+    var l1 = UInt128((n >> 64) & UInt256(0xFFFF_FFFF_FFFF_FFFF))
+    var l0 = UInt128(n & UInt256(0xFFFF_FFFF_FFFF_FFFF))
+    var d128 = UInt128(d)
+
+    var rem: UInt128 = 0
+    var t: UInt128 = (rem << 64) | l3
+    var q3 = t // d128
+    rem = t - q3 * d128
+    t = (rem << 64) | l2
+    var q2 = t // d128
+    rem = t - q2 * d128
+    t = (rem << 64) | l1
+    var q1 = t // d128
+    rem = t - q1 * d128
+    t = (rem << 64) | l0
+    var q0 = t // d128
+    rem = t - q0 * d128
+
+    var quot = (
+        (UInt256(q3) << 192)
+        | (UInt256(q2) << 128)
+        | (UInt256(q1) << 64)
+        | UInt256(q0)
+    )
+    return (quot, UInt64(rem))


### PR DESCRIPTION
This PR improves `Decimal128` arithmetic performance by optimizing the `divide()` long-division path to avoid the slow `UInt256 // UInt256` fallback whenever the divisor coefficient fits in 64 bits, and by adding an explicit `UInt256 / UInt64` schoolbook divider helper.

**Changes:**
- Add `udiv_u256_by_u64()` (4-limb schoolbook division) to speed up `UInt256 / UInt64`.
- Update `divide()` to a two-phase approach (short probe loop + bulk scaled division using the new helper when possible).
- Inline `subtract()`’s different-scale path (mirroring `add()` semantics) and mark `multiply()` as `@always_inline`; update benchmark documentation.