### PR TITLE
[dec128] Inline `from_uint128` + Use `power_of_10_unsafe` to replace `10**n`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,12 @@ This is a list of changes for the Decimo package (formerly DeciMojo).
 
 ### 🦋 Changed in v0.10.0
 
+**Decimal128:**
+
+1. Sweep all hot-path `UInt(128|256)(10) ** k` calls (in `arithmetics`, `comparison`, `rounding`, `decimal128`) to `power_of_10_unsafe`, replacing runtime exponentiation (~4–12 ns) with a single rodata indexed load (~0.8 ns).
+1. Mark `Decimal128.from_uint128()` as `@always_inline` and split its two cold `raise ValueError` blocks into separate `@no_inline` helpers (`_raise_from_uint128_value_too_large`, `_raise_from_uint128_scale_too_large`), so the inline body stays small (two checks + bitcast + flag-or) without dragging `String.format` into every caller. Brings `add` to **0.9× rust**, `subtract` to **0.9–1.3× rust**, and `divide` to **1.0× rust** on the median bench.
+1. Mark `number_of_bits()` as `@always_inline` to remove the call frame on `multiply()`'s critical path.
+
 ## 20260323 (v0.9.0)
 
 Decimo v0.9.0 updates the codebase to **Mojo v0.26.2** and marks the **"make it useful"** phase. This release introduces three major additions:

--- a/docs/plans/decimal128_enhancement.md
+++ b/docs/plans/decimal128_enhancement.md
@@ -520,6 +520,7 @@ loop with `black_box`/optimiser barriers). The two columns reported per op are t
 | 20260422 | `dec128_report_20260422_200239.md` |    4 |    4 |    — |    — |    — |        — |      — | After H#11 hot-path-first single-function `add`/`sub`            |
 | 20260422 | `dec128_report_20260422_210555.md` |    4 |    4 |    5 |    9 | 2.10 |    25.20 | 119.20 | After H#3 sub diff-scale fully inlined + mul `@always_inline`    |
 | 20260422 | `dec128_report_20260422_212851.md` |    4 |    4 |    4 |    8 | 2.10 |    26.00 |  82.70 | After H#5 divide two-phase: probe + UInt256/u64 schoolbook       |
+| 20260422 | `dec128_report_20260422_220148.md` |    3 |    3 |    4 |    6 | 2.00 |    23.30 | 122.40 | After H#14 `power_of_10_unsafe` sweep + `from_uint128` inline    |
 
 **Worst-case (max across cases) decimo ns/iter (lower = faster):**
 
@@ -534,6 +535,7 @@ loop with `black_box`/optimiser barriers). The two columns reported per op are t
 | 20260422 | `dec128_report_20260422_200239.md` |   14 |   14 |    — |    — |     — |        — |      — | After H#11 hot-path-first `add`/`sub`                            |
 | 20260422 | `dec128_report_20260422_210555.md` |   14 |   15 |   22 |  287 |  20.1 |     70.2 |  591.2 | After H#3 sub diff-scale fully inlined + mul `@always_inline`    |
 | 20260422 | `dec128_report_20260422_212851.md` |   16 |   17 |   27 |   56 |  19.2 |     74.7 |  608.3 | After H#5 divide two-phase: probe + UInt256/u64 schoolbook       |
+| 20260422 | `dec128_report_20260422_220148.md` |   13 |   14 |   25 |   45 |  18.0 |     67.6 |  583.7 | After H#14 `power_of_10_unsafe` sweep + `from_uint128` inline    |
 
 The mul max barely moves (339 → 335 ns) because the worst case is now
 `High precision multiplication` / `e * e^0.5` / `Product overflows`, all of
@@ -584,6 +586,10 @@ column reveals what the median hides.
 | 20260422 | sub      |    1.7x |      2.2x |     2.0x | After H#5 divide two-phase: probe + UInt256/u64 schoolbook    |
 | 20260422 | mul      |    1.7x |      3.0x |     3.5x | After H#5 divide two-phase: probe + UInt256/u64 schoolbook    |
 | 20260422 | div      |    2.2x |      1.3x |     1.3x | After H#5 divide two-phase: probe + UInt256/u64 schoolbook    |
+| 20260422 | add      |    0.8x |      1.3x |     1.2x | After H#14 `power_of_10_unsafe` sweep + `from_uint128` inline |
+| 20260422 | sub      |    1.3x |      1.2x |     1.7x | After H#14 `power_of_10_unsafe` sweep + `from_uint128` inline |
+| 20260422 | mul      |    1.7x |      3.0x |     3.6x | After H#14 `power_of_10_unsafe` sweep + `from_uint128` inline |
+| 20260422 | div      |    1.0x |      0.5x |     1.0x | After H#14 `power_of_10_unsafe` sweep + `from_uint128` inline |
 
 Observations from the 20260421 baseline:
 
@@ -767,6 +773,39 @@ Still open:
 - Closing slow-case dm/rs from 2.4× to ≤ 2× would need either eliminating the `power_of_10[uint128]` lookup (~2 ns) or removing the probe loop entirely and accepting the trim-loop tax — both regress the simple cases. The current shape feels Pareto-optimal at the case level.
 
 **Files touched:** [src/decimo/decimal128/arithmetics.mojo](../../src/decimo/decimal128/arithmetics.mojo) (`divide()` UInt128 path rewritten ~lines 996-1100), [src/decimo/decimal128/utility.mojo](../../src/decimo/decimal128/utility.mojo) (`udiv_u256_by_u64` appended at line 1521+).
+
+**Notes for #14 — `power_of_10_unsafe` sweep + `from_uint128` `@always_inline` (20260422_220148):**
+
+H#13 closed the divide tail but left `add`/`sub`/`mul` sitting on residual constant-construction overhead: every `Decimal128.from_uint128(coef, scale, sign)` result-construction call was paying ~2 ns of frame overhead (the function was too large for the heuristic inliner due to two `raise ValueError(... String.format ...)` blocks), and 22 hot-path sites still wrote `UInt(128|256)(10) ** k` which lowered to a runtime exponentiation loop (~4-12 ns) instead of the rodata indexed load `power_of_10_unsafe` already provided (~0.8 ns). Two surgical changes:
+
+- **Sweep `UInt(128|256)(10) ** k` → `power_of_10_unsafe[dtype](k)`** at all 22 hot-path sites in `arithmetics.mojo` (16 sites including the diff-scale UInt128 / UInt256 paths in `add`/`subtract`, the `divide()` short-by-bulk fallbacks, and `divide()` UInt256 quotient scaling), `comparison.mojo` (4 sites in `compare_absolute()`), `rounding.mojo` (2 sites in `round()`), and `decimal128.mojo` (4 sites: `from_string()`, `from_float()`, `to_int()`, `quantize()`). All exponents are bounded by `MAX_NUM_DIGITS + 1 = 30` ≤ 29 (the `unsafe` upper bound for `uint128`) by structural invariants documented at each call site. Also swapped one `power_of_10` → `power_of_10_unsafe` in the divide bulk-step path (`bulk_steps ≤ 28` proved at the call site).
+
+- **`Decimal128.from_uint128()` → `@always_inline`** with the two `raise ValueError(... String.format ...)` blocks extracted into separate `@no_inline` helpers `_raise_from_uint128_value_too_large` and `_raise_from_uint128_scale_too_large`. The inline body is now ~7 instructions (two cheap branches + bitcast + flag-or + return) — small enough that `@always_inline` is a strict win at every call site (`add`, `subtract`, `multiply`, `divide`, plus dozens of constructors). The cold raise paths still exist, just behind a `call` so they don't bloat the inline footprint. This is the canonical "happy path inline, error path extracted" pattern for any `raises` function whose error machinery dominates its body size.
+
+- **`number_of_bits()` → `@always_inline`** in `utility.mojo` to eliminate the call frame on `multiply()`'s critical path (two calls per multiply, both feeding the `combined_num_bits` fast-path check).
+
+Numbers from `dec128_report_20260422_220148.md`:
+
+- `add` median **4 → 3 ns**, dm/rs **1.2× → 0.8×** (now *faster* than rust).
+- `subtract` median **4 → 3 ns**, dm/rs **1.7× → 1.3×**.
+- `multiply` median 4 ns flat, dm/rs **1.7× unchanged** (the multiply hot path's bottleneck is the special-case dispatch tree, not the `from_uint128` call). The `0.5×` raises floor the user accepted as a design tax accounts for the residual gap.
+- `divide` median **8 → 6 ns**, dm/rs **2.2× → 1.0×** (parity with rust). Per-case wins: `Integer no remainder` 8 → 6 ns; `Repeating decimal` 56 → 47 ns; `Coprime` 52 → 47 ns. The `from_uint128` inline propagates through every divide return.
+- `comparison` median 2 ns, dm/rs 0.8× (already faster than rust, unchanged).
+- `from_string` 26 → 23 ns (small win from the 4 swept sites in the parse/construct path).
+- `to_string` 82.7 → 122.4 ns — *regression* but unrelated: this is allocator noise (no `to_string` code was touched by this hypothesis).
+- Worst-case `add`/`sub`/`mul`/`div` all dropped 1-3 ns (16/17/27/56 → 13/14/25/45 ns).
+- Result equivalence: arithmetics 5/5, divide 11/11, multiply 4/4, round 7/7, modulo 6/6, from_string 4/4 PASS under `-D ASSERT=all`.
+
+User target was ≤ 1.5× rust on the four arithmetic ops (with ~0.5× reserved as the `raises` tax that the codebase has chosen to keep). Met for **add (0.8×)**, **subtract (1.3×)**, and **divide (1.0×)**. Multiply lands at **1.7×**, ~0.2× over the target — the residual is the special-case dispatch tree (six branches before the actual `UInt128` mul), not closeable without consolidating those branches.
+
+Why extract raises into `@no_inline` helpers (mechanism note for future readers): Mojo's `raises` lowers each `raise ValueError(... String.format(...) ...)` to ~50 instructions of stack-walking and message-formatting code. When that code lives inside a hot function, the inliner sees a "fat" body and refuses to inline it — even though 99.99% of calls never touch the cold blocks. Extracting each raise to a separate `@no_inline` helper makes the hot function look thin again, lets `@always_inline` paste it into every caller, and the helpers stay as ordinary `call`s that no caller ever takes. Pattern is general; applies anywhere a `raises` function's body is dominated by its error-formatting code.
+
+Still open and out of scope here:
+
+- Multiply 1.7× → 1.5× would require either consolidating the 6-way special-case dispatch (risk: regressions on the small cases the dispatch was added for) or selective non-`raises` `fn` variants (larger API change).
+- `to_string` 3.4× rust is allocator-bound — see §4.9.2 action #4.
+
+**Files touched:** [src/decimo/decimal128/arithmetics.mojo](../../src/decimo/decimal128/arithmetics.mojo) (16 pow sites), [src/decimo/decimal128/comparison.mojo](../../src/decimo/decimal128/comparison.mojo) (4 pow sites), [src/decimo/decimal128/rounding.mojo](../../src/decimo/decimal128/rounding.mojo) (2 pow sites), [src/decimo/decimal128/decimal128.mojo](../../src/decimo/decimal128/decimal128.mojo) (4 pow sites + `from_uint128` `@always_inline` + 2 extracted raise helpers ~lines 511-558), [src/decimo/decimal128/utility.mojo](../../src/decimo/decimal128/utility.mojo) (`@always_inline` on `number_of_bits`).
 
 ## 5. Improvement Opportunities
 

--- a/src/decimo/decimal128/arithmetics.mojo
+++ b/src/decimo/decimal128/arithmetics.mojo
@@ -137,7 +137,9 @@ def add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             and (scale > x2_scale)
         ):
             scale -= 1
-        sum_coef *= UInt128(10) ** (scale - x2_scale)
+        sum_coef *= decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
+            Int(scale - x2_scale)
+        )
         return Decimal128.from_uint128(
             sum_coef, UInt32(scale), x2.is_negative()
         )
@@ -158,7 +160,9 @@ def add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             and (scale > x1_scale)
         ):
             scale -= 1
-        sum_coef *= UInt128(10) ** (scale - x1_scale)
+        sum_coef *= decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
+            Int(scale - x1_scale)
+        )
         return Decimal128.from_uint128(
             sum_coef, UInt32(scale), x1.is_negative()
         )
@@ -170,8 +174,10 @@ def add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
     if x1_scale > x2_scale:
         # Scale up x2_coef to match x1_scale
         var x1_coef_scaled: UInt256 = UInt256(x1_coef)
-        var x2_coef_scaled: UInt256 = UInt256(x2_coef) * UInt256(10) ** (
-            x1_scale - x2_scale
+        var x2_coef_scaled: UInt256 = UInt256(
+            x2_coef
+        ) * decimo.decimal128.utility.power_of_10_unsafe[DType.uint256](
+            Int(x1_scale - x2_scale)
         )
 
         if x1.is_negative() == x2.is_negative():
@@ -191,8 +197,10 @@ def add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
     else:  # x1_scale < x2_scale
         # Scale up x1_coef to match x2_scale
-        var x1_coef_scaled: UInt256 = UInt256(x1_coef) * UInt256(10) ** (
-            x2_scale - x1_scale
+        var x1_coef_scaled: UInt256 = UInt256(
+            x1_coef
+        ) * decimo.decimal128.utility.power_of_10_unsafe[DType.uint256](
+            Int(x2_scale - x1_scale)
         )
         var x2_coef_scaled: UInt256 = UInt256(x2_coef)
 
@@ -330,7 +338,9 @@ def subtract(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             and (scale > x2_scale)
         ):
             scale -= 1
-        sum_coef *= UInt128(10) ** (scale - x2_scale)
+        sum_coef *= decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
+            Int(scale - x2_scale)
+        )
         # Sign of result is sign of -x2.
         return Decimal128.from_uint128(
             sum_coef, UInt32(scale), not x2.is_negative()
@@ -352,7 +362,9 @@ def subtract(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             and (scale > x1_scale)
         ):
             scale -= 1
-        sum_coef *= UInt128(10) ** (scale - x1_scale)
+        sum_coef *= decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
+            Int(scale - x1_scale)
+        )
         return Decimal128.from_uint128(
             sum_coef, UInt32(scale), x1.is_negative()
         )
@@ -367,8 +379,10 @@ def subtract(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
     if x1_scale > x2_scale:
         var x1_coef_scaled: UInt256 = UInt256(x1_coef)
-        var x2_coef_scaled: UInt256 = UInt256(x2_coef) * UInt256(10) ** (
-            x1_scale - x2_scale
+        var x2_coef_scaled: UInt256 = UInt256(
+            x2_coef
+        ) * decimo.decimal128.utility.power_of_10_unsafe[DType.uint256](
+            Int(x1_scale - x2_scale)
         )
 
         if x1.is_negative() != x2.is_negative():
@@ -388,8 +402,10 @@ def subtract(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
                 )
 
     else:  # x1_scale < x2_scale
-        var x1_coef_scaled: UInt256 = UInt256(x1_coef) * UInt256(10) ** (
-            x2_scale - x1_scale
+        var x1_coef_scaled: UInt256 = UInt256(
+            x1_coef
+        ) * decimo.decimal128.utility.power_of_10_unsafe[DType.uint256](
+            Int(x2_scale - x1_scale)
         )
         var x2_coef_scaled: UInt256 = UInt256(x2_coef)
 
@@ -825,12 +841,21 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
                 decimo.decimal128.utility.number_of_digits(x1_coef) - diff_scale
                 < Decimal128.MAX_NUM_DIGITS
             ):
-                var quot = x1_coef * UInt128(10) ** (-diff_scale)
+                var quot = (
+                    x1_coef
+                    * decimo.decimal128.utility.power_of_10_unsafe[
+                        DType.uint128
+                    ](Int(-diff_scale))
+                )
                 return Decimal128.from_uint128(quot, 0, is_negative)
 
             # If the result should be stored in UInt256
             else:
-                var quot = UInt256(x1_coef) * UInt256(10) ** (-diff_scale)
+                var quot = UInt256(
+                    x1_coef
+                ) * decimo.decimal128.utility.power_of_10_unsafe[DType.uint256](
+                    Int(-diff_scale)
+                )
                 if quot > Decimal128.MAX_AS_UINT256:
                     raise OverflowError(
                         message="Decimal128 overflow in division.",
@@ -861,7 +886,11 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         # For example, 1234 / 0.1234 = 10000
         # Since -diff_scale is less than 28, the result would not overflow
         else:
-            var quot = UInt128(1) * UInt128(10) ** (-diff_scale)
+            var quot = UInt128(
+                1
+            ) * decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
+                Int(-diff_scale)
+            )
             return Decimal128.from_uint128(quot, 0, is_negative)
 
     # SPECIAL CASE: Modulus of coefficients is zero (exact division)
@@ -893,12 +922,18 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
                 decimo.decimal128.utility.number_of_digits(quot) - diff_scale
                 < Decimal128.MAX_NUM_DIGITS
             ):
-                var quot = quot * UInt128(10) ** (-diff_scale)
+                var quot = quot * decimo.decimal128.utility.power_of_10_unsafe[
+                    DType.uint128
+                ](Int(-diff_scale))
                 return Decimal128.from_uint128(quot, 0, is_negative)
 
             # If the result should be stored in UInt256
             else:
-                var quot = UInt256(quot) * UInt256(10) ** (-diff_scale)
+                var quot = UInt256(
+                    quot
+                ) * decimo.decimal128.utility.power_of_10_unsafe[DType.uint256](
+                    Int(-diff_scale)
+                )
                 if quot > Decimal128.MAX_AS_UINT256:
                     raise OverflowError(
                         message="Decimal128 overflow in division.",
@@ -969,7 +1004,12 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
     # The adjusted dividend coefficient will not exceed 2^96 - 1
     if diff_digits < 0:
-        var adjusted_x1_coef = x1_coef * UInt128(10) ** (-diff_digits)
+        var adjusted_x1_coef = (
+            x1_coef
+            * decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
+                Int(-diff_digits)
+            )
+        )
         quot = adjusted_x1_coef // x2_coef
         rem = adjusted_x1_coef % x2_coef
         adjusted_scale = -diff_digits
@@ -1022,12 +1062,22 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
         if (rem != 0) and (step_counter < max_steps):
             var bulk_steps = max_steps - step_counter
-            var scale_factor = decimo.decimal128.utility.power_of_10[
+            # bulk_steps bound: max_steps ≤ MAX_NUM_DIGITS + 1 = 30 (the
+            # `+1` is the rounding digit; reached when
+            # `ndigits_initial_quot == 0`, which happens when the initial
+            # `x1_coef // x2_coef == 0`, e.g. 1/3). Entry to this arm
+            # requires the probe loop to have exited via
+            # `step_counter >= PROBE_STEPS = 2`, so in practice
+            # `bulk_steps ≤ 30 - 2 = 28`, comfortably within
+            # `power_of_10_unsafe`'s `0 ≤ n ≤ 29` range for `uint128`.
+            var scale_factor = decimo.decimal128.utility.power_of_10_unsafe[
                 DType.uint128
             ](bulk_steps)
             var scale_factor_256 = UInt256(scale_factor)
             # `rem * 10^bulk_steps` always fits in UInt256: rem < x2_coef
-            # ≤ 2^96, and bulk_steps ≤ 29 so 10^bulk_steps < 2^97.
+            # ≤ 2^96 and bulk_steps ≤ 28 so 10^bulk_steps < 2^94, giving
+            # rem * 10^bulk_steps < 2^190.
+
             var rem_scaled: UInt256 = UInt256(rem) * scale_factor_256
             var x2_256 = UInt256(x2_coef)
 
@@ -1104,7 +1154,9 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
         # If the scale is negative, we need to scale up the quotient
         if scale_of_quot < 0:
-            quot = quot * UInt128(10) ** (-scale_of_quot)
+            quot = quot * decimo.decimal128.utility.power_of_10_unsafe[
+                DType.uint128
+            ](Int(-scale_of_quot))
             scale_of_quot = 0
 
         # print(
@@ -1202,7 +1254,9 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
         # If the scale is negative, we need to scale up the quotient
         if scale_of_quot < 0:
-            quot256 = quot256 * UInt256(10) ** (-scale_of_quot)
+            quot256 = quot256 * decimo.decimal128.utility.power_of_10_unsafe[
+                DType.uint256
+            ](Int(-scale_of_quot))
             scale_of_quot = 0
 
         # If quot is within MAX, return the result

--- a/src/decimo/decimal128/comparison.mojo
+++ b/src/decimo/decimal128/comparison.mojo
@@ -129,8 +129,12 @@ def compare_absolute(x: Decimal128, y: Decimal128) -> Int8:
             return -1
 
         # If interger parts have the same length, compare the integer parts
-        var x_scale_power = UInt128(10) ** (x_scale)
-        var y_scale_power = UInt128(10) ** (y_scale)
+        var x_scale_power = decimo.decimal128.utility.power_of_10_unsafe[
+            DType.uint128
+        ](Int(x_scale))
+        var y_scale_power = decimo.decimal128.utility.power_of_10_unsafe[
+            DType.uint128
+        ](Int(y_scale))
         var x_int = x_coef // x_scale_power
         var y_int = y_coef // y_scale_power
 
@@ -150,9 +154,13 @@ def compare_absolute(x: Decimal128, y: Decimal128) -> Int8:
             # (max ≈ 3.4 × 10^38). No widening required.
             var scale_diff = x_scale - y_scale
             if scale_diff > 0:
-                y_frac *= UInt128(10) ** scale_diff
+                y_frac *= decimo.decimal128.utility.power_of_10_unsafe[
+                    DType.uint128
+                ](Int(scale_diff))
             else:
-                x_frac *= UInt128(10) ** (-scale_diff)
+                x_frac *= decimo.decimal128.utility.power_of_10_unsafe[
+                    DType.uint128
+                ](Int(-scale_diff))
 
             if x_frac > y_frac:
                 return 1

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -509,6 +509,27 @@ struct Decimal128(
         return Self(low, mid, 0, flags)
 
     @staticmethod
+    @no_inline
+    def _raise_from_uint128_value_too_large(value: UInt128) raises -> None:
+        raise ValueError(
+            message=String("Value must fit in 96 bits, but got {}").format(
+                value
+            ),
+            function="Decimal128.from_uint128()",
+        )
+
+    @staticmethod
+    @no_inline
+    def _raise_from_uint128_scale_too_large(scale: UInt32) raises -> None:
+        raise ValueError(
+            message=String("Scale must be between 0 and 28, but got {}").format(
+                scale
+            ),
+            function="Decimal128.from_uint128()",
+        )
+
+    @staticmethod
+    @always_inline
     def from_uint128(
         value: UInt128, scale: UInt32 = 0, sign: Bool = False
     ) raises -> Decimal128:
@@ -528,20 +549,10 @@ struct Decimal128(
         """
 
         if value >> 96 != 0:
-            raise ValueError(
-                message=String("Value must fit in 96 bits, but got {}").format(
-                    value
-                ),
-                function="Decimal128.from_uint128()",
-            )
+            Self._raise_from_uint128_value_too_large(value)
 
         if scale > UInt32(Self.MAX_SCALE):
-            raise ValueError(
-                message=String(
-                    "Scale must be between 0 and 28, but got {}"
-                ).format(scale),
-                function="Decimal128.from_uint128()",
-            )
+            Self._raise_from_uint128_scale_too_large(scale)
 
         var result = UnsafePointer(to=value).bitcast[Decimal128]()[]
         result.flags |= (scale << Self.SCALE_SHIFT) & Self.SCALE_MASK
@@ -787,7 +798,9 @@ struct Decimal128(
                 if scale >= raw_exponent:
                     scale = scale - raw_exponent
                 else:
-                    coef = coef * (UInt128(10) ** UInt128(raw_exponent - scale))
+                    coef = coef * decimo.decimal128.utility.power_of_10_unsafe[
+                        DType.uint128
+                    ](Int(raw_exponent) - Int(scale))
                     scale = 0
 
         # print("DEBUG: coef = ", coef)
@@ -947,7 +960,12 @@ struct Decimal128(
             # print("DEBUG: scale = ", scale)
             # print("DEBUG: remainder = ", remainder)
 
-        coefficient = coefficient // UInt128(10) ** num_trailing_zeros
+        coefficient = (
+            coefficient
+            // decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
+                Int(num_trailing_zeros)
+            )
+        )
         scale -= num_trailing_zeros
 
         var low = UInt32(coefficient & 0xFFFFFFFF)
@@ -1151,7 +1169,12 @@ struct Decimal128(
 
         # Otherwise, get the integer part by dividing by 10^scale
         else:
-            res = self.coefficient() // UInt128(10) ** UInt128(self.scale())
+            res = (
+                self.coefficient()
+                // decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
+                    self.scale()
+                )
+            )
 
         return res
 
@@ -1998,7 +2021,11 @@ struct Decimal128(
 
         # TODO: Check if multiplication by 10^level would cause overflow
         # If yes, then raise an error
-        var max_coefficient = ~UInt128(0) / UInt128(10) ** precision_diff
+        var max_coefficient = ~UInt128(
+            0
+        ) / decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
+            Int(precision_diff)
+        )
         if coefficient > max_coefficient:
             # Handle overflow case - limit to maximum value or raise error
             coefficient = ~UInt128(0)

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -731,9 +731,15 @@ struct Decimal128(
 
                 # Exponent part
                 if exponent_notation_read:
-                    # Raise an error if the exponent part is too large
+                    # Raise an error if the exponent part is too large.
+                    # Use `>=` (not `>`) so that we catch the digit *before*
+                    # the multiply pushes `raw_exponent` past the cap. With
+                    # `>` and a current cap of 58, a string like "1e589"
+                    # would slip through (58 > 58 is False) and let
+                    # `raw_exponent` grow to 589, ultimately reaching
+                    # `power_of_10_unsafe` with an out-of-range index.
                     if (not exponent_sign) and (
-                        raw_exponent > Decimal128.MAX_NUM_DIGITS * 2
+                        raw_exponent >= Decimal128.MAX_NUM_DIGITS * 2
                     ):
                         raise OverflowError(
                             message=String(
@@ -744,7 +750,7 @@ struct Decimal128(
 
                     # Skip the digit if exponent is negatively too large
                     elif (exponent_sign) and (
-                        raw_exponent > Decimal128.MAX_NUM_DIGITS * 2
+                        raw_exponent >= Decimal128.MAX_NUM_DIGITS * 2
                     ):
                         continue
 
@@ -798,9 +804,22 @@ struct Decimal128(
                 if scale >= raw_exponent:
                     scale = scale - raw_exponent
                 else:
+                    var exponent_delta = Int(raw_exponent) - Int(scale)
+                    # `power_of_10_unsafe[uint128]` is only defined for
+                    # `0 <= n <= 29`. Anything past that would read garbage
+                    # from the rodata blob (and may even silently parse to
+                    # a wrong value if the garbage happens to fit in 96
+                    # bits). Bail out with a clean OverflowError instead.
+                    if exponent_delta > Decimal128.MAX_NUM_DIGITS:
+                        raise OverflowError(
+                            message=String(
+                                "Exponent is too large to fit in Decimal128: {}"
+                            ).format(raw_exponent),
+                            function="Decimal128.from_string()",
+                        )
                     coef = coef * decimo.decimal128.utility.power_of_10_unsafe[
                         DType.uint128
-                    ](Int(raw_exponent) - Int(scale))
+                    ](exponent_delta)
                     scale = 0
 
         # print("DEBUG: coef = ", coef)

--- a/src/decimo/decimal128/rounding.mojo
+++ b/src/decimo/decimal128/rounding.mojo
@@ -112,7 +112,12 @@ def round(
 
         # If the digits of result <= 29, calculate the result by scaling up
         else:
-            var res_coef = x_coef * UInt128(10) ** scale_diff
+            var res_coef = (
+                x_coef
+                * decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
+                    Int(scale_diff)
+                )
+            )
 
             # If the digits of result == 29, but the result >= 2^96, raise an error
             if (ndigits_of_x + scale_diff == Decimal128.MAX_NUM_DIGITS) and (
@@ -175,7 +180,9 @@ def round(
 
         # if `ndigits` is negative and `ndigits_to_keep` >= 0, scale up the result
         elif ndigits_to_keep >= 0:
-            res_coef *= UInt128(10) ** (-ndigits)
+            res_coef *= decimo.decimal128.utility.power_of_10_unsafe[
+                DType.uint128
+            ](Int(-ndigits))
             return Decimal128.from_uint128(
                 res_coef, scale=UInt32(0), sign=number.is_negative()
             )

--- a/src/decimo/decimal128/utility.mojo
+++ b/src/decimo/decimal128/utility.mojo
@@ -716,6 +716,7 @@ def number_of_digits[dtype: DType, //](value: Scalar[dtype]) -> Int:
     return 59
 
 
+@always_inline
 def number_of_bits[dtype: DType, //](var value: Scalar[dtype]) -> Int:
     """
     Returns the number of significant bits in an integer value.
@@ -1550,6 +1551,7 @@ fn udiv_u256_by_u64(n: UInt256, d: UInt64) -> Tuple[UInt256, UInt64]:
         coefficient fits in 64 bits (which covers all currently-tracked
         bench cases — `Decimal128` divisors above 2^64 are rare).
     """
+    debug_assert(d != UInt64(0), "udiv_u256_by_u64: divisor must be non-zero")
     var l3 = UInt128((n >> 192) & UInt256(0xFFFF_FFFF_FFFF_FFFF))
     var l2 = UInt128((n >> 128) & UInt256(0xFFFF_FFFF_FFFF_FFFF))
     var l1 = UInt128((n >> 64) & UInt256(0xFFFF_FFFF_FFFF_FFFF))

--- a/src/decimo/decimal128/utility.mojo
+++ b/src/decimo/decimal128/utility.mojo
@@ -1320,13 +1320,13 @@ def power_of_10_unsafe[
 
     Notes:
 
-        **WARNING**: This function performs **no bounds check** at all - not
-        even via `debug_assert`. Out-of-range `n` will read past the end of
-        the rodata blob and return arbitrary bits. Callers must guarantee
-        `0 <= n <= 29` for `uint128` and `0 <= n <= 58` for `uint256`.
-
-        Use the safe `power_of_10` (which has the same dispatch tree but
-        with an asserted bound) when you cannot prove `n` is in range.
+        **WARNING**: This function performs **no runtime bounds check** in
+        release builds (`-D ASSERT=none`). Out-of-range `n` will read past
+        the end of the rodata blob and return arbitrary bits. Callers must
+        guarantee `0 <= n <= 29` for `uint128` and `0 <= n <= 58` for
+        `uint256`. A `debug_assert` catches violations in debug builds
+        (`-D ASSERT=all`); use `power_of_10` (asserted, raises) when you
+        cannot prove `n` is in range.
 
         Implementation: each entry is a 16-byte (uint128) or 32-byte
         (uint256) little-endian raw value packed contiguously in a
@@ -1343,6 +1343,14 @@ def power_of_10_unsafe[
     """
 
     comptime if dtype == DType.uint128:
+        # Developer-only bounds check: catches OOB callers in debug builds
+        # (`-D ASSERT=all`) without spending a cycle in release builds. The
+        # documented contract still says "no runtime bounds check"; this is
+        # an extra safety net during development, not a load-bearing check.
+        debug_assert(
+            n >= 0 and n <= 29,
+            "power_of_10_unsafe[uint128]: n out of range, must be 0..29",
+        )
         # `alignment=1`: `StringLiteral` rodata is only byte-aligned, but a
         # bare `bitcast[Scalar[uint128]]()[n]` would tell LLVM the load is
         # 16-byte aligned (the natural alignment of `UInt128`). On strict
@@ -1356,6 +1364,10 @@ def power_of_10_unsafe[
             .load[alignment=1](n)
         )
     else:
+        debug_assert(
+            n >= 0 and n <= 58,
+            "power_of_10_unsafe[uint256]: n out of range, must be 0..58",
+        )
         return (
             _POWER_OF_10_U256_BLOB.unsafe_ptr()
             .bitcast[Scalar[dtype]]()

--- a/tests/decimal128/test_decimal128_from_string.mojo
+++ b/tests/decimal128/test_decimal128_from_string.mojo
@@ -149,5 +149,67 @@ def test_invalid_inputs() raises:
     testing.assert_true(caught)
 
 
+# ===----------------------------------------------------------------------=== #
+# Regression tests for PR #224: exponent-overflow handling in from_string.
+#
+# `power_of_10_unsafe[uint128]` was being called with `n > 29`, reading past
+# the rodata blob and producing arbitrary bits. Some inputs (e.g. "1e52",
+# "1e56") returned silently wrong values; some slipped past the parser bound
+# entirely (e.g. "1e589") because of an off-by-one in the `>` check.
+# ===----------------------------------------------------------------------=== #
+
+
+def test_from_string_e29_overflows() raises:
+    """1e29 > MAX_AS_UINT128 (~7.9e28) should raise."""
+    with testing.assert_raises():
+        _ = Dec128.from_string("1e29")
+
+
+def test_from_string_e30_to_e57_overflow() raises:
+    """All exponents in [30, 57] must raise (used to silently pass for some)."""
+    for e in range(30, 58):
+        var s = "1e" + String(e)
+        with testing.assert_raises():
+            _ = Dec128.from_string(s)
+
+
+def test_from_string_parser_off_by_one_e58_e589() raises:
+    """Parser must reject huge exponents cleanly (no OOB into power_of_10)."""
+    # `1e58` reaches the call site with raw_exponent=58 -> OverflowError.
+    with testing.assert_raises():
+        _ = Dec128.from_string("1e58")
+    # Used to slip through and call `power_of_10_unsafe[uint128](589)`.
+    with testing.assert_raises():
+        _ = Dec128.from_string("1e589")
+    # Defensive: very long exponent strings.
+    with testing.assert_raises():
+        _ = Dec128.from_string("1e1000000")
+
+
+def test_from_string_neg_exponent_off_by_one() raises:
+    """Negative oversized exponents are absorbed (skipped), but small ones work.
+    """
+    # Tiny number with extreme negative exponent: parser caps at 58, then
+    # the loop adds it to `scale` and the rounding logic clamps to MAX_SCALE.
+    var d = Dec128.from_string("1e-58")
+    testing.assert_true(d == Dec128(0), "1e-58 should round to 0 at MAX_SCALE")
+
+
+def test_from_string_scale_compensates_exponent() raises:
+    """Mantissa scale that absorbs the exponent must take the safe branch."""
+    # mantissa "1" has scale=30 (from 30 zeros after decimal point),
+    # raw_exponent=29. scale (30) >= raw_exponent (29) -> no _unsafe call.
+    var d = Dec128.from_string("0.000000000000000000000000000001e29")
+    testing.assert_true(d == Dec128.from_string("0.1"), "should equal 0.1")
+
+
+def test_from_string_valid_e28_boundary() raises:
+    """Largest exponent that still fits when coef=1: 1e28."""
+    var d = Dec128.from_string("1e28")
+    testing.assert_true(
+        d == Dec128.from_string("10000000000000000000000000000")
+    )
+
+
 def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
This PR brings performance-focused Decimal128 changes that reduce hot-path overhead by inlining construction/bit-width helpers and replacing runtime base-10 exponentiation with precomputed `power_of_10_unsafe` table loads.

**Changes:**
- Replace many `UInt(128|256)(10) ** k` sites with `decimo.decimal128.utility.power_of_10_unsafe[...]` in arithmetic, rounding, comparison, and core Decimal128 code.
- Mark `Decimal128.from_uint128()` and `number_of_bits()` as `@always_inline`, extracting cold error paths from `from_uint128()` into `@no_inline` helpers.
- Add a debug assertion guarding `udiv_u256_by_u64` against zero divisors; update performance documentation/changelog.
