### PR TITLE
[dec128] Update comparison functions, `from_string`, `to_string`, etc to improve performance

### DIFF
--- a/docs/plans/decimal128_enhancement.md
+++ b/docs/plans/decimal128_enhancement.md
@@ -62,7 +62,7 @@ corresponds to one landed PR / one bench snapshot. Rows are *append-only*.
 | 20260422 | **Granlund-Möller reciprocal divider** for UInt256 / 10^k (k ∈ [1,29]). 250→6 ns/call.   |
 |          | **Critical:** magic constant must use **ceiling** division. Floor failed 17/2000 at k=1. |
 | 20260422 | `udiv_u256_by_u64` schoolbook over u64 limbs (~12 ns vs 236 ns native UInt256/UInt256)   |
-| 20260422 | `power_of_10_unsafe` swept across 22 hot sites (was `UInt(128                            | 256)(10) ** k`) |
+| 20260422 | `power_of_10_unsafe` swept across 22 hot sites (was `UInt(128 or 256)(10) ** k`)         |
 
 ### 2.3 Performance — arithmetic ops
 
@@ -181,6 +181,7 @@ context. All P1/P2 items have landed; P3 items are tracked in §5.
 | 15  | `compare_absolute` rewrite                                 | DONE (this PR) — worst case 13.6→3.8 ns                                                    |
 | 16  | `multiply` single-pass rounding (saves second wide divide) | DONE (this PR) — High-precision 19→13 ns                                                   |
 | 17  | `from_string` per-byte switch reorder + branch merge       | DONE (this PR) — Long integer 41→22 ns                                                     |
+| 18  | `Decimal128.from_string` call `str.parse_numeric_string`   | Consolidate these two functions as one unified parsing function in `str` module            |
 
 ---
 

--- a/docs/plans/decimal128_enhancement.md
+++ b/docs/plans/decimal128_enhancement.md
@@ -1,1133 +1,349 @@
 # Decimal128 Enhancement Plan
 
-> **Date**: 2026-04-08
+> **Date**: 2026-04-08 (created), last consolidated 2026-04-23
 > **Target**: decimo >=0.9.0
 > **Mojo Version**: >=0.26.2
 >
-> 子曰工欲善其事必先利其器
-> The mechanic, who wishes to do his work well, must first sharpen his tools -- Confucius
-
-I did a thorough audit of `src/decimo/decimal128/` and compared it against other 128-bit fixed-precision decimal libraries - C# [`System.Decimal`](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Decimal.DecCalc.cs), Rust [`rust_decimal`](https://github.com/paupino/rust-decimal), Apache Arrow [`Decimal128`](https://github.com/apache/arrow/blob/main/cpp/src/arrow/util/basic_decimal.h), and Go [`govalues/decimal`](https://github.com/govalues/decimal). This document records everything I found: correctness bugs, performance bottlenecks, and improvement opportunities.
-
-Scope: only 128-bit (or near-128-bit) fixed-precision, non-floating-point decimal types. Arbitrary-precision decimals (Python `decimal.Decimal`, Java `BigDecimal`) are out of scope - they are covered by `BigDecimal`. IEEE 754 decimal128 is also out of scope - it is a floating-point format with discontinuous representation, not comparable to our fixed-point design.
-
-## 1. Cross-Language Comparison
-
-### 1.1 Storage & Layout
-
-| Feature                | Decimo Decimal128    | C# System.Decimal    | Rust rust_decimal    | Arrow Decimal128           | Go govalues/decimal             |
-| ---------------------- | -------------------- | -------------------- | -------------------- | -------------------------- | ------------------------------- |
-| Total bits             | 128                  | 128                  | 128                  | 128                        | ~128 (bool+uint64+int, may pad) |
-| Coefficient storage    | 96-bit (3×UInt32 LE) | 96-bit (3×UInt32 LE) | 96-bit (3×UInt32 LE) | 128-bit signed two's compl | 64-bit unsigned                 |
-| Max coefficient        | 2^96 − 1             | 2^96 − 1             | 2^96 − 1             | 10^38 − 1                  | 10^19 − 1                       |
-| Bound type             | Binary               | Binary               | Binary               | Decimal                    | Decimal                         |
-| Max significant digits | 29*                  | 29*                  | 29*                  | 38                         | 19                              |
-| Scale range            | 0–28                 | 0–28                 | 0–28                 | User-defined               | 0–19                            |
-| Sign storage           | Bit 31 of flags      | Bit 31 of flags      | Bit 31 of flags      | Two's complement           | Bool field                      |
-| Endianness             | Little-endian        | Little-endian        | Little-endian        | Platform-native            | N/A                             |
-
-\* 29 digits, but the leading digit can only be 0–7 (since 10^29 − 1 > 2^96 − 1). This is pretty dirty and difficult to handle. I think the current implementation is not the most optimized. Need to check and refine.
-
-Decimo, C#, and Rust share the same layout - a proven design. Arrow and govalues use a fundamentally different approach with decimal-bounded coefficients (10^p − 1 instead of 2^N − 1), which gives them cleaner digit semantics at the cost of unused bit range.
-
-### 1.2 Special Values
-
-| Feature       | Decimo             | C#         | Rust | Arrow | Go govalues |
-| ------------- | ------------------ | ---------- | ---- | ----- | ----------- |
-| +Infinity     | ✗ (removed - §3.1) | ✗ (throws) | ✗    | ✗     | ✗           |
-| −Infinity     | ✗ (removed)        | ✗          | ✗    | ✗     | ✗           |
-| NaN           | ✗ (removed - §3.1) | ✗          | ✗    | ✗     | ✗           |
-| Negative zero | ✗                  | ✗          | ✗    | ✗     | ✗           |
-| Subnormals    | ✗                  | ✗          | ✗    | ✗     | ✗           |
-
-None of the comparable 128-bit fixed-precision libraries support NaN or Infinity. We removed our broken NaN/Infinity support (§3.1) to match the established paradigm - all four comparable libraries simply raise errors for undefined operations.
-
-### 1.3 Rounding Modes
-
-| Mode                 | Decimo | C#                       | Rust        | Arrow           | Go govalues    |
-| -------------------- | ------ | ------------------------ | ----------- | --------------- | -------------- |
-| HALF_EVEN (banker's) | ✓      | ✓ (default)              | ✓ (default) | ✓ (default)     | ✓ (default)    |
-| HALF_UP              | ✓      | ✓ (`AwayFromZero`)       | ✓           | ✓ (`HALF_UP`)   | ✓ (`HalfUp`)   |
-| HALF_DOWN            | ✓      | ✗                        | ✓           | ✓ (`HALF_DOWN`) | ✓ (`HalfDown`) |
-| UP (away from zero)  | ✓      | ✓ (`AwayFromZero`)       | ✓           | ✓ (`UP`)        | ✓ (`Up`)       |
-| DOWN (truncate)      | ✓      | ✓ (`ToZero`)             | ✓           | ✓ (`DOWN`)      | ✓ (`Down`)     |
-| CEILING              | ✓      | ✓ (`ToPositiveInfinity`) | ✓           | ✓ (`CEILING`)   | ✓ (`Ceiling`)  |
-| FLOOR                | ✓      | ✓ (`ToNegativeInfinity`) | ✓           | ✓ (`FLOOR`)     | ✓ (`Floor`)    |
-
-All five libraries (including us) support these 7 rounding modes. We are on par.
-
-### 1.4 Arithmetic Coverage
-
-| Operation            | Decimo          | C#               | Rust       | Arrow     | Go govalues  |
-| -------------------- | --------------- | ---------------- | ---------- | --------- | ------------ |
-| add                  | ✓               | ✓                | ✓          | ✓         | ✓            |
-| subtract             | ✓ (via add)     | ✓                | ✓          | ✓         | ✓            |
-| multiply             | ✓               | ✓                | ✓          | ✓         | ✓            |
-| divide               | ✓               | ✓                | ✓          | ✓         | ✓ (`Quo`)    |
-| truncate_divide      | ✓               | ✓ (`Truncate`)   | ✓          | ✗         | ✓ (`QuoRem`) |
-| modulo               | ✓               | ✓ (`%`)          | ✓          | ✗         | ✓ (`Rem`)    |
-| power (int exponent) | ✓               | ✗ (use Math.Pow) | ✓ (`powi`) | ✗         | ✓ (`PowInt`) |
-| sqrt                 | ✓               | ✗                | ✓          | ✗         | ✓            |
-| root (nth)           | ✓               | ✗                | ✗          | ✗         | ✗            |
-| exp                  | ✓               | ✗                | ✓          | ✗         | ✗            |
-| ln                   | ✓               | ✗                | ✓          | ✗         | ✗            |
-| log10                | ✓               | ✗                | ✗          | ✗         | ✗            |
-| log (arbitrary base) | ✓               | ✗                | ✗          | ✗         | ✗            |
-| abs                  | ✓               | ✓                | ✓          | ✓         | ✓            |
-| negate               | ✓               | ✓                | ✓          | ✓         | ✓            |
-| round                | ✓               | ✓                | ✓          | ✓         | ✓            |
-| quantize             | ✓               | ✗                | ✗          | via round | ✗            |
-| factorial            | ✓ (0–27 lookup) | ✗                | ✗          | ✗         | ✗            |
-| min / max            | ✗               | ✓                | ✓          | ✓         | ✓            |
-| normalize            | ✗               | ✗                | ✓          | ✗         | ✗            |
-
-Our arithmetic coverage is the most complete among all five libraries - we are the only one with `root`, `log10`, `log`, and `factorial`. Matching Rust on `exp` and `ln`. The gap is `min`/`max` which every other library provides and we do not.
-
-## 2. The Coefficient Bound Problem
-
-This is probably the biggest architectural concern I found. It affects performance, code complexity, and user-facing semantics.
-
-### 2.1 The Problem
-
-Our max coefficient is 2^96 − 1 = 79,228,162,514,264,337,593,543,950,335. This is a 29-digit number, but the leading digit can only be 0–7. The number 80,000,000,000,000,000,000,000,000,000 (which has only 2 significant digits) is out of range. Meanwhile, all 28-digit numbers fit.
-
-This creates a messy boundary: after every arithmetic operation that might produce a wide result (multiplication, addition with carry, etc.), I need to check whether the coefficient exceeds 2^96 − 1 and, if so, round it down. The rounding itself is non-trivial because the boundary is not at a clean decimal digit - I cannot just drop the last digit. The `fit_to_max_coefficient` + `round_coefficient` pair in `utility.mojo` handles this (replacing the old `truncate_to_max` / `round_to_keep_first_n_digits`).
-
-### 2.2 How Other Libraries Handle This
-
-#### C# System.Decimal - [`ScaleResult()`](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Decimal.DecCalc.cs) (binary bound, same as us)
-
-.NET's approach is heavily optimized. The core function `ScaleResult()` in `Decimal.DecCalc.cs`:
-
-1. Estimates how many decimal digits to remove using `LeadingZeroCount` and the constant `log10(2) ≈ 77/256`.
-2. Divides the wide result (stored in a `Buf24`, up to 192 bits) by powers of 10, using `DivByConst()` specialized per constant (10^1 through 10^9) for maximum speed - on 64-bit targets, these use compiler-generated multiply-by-reciprocal.
-3. Applies banker's rounding with a sticky bit for lost precision.
-4. If rounding causes a carry that pushes above 96 bits again, scales down by 10 one more time.
-
-Additional C# tricks:
-
-- `SearchScale()` - binary search using precomputed `OVFL_MAX_N_HI` constants to find the largest safe scale-up factor.
-- `PowerOvflValues[]` - table of largest 96-bit values that won't overflow when multiplied by 10^1 through 10^8.
-- `Unscale()` - efficiently removes trailing zeros using binary search: try 10^8, 10^4, 10^2, 10^1, with quick-reject bit checks (e.g., `(low & 0xF) == 0` before trying 10^4).
-- `OverflowUnscale()` - when quotient overflows by exactly 1 bit, feeds the carry back in and divides by 10, avoiding a full rescale.
-
-The bottom line: .NET has hundreds of lines of intricate, heavily-optimized code just for this boundary handling. Every multiply that exceeds 96 bits pays for multi-word division.
-
-#### Rust rust_decimal - [Port of .NET](https://github.com/paupino/rust-decimal/blob/master/src/ops/common.rs) (binary bound, same as us)
-
-`rust_decimal` is essentially a Rust port of .NET's `DecCalc`. The `Buf24::rescale()` in `ops/common.rs` is the equivalent of `ScaleResult()`. Same `log10(2) × 256 = 77` trick, same `OVERFLOW_MAX_N_HI` constants, same `POWER_OVERFLOW_VALUES` table.
-
-One difference: `rust_decimal` returns `CalculationResult::Overflow` instead of throwing, letting the caller handle it.
-
-#### Apache Arrow Decimal128 - [256-bit promotion](https://github.com/apache/arrow/blob/main/cpp/src/gandiva/precompiled/decimal_ops.cc) (decimal bound)
-
-Arrow sidesteps the problem entirely by capping at 10^38 − 1 instead of 2^128 − 1. The overflow check is just `abs(value) < 10^precision` - a single comparison against a precomputed constant.
-
-For multiplication that might overflow 128 bits, Arrow promotes to `int256_t` (Boost or compiler `__int128`-based), multiplies, scales down by `10^delta_scale` in one clean division, then converts back. This replaces .NET's iterative divide-and-round loop with a single wide multiplication + one division.
-
-The `FitsInPrecision(precision)` check is trivially a comparison against a table entry. No multi-step rescaling needed for the check itself.
-
-#### Go govalues/decimal - [Two-tier fast path](https://github.com/govalues/decimal/blob/main/decimal.go) (decimal bound)
-
-`govalues/decimal` uses the most elegant approach. Max coefficient = 10^19 − 1 (fits in `uint64`).
-
-1. Fast path: try the operation using native 64-bit arithmetic. If overflow detected (e.g., `z/y != x || z > maxFint`), fall through.
-2. Slow path: redo with `big.Int` (arbitrary precision), compute exact result, then round to 19 digits using `rshHalfEven` (right-shift in decimal = divide by 10^N, round half-to-even).
-
-Since the bound IS a power of 10, the rounding is clean: just count digits, divide by 10^excess, round. No awkward non-decimal boundary to deal with.
-
-### 2.3 Comparison
-
-| Strategy            | Used by           | Bound check cost      | Overflow rounding cost                  | Code complexity |
-| ------------------- | ----------------- | --------------------- | --------------------------------------- | --------------- |
-| Binary (2^96 − 1)   | C#, Rust, Decimo  | Cheap (bit compare)   | Expensive (multi-word ÷10^N, iterative) | High            |
-| Decimal (10^38 − 1) | Arrow, SQL Server | Cheap (one compare)   | Cheap (one wide ÷10^N)                  | Low             |
-| Decimal (10^19 − 1) | govalues/decimal  | Trivial (one compare) | Trivial (big.Int fallback + round)      | Very low        |
-
-### 2.4 Implications for Decimo
-
-Since we follow the C#/Rust paradigm (binary bound, 2^96 − 1), the coefficient-fitting complexity is inherent. What we have done so far:
-
-1. (Done) Adopted three .NET `ScaleResult` optimisations in the new `round_coefficient()` function: single-division remainder, `2×remainder` vs `divisor` half-comparison, and caller-supplied digit-removal count. The old `truncate_to_max` and `round_to_keep_first_n_digits` are replaced by `fit_to_max_coefficient` + `round_coefficient`. Possible future work: CLZ-based digit estimation (`LeadingZeroCount × 77/256`), precomputed `POWER_OVERFLOW_VALUES` table for safe scale-up, and `Unscale()` trailing-zero removal with quick-reject bit checks.
-
-2. Consider decimal bound for a future Decimal256. If I ever widen to full 128-bit coefficient, using 10^38 − 1 as the max (matching Arrow and SQL Server) would eliminate this problem entirely and give us interoperability with Arrow wire format and SQL `decimal(38)`.
-
-3. Document the "29 digits but not 29 nines" behavior clearly. Users should know that "29 digits of precision" really means "28 full digits plus a leading digit 0–7".
-
-### 2.5 Using UInt128/UInt256 as Acceleration Bridge
-
-Mojo now has native `UInt128` and `UInt256` types (via `Scalar[DType.uint128]` and `Scalar[DType.uint256]`). The codebase already uses them - `coefficient()` bitcasts the three UInt32 words to UInt128, and `multiply()` uses UInt256 for intermediate products. But there are more opportunities:
-
-- In `round_coefficient` and `fit_to_max_coefficient`, the divmod operations on UInt128/UInt256 exploit the fact that Mojo compiles to LLVM IR, where UInt128 division on 64-bit targets translates to one `___udivti3` library call. LLVM canonicalizes `a % b` to `sub(a, mul(udiv(a, b), b))` and CSE-deduplicates the shared `udiv` against the explicit `a // b`, so writing `// + %` already lowers to a single divmod (see plan §4.7 for the asm-level verification). Manual `value - truncated * divisor` rewrites do not help and on UInt64 are 2× slower.
-- The `number_of_bits` loop (§4.1) could be replaced by casting UInt128 to two UInt64s and using `count_leading_zeros` on the high word - this gives O(1) bit width instead of a 128-iteration loop (~96 in practice for Decimal128 coefficients).
-- Arrow's approach of promoting to 256-bit for multiply is directly applicable since we already have UInt256. Instead of the current 3×UInt32 partial-product approach in some code paths, we could do: `UInt256(x_coef) * UInt256(y_coef)`, then scale/truncate the result. This is simpler and likely just as fast since LLVM will optimize the wide multiply.
-
-In short: we already depend on UInt128/UInt256 for the core paths. The opportunity is to use them more consistently and eliminate the remaining manual multi-word arithmetic.
-
-### 2.6 Proposed: Steal Bits from Flags Word to Eliminate the Bound Mismatch
-
-The current 96-bit binary coefficient + 32-bit flags layout (mirroring `System.Decimal`) leaves **24 bits unused** in the flags word (only sign bit + 5-bit scale field are populated; bits 0–15 and 24–30 are unused). The "29 digits but leading 0–7" boundary problem in §2.1 is purely an artifact of holding the coefficient at 96 bits when the flags word has space to spare.
-
-**Proposal:** widen the coefficient field by stealing N unused bits from flags, eliminating the dual binary+decimal boundary check entirely.
-
-| Coefficient bits | Max coefficient |    Full digits | Bits stolen from flags | Wins                                                             |
-| ---------------- | --------------- | -------------: | ---------------------: | ---------------------------------------------------------------- |
-| 96 (today)       | 2^96 − 1        |       29 (0–7) |                      0 | Status quo; messy boundary                                       |
-| 97               | 2^97 − 1        |       30 (0–1) |                      1 | Marginal; still messy                                            |
-| **100**          | **10^30 − 1**   | **30 (clean)** |                      4 | **Eliminates §2 boundary; +1 digit precision over .NET/Rust**    |
-| **107**          | **10^32 − 1**   | **32 (clean)** |                     11 | **Real competitive edge: +3 digits over .NET/Rust, still clean** |
-| 110              | 2^110 − 1       |       33 (0–1) |                     14 | Diminishing returns                                              |
-
-**Recommended target: 107-bit coefficient → 10^32 − 1 (32 full digits, clean decimal bound).**
-
-Trade-offs:
-
-| Aspect                                      | Impact                                                                                                                                                                                                   |
-| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Eliminates §2 architectural concern         | ✓ — `fit_to_max_coefficient` becomes a single `digits ≤ 32` check; no more "binary bound + leading-digit check" combo.                                                                                   |
-| Beats .NET/Rust on precision                | ✓ — 32 full digits vs their 28-full-plus-0-to-7 ≈ 28.9 digits. A real, user-visible competitive advantage.                                                                                               |
-| Hot-path arithmetic perf                    | Zero impact — coefficient is already a `UInt128` internally (per §4.9.1 probe (2): `coefficient()` is `@always_inline` bitcast, ~0 ns).                                                                  |
-| `fit_to_max_coefficient` perf               | **Faster** — drops one of the two boundary checks. Called after every multiply / add-with-carry, so this compounds.                                                                                      |
-| `number_of_digits` semantics                | Cleaner — full 32-digit range, no leading-digit special case in tests.                                                                                                                                   |
-| Cache footprint / `TrivialRegisterPassable` | Unchanged — still 128 bits, still register-passable.                                                                                                                                                     |
-| Loses .NET binary-layout interop            | **Not material for decimo.** No C ABI exports; .NET `Decimal` itself isn't stable C-ABI-exposed; real interop happens via string / Arrow / Protobuf round-trip, none of which depend on internal layout. |
-| `from_words(low, mid, high, flags)` API     | Breaking change — `flags` layout shifts. Migration is mechanical but is a public-API break; bump to a major version.                                                                                     |
-| Scale field width                           | Could stay 5 bits (max 31) or widen to 6 bits (max 63) if we want symmetric scale range. Recommend keep at 5 bits (scale 0–31) to match precision.                                                       |
-| Phase 4 `normalize()` (§5.4)                | Easier — no leading-digit edge case to worry about.                                                                                                                                                      |
-| Test fixtures                               | TOML test cases are decimal-string-based and unaffected. Only `from_words` callers (none in production code; only `tests/test_*_from_words.mojo`) need updates.                                          |
-
-**Action items if accepted:**
-
-1. Define new flag-word layout: bits 0–106 = coefficient (across the existing 96-bit field + 11 stolen bits), bit 31 of flags = sign, bits 24–28 = scale (0–31), other bits reserved.
-2. Update `Decimal128.coefficient()`, `from_words()`, `from_uint128()`, scale getter/setter — all `@always_inline` bitcast paths.
-3. Replace `fit_to_max_coefficient`'s binary-bound check + leading-digit fix-up with a single decimal-digit-count check against 32.
-4. Drop the "29 digits but leading 0–7" wart from §1.1 and §2.1 documentation.
-5. Update `MAX_VALUE` constant and any tests asserting it.
-6. Re-run cross-language bench (§4.9.3) to confirm no perf regression on `add` / `mul` / `div`. **Expected: small speedup** on overflow-prone paths because `fit_to_max_coefficient` is simpler.
-7. Add a migration note to changelog (breaking: `from_words` flag layout, max coefficient widened).
-
-**Recommended priority: P5 (long-term nice-to-have).** This is a *polish* item, not a *competitive* item. Realistic landscape: decimo's audience is Mojo users (rust_decimal is pure Rust with no Mojo bindings; FFI-bridging it is impractical), and 28-digit precision already covers >99% of financial/accounting workloads. 32-digit precision is a clean architectural win that eliminates the §2 boundary wart and would simplify code, but it neither attracts new users nor closes any real gap. Defer until the perf workstream (§4.9) is fully landed and we have spare cycles for an architecturally clean breaking-change release. Until then, keep §2.6 as a documented design proposal, not a roadmap commitment.
-
-## 3. Correctness Bugs
-
-### 3.1 NaN/Infinity Implementation Was Broken (Removed) — Done
-
-File: `decimal128.mojo`. The NaN/Infinity support had multiple compounding bugs (mask mismatch, `is_zero()` returning True, no arithmetic propagation). Since no comparable 128-bit fixed-precision library supports NaN or Infinity (§1.2), we removed the support entirely. Operations that would produce undefined results now raise errors, matching C#, Rust, Arrow, and govalues. Removed: `NAN()`, `NEGATIVE_NAN()`, `INFINITY()`, `NEGATIVE_INFINITY()`, `NAN_MASK`, `INFINITY_MASK`, `is_nan()`, `is_infinity()` and their callers.
-
-### 3.2 `from_words` Uses `testing.assert_true` in Production Code — Done
-
-File: `decimal128.mojo`, lines ~344, 351. The function used `testing.assert_true` to validate arguments, which panics with a test-failure message rather than raising a recoverable error. Replaced with `raise Error(...)` for both scale and coefficient validation.
-
-### 3.3 Division Hardcodes Rounding Behavior — Open (Low)
-
-`arithmetics.mojo` `divide()` always uses banker's rounding (HALF_EVEN). Same as C#/Rust/Arrow/govalues for the `/` operator. If we ever want configurable rounding, add a `divide(x, y, rounding_mode)` overload. Low priority.
-
-### 3.4 `root()` Trailing-Zero Recovery Can Overflow `UInt128` — Open (Medium)
-
-File: `exponential.mojo`, in the exact-root recovery branch of `root(x, n)`.
-The branch evaluates `x_coef * power_of_10[uint128](n)` and compares it to
-`guess_coef ** n` to detect whether the n-th root is exact and trim a single
-trailing zero from `guess_coef`. Two problems:
-
-1. **`UInt128` overflow in `x_coef * 10^n`.** `Decimal128`'s coefficient is
-   96-bit (max `~7.92e28`), so the multiplication only stays within
-   `UInt128` (`< 2^128 ~= 3.4e38`) when `10^n < 2^128 / x_coef`. In the
-   worst case this allows only `n <= 9`. For `n in [10, 38]` the
-   multiplication can silently wrap, causing the equality check to either
-   accept a wrong "exact root" (false positive) or miss a real one (false
-   negative).
-2. **`guess_coef ** n` already uses unchecked exponentiation.** The same
-   branch raises `guess_coef` to the n-th power without overflow detection;
-   for large `n` and non-trivial `guess_coef` the result also wraps in
-   `UInt128`.
-
-Current PR-221 mitigation: the call site is guarded with `if n <= 38` so we
-at least don't read past the `power_of_10[uint128]` bisect tree. The
-multiplication overflow is **not** addressed.
-
-Suggested fix (out of scope for PR-221):
-
-- Compute the comparison in `UInt256` (using `power_of_10[uint256]`), which
-  has plenty of headroom (`2^256 ~= 1.16e77` vs. worst-case product
-  `~7.92e28 * 1e38 = 7.92e66`).
-- Or compute `guess_coef ** n` and `x_coef * 10^n` lazily and short-circuit
-  on detected overflow, falling through to the `return guess` path.
-- A broader audit of `root()` and `sqrt()` exact-recovery branches is
-  warranted; both rely on similar implicit-no-overflow assumptions.
-
-## 4. Performance Bottlenecks
-
-### 4.1 `number_of_bits()` Used a Loop — Done
-
-File: `utility.mojo`. The original implementation was an O(n)-bit while-loop over the input — up to 128 iterations on a generic `UInt128`. C#'s [`ScaleResult`](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Decimal.DecCalc.cs) uses `LeadingZeroCount`, which is a single hardware instruction.
-
-Fix: delegate to `std.bit.bit_width`, which lowers to LLVM's `count_leading_zeros` intrinsic (single-instruction for ≤64-bit, two CLZs for 128-bit). Now O(1) in bit width regardless of input. See §2.5 for the broader use of UInt128/UInt256 as an acceleration bridge.
-
-### 4.2 `power_of_10` Not Using Precomputed Constants Efficiently — Done
-
-File: `utility.mojo`. The function had hardcoded return values for n=0–32, but for n=33 onward it fell back to `ValueType(10) ** n` which computes via loop.
-
-Fix: extended hardcoded constants up to n=58 (max needed for UInt256 products of two 29-digit numbers). The cache layer remains for values beyond the hardcoded range, but in practice n ≤ 58 covers all Decimal128 arithmetic paths.
-
-### 4.3 `round_to_keep_first_n_digits` Lacked .NET-style Optimisations — Done
-
-File: `utility.mojo`. Two real inefficiencies vs .NET's [`ScaleResult`](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Decimal.DecCalc.cs):
-
-1. **Expensive half-comparison** — the cutoff `5 * power_of_10(n − 1)` required an extra power-of-10 lookup and a wide multiply. .NET instead compares `2 * remainder` against `divisor` (a single left-shift).
-2. **Redundant `number_of_digits` call** — always recomputed even when the caller already knew it.
-
-A third candidate ("replace `value % divisor` with `value - truncated * divisor`") was tried but the microbenchmark in §4.7 plus ARM64 asm inspection showed LLVM canonicalizes `urem` to `sub(a, mul(udiv, b))` and CSE-deduplicates the shared `udiv`, so `// + %` and `// + (a - q*b)` lower to identical code.
-
-Fix: introduced `round_coefficient(value, ndigits_to_remove, sign, rounding_mode)` with the half-comparison shortcut and explicit `ndigits_to_remove`. All 10 production callers migrated; old function deprecated. Also: hoisted `UInt256(x2_coef)` out of the long-division UInt256 loop (the only real win from the §4.7 investigation).
-
-### 4.4 `ln()` Range Reduction Uses Loops
-
-File: `exponential.mojo`, lines 727–746
-
-The `ln()` function reduces input to [0.5, 2.0) in two while-loop stages:
-
-```mojo
-# Step 1: divide-by-10 until 0.1 <= m < 10
-while m >= decimo.decimal128.constants.M10():
-    m = m / decimo.decimal128.constants.M10()
-    q += 1
-
-# Step 2: divide-by-2 until 0.5 <= m < 2
-while m >= decimo.decimal128.constants.M2():
-    m = m / decimo.decimal128.constants.M2()
-    p += 1
-```
-
-For `ln(1e28)`, Step 1 runs ~28 times (one division per decimal digit) and Step 2 runs ~3–4 more times. Each iteration is a full Decimal128 division - the most expensive primitive in the package.
-
-Fix: use the identity `ln(a × 10^q) = ln(a) + q × ln(10)` and read `q` directly from the input scale + a digit count, replacing Step 1 with a constant-time scale adjustment. Step 2 can be reduced by computing `bit_width(coefficient) − target_width` and dividing by the appropriate `power_of_2` in a single shot. Expected: ~30 divisions → 1 scale-fix + 1 division.
-
-This is now the highest-value remaining performance lever - `ln()` and `log10()` are the slowest non-divide primitives.
-
-### 4.5 Series Computations Cap at 500 Iterations
-
-File: `exponential.mojo`
-
-Both `exp_series` and `ln_series` loop up to 500 with convergence check `term.is_zero()`. In practice they converge in 30–60 iterations. The issue: `is_zero()` triggers only when the term underflows to exactly zero, which may require a few extra iterations beyond when the term is already too small to affect the result.
-
-Fix: break early if the term is smaller than 10^(−29) - it cannot change the result at our precision.
-
-### 4.6 `from_string` optimization
-
-`from_string` processes digits one at a time. File: `decimal128.mojo`, line 543.
-
-```mojo
-coef = coef * 10 + digit
-```
-
-Each iteration does a UInt128 multiply-by-10 and add.
-
-**Empirical baseline** (`temp/bench_from_string.mojo`, M-series Apple Silicon, 50_000 iters per sample, best of 3):
-
-| Input                                      | Release (`-D ASSERT=none`) | Debug (`-D ASSERT=all --debug-level=full`) |
-| ------------------------------------------ | -------------------------- | ------------------------------------------ |
-| `1234567890123456789012345678` (28 digits) | 56 ns/call                 | 70 ns/call                                 |
-| `12345.67890123456789012345`               | 53 ns/call                 | 66 ns/call                                 |
-| `0.0000000000000000000000001234`           | 54 ns/call                 | 71 ns/call                                 |
-| `-9999999999999999999999999999`            | 61 ns/call                 | 76 ns/call                                 |
-| `1.23456789e15`                            | 28 ns/call                 | 35 ns/call                                 |
-
-At ~50–70 ns/call for full-precision strings the absolute cost is already low. The digit-batching trick (group up to 9 digits into a UInt64 then one `coef * 10^k + batch` per chunk) is a clean 5–7× reduction on the inner loop and would bring us closer to rust_decimal's `FromStr` (~20–30 ns/call). Worth doing, but rank below §4.4 since `ln()`/`log10()` dominate end-to-end runtime in any real workload.
-
-A second, mostly-orthogonal cleanup: `Decimal128.from_string()` reimplements parsing logic that `str.parse_numeric_string()` (used by `BigDecimal.from_string()`) already covers. Switching to the shared scanner would shrink the surface area at no perf cost. Defer until after the digit-batching change so the perf delta is measurable.
-
-### 4.7 Division Loop: Separate `//` and `%` Operations (Investigated, No Change)
-
-File: `arithmetics.mojo`
-
-The long-division digit-extraction loop in `divide()` executes:
-
-```mojo
-digit = rem // x2_coef
-rem = rem % x2_coef
-```
-
-It looks like two separate 128-bit (or 256-bit) divisions on the same operands, so the natural "optimization" is the trick used in `round_coefficient` (§4.3): replace the second division with `rem - digit * x2_coef`.
-
-**Empirical microbenchmark** (`temp/bench_divmod.mojo`, M-series Apple Silicon, `--debug-level=line-tables -D ASSERT=none`, 200_000 iters per call, best of 3):
-
-| Type    | `q = a // b; r = a % b` | `q = a // b; r = a - q*b` | Winner                    |
-| ------- | ----------------------- | ------------------------- | ------------------------- |
-| UInt64  | **0.105 ms**            | 0.207 ms                  | `// + %` is **2× faster** |
-| UInt128 | 0.547 ms                | 0.519 ms                  | tied (within noise)       |
-| UInt256 | **0.660 ms**            | 0.690 ms                  | `// + %` is ~5% faster    |
-
-Why: inspecting `mojo build --emit=asm -O3` output on aarch64 (Apple Silicon) shows that for **both** patterns the compiler emits exactly one division - a single `___udivti3` library call for UInt128 (or one `udiv` instruction for UInt64) - followed by an inline `mul + sub` for the remainder. The mechanism is LLVM's `DivRemPairs` / instruction-combining pass: `urem(a, b)` is canonicalized to `sub(a, mul(udiv(a, b), b))`, and the shared `udiv` is then CSE-deduplicated against the explicit `a // b`. So writing `a % b` does **not** issue a second division; the manual `a - q * b` rewrite gives the compiler nothing extra and is strictly more source code to maintain.
-
-Reproduction recipe: write each pattern as an `@export fn` taking runtime (non-constant) inputs, build with `pixi run mojo build --emit=asm -O3 <file>.mojo -o <file>.s`, then `grep` the output for the function symbols and count `bl ___udivti3` / `udiv` instructions per body - both should appear exactly once.
-
-Note: the `// + %` pattern *is* the canonical way to access divmod in Mojo - there is no separate `divmod` primitive in `std`, and one is not needed.
-
-**Action taken:** kept the `// + %` form unchanged. The only related change was hoisting `UInt256(x2_coef)` out of the UInt256 loop into a single `x2_coef256` local, so the `UInt256(...)` lift no longer runs every iteration.
-
-The `round_coefficient` rewrite (§4.3) used to use the same `value - truncated * divisor` form on the same assumption; it has now been switched back to the natural `// + %` for consistency.
-
-### 4.8 Decimal128 Unit Test Suite Is Surprisingly Slow
-
-Empirical observation: running the Decimal128 suite via `pixi run test decimal128` takes several minutes - anecdotally slower than the heap-based BigDecimal suite. Wall-clock breakdown of representative files (M-series macOS, ASSERT=all + `--debug-level=full`, the flags used by `tests/test.sh`):
-
-| Test file                          | Real (s) | Reported per-test (s) | Cases |
-| ---------------------------------- | -------- | --------------------- | ----- |
-| `test_decimal128_arithmetics.mojo` | ~7       | 35.9 (test runner)    | 53    |
-| `test_decimal128_quantize.mojo`    | ~5       | 30.9 (test runner)    | ~6    |
-| `test_decimal128_from_string.mojo` | ~3       | 1.6                   | many  |
-| `test_decimal128_comparison.mojo`  | <1       | 0.018                 | 10    |
-| `test_decimal128_utility.mojo`     | <1       | 0.04                  | 8     |
-
-For comparison, `test_bigdecimal_arithmetics.mojo` runs in ~12 s real / 94 s reported under the same flags. So the per-test reported numbers from the mojo test runner are **inflated** vs. true wall-clock (likely include JIT/instrumentation overhead under `--debug-level=full`).
-
-Investigated bottlenecks (in priority order):
-
-1. **`-D ASSERT=all --debug-level=full` is 5–7× slower than release.**
-   Re-running `test_decimal128_arithmetics.mojo` with `-D ASSERT=none` and no debug flags drops wall-clock from 7.32 s to **1.06 s**. Most of the perceived slowness comes from these flags, which (a) emit full debug info, (b) compile every `debug_assert(...)` into a real branch (and `power_of_10` has many of them), and (c) prevent inlining of the UInt128/UInt256 operations that are everywhere on the hot path. UInt128/UInt256 are software-emulated on aarch64, so missed inlining is especially costly.
-   *Recommendation:* keep `-D ASSERT=all --debug-level=full` for CI, but add a fast inner-loop variant (`pixi run testfast` → `-D ASSERT=none` and `--debug-level=line-tables-only`) for development.
-
-2. **Per-file JIT compilation dominates short tests.**
-   `tests/test.sh` invokes `mojo run -I src ... <file>` once per test file. Each invocation re-parses the entire `decimo` package and JIT-compiles the test binary (≈ 0.5–1 s of fixed cost per file). With 17 Decimal128 files, that is 10–15 s of pure compile overhead before any test code runs.
-   *Recommendation:* either (a) build the test binaries with `mojo build` once and reuse them, or (b) consolidate small files into fewer test binaries. The `mojo test` discovery flow (single binary per package) would also fix this.
-
-3. **TOML parser walks the file char-by-char, allocating heavily.**
-   `parse_file` (`src/decimo/toml/parser.mojo:1033`) reads the entire file into a `String`, then `TOMLParser` scans it character-by-character. `expand_value` (`src/decimo/tests.mojo:213`) does additional `String += ch` concatenations inside `{C,N}` pattern expansion, each of which is an O(n) allocation. For TOML files in the hundreds of lines this is a measurable but secondary cost.
-   *Recommendation:* use a `StringBuilder`/byte buffer in `expand_value` instead of `+=` on `String`. Lower priority than (1) and (2).
-
-4. **TOML re-parsing within a file (lower priority once 1+2 are addressed).**
-   Inside `test_decimal128_from_string.mojo`, the suite is reasonably structured (one `parse_file` call shared via `_run_unary_section`), but other files (e.g. `test_decimal128_arithmetics.mojo`) call `parse_file` once at the top of each test function. With 5 test functions in arithmetics, that's 5 disk reads + 5 parses of the same TOML file per process.
-   *Recommendation:* hoist `parse_file(file_path)` into a module-level cache, or pass the parsed `TOMLDocument` into a helper that runs all sections.
-
-5. **`Python.import_module("decimal")` per test function.**
-   `test_decimal128_arithmetics` imports `decimal` once in its body, but several other files (and the failure-path `pydecimal.Decimal(...)` calls) repeatedly cross the FFI boundary. Each Python interop call has ~µs overhead and triggers GIL acquisition. Only relevant on failure paths today; impact is small.
-   *Recommendation:* keep Python comparisons strictly to failure-debug output; don't add them to hot loops.
-
-6. **`Dec128(string)` (i.e. `from_string`) is the inner-loop allocator.**
-   Every TOML test row constructs `Dec128(test_case.a)` + `Dec128(test_case.b)`. Each call walks the input byte-by-byte, doing one UInt128 multiply-add per character (see §4.6). For 53 arithmetic test cases × 2 operands × ~10 chars = ~1000 multiply-adds before any *actual* arithmetic happens. Fixing §4.6 (digit batching) would directly speed up the test suite.
-
-7. **Misleading internal timer.**
-   The `PASS [ NN.NNN ]` value emitted by Mojo's test runner does not match `/usr/bin/time` wall-clock - it appears to include compilation/instrumentation cost rather than pure execution time. This makes `test_decimal128_arithmetics` look pathologically slow (35 s reported) when the actual run is ~7 s. Worth keeping in mind when prioritising - the test code itself isn't as bad as the runner suggests; the test *infrastructure* (flags + per-file JIT) is.
-
-Combined fix priority for Phase 3: (1) split the inner-loop dev workflow from the CI flags, (2) consolidate/cached TOML parsing, (3) attack `from_string` (§4.6) since it has independent value beyond tests.
-
-### 4.9 Per-Operation Arithmetic Overhead vs Other Libraries (Top Priority)
-
-Direct head-to-head benchmark (`temp/bench_decimo.mojo` vs `temp/rust_compare/`, both built `--release` / `-D ASSERT=none`, 200_000 iters per op, best of 5, M-series Apple Silicon):
-
-| Operation                             | rust_decimal | decimo.Decimal128 | decimo / rust |
-| ------------------------------------- | ------------ | ----------------- | ------------- |
-| `add` (two mid-scale operands)        | **22 ns**    | 624 ns            | **28×**       |
-| `mul` (two mid-scale operands)        | **25 ns**    | 754 ns            | **30×**       |
-| `div` (mid-scale dividend / divisor)  | **33 ns**    | 809 ns            | **25×**       |
-| `to_string` (mid-scale 25-char value) | **69 ns**    | 515 ns            | 7.5×          |
-| `cmp` (two close values)              | **2 ns**     | 13 ns             | 6×            |
-
-> Let's keep this table with the original numbers for comparison. After each optimization step, we add a new table below with the updated numbers. We also have a brief table whose columns are historical decimo/rust ratios, so we can track the improvement over time.
-
-This is far worse than the “~2× gap” the plan previously assumed. The from_string gap (§4.6) is small (~2–3×); the arithmetic gap is the real story and overshadows every other perf item in the plan.
-
-**Hypothesised causes** (must be confirmed with profiling before attacking):
-
-1. ~~**`coefficient()` reconstructs UInt128 from 3×UInt32 on every call.** `add`/`subtract`/`multiply`/`compare` all start with at least two `coefficient()` calls. Rust stores the coefficient as a single 96-bit field that bitcasts directly. We should add an `@always_inline` direct-load fast path~~or store the coefficient as `UInt128` natively (with the flags packed elsewhere)~~. Bitcast the 4 UInt32 words to a single UInt128 and mask off the sign/scale bits in one shot, then use that UInt128 directly in the operators instead of working on the three UInt32s and reconstructing UInt128 repeatedly. I think this is the single biggest low-hanging fruit on the hot path.~~
-2. **`raises` overhead on every operator.** `__add__`, `__mul__`, `__truediv__` are all `raises` even when overflow is impossible. Rust’s `+`/`*`/`/` are infallible (panicking) by default and `checked_*` is opt-in. Each `raises` call adds an error-pointer setup + branch. Add a non-raising fast path that assumes no overflow and panics if the assumption is violated (matching Rust default). For example, `add_unchecked` that assumes no overflow, then `add` that calls `add_unchecked` and checks for overflow in debug but not in release. The primary win is removing `raises`; `@always_inline` is an optional secondary win to ensure call overhead doesn’t eat the savings on the integer fast path — measure first and add only if the inliner doesn’t pick it up.
-3. **Scale alignment uses `power_of_10(diff)` lookups + a wide multiply** even when scales already match. Add a `if scale_a == scale_b` short-circuit at the top of `add`.
-4. **Multiply always promotes to UInt256** even when `coef_a * coef_b` provably fits in UInt128 (which is most cases for 14-digit-ish inputs). Add a UInt128 fast path with overflow check.
-5. **Divide uses a long-division digit loop in Mojo**; rust_decimal uses a UInt128 hardware divide for the common case. Adopt the same fast path.
-6. **`to_string` likely allocates a `String` builder per call.** rust_decimal uses a stack `[u8; 32]` buffer. We can do the same with `InlineArray[UInt8, 64]` and a single `String(bytes)` at the end.
-
-**Empirical Decomposition** (`temp/bench_decompose.mojo`) [§4.9.1]
-
-Each row isolates one suspected cost (1_000_000 iters/op, best of 5, same machine/build flags):
-
-| Probe                                       | ns/op    | Notes                                                              |
-| ------------------------------------------- | -------- | ------------------------------------------------------------------ |
-| (1) raw `UInt128 + UInt128`                 | **~0**   | Loop fully constant-folded by LLVM                                 |
-| (2) 2× `Decimal128.coefficient()`           | **~0**   | `@always_inline` bitcast - already optimal at this site            |
-| (3) 2× `Decimal128.is_integer()`            | **~250** | Each call is `coefficient % power_of_10[scale]` - full UInt128 mod |
-| (4) `Decimal128.from_uint128(value, 20, 0)` | **~1.6** | Basically free                                                     |
-| (5) `add()` same scale (20,20)              | **~691** | = 2 × `add` calls per iter ⇒ **~345 ns per add**                   |
-| (6) `add()` different scale (20,10)         | **~647** | UInt256 promotion path (~324 ns/call)                              |
-| (7) `add()` integers (scale 0,0)            | **9**    | **Faster than rust_decimal's 22 ns** - fast path is excellent      |
-| (8) `mul()` integers (scale 0,0)            | **8**    | **Faster than rust_decimal's 25 ns**                               |
-| (9) `mul()` fractional (12,12)              | **~802** | UInt256 promotion + scale rebalance                                |
-
-#### 4.9.2 Marginal-Value Ranking (Validated Against Decomposition)
-
-Mapped against the hypotheses above, ranked by **measured ns saved per fractional add()**:
-
-| Rank | Hypothesis (H#x.y from §4.9.1)               | Evidence                | Marginal value         | Verdict / next action                                                                                                         |
-| ---- | -------------------------------------------- | ----------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| 1    | H#3.1 `is_integer()` × 2 wastes UInt128 mod  | (3)=250ns, ¬(7)         | ~125 ns / add          | ✓ **DONE 20260421** — three-step landing; see notes below                                                                     |
-| 2    | H#2 `def raises` operators not inlined       | (5)−(3)−rest ≈ 80 ns    | 40-80 ns / add         | **Likely.** Add non-raising `add_unchecked`; `__add__` calls it (consider `@always_inline` if the inliner doesn’t pick it up) |
-| 3    | H#4 UInt256 promotion in `mul` when fits 128 | (9)=802ns, prod<2^96    | ~200 ns / mul          | **Confirmed.** `__umulh` high-half check; promote only on overflow                                                            |
-| 4    | H#3 UInt256 promotion in `add` (diff scale)  | (6)≈(5)                 | ~30-50 ns              | Marginal; after #1–#3                                                                                                         |
-| 5    | H#5 divide long-division loop                | div=809ns total         | TBD ~200-400ns         | Probe divide-only decomposition first                                                                                         |
-| 6    | H#6 `to_string` per-call allocation          | 515 ns vs rust 69       | ~300 ns / call         | **Confirmed.** Stack `InlineArray[UInt8,64]` + single `String` build                                                          |
-| 7    | H#1 `coefficient()` reconstruction           | (2)≈0 ns                | ~0 ns ✗                | **Disproven** for `add`/`mul` hot path; native UInt128 field separate                                                         |
-| 8    | `from_uint128()` raises/check overhead       | (4)=1.6 ns              | ~0 ns ✗                | **Disproven.** Don't touch                                                                                                    |
-| 9    | H#4.1 `is_integer()` branch in `multiply()`  | bench: 548-759 → 5-6 ns | ~550-750 ns/mul on hit | ✓ **DONE (this PR)** — branch removed; see notes below                                                                        |
-
-**Notes for #1 (three-step landing):**
-
-- **(a) Hoist the same-scale branch above the `is_integer` branch in `add()`** (`arithmetics.mojo`, commit `ee1c0db`). Correctness preserved (`coefficient + coefficient < MAX_AS_UINT128`, `x1.scale == x2.scale`); `subtract()` benefits transitively via `x1 + (-x2)`. Add median 106 → 5 ns/iter (~21×); sub median 123 → 6 ns/iter (~20×). Report: `dec128_report_20260421_203452.md`.
-- **(b) Cheap pre-check in `is_integer()`** (`decimal128.mojo`, commit `63c0445`). Test `(self.low & ((1 << scale) - 1)) != 0` fast-rejects on divisibility-by-`2^scale` before the full UInt128 `% 10^scale` (max scale 28 fits in the low UInt32). Initially measured against `add()` (`Mixed magnitudes` 121 → 14 ns), but step (c) below later removed all `is_integer()` calls from `add()`. The pre-check is still useful for **`multiply()`** (which still has an `is_integer` branch) and for any external caller of the public `is_integer()` API, so it stays. Report: `dec128_report_20260421_205835.md`.
-- **(c) Remove the `is_integer` branch from `add()` entirely** (`arithmetics.mojo`, implemented in this PR). Branch dispatch costs ~250 ns even with the (b) pre-check, while the UInt256 fall-through costs only ~110 ns — the branch was a net loss even when triggered. Three new `Both integer, different scale` cases added to `add.toml` and `subtract.toml`. Those cases drop 121-136 → 6-14 ns (~10-20×); the existing `Different scales` case drops 109 → 7 ns (~15×) because `is_integer()` is no longer dispatched on the no-integer path either. Report: `dec128_report_20260421_211510.md`.
-
-**Notes for #9 (H#4.1 — `is_integer()` branch in `multiply()`):**
-
-- **Removed in this PR** (`arithmetics.mojo`). The branch was symmetric to #1(c) but worse: dispatch needed two `is_integer()` calls (~125 ns each even with the cheap pre-check), then promoted the integral parts into UInt256 and did a UInt256 multiply + UInt256 power-of-10 rescale. Total cost on the "Both integer, different scale" cases was 548-759 ns/iter. Removing it lets the same inputs fall through to the existing `combined_num_bits <= 96` UInt128 fast path: the integral parts already share all the trailing zeros that disappear during rounding, so no precision is lost. Three new cases added to `multiply.toml`; measured 548-759 → 5-6 ns/iter (~100×). No regression on the other 13 multiply cases. Tests: `tests/decimal128/test_decimal128_multiply.mojo` (4/4 PASS) plus full per-file regression sweep on the other dec128 tests.
-- **Companion cleanup in `multiply()`:** the `combined_num_bits <= 96 / combined_scale > MAX_SCALE` arm contained dead code: after `min(MAX_SCALE, combined_scale)` clamps, the subsequent `if final_scale > MAX_SCALE` second-pass-rounding branch was unreachable. Removed. (The same pattern in the `<= 128` and `> 128` arms is *not* dead because `final_scale = combined_scale - digits_removed` can still exceed `MAX_SCALE` there.)
-- **Companion micro-opt in `round_coefficient` / `fit_to_max_coefficient`:** added a comptime `skip_digit_check: Bool = False` parameter to `round_coefficient`; `fit_to_max_coefficient` instantiates with `True` because it has just computed `ndigits = number_of_digits(value)` and `digits_to_remove = ndigits - 29 < ndigits`, making the inner `ndigits_to_remove > number_of_digits(value)` guard provably false. The `@parameter if not skip_digit_check` branch is constant-folded away. Saves one `number_of_digits` call (~50 ns on UInt256) on every multiply that hits `combined_num_bits > 96`. Measured: `High precision multiplication` 256 → ~232 ns/iter (~10% on this hot case). The `e * e^0.5` and `Product overflows precision` cases were within run-to-run noise; treated as neutral. All hot callers from `decimal128.mojo`, `rounding.mojo`, and the divide/exp_ln paths still default to `skip_digit_check=False` (the safe behaviour), so no other call site is affected.
-- **Investigated but not landed:** an `InlineArray`-based LUT for `power_of_10[uint128|uint256]` (currently an if/elif tree of literals). A standalone probe with an opaque runtime `n` showed the if-tree at ~120 ns/call vs LUT at ~0 ns. However in the actual multiply hot path the LUT version slightly *regressed* the heavy cases (`High precision` 256 → 273 ns, `e * e^0.5` 346 → 413 ns, `Product overflows` 231 → 270 ns). Root cause as already documented in `utility.mojo`: Mojo currently lacks module-level mutable variables, so the comptime `alias TABLE = _build_power_of_10_table[dtype]()` is materialised per inlined call site as a 79 × 32-byte global; with `power_of_10` invoked from many sites in `round_coefficient` / `fit_to_max_coefficient`, this bloats the icache and the runtime-`n` indexed load can't be hoisted, whereas the if-tree's literal returns let LLVM keep results in registers across multiple invocations on the same `n`. **Verdict: not worth landing today**; revisit when Mojo gains module-level cached variables (one shared LUT per `dtype`). Tracked here so the next pass starts from this measurement.
-
-- **Real culprit found 20260422 — `String.format()` inside `debug_assert(...)` is eagerly evaluated even with `-D ASSERT=none`.** Re-investigating the LUT regression above with `--emit=asm`, the supposedly-empty `debug_assert(False, "msg {}".format(n))` lines in `power_of_10[uint128]` / `power_of_10[uint256]` were emitting `KGEN_CompilerRT_AlignedAlloc` + `String.write` + `String._iadd` calls into the hot loop — ~115 ns/call of pure allocation overhead, dwarfing the ~5 ns LUT/if-tree decision. Fix: drop `.format(n)` from the bound-check messages (the bound is a compile-time-known constant per `@parameter` branch, so the message has no runtime info to encode). Microbench: power_of_10 standalone cost 115 → 1.3 ns/call (~88×). Cross-op multiply max collapsed from 339 → 262 ns/iter; divide max 361 → 307 ns/iter — both because `power_of_10` sits on those hot paths through `round_coefficient` / `fit_to_max_coefficient`. The same audit found two more `debug_assert(... + String(rounding_mode))` sites in `utility.mojo` (`round_coefficient` / `round_to_keep_first_n_digits` unreachable `else` branches); fixed identically. **LUT representation re-evaluated after the fix:** with the `.format()` overhead removed, both the if-tree and a string-literal-rodata bitcast LUT (~1.3 ns/call) deliver near-equal end-to-end multiply numbers, so the codebase keeps the more elegant balanced **bisect if/else tree** (depth ~5/6, ~85/175 lines for u128/u256) instead of the ugly bitcast trick. **Reproducer for the Mojo team:** `/tmp/repro_debug_assert_format.mojo` shows the `.format()` form is 56× slower than a bare string literal under `-D ASSERT=none`. Worth filing upstream — `debug_assert` should treat its message argument as lazy (e.g. wrap in a closure or `@parameter` lambda).
-- **Investigated but not landed (H#4 itself):** the original H#4 hypothesis was "skip UInt256 promotion when the actual product fits in UInt128" via a `__umulh`-style high-half check. After analysing the real bench distribution, the slow cases (`High precision multiplication`, `e * e^0.5`, `Product overflows`) all have `combined_num_bits` ≥ 186, so the actual product is genuinely 180+ bits and *cannot* fit in UInt128 — the UInt256 promotion is mandatory there. The only inputs that would benefit are those with `combined_num_bits ∈ [129, 130]` where the bit-count upper-bound is loose by one; none of the bench cases land in that window, so the saving would be invisible. **Verdict: deprioritised** — the productive multiply optimisations are in `round_coefficient` (number-of-digits / power-of-10), not in the multiply itself.
-
-**Action plan (Phase 3, supersedes prior §4.9 priority - re-ordered by validated marginal value):**
-
-1. **Cheap `is_integer` pre-check or restructure** (P1, ~125 ns/add saved). Either short-circuit `is_integer` on a low-bit-chunk test before the full UInt128 mod, **or** simply move the `same scale` branch above the `is_integer` branch in `add()` - the same-scale UInt128 path already correctly handles two integers with positive scale.
-2. **Non-raising `add_unchecked` / `mul_unchecked` fast path** (P1, ~40-80 ns/op saved). Non-raising `fn` covering the same-scale-fits-in-UInt128 case; have `def add` call it and only enter the slow path on detected overflow. `@always_inline` optional — add only if benchmarks show the call overhead is not eliminated by the default inliner.
-3. **UInt128-only `multiply` fast path** (P1, ~200 ns/mul saved). Use `__umulh`-style intrinsic; if high-64 of the 128×128→256 product is zero, the result fits and we skip UInt256 entirely.
-4. **`to_string` inline buffer** (P2, ~300 ns/call saved). Replace per-call `String` builder with a 64-byte stack buffer, single final `String(StringSlice(buf))`.
-5. **Probe `divide`** (P2). Add probes (10)-(11) to `bench_decompose.mojo` to isolate the long-division-loop cost before refactoring.
-6. **Same-scale early return in `add()`** (P3, ~30 ns/add when applicable). Add `if x1_scale == x2_scale: return _add_same_scale(...)` near the top - covered for free if action #1 restructures.
-7. Re-run both benchmarks after each change. Targets: add ≤ 80 ns, mul ≤ 100 ns, div ≤ 200 ns, to_string ≤ 150 ns.
-
-This is now the **single highest-value perf workstream** in the plan - ahead of §4.4 (`ln()`) and §4.6 (`from_string`). The good news the decomposition reveals: integer fast paths are already faster than rust_decimal, so the architecture works; we just need to apply the same care to the fractional path.
-
-#### 4.9.3 Historical Performance Tracking (Cross-Library Median ns/iter)
-
-Numbers come from `benches/decimal128/run_all.sh`. The bench harness times each case as **best-of-5** runs (each run = `iters` back-to-back ops in a tight
-loop with `black_box`/optimiser barriers). The two columns reported per op are then computed across all TOML cases for that op:
-
-- **median** ns/iter = median of the per-case best-of-5 numbers (typical case).
-- **max** ns/iter = slowest per-case best-of-5 number (worst case — useful because the long tail is what the next round of optimisation should attack).
-
-`dm/rs` = decimo / rust_decimal ratio (>1 means decimo is slower). After each optimisation landing, append a new row — do **not** edit prior rows. The **absolute** table tracks decimo timings; the **worst-case** table mirrors it with maxima; the **ratio** table tracks the competitive position.
-
-**Absolute decimo median ns/iter (lower = faster):**
-
-| date     | report                             |  add |  sub |  mul |  div |  cmp | from_str | to_str | note                                                             |
-| -------- | ---------------------------------- | ---: | ---: | ---: | ---: | ---: | -------: | -----: | ---------------------------------------------------------------- |
-| 20260421 | `dec128_report_20260421_112354.md` |  106 |  123 |    4 |    8 |    0 |    24.25 | 128.30 | Before any optimisations                                         |
-| 20260421 | `dec128_report_20260421_203452.md` |    5 |    6 |    4 |    8 | 2.10 |    24.15 | 127.00 | After H#3.1 `add()` reorder                                      |
-| 20260421 | `dec128_report_20260421_205835.md` |    5 |    6 |    5 |    8 | 2.10 |    22.45 | 126.60 | After H#3.1 `is_integer()` cheap pre-check                       |
-| 20260421 | `dec128_report_20260421_211510.md` |    5 |  6.5 |    6 |    9 | 2.10 |    21.80 | 129.60 | After H#3.1 `is_integer` branch removed from `add`               |
-| 20260422 | `dec128_report_20260422_071048.md` |    5 |    7 |    5 |    8 | 2.10 |    23.10 | 124.30 | After H#4.1 `is_integer` branch removed from `mul`               |
-| 20260422 | `dec128_report_20260422_085601.md` |    5 |    7 |    9 |    9 | 2.10 |    28.20 | 134.60 | After removing `format` from `debug_assert` + bisect if/else LUT |
-| 20260422 | `dec128_report_20260422_124242.md` |    5 |    6 |    5 |    8 | 2.10 |    22.65 | 136.00 | After Granlund-Möller UInt256 / 10^k                             |
-| 20260422 | `dec128_report_20260422_200239.md` |    4 |    4 |    — |    — |    — |        — |      — | After H#11 hot-path-first single-function `add`/`sub`            |
-| 20260422 | `dec128_report_20260422_210555.md` |    4 |    4 |    5 |    9 | 2.10 |    25.20 | 119.20 | After H#3 sub diff-scale fully inlined + mul `@always_inline`    |
-| 20260422 | `dec128_report_20260422_212851.md` |    4 |    4 |    4 |    8 | 2.10 |    26.00 |  82.70 | After H#5 divide two-phase: probe + UInt256/u64 schoolbook       |
-| 20260422 | `dec128_report_20260422_220148.md` |    3 |    3 |    4 |    6 | 2.00 |    23.30 | 122.40 | After H#14 `power_of_10_unsafe` sweep + `from_uint128` inline    |
-
-**Worst-case (max across cases) decimo ns/iter (lower = faster):**
-
-| date     | report                             |  add |  sub |  mul |  div |   cmp | from_str | to_str | note                                                             |
-| -------- | ---------------------------------- | ---: | ---: | ---: | ---: | ----: | -------: | -----: | ---------------------------------------------------------------- |
-| 20260421 | `dec128_report_20260421_203452.md` |  121 |  121 |  500 |  359 | 18.10 |   177.60 | 586.70 | After H#3.1 `add()` reorder                                      |
-| 20260421 | `dec128_report_20260421_205835.md` |  109 |  111 |  359 |  371 | 18.30 |   182.30 | 596.80 | After H#3.1 `is_integer()` cheap pre-check                       |
-| 20260421 | `dec128_report_20260421_211510.md` |   14 |   15 |  339 |  361 | 18.20 |   185.80 | 587.30 | After H#3.1 `is_integer` branch removed from `add`               |
-| 20260422 | `dec128_report_20260422_071048.md` |   16 |   16 |  335 |  356 | 19.10 |   175.60 | 578.30 | After H#4.1 `is_integer` branch removed from `mul`               |
-| 20260422 | `dec128_report_20260422_085601.md` |   17 |   16 |  262 |  307 | 19.80 |    68.40 | 577.90 | After removing `format` from `debug_assert` + bisect if/else LUT |
-| 20260422 | `dec128_report_20260422_124242.md` |   14 |   15 |   22 |  257 | 17.40 |    65.30 | 554.50 | After Granlund-Möller UInt256 / 10^k                             |
-| 20260422 | `dec128_report_20260422_200239.md` |   14 |   14 |    — |    — |     — |        — |      — | After H#11 hot-path-first `add`/`sub`                            |
-| 20260422 | `dec128_report_20260422_210555.md` |   14 |   15 |   22 |  287 |  20.1 |     70.2 |  591.2 | After H#3 sub diff-scale fully inlined + mul `@always_inline`    |
-| 20260422 | `dec128_report_20260422_212851.md` |   16 |   17 |   27 |   56 |  19.2 |     74.7 |  608.3 | After H#5 divide two-phase: probe + UInt256/u64 schoolbook       |
-| 20260422 | `dec128_report_20260422_220148.md` |   13 |   14 |   25 |   45 |  18.0 |     67.6 |  583.7 | After H#14 `power_of_10_unsafe` sweep + `from_uint128` inline    |
-
-The mul max barely moves (339 → 335 ns) because the worst case is now
-`High precision multiplication` / `e * e^0.5` / `Product overflows`, all of
-which have `combined_num_bits ≥ 186` and so genuinely need the UInt256
-`round_coefficient` pipeline (~120 ns of which is the runtime-`n`
-`power_of_10[uint256]` if-tree). The H#4.1 branch removal helped the
-*previously slow* "Both integer, different scale" cases: they collapsed from
-548–759 ns to 5–6 ns and now sit at the median, not the max — so the max
-column reveals what the median hides.
-
-**Decimo / competitor ratio (>1 = decimo slower; <1 = decimo faster):**
-
-| date     | op       | dm/rust | dm/csharp | dm/vbnet | notes                                                         |
-| -------- | -------- | ------: | --------: | -------: | ------------------------------------------------------------- |
-| 20260421 | add      |   21.2x |     43.1x |    59.2x | Before any optimizations                                      |
-| 20260421 | sub      |   61.5x |     59.0x |    68.7x | Before any optimizations                                      |
-| 20260421 | mul      |    1.6x |      2.9x |     4.4x | Before any optimizations                                      |
-| 20260421 | div      |    1.4x |      0.5x |     1.5x | Before any optimizations                                      |
-| 20260421 | cmp      |    0.0x |      0.0x |     0.0x | Before any optimizations                                      |
-| 20260421 | from_str |    2.6x |      0.7x |     0.7x | Before any optimizations                                      |
-| 20260421 | to_str   |    3.6x |      4.2x |     4.3x | Before any optimizations                                      |
-| 20260421 | add      |    2.2x |      2.0x |     2.7x | After H#3.1 `add()` reorder                                   |
-| 20260421 | sub      |    2.1x |      3.1x |     3.1x | After H#3.1 `add()` reorder                                   |
-| 20260421 | mul      |    1.8x |      2.6x |     3.6x | After H#3.1 `add()` reorder                                   |
-| 20260421 | div      |    1.4x |      0.6x |     1.4x | After H#3.1 `add()` reorder                                   |
-| 20260421 | cmp      |    0.8x |      1.4x |     1.1x | After H#3.1 `add()` reorder                                   |
-| 20260421 | from_str |    2.4x |      0.7x |     0.7x | After H#3.1 `add()` reorder                                   |
-| 20260421 | to_str   |    3.5x |      4.3x |     4.1x | After H#3.1 `add()` reorder                                   |
-| 20260421 | add      |    2.2x |      2.0x |     2.8x | After H#3.1 `is_integer()` pre-check                          |
-| 20260421 | sub      |    2.9x |      2.8x |     2.7x | After H#3.1 `is_integer()` pre-check                          |
-| 20260421 | mul      |    1.9x |      3.0x |     4.6x | After H#3.1 `is_integer()` pre-check                          |
-| 20260421 | div      |    1.5x |      0.6x |     1.3x | After H#3.1 `is_integer()` pre-check                          |
-| 20260421 | cmp      |    0.8x |      1.4x |     1.1x | After H#3.1 `is_integer()` pre-check                          |
-| 20260421 | from_str |    2.4x |      0.6x |     0.6x | After H#3.1 `is_integer()` pre-check                          |
-| 20260421 | to_str   |    3.5x |      4.4x |     4.3x | After H#3.1 `is_integer()` pre-check                          |
-| 20260421 | add      |    1.5x |      2.2x |     1.9x | After H#3.1 `is_integer` branch removed from `add()`          |
-| 20260421 | sub      |    3.3x |      3.6x |     2.9x | After H#3.1 `is_integer` branch removed from `add()`          |
-| 20260422 | mul      |    2.3x |      3.7x |     4.4x | After H#4.1 `is_integer` branch removed from `mul()`          |
-| 20260422 | div      |    1.6x |      0.6x |     1.5x | After H#4.1 `is_integer` branch removed from `mul()`          |
-| 20260422 | mul      |    1.8x |      3.8x |     4.4x | After G-M UInt256 / 10^k                                      |
-| 20260422 | add      |    1.3x |      1.7x |     1.5x | After H#11 hot-path-first `add`/`sub`                         |
-| 20260422 | sub      |    2.0x |      1.9x |     1.7x | After H#11 hot-path-first `add`/`sub`                         |
-| 20260422 | add      |    1.1x |      1.5x |     1.3x | After H#3 sub diff-scale fully inlined + mul `@always_inline` |
-| 20260422 | sub      |    1.7x |      1.6x |     1.5x | After H#3 sub diff-scale fully inlined + mul `@always_inline` |
-| 20260422 | mul      |    1.9x |      4.6x |     4.2x | After H#3 sub diff-scale fully inlined + mul `@always_inline` |
-| 20260422 | div      |    1.6x |      0.7x |     1.7x | After H#3 sub diff-scale fully inlined + mul `@always_inline` |
-| 20260422 | add      |    1.2x |      2.0x |     2.0x | After H#5 divide two-phase: probe + UInt256/u64 schoolbook    |
-| 20260422 | sub      |    1.7x |      2.2x |     2.0x | After H#5 divide two-phase: probe + UInt256/u64 schoolbook    |
-| 20260422 | mul      |    1.7x |      3.0x |     3.5x | After H#5 divide two-phase: probe + UInt256/u64 schoolbook    |
-| 20260422 | div      |    2.2x |      1.3x |     1.3x | After H#5 divide two-phase: probe + UInt256/u64 schoolbook    |
-| 20260422 | add      |    0.8x |      1.3x |     1.2x | After H#14 `power_of_10_unsafe` sweep + `from_uint128` inline |
-| 20260422 | sub      |    1.3x |      1.2x |     1.7x | After H#14 `power_of_10_unsafe` sweep + `from_uint128` inline |
-| 20260422 | mul      |    1.7x |      3.0x |     3.6x | After H#14 `power_of_10_unsafe` sweep + `from_uint128` inline |
-| 20260422 | div      |    1.0x |      0.5x |     1.0x | After H#14 `power_of_10_unsafe` sweep + `from_uint128` inline |
-
-Observations from the 20260421 baseline:
-
-- `add`/`sub` are the worst gaps — fractional-scale paths dominate (consistent with §4.9.1 decomposition).
-- `mul` is already within 2–3× — the integer fast path lands cleanly; gap is only on UInt256-promoting cases.
-- `div` already beats C# (`dm/cs = 0.5x`) — our long-division Mojo loop is competitive with .NET.
-- `cmp` is essentially free for decimo (rounds to 0 ns/iter) — already faster than all three.
-- `to_str` gap is purely allocator-driven (per-call `String` builder) — §4.9.2 action #4 directly targets this.
-
-Observations from the `203452` run (after H#3.1 `add()` reorder — `same-scale` branch hoisted above `is_integer()` to avoid two UInt128 modulus operations on the common path; `subtract()` benefits transitively because it shares the `add()` core):
-
-- **`add` median: 106 → 5 ns/iter (~21× faster)**, decimo ratio vs rust collapses from 21.2× to 2.2× — now within striking distance of native implementations on the same-scale path.
-- **`sub` median: 123 → 6 ns/iter (~20× faster)**, ratio vs rust 61.5× → 2.1× (largest single relative improvement in the table).
-- **`cmp` reported as 2.10 ns/iter** instead of the previous 0.0 — the prior 0.0 was a measurement artefact (constant folding); the optimiser-barrier work in `_bench_one` now produces honest numbers, and decimo is still competitive (`dm/rs = 0.8x`).
-- `mul`, `div`, `from_str`, `to_str` are unchanged because no code change touched their hot paths; the next priorities are §4.9.2 actions #2 (non-raising fast path) and #3 (UInt128-only `multiply`).
-- The remaining add/sub gap is dominated by **different-scale cases** (`Different scales`: 115 ns; `Mixed magnitudes`: 121 ns) — these still take the UInt256 path and are §4.9.2 action #6 (a separate same-scale-is-cheaper-than-different optimisation).
-
-Observations from the `205835` run (after the `is_integer()` cheap pre-check landed in `decimal128.mojo` — a `(self.low & ((1 << scale) - 1)) != 0` test fast-rejects on divisibility-by-`2^scale` before falling back to the full UInt128 `% 10^scale` modulus):
-
-- **`add` `Mixed magnitudes`: 121 → 14 ns (~8.6× faster)** — this is the case where one operand (`0.000000001`) has `low=1, scale=9, mask=0x1FF`, and the bottom-bit AND fast-rejects without any modulus. The `is_integer()` short-circuit (`x1 and x2`) then skips the second operand entirely, saving the full ~125 ns mod that previously dominated this case.
-- **Median timings unchanged at the table level** (add=5, sub=6) because the median is already pinned by the same-scale fast path landed in the previous run; the win is concentrated in the long tail of cases that still reach `is_integer()`.
-- **`Different scales` (109 ns) and the `subtract` different-scale case (111 ns)** are roughly flat vs the previous run — these cases reach the UInt256 promotion regardless of `is_integer()`, so the remaining ~110 ns is now genuinely the UInt256 promotion cost (§4.9.2 action #6 territory).
-- `from_str` improved 24.15 → 22.45 ns (~7%) and `to_str` 127.00 → 126.60 ns; these are noise-level fluctuations as no code path was touched.
-- Result equivalence preserved: add 11/11, sub 11/11, no new mismatches.
-
-Observations from the `211510` run (after the third sub-step — the `elif x1.is_integer() and x2.is_integer():` branch was removed entirely from `arithmetics.mojo` `add()`, with the previously-tracked benches augmented by three new "Both integer, different scale" cases (small / medium / wide gap) added to both `add.toml` and `subtract.toml`):
-
-- **The `is_integer` branch was a NET LOSS even when triggered.** The branch dispatch alone called `is_integer()` twice (~250 ns, even with the cheap pre-check) and then performed extra UInt128 arithmetic + power-of-10 multiply, while the UInt256 fall-through path costs only ~110 ns end-to-end. Removing the branch is therefore a strict win — both for the cases it used to catch *and* for the cases that fell through it.
-- **New `Both integer, different scale` cases (the cases the branch was supposedly designed to optimise):** add `(small) 123 → 7 ns (~17×)`, `(medium) 121 → 6 ns (~20×)`, `(wide gap) 136 → 14 ns (~10×)`; sub `(small) 118 → 7 ns (~17×)`, `(medium) 132 → 10 ns (~13×)`, `(wide gap) 149 → 15 ns (~10×)`.
-- **Existing `Different scales` case (neither operand integer): add 109 → 7 ns (~15×)**, sub `111 → 7 ns (~16×)`. Even cases that should not have benefited from the branch removal speed up — because the `is_integer()` fast-reject pre-check, while cheap, was still being executed twice on every add of differently-scaled operands.
-- **Mixed magnitudes** stays at 14 ns (the pre-check still wins for it, and it always took the UInt256 path after the branch failed). Same-scale fast path (~5 ns) is untouched.
-- **Result equivalence preserved**: add 14/14, sub 14/14, no new mismatches across all four languages.
-- **Take-away:** branches that test a non-trivial predicate to skip a moderately-priced fall-through are often anti-optimisations; always measure the dispatch cost separately from the body cost.
-
-Observations from the `085601` run (after stripping `.format(n)` / `+ String(rounding_mode)` from three `debug_assert(...)` sites in `utility.mojo` and switching `power_of_10[uint128|uint256]` from a long if/elif chain to a balanced bisect if/else tree):
-
-- **`debug_assert` does NOT lazy-evaluate its message argument under `-D ASSERT=none`.** Asm inspection of `power_of_10` (`--emit=asm -O3 -D ASSERT=none`) showed `KGEN_CompilerRT_AlignedAlloc` + `String._iadd` + `String.write` calls in the supposedly-empty hot loop, all from the `debug_assert(False, "...{}".format(n))` bound-check messages. Standalone microbench: power_of_10 cost 115 → 1.3 ns/call (~88×). Single-file reproducer: `/tmp/repro_debug_assert_format.mojo` shows a 56× slowdown of `debug_assert(True, "msg {}".format(x))` vs `debug_assert(True, "msg")` even with `-D ASSERT=none`. Filed for the Mojo compiler team.
-- **Cross-op end-to-end impact (where `power_of_10` lives on the hot path through `round_coefficient` / `fit_to_max_coefficient`):**
-  - `multiply` max: **335 → 262 ns/iter (~22% off the worst case)**. The slow tail (`High precision`, `e * e^0.5`, `Product overflows`) was largely paying for the eager `.format()` allocations inside `power_of_10`.
-  - `divide` max: **356 → 307 ns/iter (~14% off the worst case)** — same root cause via the rounding helpers.
-  - `from_string` max: **175.6 → 68.4 ns/iter (~61% off the worst case)** — `from_string` exercises `power_of_10` heavily on every parse.
-  - `to_string` max: 578.3 → 577.9 (flat — `to_string` doesn't go through `power_of_10`; this is now the dominant remaining tail item, addressed by §4.9.2 action #4).
-- **Median timings shifted slightly** (`mul` median 5 → 9, `from_str` median 23 → 28). Two contributing factors: (a) the bisect if/else tree costs ~2 ns/call vs the prior linear if-tree's ~1.3 ns when the LUT actually lands in registers, and (b) run-to-run variance on cases that already sit at single-digit nanoseconds. The trade-off was deliberate: the bisect tree is much more elegant than the rejected bitcast-string-literal LUT, and the median regression is tiny next to the 22-61% wins on the worst-case tails. Previous LUT investigations (§4.9.2 #9 fourth bullet) had wrongly concluded "LUT regresses heavy cases by 17-67 ns" — that finding is now retracted: the regression was entirely the eager `.format()` overhead inside the per-call-site materialised LUT, not the LUT itself.
-- **Companion fix in two `debug_assert(False, "..." + String(rounding_mode))` unreachable `else` branches** in `utility.mojo` (`round_coefficient` / `round_to_keep_first_n_digits`). Same eager-evaluation hazard as `.format()`. Removed the dynamic `String(...)` concat — kept a plain string literal — since the message has no runtime info to encode (the branch is unreachable when assertions are off, and a constant identifier is enough when they are on).
-- **Repository-wide audit clean:** a regex + paren-balanced multi-line walk over `src/decimo/*.mojo` confirms there are no remaining `debug_assert(...)` calls that build a `String` via `.format()` or `+ String(...)` in their message argument. Future `debug_assert` calls should use plain string literals only until/unless Mojo gains lazy-message support.
-- **Result equivalence preserved:** add 14/14, sub 14/14, mul 15/16 (the long-standing `multiply by zero` rust-style scale mismatch in §5.7), div 11/11, cmp 30/30, from_str 16/16, to_str 9/9.
-- **Take-away:** when LLVM-generated asm shows allocator calls inside a loop you "know" is allocation-free, suspect eager-evaluation of *non-source-visible* arguments (e.g. `debug_assert` messages, default values, `print` arguments). The Mojo language reference says nothing about `debug_assert`'s message-argument evaluation order; this should either change or be documented prominently.
-
-**Notes for #10 — Granlund-Möller reciprocal divider for UInt256 / 10^k (20260422_122336):**
-
-The `085601` run still showed multiply max ~262 ns (and divide max ~307 ns), with the cross-op overview putting decimo at 1.8× rust on multiply medians but **42× rust** on the worst case (`e × e^0.5`, ~252 ns vs ~6 ns). Asm + isolated micro-benchmarking localised the cost to a single line in `round_coefficient[uint256]`: `truncated = value // divisor` where `divisor = power_of_10_unsafe[uint256](k)` for k ∈ [1, 29]. LLVM lowers UInt256 division to a portable shift-subtract software loop; one such call costs ~250 ns even when the divisor is a known compile-time-class constant.
-
-**Fix: Granlund-Möller saturating-reciprocal divider** (`udiv_u256_by_pow10_gm`, named after Hacker's Delight §10-9). For each k ∈ [1, 29], pre-compute a 256-bit magic constant `mp = ⌈2^(N+ℓ)/d⌉ − 2^N` (with N = 256 and ℓ = `bit_width(d) − 1`). At runtime: `t1 = mulhi_256(mp, n); q = (((n − t1) >> 1) + t1) >> (ℓ − 1)`. The 30 `mp` values are stored in a 32-byte-per-entry rodata blob (`_GM_RECIPROCAL_BLOB`) and the 30 `ℓ−1` shift counts in a 30-byte sidecar (`_GM_SHIFT_BLOB`), bitcast-indexed for one-load access (same trick as `power_of_10_unsafe`). `mulhi_256(a, b)` uses four `UInt256(u128_a) * UInt256(u128_b)` cross-products and adds the carry; LLVM compiles this to a tight straight-line sequence of native `umulh` + `mul` instructions. **Cost: ~6 ns/call standalone; e × e^0.5 dropped 252 → 20 ns/iter — 12.6× faster than the prior code path, and 5.6× FASTER than rust\_decimal's 111 ns on the same case.**
-
-- **Critical correctness detail:** the magic constant must use **ceiling** division: `mp = -((-(1 << (N+ℓ))) // d) − (1 << N)`. An initial implementation using floor division failed 17/2000 random-input tests at k = 1; switching to ceiling brought the failure rate to 0/2000 across all k ∈ [1, 29].
-
-- **Why no fallback algorithm is shipped:** k ∈ [1, 29] covers every `Decimal128` multiply/round call site (since `combined_num_bits ≤ 192` implies `k ≤ 29`). For any future caller that exceeds that range, `round_coefficient` falls back to the native `value // divisor` path — slow but correct, and only as a defensive guard. An intermediate prototype (a u32-limb schoolbook divider modelled after rust_decimal's `Buf24::rescale`) was implemented and benchmarked at ~22 ns/call on the worst case — already a 11× improvement over the native UInt256 divide — but G-M's ~6 ns is strictly better and equally simple, so the schoolbook variant was removed before this commit landed.
-
-- **Validation:** `tests/decimal128/test_decimal128_gm_divider.mojo` (5 tests) cross-checks G-M against the native `v // 10^k` for every k ∈ [1, 29] over 28 deterministic stress samples (zeros, ones, 10^k boundaries, 2^n, near-prime constants, MAX_AS_UINT128²), plus pow-of-10 edge-points (10^k − 1, 10^k, 10^k + 1, 2·10^k − 1, 2·10^k), end-to-end multiply checks, and the floor-divide invariant `q·d ≤ v < (q+1)·d`. All pass under `-D ASSERT=all`.
-
-End-to-end impact in the `124242` cross-language report:
-
-- **multiply max: 262 → 22 ns/iter** — ~12× speedup on the worst case, and (uniquely so far) decimo now has the smallest worst-case multiply cost among the four languages on the `e × e^0.5` row (~20 ns vs rust 111 ns vs csharp 32 ns vs vbnet 35 ns).
-- **multiply median: 9 → 5 ns/iter** — back to the level last seen at the `071048` snapshot, undoing the slight median regression introduced by the bisect LUT.
-- **divide max: 307 → 253 ns/iter** — small win (the same `round_coefficient[uint256]` path is reused inside `divide()` when the result needs scale-down).
-- **multiply ratio dm/rust: 2.3× → 1.8×** — closes most of the remaining gap; the residual factor is the per-call overhead on cases where decimo already does the right divisor-class dispatch but rust gets to skip the class entirely (32-bit-coefficient fast paths).
-- **No regression** in result-equivalence: add 14/14, sub 14/14, mul 15/16 (same `multiply by zero` rust-style scale mismatch as before — a presentation difference, not a value difference), div 11/11, cmp 30/30, from_str 16/16, to_str 9/9.
-
-**Take-away:** when LLVM lowers a wide-integer division to a software loop (visible as a long shift-subtract sequence in `--emit=asm`), and the divisor class is a small fixed set of compile-time constants, a Granlund-Möller reciprocal table is the right answer — but use ceiling division for the magic constant or the saturating-reciprocal identity does not hold at the divisor boundary.
-
-**Multiply test coverage expansion (orthogonal observation, same commit):** while landing the GM divider, `tests/decimal128/test_data/decimal128_multiply.toml` was extended with **74 stress cases** under a new `[[gm_stress_tests]]` section covering k ∈ [1, 28] of the GM divider sweep plus large-int × small-fraction, MAX-class, transcendental, negative-product, and all-integer variants. The expected values were cross-checked against **three independent industry references**: Rust `rust_decimal` 1.36, C# `System.Decimal` (.NET 10), and VB.NET `System.Decimal` (.NET 10) — all three agree byte-for-byte on every case. The first sweep flagged 3 divergences (k=14, 15, 16) where decimo was 1 ULP off from the three-way consensus; root-cause analysis showed decimo's `multiply` was applying HALF_EVEN **twice** (once inside `fit_to_max_coefficient`, again inside the final `round_coefficient` when `final_scale > MAX_SCALE`), and the fit-then-round sequence can disagree with a single-step quantize on a half-ulp tie.
-
-**Multiply rounding fix (single-step round from full-precision product):** rather than annotate the divergences as expected, the underlying bug was patched at the root in both `combined_num_bits ≤ 128` (UInt128) and `combined_num_bits ≤ 192` (UInt256) branches of `multiply()` in `arithmetics.mojo`. The fast `combined_num_bits ≤ 96` branch already round-trips in a single step and is unchanged. The fix preserves the full-precision product as `prod_orig` before the first `fit_to_max_coefficient` pass; if `final_scale > MAX_SCALE` after that pass, instead of rounding the already-fitted coefficient again, it re-rounds `prod_orig` once with `total_drop = digits_removed + (final_scale − MAX_SCALE)` so HALF_EVEN sees the true full-precision tie/non-tie bits exactly once. A rare retry (`total_drop + 1`, dropping `final_scale` to `MAX_SCALE − 1`) handles the boundary case where the single-step rounded coefficient still exceeds `MAX_AS_UINT128` / `MAX_AS_UINT256`. The first attempt (replacing fit+round with round-then-fit using only `combined_scale − MAX_SCALE` as the drop count) regressed `exp_ln` catastrophically — `e^20` returned ~54 instead of ~485M — because dropping only the trailing-scale digits leaves a multi-MAX_COEF residue that `fit_to_max`'s try-29/try-28 retry cannot rescue; keeping `fit_to_max` as the first MAX_COEF reducer and redirecting only the second rounding step is what actually works. **All 74 stress cases now match the rust/cs/vb consensus** and all 18 decimal128 test files pass with zero regressions (incl. multiply 4/4, exp_ln 7/7, divide 11/11, sqrt 8/8, root_power 9/9). Two TOML cases that produce zero with `final_scale > MAX_SCALE` still carry an inline note that rust trims the trailing zero string to `"0"` while decimo preserves the full-scale `"0.0000…"` form — that is a presentation difference, not a value difference.
-
-**Notes for #11 — Hot-path-first single-function `add()` / `subtract()` (20260422_200239):**
-
-After §4.9.2 #1 collapsed the legacy `add()` from ~106 ns to ~5 ns by hoisting the same-scale branch above `is_integer()`, the remaining 5 ns/op gap to rust_decimal (rust ~2.4 ns) was small enough that micro-architectural costs started to dominate. An empirical decomposition (`temp/bench_unchecked_overhead.mojo` + `temp/bench_add_candidates.mojo`, deleted after analysis) split the cost two ways:
-
-- **`def raises` calling-convention overhead: ~1.5 ns/op** (a non-raising `fn` doing the same work measured at ~1.3 ns; the same body wrapped in `def raises` measured at ~4.0 ns standalone — the gap shrinks inside a real call site to ~1.5 ns once the inliner can see the error-pointer).
-- **Top-of-function branch dispatch (six `if/elif` arms in the legacy body): ~1.7 ns/op**, even when the *first* arm hits — each arm's predicate computation (e.g. `x1.coefficient() == 0`, `x1.is_integer()`, `x1.scale() == x2.scale()`) sits in the linear scan before the `same_scale` arm.
-
-§4.9.2 action #2 had originally proposed a non-raising `add_unchecked` fast path. A six-candidate sweep (A=re-order branches; B=drop both zero-special arms entirely; C=combined zero pre-test; D=split with `@always_inline`; E=push the zero-special into the slow tail; F=E + `@always_inline` on the public wrapper) measured against 17 input shapes (same/diff scale, both/one/neither integer, both/one/neither zero, sign combinations, near-MAX coefficients) found that the bulk of the win came from two micro-changes:
-
-- **Re-ordering the body so the same-scale UInt128 path is checked first** (the predicate `x1.scale() == x2.scale()` is one cheap UInt32 compare, and dominant in real workloads).
-- **Routing the zero-with-different-scale special into the slow tail** instead of letting it sit at the top — the slow tail's body is long enough that an extra coefficient-equality test is dwarfed by the UInt256 work it gates.
-
-An exploratory revision split these into `_add_same_scale_uint128` / `_add_diff_scale_uint256` / `_add_zero_special` / `_add_slow` helpers with `@always_inline` on the public wrapper, and bench-measured at add 3 ns / sub 4 ns. On code-style review the helper split was rejected in favour of keeping the historic single-function shape used for every other op in `arithmetics.mojo`; the two micro-changes above were folded back into a single-function form. The `@always_inline` on the public `def raises` is retained because dropping it costs ~1 ns/op on the hot path (5 vs 4 ns/iter measured) and is the only `@always_inline` that survives — the legacy four-helper layout has been deleted.
-
-The architecture is **one function each for `add` and `subtract`, public API contract preserved**:
-
-```mojo
-@always_inline
-def add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
-    # CASE: Same scale (UInt128 fast path)            <- placed first
-    # CASE: One operand is zero (different scales)    <- promotes to max scale
-    # CASE: Different scales, both non-zero (UInt256 path)
-
-@always_inline
-def subtract(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
-    # CASE: Same scale (UInt128 fast path)            <- inlined directly
-    # CASE: Different scales -> return add(x1, negative(x2))
-```
-
-`subtract()`'s same-scale path is inlined directly (mirroring `add()`'s but with `is_negative()` *in*equality as the "same effective sign" branch since `x1 - x2 = x1 + (-x2)`). The different-scale path delegates to `add(x1, negative(x2))` rather than re-implementing the rare branch — `negative()` on `Decimal128` is a sign-bit flip, single-cycle, so the negate-then-add detour is negligible relative to the UInt256 promotion that dominates that arm.
-
-End-to-end impact in the `dec128_report_20260422_200239.md` cross-language report (rebenched twice for stability):
-
-- **`add` median: 5 → 4 ns/iter (~20% faster)**, dm/rs **2.1× → 1.3×** — decimo is now within ~30% of `rust_decimal` on the hot path; the remaining gap is essentially the `def raises` calling-convention overhead, which cannot be eliminated without also removing the overflow-detection contract that the public API documents.
-- **`subtract` median: 6 → 4 ns/iter (~33% faster)**, dm/rs **2.6× → 2.0×**. Subtract is now on par with add; the previous 1 ns gap closed once the same-scale fast path was inlined directly into `subtract()` rather than reaching it through `add(x1, negative(x2))`.
-- **`add` worst case (Mixed magnitudes / wide-gap UInt256): 15 → 14 ns** (run-to-run noise; the UInt256 path itself is unchanged).
-- **No change** to `multiply`, `divide`, `comparison`, `from_string`, or `to_string` — the change is strictly on `add`/`sub`.
-- **Result equivalence preserved:** add 14/14, sub 14/14 (no new mismatches across rust / csharp / vbnet).
-- **Test suite:** `tests/decimal128/test_decimal128_arithmetics.mojo` (5/5 PASS in 77.7 s under `-D ASSERT=all`); inline subtract smoke test on 11 representative shapes (positive/negative, same/diff scale, with/without zero) all match the prior `add(x1, negative(x2))` results byte-for-byte.
-
-**Code-base footprint:** the experimental `add_v_a` … `add_v_f` candidate functions, `add_unchecked` / `add_unchecked_full` exploratory wrappers, the four-helper split (`_add_same_scale_uint128`, `_add_diff_scale_uint256`, `_add_zero_special`, `_add_slow`, `_sub_same_scale_uint128`, `_sub_slow`), the `_add_legacy` body, and the `temp/bench_add_candidates.mojo` / `temp/bench_unchecked_overhead.mojo` / `temp/check_candidates.mojo` probe files were all removed before commit. The final `arithmetics.mojo` keeps the historic single-function shape — one `def add` and one `def subtract` — with `# CASE:` markers separating the dispatch arms inside each.
-
-**Take-aways:**
-
-- *§4.9.2 action #2 ("non-raising `add_unchecked` fast path") is closed without shipping a public `unchecked` variant.* Hot-path-first branch ordering captures most of the same win (~1 ns/op on the median) without doubling the API surface. The original §4.9 §4.9.2 estimate of "~40-80 ns/op saved" from the non-raising route was off by ~30-50× — a useful reminder that performance hypotheses derived from "what other libraries do" must be empirically decomposed before they drive an architecture change.
-- *Keep the public `def raises` API.* The `def raises` overhead is real (~1.5 ns) but is also the contract decimo documents (`__add__` raises `OverflowError` on UInt128 overflow at scale 0). Removing it would change the contract; closing the gap from 1.3× to 1.0× isn't worth that.
-- *When a hot path is small, the *count of branches* before the fast arm matters more than the body of the fast arm.* The legacy `add()` had a 6-arm linear scan; even the cheapest arm pays for the predicate of every prior arm. Putting the most-common branch first and routing rare cases into the cold tail of the same function captures most of the dispatch win without forcing the function to be split into helpers.
-- *Helper-function decomposition costs ~1 ns over a well-ordered monolith.* An exploratory four-helper split measured 3/4 ns vs the monolith's 4/4 ns, but the readability penalty (six new private symbols for arms that are each called from exactly one place) wasn't worth the 1 ns. Helpers should be reserved for genuinely shared code paths, not for rhetorical "decomposition".
-
-**Files touched:** [src/decimo/decimal128/arithmetics.mojo](../../src/decimo/decimal128/arithmetics.mojo) (the entire `add` / `subtract` neighbourhood, lines ~46–340).
-
-**Notes for #12 — Subtract diff-scale fully inlined + multiply `@always_inline` (20260422_210555):**
-
-H#11 left `subtract()`'s diff-scale arm calling `add(x1, negative(x2))` on the assumption that the negate was free and UInt256 work dominated. The `200239` report showed otherwise: subtract `Decimals with different scales` ran 12 ns vs rust 2.33 (5.1×), and the three `Both integer, different scale` cases sat at 9–19 ns (3.9–4.3×). The detour cost ~3 ns — a `def raises` call into `add()`, a non-inlined `negative()`, and the `try/except` rethrow that fixed up the error message. Against ~5 ns of UInt256 promotion that's a 50% tax.
-
-Fix: inline the whole diff-scale block into `subtract()`. It mirrors `add()` line-for-line with two algebraic substitutions for `x1 − x2 = x1 + (−x2)`:
-
-- The "same effective sign" branch (which adds magnitudes) tests `is_negative() != is_negative()` instead of `==`.
-- Sign assignments that would read `x2.is_negative()` read `not x2.is_negative()`.
-
-The one-operand-zero case is also inlined; `0.0 - -0.00 == 0.00` still holds. The overflow message reads `"Subtraction result exceeds Decimal128 precision."` directly, no rethrow.
-
-Companion: `@always_inline` on `multiply()`. The body had no annotation; adding it lets the integer fast path (`combined_num_bits ≤ 96`) lose its call frame.
-
-Numbers from `dec128_report_20260422_210555.md`:
-
-- `subtract` median 4 ns (flat), dm/rs 2.0× → 1.7×.
-- `subtract` `Decimals with different scales` 12 → 10 ns; `Both integer, different scale (small/medium/wide gap)` 9/12/19 → 6/5/15 ns. The wide-gap case stays at 3.4× rust because rust uses a 32-bit fast path that decimo's unconditional 96→256 promotion can't replicate.
-- `multiply` median 5 ns (flat); the 22-24 ns worst case is unchanged because it's bound by the GM-divider, not the call site.
-- `add` dm/rs 1.3× → 1.1× (re-measurement; body untouched).
-- Result equivalence: add 14/14, sub 14/14, mul 15/16 (unchanged), div 9/11 (unchanged), cmp 30/30, from_str 16/16, to_str 9/9.
-- Tests: `test_decimal128_arithmetics.mojo` 5/5 PASS in 41.7 s under `-D ASSERT=all`.
-
-Still open and out of scope here:
-
-- `multiply` `High precision` 24 ns vs rust 6.6 (3.6×) and `Product overflows` 22 vs 8.75 (2.5×) — both on the UInt256 + GM path. Closing the gap needs either a 128-bit fast path that detects when the product fits in `UInt128` despite `combined_num_bits > 96`, or a different rounding strategy.
-- `divide` `Repeating decimal` 287 vs rust 12.5 (22.9×), `High precision` 248 vs 24.3 (10.2×), `Coprime` 175 vs 21 (8.2×) — the single-digit-per-step long-division loop. The fix is to multiply numerator by `10^k` once and hardware-divide once, but that's a major refactor of `divide()` and is left for a follow-up.
-
-**Files touched:** [src/decimo/decimal128/arithmetics.mojo](../../src/decimo/decimal128/arithmetics.mojo) (`subtract()` diff-scale arm rewritten ~lines 289–410; `@always_inline` on `multiply()` at ~line 472).
-
-**Notes for #13 — Divide two-phase: probe loop + UInt256/u64 schoolbook (20260422_212851):**
-
-H#12 left the divide tail open: `Repeating decimal` 287 ns vs rust 12.5 (22.9×), `High precision` 248 vs 24.3 (10.2×), `Coprime` 175 vs 21 (8.2×). All three sat on the same per-digit long-division loop — `rem *= 10; digit = rem // x2_coef; rem %= x2_coef` — running 25-28 iterations. Each iteration is one UInt128 div + one UInt128 mod + a multiply, ~10 ns apiece on M4 (UInt128 division goes through `__udivti3`).
-
-The first instinct — "do it in one big divide" — does not work. A single `UInt256 / UInt256` divide costs ~236 ns through the software fallback, only marginally better than the 280 ns loop. What does work is splitting the dividend into u64 limbs:
-
-- Add `udiv_u256_by_u64(n: UInt256, d: UInt64)` to [utility.mojo](../../src/decimo/decimal128/utility.mojo). Four-step schoolbook over the 64-bit limbs of `n`, each step one `UInt128 / UInt128` divide where the divisor is `< 2^64`. Hardware-fast: ~12 ns end-to-end vs 236 ns for the symmetric divide. Tested 0/2000 mismatches against `n // d` over random UInt256/UInt64 pairs.
-- Every `Decimal128` divisor fits in `UInt128 ≤ 2^96`, and the bench cases all happen to fit in `UInt64`, so the u64-divisor path covers them. The 96-bit-divisor fallback (rare) keeps the original `UInt256 // UInt256`.
-
-Naive replacement (rip the loop out, scale by `10^max_steps` once, divide once) regressed `Simple decimal division` 19 → 154 ns. Two reasons: (1) we always padded out to `max_steps = 29` digits even when the result terminated in 1, then needed a 28-iteration trim loop to strip trailing zeros; (2) the trim itself was per-digit `quot %= 10; quot //= 10`, which is two UInt128 ops × 28 iterations.
-
-Two-phase fix:
-
-- *Phase 1: probe.* Run the original per-digit loop, but cap it at `PROBE_STEPS = 2`. Catches the common "terminates in ≤ 2 digits" cases (`10.5 / 2.5`, `123.45 / -2`) for ~10 ns total. The probe constant is a sweet spot — 1 missed `1/8`-shaped cases, 4 added 20 ns to the bulk-finish path.
-- *Phase 2: bulk finish.* If the remainder is still non-zero, scale the *remaining* `bulk_steps = max_steps - 2` digits with one `power_of_10[uint128]` lookup, run `udiv_u256_by_u64`, fold the result back into `quot`. Trim trailing zeros bisect-style (16/8/4/2/1 chunks of `pow_of_10`) so the worst case is ~5 UInt128 div-mods instead of 28.
-
-Numbers from `dec128_report_20260422_212851.md`:
-
-- `divide` median 9 → 8 ns, dm/rs 1.6× → 2.2× (median rises because the cheap cases got cheaper relative to the slow cases — see worst-case column).
-- `divide` worst-case max **287 → 56 ns**, the headline win. Per-case: `Repeating decimal` 287 → 57 (22.9× → 3.6×), `High precision` 248 → 59 (10.2× → 2.4×), `Coprime` 175 → 52 (8.2× → 2.4×). All three sit at ~3× rust now — still above the 2× target, bound by the `udiv_u256_by_u64` itself plus the 2-step probe overhead.
-- `divide` `Simple decimal` 19 → 26 ns and `Negative` 21 → 26 ns — small regression versus the pure per-digit loop. The `PROBE_STEPS = 2` cap means these terminate in phase 1 (1 digit needed) but pay a couple of extra branch evals before exiting. Acceptable trade for 3.6× → 2.4× on the slow cases.
-- Result equivalence and tests: `test_decimal128_divide.mojo` 11/11 PASS in 24.0 s under `-D ASSERT=all`; `test_decimal128_arithmetics.mojo` 5/5 PASS in 76.0 s.
-
-Still open:
-
-- The 96-bit-divisor fallback is untouched (no bench case exercises it). If a workload appears with a 7-digit-plus divisor, `udiv_u256_by_u96` would slot in next to `udiv_u256_by_u64`.
-- Closing slow-case dm/rs from 2.4× to ≤ 2× would need either eliminating the `power_of_10[uint128]` lookup (~2 ns) or removing the probe loop entirely and accepting the trim-loop tax — both regress the simple cases. The current shape feels Pareto-optimal at the case level.
-
-**Files touched:** [src/decimo/decimal128/arithmetics.mojo](../../src/decimo/decimal128/arithmetics.mojo) (`divide()` UInt128 path rewritten ~lines 996-1100), [src/decimo/decimal128/utility.mojo](../../src/decimo/decimal128/utility.mojo) (`udiv_u256_by_u64` appended at line 1521+).
-
-**Notes for #14 — `power_of_10_unsafe` sweep + `from_uint128` `@always_inline` (20260422_220148):**
-
-H#13 closed the divide tail but left `add`/`sub`/`mul` sitting on residual constant-construction overhead: every `Decimal128.from_uint128(coef, scale, sign)` result-construction call was paying ~2 ns of frame overhead (the function was too large for the heuristic inliner due to two `raise ValueError(... String.format ...)` blocks), and 22 hot-path sites still wrote `UInt(128|256)(10) ** k` which lowered to a runtime exponentiation loop (~4-12 ns) instead of the rodata indexed load `power_of_10_unsafe` already provided (~0.8 ns). Two surgical changes:
-
-- **Sweep `UInt(128|256)(10) ** k` → `power_of_10_unsafe[dtype](k)`** at all 22 hot-path sites in `arithmetics.mojo` (16 sites including the diff-scale UInt128 / UInt256 paths in `add`/`subtract`, the `divide()` short-by-bulk fallbacks, and `divide()` UInt256 quotient scaling), `comparison.mojo` (4 sites in `compare_absolute()`), `rounding.mojo` (2 sites in `round()`), and `decimal128.mojo` (4 sites: `from_string()`, `from_float()`, `to_int()`, `quantize()`). All exponents are bounded by `MAX_NUM_DIGITS + 1 = 30` ≤ 29 (the `unsafe` upper bound for `uint128`) by structural invariants documented at each call site. Also swapped one `power_of_10` → `power_of_10_unsafe` in the divide bulk-step path (`bulk_steps ≤ 28` proved at the call site).
-
-- **`Decimal128.from_uint128()` → `@always_inline`** with the two `raise ValueError(... String.format ...)` blocks extracted into separate `@no_inline` helpers `_raise_from_uint128_value_too_large` and `_raise_from_uint128_scale_too_large`. The inline body is now ~7 instructions (two cheap branches + bitcast + flag-or + return) — small enough that `@always_inline` is a strict win at every call site (`add`, `subtract`, `multiply`, `divide`, plus dozens of constructors). The cold raise paths still exist, just behind a `call` so they don't bloat the inline footprint. This is the canonical "happy path inline, error path extracted" pattern for any `raises` function whose error machinery dominates its body size.
-
-- **`number_of_bits()` → `@always_inline`** in `utility.mojo` to eliminate the call frame on `multiply()`'s critical path (two calls per multiply, both feeding the `combined_num_bits` fast-path check).
-
-Numbers from `dec128_report_20260422_220148.md`:
-
-- `add` median **4 → 3 ns**, dm/rs **1.2× → 0.8×** (now *faster* than rust).
-- `subtract` median **4 → 3 ns**, dm/rs **1.7× → 1.3×**.
-- `multiply` median 4 ns flat, dm/rs **1.7× unchanged** (the multiply hot path's bottleneck is the special-case dispatch tree, not the `from_uint128` call). The `0.5×` raises floor the user accepted as a design tax accounts for the residual gap.
-- `divide` median **8 → 6 ns**, dm/rs **2.2× → 1.0×** (parity with rust). Per-case wins: `Integer no remainder` 8 → 6 ns; `Repeating decimal` 56 → 47 ns; `Coprime` 52 → 47 ns. The `from_uint128` inline propagates through every divide return.
-- `comparison` median 2 ns, dm/rs 0.8× (already faster than rust, unchanged).
-- `from_string` 26 → 23 ns (small win from the 4 swept sites in the parse/construct path).
-- `to_string` 82.7 → 122.4 ns — *regression* but unrelated: this is allocator noise (no `to_string` code was touched by this hypothesis).
-- Worst-case `add`/`sub`/`mul`/`div` all dropped 1-3 ns (16/17/27/56 → 13/14/25/45 ns).
-- Result equivalence: arithmetics 5/5, divide 11/11, multiply 4/4, round 7/7, modulo 6/6, from_string 4/4 PASS under `-D ASSERT=all`.
-
-User target was ≤ 1.5× rust on the four arithmetic ops (with ~0.5× reserved as the `raises` tax that the codebase has chosen to keep). Met for **add (0.8×)**, **subtract (1.3×)**, and **divide (1.0×)**. Multiply lands at **1.7×**, ~0.2× over the target — the residual is the special-case dispatch tree (six branches before the actual `UInt128` mul), not closeable without consolidating those branches.
-
-Why extract raises into `@no_inline` helpers (mechanism note for future readers): Mojo's `raises` lowers each `raise ValueError(... String.format(...) ...)` to ~50 instructions of stack-walking and message-formatting code. When that code lives inside a hot function, the inliner sees a "fat" body and refuses to inline it — even though 99.99% of calls never touch the cold blocks. Extracting each raise to a separate `@no_inline` helper makes the hot function look thin again, lets `@always_inline` paste it into every caller, and the helpers stay as ordinary `call`s that no caller ever takes. Pattern is general; applies anywhere a `raises` function's body is dominated by its error-formatting code.
-
-Still open and out of scope here:
-
-- Multiply 1.7× → 1.5× would require either consolidating the 6-way special-case dispatch (risk: regressions on the small cases the dispatch was added for) or selective non-`raises` `fn` variants (larger API change).
-- `to_string` 3.4× rust is allocator-bound — see §4.9.2 action #4.
-
-**Files touched:** [src/decimo/decimal128/arithmetics.mojo](../../src/decimo/decimal128/arithmetics.mojo) (16 pow sites), [src/decimo/decimal128/comparison.mojo](../../src/decimo/decimal128/comparison.mojo) (4 pow sites), [src/decimo/decimal128/rounding.mojo](../../src/decimo/decimal128/rounding.mojo) (2 pow sites), [src/decimo/decimal128/decimal128.mojo](../../src/decimo/decimal128/decimal128.mojo) (4 pow sites + `from_uint128` `@always_inline` + 2 extracted raise helpers ~lines 511-558), [src/decimo/decimal128/utility.mojo](../../src/decimo/decimal128/utility.mojo) (`@always_inline` on `number_of_bits`).
-
-## 5. Improvement Opportunities
-
-### 5.1 `Stringable` / `Writable` / `__hash__`
-
-`Decimal128` already conforms to `Writable` (modern replacement for `Stringable`); `String(d)` and `print(d)` work today.
-
-Missing: **`__hash__`** — C# and Rust both hash their decimal types. Approach: hash the normalized form (strip trailing zeros, then hash coefficient + scale + sign). Depends on §5.4 (`normalize()`).
-
-### 5.2 Better `from_float` Accuracy
-
-Verified via direct read of `decimal128.mojo` line 829–920: `from_float` already does IEEE 754 bit extraction (`UnsafePointer(to=abs_value).bitcast[UInt64]()`, mask out exponent, derive `decimal_exp` from `binary_exp * log10(2)`). It does **not** route through string conversion.
-
-What remains: the post-extraction loop fine-tunes `coefficient` digit-by-digit; this could be tightened with a Grisu-style table lookup. Lower priority - most users converting from `Float64` accept the documented 15–16 significant digit cap.
-
-For reference: Rust [`rust_decimal::Decimal::from_f64`](https://docs.rs/rust_decimal/latest/rust_decimal/struct.Decimal.html#method.from_f64) uses the same IEEE 754 extraction approach.
-
-### 5.3 `min()` / `max()` / `clamp()`
-
-All four comparable libraries provide `min`/`max`. Easy to implement.
-
-### 5.4 Canonicalization / `normalize()`
-
-Strip trailing zeros: `1.200` (coef=1200, scale=3) → `1.2` (coef=12, scale=1). Useful for hashing (§5.1) and reducing coefficient size for faster subsequent arithmetic. Rust [`rust_decimal`](https://docs.rs/rust_decimal/latest/rust_decimal/struct.Decimal.html#method.normalize) has `normalize()`.
-
-### 5.5 Wider Testing for Edge Cases
-
-Some test cases worth adding:
-
-| Test Case                                | Expected Behavior           |
-| ---------------------------------------- | --------------------------- |
-| `from_words` with scale > 28             | Error (not assertion panic) |
-| `from_words` with coefficient > 2^96 − 1 | Error (not assertion panic) |
-| `is_one()` with 1.0, 1.00, 1.000         | True                        |
-| Max coefficient after multiply           | Correct rounding            |
-| 29-digit numbers near 2^96 − 1 boundary  | Correct truncate/round      |
-
-### 5.6 Rust `rust_decimal` Parity Gaps (Competitive Surface)
-
-A scan of the public `decimal128` API against `rust_decimal::Decimal` surfaces the following missing surface area. The goal is API competitiveness for users porting code from Rust; perf-wise we are already in the same order of magnitude (see §4.6 from_string benchmarks vs Rust's ~25 ns).
-
-| Rust API                            | Mojo equivalent                       | Status / suggested action                                |
-| ----------------------------------- | ------------------------------------- | -------------------------------------------------------- |
-| `Decimal::trunc()`                  | (none - `__round__` rounds half-even) | Add `trunc()` (toward zero)                              |
-| `Decimal::floor()` / `ceil()`       | (none)                                | Add free functions in `arithmetics.mojo`                 |
-| `Decimal::fract()`                  | (none)                                | Add `fract()` (= `x - x.trunc()`)                        |
-| `Decimal::signum()`                 | (none - only `is_negative()`)         | Add `signum() -> Decimal128` returning {−1, 0, 1}        |
-| `Decimal::mantissa()` + `scale()`   | `coefficient()` + `scale()`           | Already present                                          |
-| `Decimal::unpack()`                 | (none - three-word `from_words`)      | Add `unpack() -> (UInt128, UInt32, Bool)` for round-trip |
-| `Decimal::set_scale(u32)`           | `quantize()` is close                 | Document quantize as the equivalent                      |
-| `checked_add` / `checked_mul` / …   | All ops `raises`                      | Mojo idiom is already raise-based; document mapping      |
-| `Hash` impl                         | (none)                                | See §5.1                                                 |
-| `min` / `max`                       | (none)                                | See §5.4                                                 |
-| `normalize()`                       | (none)                                | See §5.5                                                 |
-| `from_str_exact()`                  | `from_string` (always exact)          | Already present                                          |
-| `Serialize` / `Deserialize` (serde) | (none - string round-trip only)       | Out of scope until Mojo gets a serde-equivalent          |
-
-**Action items grouped:**
-
-- *Trivial* (1–2 lines each): `trunc`, `floor`, `ceil`, `fract`, `signum`, `unpack`. Implement together as a single PR.
-- *Already covered*: `mantissa`/`scale`, `checked_*` (via `raises`), `from_str_exact`.
-- *Tracked elsewhere*: `Hash` (§5.1), `min`/`max`/`clamp` (§5.3), `normalize` (§5.4).
-- *Out of scope today*: serde - wait for the Mojo ecosystem.
-
-No behavioural changes are needed to be "competitive" with rust_decimal on perf for **string parsing** - the asm-level investigation in §4.7 plus the from_string benchmark in §4.6 confirm we are within ~2–3× there. **Arithmetic is a different story**: the head-to-head numbers in §4.9 show large remaining gaps on `add`/`sub`, which is the dominant remaining workstream. The Rust-parity API surface (this section) is independent of that perf work.
-
-### 5.7 Result-Equivalence vs `rust_decimal`, C# `System.Decimal`, and VB.NET `System.Decimal` (Empirical, IEEE 754-2008 Compliance)
-
-The cross-language harness in `benches/decimal128/` runs the *same* TOML cases through **decimo**, **`rust_decimal` (Rust)**, **`System.Decimal` (.NET / C#)**, and **`System.Decimal` (.NET / VB.NET)** and flags result-string mismatches. As of `dec128_report_20260421_*.md` (11/11/13/11/30/16/9 cases per op), the **only divergences are trailing-zero / scale differences in `multiply` and `divide`**, all of which `rust_decimal` gets wrong relative to the IEEE 754-2008 / IBM General Decimal Arithmetic "preferred (ideal) exponent" rule — and on every disputed case, **C# and VB.NET `System.Decimal` agree with decimo, not with `rust_decimal`** (3 implementations to 1):
-
-| op       | inputs        | decimo    | C# `System.Decimal` | VB.NET `System.Decimal` | rust_decimal | spec verdict                                                                                                                                                                          |
-| -------- | ------------- | --------- | ------------------- | ----------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| multiply | `123.45 × 0`  | `0.00`    | `0.00`              | `0.00`                  | `0`          | **decimo + .NET correct.** `exp(0×X) = exp(a) + exp(b) = -2 + 0 = -2`, so coefficient `0` at exponent `-2` is `0.00`. rust strips the scale.                                          |
-| divide   | `10.5 / 2.5`  | `4.2`     | `4.2`               | `4.2`                   | `4.20`       | **decimo + .NET correct.** Ideal exponent for divide = `exp(a) − exp(b) = -1 − (-1) = 0`; result `4.2` (exact at exp `-1`) is preferred over `4.20` (exp `-2`). rust pads spuriously. |
-| divide   | `123.45 / -2` | `-61.725` | `-61.725`           | `-61.725`               | `-61.7250`   | **decimo + .NET correct.** Exact result needs exp `-3` (`-61725 × 10⁻³`); ideal exp `-2` would require fractional coefficient. rust adds an unjustified trailing zero.                |
-
-**Conclusion:** decimo's scale handling matches IEEE 754-2008 §3.3 (preferred exponent rules), the IBM General Decimal Arithmetic Specification §4.1, **and** the de-facto reference implementation in .NET BCL (`System.Decimal`, also a 128-bit fixed-precision decimal — same type, two language frontends). `rust_decimal` is the lone outlier among the four canonical implementations surveyed. **No remediation is needed on the decimo side.**
-
-**Action items elsewhere:**
-
-- Add a regression test asserting these exact strings for the three cases above in `tests/test_arithmetic.mojo` (or wherever the multiply/divide suite lives), so we catch any future regression toward "rust-style" trailing zeros.
-- Add a one-paragraph note in `docs/user_manual.md` (Decimal128 chapter) calling out that scale follows IEEE 754-2008 / IBM Decimal Arithmetic preferred-exponent rules (matching .NET `System.Decimal`), since this differs visibly from `rust_decimal` and may surprise users porting code.
-
-## 6. Priority Summary
-
-Open items (in priority order):
-
-| #   | Issue                                                     | Severity      | Effort  | Priority |
-| --- | --------------------------------------------------------- | ------------- | ------- | -------- |
-| 4.9 | Arithmetic gap vs rust_decimal (add/sub dominant)         | Critical      | Large   | P1       |
-| 2.6 | Steal flag bits to extend coefficient to 10^32-1 (32 dig) | Architectural | Medium  | P2       |
-| 4.2 | `ln()` range reduction loops                              | High          | Medium  | P2       |
-| 5.6 | Rust parity (trunc/floor/ceil/fract/signum/unpack)        | Enhancement   | Small   | P2       |
-| 5.7 | Regression tests pinning IEEE 754 preferred-exp scale     | Enhancement   | Trivial | P2       |
-| 5.3 | `min/max/clamp`                                           | Enhancement   | Trivial | P3       |
-| 5.4 | `normalize()`                                             | Enhancement   | Small   | P3       |
-| 5.1 | `__hash__` (depends on §5.4)                              | Enhancement   | Small   | P3       |
-| 4.4 | `from_string` digit batching + shared scanner             | Medium        | Medium  | P3       |
-| 4.6 | Test suite slow (flags + per-file JIT)                    | Medium        | Medium  | P3       |
-| 5.5 | Edge case tests                                           | Enhancement   | Medium  | P3       |
-| 4.3 | Series convergence tolerance                              | Low           | Small   | P4       |
-| 3.3 | Division rounding mode (configurable)                     | Low           | Medium  | P4       |
-| 5.2 | Better `from_float` (Grisu-style)                         | Enhancement   | Medium  | P4       |
-
-Done items (kept for tracking, not actionable):
-
-| #   | Issue                                            | Severity | Effort | Status            |
-| --- | ------------------------------------------------ | -------- | ------ | ----------------- |
-| 3.1 | NaN/Inf removed                                  | Critical | Small  | Done              |
-| 3.2 | `from_words` uses `testing.assert_true`          | Medium   | Small  | Done              |
-| 4.1 | `number_of_bits` loop                            | Medium   | Small  | Done              |
-| 4.2 | `power_of_10` not fully precomputed              | High     | Small  | Done              |
-| 4.3 | `round_to_keep_first_n_digits` lacks .NET tricks | High     | Medium | Done              |
-| 4.5 | Separate `//` and `%` in division loop           | Medium   | Small  | Verified-NoChange |
-
-## 7. Execution Order
-
-**Phase 1 (correctness)** — Done. NaN/Inf removed; `from_words` raises on invalid input.
-
-**Phase 2 (coefficient-bound perf)** — Done. `power_of_10` extended to n=58; `round_coefficient` with .NET tricks; `number_of_bits` via `bit_width` intrinsic.
-
-**Phase 3 (general perf)** — close the rust_decimal gap. This is the actual competitive workstream.
-
-1. **Close the arithmetic gap (§4.9)** — highest priority. Restructure `add()` to short-circuit before `is_integer`; non-raising `add_unchecked`/`mul_unchecked` fast paths; UInt128-only `multiply` fast path; inline `to_string` buffer. Re-bench after each change and append a new row to the §4.9.3 tracking table.
-2. **Improve `ln()` range reduction (§4.4)** — 30 divisions → 1 via scale-read + bit-width single-shot.
-3. **`from_string` digit batching (§4.6)** — ~55 ns/call → target ~25 ns.
-4. **Test-suite latency (§4.8)** — split dev/CI flag profiles, hoist `parse_file`, consolidate per-file JIT.
-
-**Phase 4 (enhancements / Rust parity)**:
-
-1. `trunc` / `floor` / `ceil` / `fract` / `signum` / `unpack` (§5.6) — single small PR.
-2. Regression tests pinning IEEE 754-2008 preferred-exp behaviour for the three §5.7 cases + user-manual note.
-3. `min/max/clamp` (§5.3).
-4. `normalize()` (§5.4).
-5. `__hash__` (§5.1) — depends on `normalize()` for stable hashes.
-6. Tighten `from_float` accuracy with Grisu-style table (§5.2).
-
-**Phase 5 (long-term, deferred)**:
-
-1. **Steal flag bits to widen coefficient to 10^32−1 (§2.6)** — architectural cleanup, not a competitive driver. Defer until perf parity (§4.9) is solid and there is appetite for a breaking-change major release. Documented as a design proposal; not on the active roadmap.
-
-## Appendix A. Survey of 128-Bit Fixed-Precision Decimal Types
-
-> **Scope:** 128-bit (or near-128-bit) fixed-precision, non-floating-point decimal types across
-> programming languages and libraries. This explicitly **excludes** arbitrary-precision decimals
-> (Python `decimal.Decimal`, Java `BigDecimal`, Go `shopspring/decimal`, Go `cockroachdb/apd`) and
-> IEEE 754 decimal128 (which is a floating-point format with 34-digit significand, exponent range
-> −6176 to +6111, and NaN/Infinity/subnormals).
-
-### A.1 Detailed Comparison Table
-
-| Name                 | Language / Platform           | Total Bits                      | Coefficient Storage                              | Max Coefficient                                      | Max Sig. Digits | Scale Range                | NaN / ±Inf |
-| -------------------- | ----------------------------- | ------------------------------- | ------------------------------------------------ | ---------------------------------------------------- | --------------- | -------------------------- | ---------- |
-| **System.Decimal**   | C# / .NET CLR                 | 128                             | 96-bit unsigned (3×Int32: lo, mid, hi)           | 2^96 − 1 = 79,228,162,514,264,337,593,543,950,335    | 29              | 0–28                       | No         |
-| **rust_decimal**     | Rust (crate)                  | 128                             | 96-bit unsigned (3×u32: lo, mid, hi)             | 2^96 − 1 (same as C#)                                | 29              | 0–28                       | No         |
-| **VB.NET Decimal**   | VB.NET / .NET CLR             | 128                             | Identical to C# (same CLR type `System.Decimal`) | 2^96 − 1                                             | 29              | 0–28                       | No         |
-| **Arrow Decimal128** | Apache Arrow (cross-language) | 128                             | 128-bit two's complement signed integer          | 10^p − 1 (bounded by declared precision p, max p=38) | 38              | User-defined (any integer) | No         |
-| **govalues/decimal** | Go (module)                   | 128 (1 bool + 1 uint64 + 1 int) | 64-bit unsigned integer (uint64 coefficient)     | 10^19 − 1 = 9,999,999,999,999,999,999                | 19              | 0–19                       | No         |
-
-Other non-128-bit types for reference:
-
-| Name                          | Language / Platform    | Total Bits     | Coefficient Storage                    | Max Coefficient                                                                   | Max Sig. Digits   | Scale Range            | NaN / ±Inf |
-| ----------------------------- | ---------------------- | -------------- | -------------------------------------- | --------------------------------------------------------------------------------- | ----------------- | ---------------------- | ---------- |
-| **Swift Decimal** (NSDecimal) | Swift / Foundation     | 160 (20 bytes) | 128-bit mantissa (8×UInt16)            | Up to 38 decimal digits; mantissa is 128 bits but capped at 10^38 − 1 in practice | 38                | Exponent: −128 to +127 | NaN only   |
-| **SQL Server decimal(38)**    | T-SQL / SQL Server     | 136 (17 bytes) | 128-bit unsigned integer (4×Int32)     | 10^38 − 1 = 99,999,999,999,999,999,999,999,999,999,999,999,999                    | 38                | 0 to p (max 38)        | No         |
-| **Delphi Currency**           | Delphi / Object Pascal | 64             | 64-bit signed integer (scaled by 10^4) | 2^63 − 1 = 922,337,203,685,477.5807                                               | 19 (4 fractional) | Fixed at 4             | No         |
-
-### A.2 Notes on Each Type
-
-#### C# System.Decimal (and VB.NET, F#)
-
-The .NET CLR `System.Decimal` is the reference design that Decimo Decimal128, Rust `rust_decimal`,
-and several others copy. Its 128-bit layout packs a 96-bit unsigned coefficient into three 32-bit
-words (`lo`, `mid`, `hi`), with a 32-bit flags word encoding: sign in bit 31, scale in bits 16–20
-(value 0–28), and bits 0–15 & 21–30 reserved (must be zero).
-
-Constructor: `Decimal(Int32 lo, Int32 mid, Int32 hi, Boolean isNegative, Byte scale)`.
-
-Max value: ±79,228,162,514,264,337,593,543,950,335 (= 2^96 − 1). This is **not** a round decimal
-number - the upper bound is a power-of-2 boundary, not 10^29 − 1.
-
-No NaN, no Infinity. `INumberBase<Decimal>.IsNaN()` always returns `false`.
-
-#### Rust rust_decimal
-
-Mirrors the C# layout exactly: `lo: u32, mid: u32, hi: u32` for the 96-bit coefficient, flags word
-with sign + scale. `MAX = 79_228_162_514_264_337_593_543_950_335`. Serializes to 16 bytes
-(4 bytes flags + 12 bytes coefficient). The `from_parts(lo, mid, hi, negative, scale)` constructor
-matches C# directly.
-
-No NaN, no Infinity. The `MathematicalOps` trait adds `sqrt()`, `exp()`, `ln()`, `pow()`, etc.
-
-#### Apache Arrow Decimal128
-
-Fundamentally different from the C#/Rust design. Arrow Decimal128 stores the value as a **128-bit
-two's complement signed integer**, not a 96-bit unsigned coefficient. The value represents
-`integer_value / 10^scale`, where `precision` (1–38) and `scale` are declared in the schema.
-
-The max representable coefficient for `decimal128(38, 0)` is 10^38 − 1 (= 38 nines), which is
-much smaller than 2^127 − 1 ≈ 1.7 × 10^38. Arrow deliberately caps at 10^precision − 1 rather
-than using the full bit range, to ensure consistent decimal digit semantics.
-
-Schema definition (Apache Arrow `Schema.fbs`):
-
-```txt
-table Decimal { precision: int; scale: int; bitWidth: int = 128; }
-```
-
-No NaN, no Infinity. Each column has a single fixed precision and scale.
-
-#### Swift Foundation Decimal (NSDecimal)
-
-Not truly 128-bit - the struct is **160 bits (20 bytes)**. Layout:
-
-- `exponent: Int8` (−128 to +127)
-- `lengthFlagsAndReserved: UInt8` (4-bit length, 1-bit isNegative, 1-bit isCompact, 2-bit reserved)
-- `reserved: UInt16`
-- `mantissa: (UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16)` - 8×UInt16 = 128 bits
-
-The 128-bit mantissa can theoretically hold values up to 2^128 − 1, but the `_length` field (4 bits, max 15) indicates how many of the 8 UInt16 slots are used, and Apple documents the max as 38 significant decimal digits (i.e., effectively capped at 10^38 − 1).
-
-Unlike C# and Rust, Swift Decimal **supports NaN** (`isNaN` property). It does NOT support Infinity in practice - the `isInfinite` property exists (inherited from `FloatingPoint` protocol) but Apple's implementation does not produce or handle Infinity values meaningfully.
-
-#### SQL Server decimal / numeric
-
-SQL Server `decimal(p, s)` with max precision 38. Storage size varies by precision:
-
-| Precision | Storage Bytes |
-| --------- | ------------- |
-| 1–9       | 5             |
-| 10–19     | 9             |
-| 20–28     | 13            |
-| 29–38     | 17            |
-
-At precision 29–38, the storage is 17 bytes: 1 byte for sign + 16 bytes (128 bits) for the
-unsigned integer coefficient. The max value is 10^38 − 1 (38 nines). This is a decimal-bounded
-maximum, not a binary one. Valid values range from `-(10^p - 1)` to `+(10^p - 1)`.
-
-No NaN, no Infinity. `decimal` and `numeric` are synonyms; both are fixed precision and scale.
-
-#### Go govalues/decimal
-
-A high-performance, zero-allocation decimal designed for financial systems. Internally uses a `uint64` coefficient (max 10^19 − 1 = 9,999,999,999,999,999,999) with 19-digit precision and scale 0–19. The struct fits in 128 bits total (bool sign + uint64 coefficient + int scale, though Go struct layout may pad slightly).
-
-No NaN, no Infinity, no negative zero, no subnormals. Immutable, panic-free (returns errors). Uses half-to-even rounding by default. Falls back to `big.Int` for intermediate calculations to maintain correctness, but final results are always rounded to 19 digits.
-
-#### Delphi Currency
-
-Only 64 bits, included for completeness. A 64-bit signed integer scaled by 10^4 (i.e., always exactly 4 decimal places). Max value: 922,337,203,685,477.5807. Not truly 128-bit, but it is a notable example of a fixed-point decimal type in the wild.
-
-### A.3 Eliminated Candidates
-
-The following were investigated but **excluded** because they are arbitrary-precision (not fixed-precision within 128 bits):
-
-| Name                   | Language   | Reason for Exclusion                                                                                                           |
-| ---------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| **shopspring/decimal** | Go         | Arbitrary precision; uses `math/big.Int` internally. No fixed bit width.                                                       |
-| **cockroachdb/apd**    | Go         | Arbitrary precision; `Decimal.Coeff` is a `BigInt` (wrapper around `big.Int`). Implements the General Decimal Arithmetic spec. |
-| **PostgreSQL numeric** | PostgreSQL | Variable-length arbitrary precision. Stored as variable-length array of base-10000 digits. No 128-bit limit.                   |
-| **GCC __int128**       | C/C++      | A 128-bit integer, not a decimal type. Could be used to build a decimal library but is not one itself.                         |
-
-### A.4 Critical Analysis: Coefficient Upper Bound Approaches
-
-There are **two fundamentally different approaches** to bounding the coefficient in fixed-precision decimal types:
-
-#### Approach 1: Binary Bound (2^N − 1)
-
-**Used by:** C# System.Decimal, Rust rust_decimal, Decimo Decimal128
-
-The coefficient is an N-bit unsigned integer, and the maximum value is the full binary range 2^N − 1. For 96-bit coefficients:
-
-- Max = 2^96 − 1 = **79,228,162,514,264,337,593,543,950,335**
-- This is a 29-digit number, but the leading digit can only be 0–7 (since 10^29 − 1 > 2^96 − 1)
-- Consequence: The first significant digit is constrained. You get 29 digits only when the leading
-  digit is ≤ 7. You get the full 0–9 range only for 28-digit numbers.
-
-**Pros:**
-
-- Natural fit for hardware - the coefficient is just a native (multi-word) integer
-- Simple bounds check: just compare against 2^96 − 1
-- Slightly larger range than 10^28 − 1 (about 7.9× more values in the 29th digit range)
-
-**Cons:**
-
-- The "truncate-to-max" problem: when an operation produces a coefficient > 2^96 − 1, you must either raise an error or round. The boundary is not at a clean decimal digit boundary, which makes rounding semantics awkward. E.g., 80,000,000,000,000,000,000,000,000,000 (8×10^28) is out of range, even though it only needs 2 significant digits.
-- Non-uniform digit range: the 29th digit has range 0–7, not 0–9. This is confusing for users.
-
-#### Approach 2: Decimal Bound (10^p − 1)
-
-**Used by:** Apache Arrow Decimal128, SQL Server decimal(38), Swift Decimal, govalues/decimal
-
-The coefficient is bounded by 10^p − 1, where p is the declared precision. Even if the underlying storage has more bits available, values above 10^p − 1 are not representable.
-
-For Arrow/SQL precision 38:
-
-- Max = 10^38 − 1 = **99,999,999,999,999,999,999,999,999,999,999,999,999** (38 nines)
-- Fits in 128 bits (10^38 − 1 < 2^127 − 1), with ~90 bits of the 128 used
-- Every digit position has the full 0–9 range
-
-For govalues/decimal precision 19:
-
-- Max = 10^19 − 1 = **9,999,999,999,999,999,999** (19 nines)
-- Fits in a single uint64 (10^19 − 1 < 2^64 − 1), with ~63 bits of the 64 used
-
-**Pros:**
-
-- Clean decimal semantics: every digit position has the full 0–9 range
-- No "truncate-to-max" confusion at non-decimal boundaries
-- Precision is exactly p significant decimal digits, no asterisks
-- Easier to reason about for financial applications
-
-**Cons:**
-
-- Wastes some of the available bit range (Arrow uses ~126.5 of 128 bits; govalues uses ~63.1 of 64)
-- Bounds checking requires a comparison against a decimal constant, not a simple overflow check
-
-#### Implications for Decimo
-
-Decimo follows the C#/Rust approach (binary bound, 2^96 − 1). This means:
-
-1. **The coefficient-fitting logic IS a concern:** When multiplying two 29-digit numbers, the intermediate product can have up to 58 digits. If the result after scale adjustment still exceeds 2^96 − 1, we must handle it. The current behavior should be documented: do we raise an error, or do we round to fit?
-
-2. **The non-uniform 29th digit** should be documented. Users may expect that "29 digits of precision" means they can represent any 29-digit number, but `99,999,999,999,999,999,999,999,999,999` (29 nines) = ~10^29 is > 2^96 and therefore out of range. The actual guarantee is "28 full digits plus a leading digit 0–7".
-
-3. **If we ever consider a Decimal256 or widen to full 128-bit coefficient:** We should evaluate whether to switch to the decimal-bounded approach (10^38 − 1 with 128-bit storage, matching Arrow/SQL) vs. staying with binary bound (2^128 − 1, giving ~38.5 digits with non-uniform leading digit). The Arrow/SQL approach would give us exact compatibility with SQL Server `decimal(38)` and Arrow `Decimal128` wire format, which is a significant interoperability advantage.
+> 子曰：工欲善其事，必先利其器。
+
+This document tracks the Decimal128 audit started on 2026-04-08 and the
+performance work that followed. It is the single source of truth for the
+arithmetic / parse / format hot-path optimisation effort.
+
+---
+
+## 1. Cross-Language Snapshot
+
+Scope: 128-bit (or near-128-bit) **fixed-precision** decimal types.
+Out of scope: arbitrary-precision (`BigDecimal`, Python `Decimal`),
+IEEE 754 decimal128 (floating point with NaN/Inf).
+
+| Library               | Layout                               | Max coef  | Digits | NaN/Inf |
+| --------------------- | ------------------------------------ | --------- | ------ | ------- |
+| **decimo Decimal128** | 96-bit coef (3×UInt32 LE) + 32 flags | 2^96 − 1  | 29\*   | No      |
+| C# `System.Decimal`   | identical to decimo                  | 2^96 − 1  | 29\*   | No      |
+| Rust `rust_decimal`   | identical to decimo                  | 2^96 − 1  | 29\*   | No      |
+| Apache Arrow Dec128   | 128-bit two's-comp signed            | 10^p − 1  | ≤ 38   | No      |
+| Go `govalues/decimal` | 64-bit coef                          | 10^19 − 1 | 19     | No      |
+
+\* 29 digits but the leading digit can only be 0–7 (since
+`10^29 − 1 > 2^96 − 1`); §6 lists this as an architectural concern.
+
+Arithmetic coverage (decimo vs others): we are the most complete —
+the only library with `root`, `log10`, `log` (arbitrary base) and
+`factorial`. Missing only `min`/`max`/`clamp` and `normalize()` (§5).
+
+---
+
+## 2. Change History — Done
+
+Dated by report file under `benches/decimal128/reports/`. Every row
+corresponds to one landed PR / one bench snapshot. Rows are *append-only*.
+
+### 2.1 Correctness
+
+| Date     | Item                                                                               |
+| -------- | ---------------------------------------------------------------------------------- |
+| earlier  | NaN/Infinity removed (matches all 4 reference libraries)                           |
+| earlier  | `from_words` now raises on invalid input (was `testing.assert_true` in production) |
+| 20260423 | `power_of_10_unsafe[uint128]` OOB defence (3 layers; PR #221/#224)                 |
+| 20260423 | `multiply` single-step rounding fix (re-round `prod_orig`, not the rounded value)  |
+
+### 2.2 Performance utility
+
+| Date     | Item                                                                                     |
+| -------- | ---------------------------------------------------------------------------------------- |
+| earlier  | `number_of_bits` → `bit_width` (LLVM `clz` intrinsic)                                    |
+| earlier  | `power_of_10` precomputed up to n=58                                                     |
+| earlier  | `round_coefficient` with .NET `2*remainder vs divisor` shortcut + `skip_digit_check`     |
+| 20260422 | **`debug_assert(..., "msg {}".format(n))` audit** — `.format()` is *not* lazy under      |
+|          | `-D ASSERT=none`; eager `String.format` allocates inside hot loops. All sites swept.     |
+| 20260422 | `power_of_10[uint128/uint256]` → balanced bisect if/else tree (depth ~5/6)               |
+| 20260422 | **Granlund-Möller reciprocal divider** for UInt256 / 10^k (k ∈ [1,29]). 250→6 ns/call.   |
+|          | **Critical:** magic constant must use **ceiling** division. Floor failed 17/2000 at k=1. |
+| 20260422 | `udiv_u256_by_u64` schoolbook over u64 limbs (~12 ns vs 236 ns native UInt256/UInt256)   |
+| 20260422 | `power_of_10_unsafe` swept across 22 hot sites (was `UInt(128                            | 256)(10) ** k`) |
+
+### 2.3 Performance — arithmetic ops
+
+Each row landed one hypothesis (H#x) — see §3 for the validated marginal
+value before the fact and §2.4 / §2.5 for end-to-end snapshots.
+
+| Date     | Item                                                                                 |
+| -------- | ------------------------------------------------------------------------------------ |
+| 20260421 | H#3.1(a) Hoist `same scale` branch above `is_integer()` in `add()`. add 106→5 ns     |
+| 20260421 | H#3.1(b) `is_integer()` cheap pre-check `(low & ((1<<scale)-1)) != 0` (still useful  |
+|          | for `multiply()` and external callers; removed from `add()` in step (c))             |
+| 20260421 | H#3.1(c) Remove `is_integer` branch from `add()` entirely — was net loss even when   |
+|          | triggered (dispatch ~250 ns, fall-through ~110 ns). add `Both integer` 121→6 ns      |
+| 20260422 | H#4.1 Remove `is_integer` branch from `multiply()` (same logic). 548-759→5-6 ns      |
+| 20260422 | `fit_to_max_coefficient` instantiates `round_coefficient[skip_digit_check=True]`     |
+| 20260422 | H#11 Hot-path-first single-function `add`/`sub`. Same-scale branch first, zero-with- |
+|          | diff-scale routed into the cold tail. add 5→4 ns (dm/rs 2.1→1.3)                     |
+| 20260422 | H#3 `subtract()` diff-scale arm fully inlined (no `add(x1, negative(x2))` detour);   |
+|          | `@always_inline` on `multiply()`. sub `diff scale` 12→10 ns                          |
+| 20260422 | H#5 `divide()` two-phase: probe loop (≤2 iters) + `udiv_u256_by_u64` bulk finish +   |
+|          | bisect-style trailing-zero trim. divide max **287→56 ns**                            |
+| 20260422 | H#14 `power_of_10_unsafe` sweep + `from_uint128` `@always_inline` with `raises`      |
+|          | extracted into `@no_inline` helpers. add dm/rs 1.2→0.8; divide dm/rs 2.2→1.0         |
+
+### 2.4 Performance — comparison / format / parse (this PR)
+
+| Date     | Item                                                                                 |
+| -------- | ------------------------------------------------------------------------------------ |
+| 20260423 | **`compare_absolute` rewrite.** Same-scale → direct UInt128 compare. Different scale |
+|          | → scale-up smaller side and compare (UInt128 if scale_diff ≤ 9, else UInt256).       |
+|          | Eliminates 2 `number_of_digits` + 4 `power_of_10_unsafe` + 2 wide div + 2 wide mod   |
+|          | per call. Worst case 13.6 → 3.8 ns.                                                  |
+| 20260423 | **`to_str` / `write_to` rewrite.** `write_to` now contains all formatting; `to_str`  |
+|          | is a thin wrapper. Digits extracted into a 32-byte `InlineArray` right-aligned via   |
+|          | 9-digit chunks (UInt128 // 10^9 outer + UInt32 // 10 inner). One `StringSlice` write |
+|          | per logical span. Median 0.4× rust, worst case ~1.1× rust.                           |
+| 20260423 | **`multiply` single-pass rounding.** When `prod > MAX_AS_UINT128` *or*               |
+|          | `combined_scale > MAX_SCALE`, compute `drop = max(drop_for_fit, drop_for_scale)` in  |
+|          | one shot and call `round_coefficient` once. Replaces the old two-pass                |
+|          | `fit_to_max_coefficient` + re-round pattern. Saves ~5 ns + one wide divide. Applied  |
+|          | to both `combined_num_bits ≤ 128` and `≤ 192` branches. **`High precision multiply`  |
+|          | 19 → 13 ns.**                                                                        |
+| 20260423 | **`from_string` parser.** (a) Drop the separate non-ASCII pre-scan loop (folded into |
+|          | the `else` arm). (b) Reorder the per-byte switch so the digit branch (48–57) comes   |
+|          | first. (c) Merge the separate '0' and '1–9' branches into one. **Long integer        |
+|          | 41 → 22 ns; Long fractional 71 → 46 ns; Maximum coefficient 64 → 36 ns.**            |
+
+### 2.5 Performance tracking — absolute decimo median ns/iter
+
+Lower = faster. Numbers come from `benches/decimal128/run_all.sh`
+(best-of-5, `-D ASSERT=none`). Append-only.
+
+| Date     |  add |  sub |  mul |  div |  cmp | from_str | to_str | note                                               |
+| -------- | ---: | ---: | ---: | ---: | ---: | -------: | -----: | -------------------------------------------------- |
+| 20260421 |  106 |  123 |    4 |    8 |    0 |    24.25 | 128.30 | Before any optimisations (cmp inaccurate)          |
+| 20260421 |    5 |    6 |    4 |    8 | 2.10 |    24.15 | 127.00 | After H#3.1 add reorder                            |
+| 20260421 |    5 |  6.5 |    6 |    9 | 2.10 |    21.80 | 129.60 | After H#3.1 is_integer removed from add            |
+| 20260422 |    5 |    7 |    5 |    8 | 2.10 |    23.10 | 124.30 | After H#4.1 is_integer removed from mul            |
+| 20260422 |    5 |    6 |    5 |    8 | 2.10 |    22.65 | 136.00 | After Granlund-Möller UInt256 / 10^k               |
+| 20260422 |    4 |    4 |    5 |    9 | 2.10 |    25.20 | 119.20 | After H#3 sub diff-scale inlined + mul ais         |
+| 20260422 |    4 |    4 |    4 |    8 | 2.10 |    26.00 |  82.70 | After H#5 divide two-phase                         |
+| 20260422 |    3 |    3 |    4 |    6 | 2.00 |    23.30 | 122.40 | After H#14 power_of_10_unsafe sweep + from_uint128 |
+| 20260423 |  3.5 |    2 |  3.5 |    5 |  3.2 |    14.05 |  16.60 | After §2.4 (compare/write_to/multiply/from_string) |
+
+### 2.6 Performance tracking — worst-case (max across cases) ns/iter
+
+| Date     |  add |  sub |  mul |  div |  cmp | from_str | to_str | note                                           |
+| -------- | ---: | ---: | ---: | ---: | ---: | -------: | -----: | ---------------------------------------------- |
+| 20260421 |  121 |  121 |  500 |  359 | 18.1 |   177.60 | 586.70 | After H#3.1 add reorder                        |
+| 20260422 |   17 |   16 |  262 |  307 | 19.8 |    68.40 | 577.90 | After debug_assert .format sweep + bisect tree |
+| 20260422 |   14 |   15 |   22 |  257 | 17.4 |    65.30 | 554.50 | After Granlund-Möller                          |
+| 20260422 |   13 |   14 |   25 |   45 | 18.0 |    67.60 | 583.70 | After H#14                                     |
+| 20260423 |    5 |    4 |   23 |   54 |  4.2 |    46.20 |  83.30 | After §2.4                                     |
+
+### 2.7 Performance tracking — decimo / rust ratio (>1 = decimo slower)
+
+| Date     |   add |   sub |  mul |  div |  cmp | from_str | to_str |
+| -------- | ----: | ----: | ---: | ---: | ---: | -------: | -----: |
+| 20260421 | 21.2x | 61.5x | 1.6x | 1.4x | 0.0x |     2.6x |   3.6x |
+| 20260422 |  0.8x |  1.3x | 1.7x | 1.0x | 0.8x |     1.4x |   3.4x |
+| 20260423 |  1.2x |  0.8x | 1.5x | 0.9x | 1.2x |     1.4x |   0.4x |
+
+The 20260423 row reflects the post-§2.4 cross-op overview from
+`dec128_report_20260423_145648.md`. **All medians ≤ 1.5× rust.** The
+worst-case "≤ 1.5×" target is met for `add`, `sub`, `cmp`, `to_str`. It
+is missed on the long tail of `multiply` (worst 2.0×, e.g. `High precision`
+13 vs 6.46 ns), `divide` (worst 3.9×, `Repeating decimal` 47 vs 12.12 ns),
+and `from_string` (worst 2.1×, `Long integer` 24.7 vs 11.5 ns). Closing
+those last gaps requires deeper algorithmic work (see §5.4).
+
+---
+
+## 3. Hypothesis Ledger
+
+Marginal-value ranking from the original §4.9 decomposition, kept for
+context. All P1/P2 items have landed; P3 items are tracked in §5.
+
+| H#  | Hypothesis                                                 | Outcome                                                                                    |
+| --- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| 1   | `coefficient()` reconstructs UInt128 each call             | DISPROVEN — already `@always_inline` bitcast (~0 ns)                                       |
+| 2   | `def raises` calling-convention overhead                   | DONE — kept `def raises`, hot-path-first ordering captured the win (H#11)                  |
+| 3   | UInt256 promotion in `add` when scales differ              | DONE — `subtract` diff-scale fully inlined                                                 |
+| 3.1 | `is_integer()` ×2 wastes UInt128 mod                       | DONE — three-step landing 21→2.1 ns                                                        |
+| 4   | UInt256 promotion in `mul` when product fits UInt128       | DEPRIORITISED — bench cases all have `combined_num_bits ≥ 186`, mandatory UInt256          |
+| 4.1 | `is_integer` branch in `multiply()`                        | DONE — removed; 548→5 ns on `Both integer`                                                 |
+| 5   | divide long-division loop                                  | DONE — two-phase probe + UInt256/u64 schoolbook                                            |
+| 6   | `to_string` per-call allocation                            | DONE (this PR) — `write_to` writes digits via 32-byte `InlineArray` + single `StringSlice` |
+| 7   | bitcast 4×UInt32 → single UInt128 in `coefficient()`       | DISPROVEN                                                                                  |
+| 8   | `from_uint128()` raises overhead                           | DISPROVEN initially, but H#14 found it once `from_uint128` is `@always_inline`             |
+| 9   | Power-of-10 LUT vs if/elif tree                            | LANDED bisect tree; LUT regressed when `debug_assert .format` was eager                    |
+| 10  | Granlund-Möller reciprocal for `UInt256 / 10^k`            | DONE — 250→6 ns                                                                            |
+| 11  | Hot-path-first single-function `add` / `sub`               | DONE — add 5→4 ns                                                                          |
+| 12  | `subtract` diff-scale: inline vs `add(x1, negative(x2))`   | DONE — saves ~3 ns / op                                                                    |
+| 13  | divide two-phase: probe + bulk finish                      | DONE — divide max 287→56 ns                                                                |
+| 14  | `power_of_10_unsafe` sweep + `from_uint128` always-inline  | DONE — divide median 8→6 ns; raises extracted to `@no_inline` helpers                      |
+| 15  | `compare_absolute` rewrite                                 | DONE (this PR) — worst case 13.6→3.8 ns                                                    |
+| 16  | `multiply` single-pass rounding (saves second wide divide) | DONE (this PR) — High-precision 19→13 ns                                                   |
+| 17  | `from_string` per-byte switch reorder + branch merge       | DONE (this PR) — Long integer 41→22 ns                                                     |
+
+---
+
+## 4. Lessons Learnt (the reusable bits)
+
+1. **`debug_assert` does NOT lazy-evaluate its message argument** under
+   `-D ASSERT=none`. `String.format` allocates and runs inside the hot
+   loop anyway. Use plain string literals only. Filed as a Mojo-team
+   reproducer: `/tmp/repro_debug_assert_format.mojo`.
+
+2. **`urem` lowers to `sub(a, mul(udiv, b))` and CSE-deduplicates with
+   the explicit `// + %`.** Writing `q = a // b; r = a - q*b` gives
+   the compiler nothing extra and adds source noise. Confirmed at the
+   ARM64 asm level. Use the natural `// + %` form.
+
+3. **Branches that test a non-trivial predicate to skip a moderately-
+   priced fall-through are often anti-optimisations.** Always measure
+   the dispatch cost separately from the body cost. The `is_integer`
+   branches in `add()` and `multiply()` were both net losses *even when
+   triggered*.
+
+4. **For raises functions on the hot path, extract each `raise ... .format(...)`
+   into a `@no_inline` helper.** Lets `@always_inline` actually fire.
+   `from_uint128` benefited the most.
+
+5. **Granlund-Möller needs ceiling division** for the magic constant
+   `mp = ⌈2^(N+ℓ)/d⌉ − 2^N`. Floor failed 17/2000 random tests at k=1.
+
+6. **When LLVM lowers wide-integer division to a software loop and the
+   divisor is one of a small fixed set of compile-time constants, a
+   reciprocal table is the right answer** — but verify against the
+   native divide on a randomised sweep across the entire k range.
+
+7. **The count of branches before the fast arm matters more than the
+   body of the fast arm.** A 6-arm linear scan makes even the cheapest
+   arm pay for the predicates of every prior arm. Hot path first; rare
+   cases routed to the cold tail of the same function.
+
+8. **Helper-function decomposition costs ~1 ns over a well-ordered
+   monolith.** Reserve helpers for genuinely shared code paths, not
+   for rhetorical "decomposition".
+
+9. **`from_string`-style state-machine parsers benefit hugely from
+   reordering the per-byte switch so the digit branch comes first.**
+   Two-pass scans (e.g. a separate pre-pass for non-ASCII) should be
+   folded into the main loop's `else` arm.
+
+10. **For `to_string`, build the digit buffer right-aligned in a fixed
+    `InlineArray` and emit via a single `StringSlice`.** Avoid per-byte
+    `writer.write` calls and avoid an intermediate `String` builder.
+
+11. **For multi-pass rounding, compute the total drop count in one shot
+    when both constraints are independent (e.g. coefficient-fits and
+    scale-fits in `multiply`).** The boundary case (round-up carries
+    past `MAX_COEF`) is handled by a single `if rounded > MAX: drop +=
+    1; round again` — and the re-round must use the **original** value,
+    not the already-rounded one (subtle bug introduced and fixed in this
+    PR for the UInt256 branch).
+
+---
+
+## 5. Open Items / Future Improvements
+
+### 5.1 Worst-case ratios still > 1.5× rust
+
+These are the residual gaps after this PR. Each requires algorithmic
+work, not micro-optimisation.
+
+| Op       | Worst case                      | decimo |  rust | dm/rs | Likely root cause                                                                                            |
+| -------- | ------------------------------- | -----: | ----: | ----: | ------------------------------------------------------------------------------------------------------------ |
+| multiply | High precision multiplication   |   13.0 |  6.50 |  2.0× | UInt128 path: 17×17-digit prod, mandatory `round_coefficient` work                                           |
+| multiply | Multiplication by zero          |    4.0 |  1.38 |  2.9× | Per-call dispatch overhead (raises + special-case tree)                                                      |
+| multiply | Negative numbers                |    4.0 |  1.08 |  3.7× | Same                                                                                                         |
+| multiply | e * e^0.5                       |   23.0 | 27.79 |  0.8× | UInt256 path; *faster* than rust                                                                             |
+| divide   | Division with repeating decimal |   47.0 | 12.12 |  3.9× | Rust uses a `div_internal` magic-multiply trick; decimo's two-phase loop still pays 28 digits' worth of bulk |
+| divide   | High precision division         |   48.0 | 19.21 |  2.5× | Same                                                                                                         |
+| divide   | Large coprime quotient          |   43.0 | 16.88 |  2.5× | Same                                                                                                         |
+| from_str | Long integer part (20 digits)   |   24.7 | 11.52 |  2.1× | UInt128 multiply-by-10 per digit; could batch into u64 chunks                                                |
+| from_str | Long fractional (28 digits)     |   46.2 | 27.12 |  1.7× | Same                                                                                                         |
+| from_str | Zero value                      |    4.3 |  1.79 |  2.4× | Per-call dispatch; rust has a 2-byte fast path                                                               |
+
+**Possible follow-ups** (none committed):
+
+- *divide* (highest impact): adopt rust_decimal's reciprocal-multiplication
+  approach. Pre-compute reciprocals of common divisors or use a single
+  hardware `__udivti3` + correction, instead of the per-digit loop.
+- *from_string*: digit batching — accumulate up to 19 digits in a `UInt64`,
+  then `coef = coef * 10^k + batch` once per chunk. ~5–7× reduction on the
+  inner-loop multiplies. Targeted estimate: 24 → ~14 ns on `Long integer`.
+- *multiply per-call dispatch*: collapse the 6-way special-case tree into
+  3 branches (zero short-circuit, integer fast path, general). Risk:
+  regressions on the cases the dispatch was added for.
+
+### 5.2 API gaps vs `rust_decimal`
+
+Trivial additions (one PR): `trunc`, `floor`, `ceil`, `fract`, `signum`,
+`unpack`. Tracked separately:
+
+- `min` / `max` / `clamp`
+- `normalize()` (strip trailing zeros)
+- `__hash__` (depends on `normalize`)
+
+### 5.3 `ln()` / `log10()` range reduction
+
+`ln()` reduces input to `[0.5, 2.0)` via two while-loops; for `ln(1e28)`
+that's ~30 full Decimal128 divisions. Use `ln(a × 10^q) = ln(a) + q × ln(10)`
+to read `q` directly from the input scale. Bit-width can collapse the second
+loop similarly. Expected: ~30 divs → 1 scale-fix + 1 div.
+
+### 5.4 Test-suite latency
+
+Two factors dominate. `-D ASSERT=all --debug-level=full` is 5–7× slower
+than release; per-file JIT adds ~0.5–1 s of fixed cost × 17 files.
+Recommendation: a `pixi run testfast` profile (no debug info,
+`-D ASSERT=none`); long-term, switch to `mojo test` single-binary
+discovery when available.
+
+### 5.5 Architectural: 96-bit coefficient → 32-digit decimal-bounded
+
+The `2^96 − 1` upper bound has a non-clean decimal boundary (29 digits
+but leading digit only 0–7). A future major release could repurpose 5
+unused bits in the flags word to extend the coefficient to `10^32 − 1`,
+unifying the digit semantics. Documented as a long-term proposal; not
+on the active roadmap. See git history (pre-2026-04-23) for the full
+analysis.
+
+---
+
+## 6. Result-Equivalence vs `rust_decimal` / .NET (3 vs 1 verdict)
+
+The cross-language harness flags trailing-zero / scale-string differences
+in `multiply` and `divide`. On every disputed case **decimo, C# and
+VB.NET `System.Decimal` agree** against `rust_decimal`:
+
+| op       | inputs        | decimo / .NET | rust_decimal | Verdict                                                                                           |
+| -------- | ------------- | ------------- | ------------ | ------------------------------------------------------------------------------------------------- |
+| multiply | `123.45 × 0`  | `0.00`        | `0`          | **decimo + .NET correct.** `exp(0×X) = exp(a)+exp(b) = -2`, so `0` at exp `-2` is `0.00`.         |
+| divide   | `10.5 / 2.5`  | `4.2`         | `4.20`       | Ideal exponent for divide = `exp(a)−exp(b) = 0`; `4.2` (exact at exp `-1`) preferred over `4.20`. |
+| divide   | `123.45 / -2` | `-61.725`     | `-61.7250`   | Exact result needs exp `-3`; ideal exp `-2` would require fractional coef.                        |
+
+decimo follows IEEE 754-2008 §3.3 (preferred exponent) and the IBM
+General Decimal Arithmetic spec §4.1, matching .NET BCL. `rust_decimal`
+is the lone outlier among the four references surveyed. **No
+remediation needed on the decimo side.**
+
+To-do: add a regression test pinning these exact strings, and a one-
+paragraph note in the user manual.
+
+---
+
+## 7. Priority Summary
+
+Open items, in priority order:
+
+| #   | Issue                                                 | Effort  | Priority |
+| --- | ----------------------------------------------------- | ------- | -------- |
+| 5.1 | divide repeating-decimal long tail (47 → ≤ 19 ns)     | Large   | P1       |
+| 5.1 | from_string digit batching                            | Medium  | P2       |
+| 5.3 | `ln()` range reduction loops                          | Medium  | P2       |
+| 5.2 | `trunc`/`floor`/`ceil`/`fract`/`signum`/`unpack`      | Small   | P2       |
+| 6.0 | Regression tests pinning IEEE 754 preferred-exp scale | Trivial | P2       |
+| 5.2 | `min`/`max`/`clamp`                                   | Trivial | P3       |
+| 5.2 | `normalize()`                                         | Small   | P3       |
+| 5.2 | `__hash__` (depends on `normalize()`)                 | Small   | P3       |
+| 5.4 | Test-suite latency                                    | Medium  | P3       |
+| 5.5 | Steal flag bits → 32-digit coefficient                | Large   | P4       |

--- a/src/decimo/decimal128/arithmetics.mojo
+++ b/src/decimo/decimal128/arithmetics.mojo
@@ -673,46 +673,60 @@ def multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
     if combined_num_bits <= 128:
         var prod: UInt128 = x1_coef * x2_coef
-        var prod_orig = prod  # preserve full precision for single-step round
 
-        # Use fit_to_max_coefficient to handle the try-29/try-28 pattern.
-        # digits_removed tells us how many least-significant digits were
-        # rounded away. If digits_removed > combined_scale, we've lost
-        # integral digits → overflow.
-        var fitted = decimo.decimal128.utility.fit_to_max_coefficient(prod)
-        var digits_removed = fitted[1]
+        # Fast path: product already fits Decimal128 capacity and the
+        # combined scale is in range — return without any rounding work.
+        if (
+            prod <= Decimal128.MAX_AS_UINT128
+            and combined_scale <= Decimal128.MAX_SCALE
+        ):
+            return Decimal128.from_uint128(
+                prod, UInt32(combined_scale), is_negative
+            )
 
-        if digits_removed > combined_scale:
+        # Single-pass rounding: compute the total digits to drop so that
+        # both the coefficient (≤ MAX_AS_UINT128) and the scale (≤
+        # MAX_SCALE) constraints are satisfied in one `round_coefficient`
+        # call. Saves the extra `number_of_digits` + wide divide that the
+        # old `fit_to_max_coefficient` + re-round pattern incurred.
+        var ndigits = decimo.decimal128.utility.number_of_digits(prod)
+        var drop_for_scale = Int(combined_scale) - Decimal128.MAX_SCALE
+        var drop_for_fit: Int
+        if prod > Decimal128.MAX_AS_UINT128:
+            # 29-digit values that still exceed MAX_AS_UINT128 need one
+            # explicit digit removed (`max(1, ndigits - 29)` handles both
+            # the boundary and any larger overflow uniformly).
+            drop_for_fit = max(1, ndigits - Decimal128.MAX_NUM_DIGITS)
+        else:
+            drop_for_fit = 0
+
+        var drop = max(drop_for_scale, drop_for_fit)
+        if drop > Int(combined_scale):
             raise OverflowError(
                 message="Decimal128 overflow in multiplication.",
                 function="multiply()",
             )
 
-        prod = fitted[0]
-        var final_scale = combined_scale - digits_removed
-
-        if final_scale > Decimal128.MAX_SCALE:
-            # Single-step rounding fix (rust_decimal / System.Decimal
-            # parity): instead of rounding the already-rounded `prod` a
-            # second time, re-round the original full-precision product
-            # with the total number of digits to drop. This avoids the
-            # off-by-1 last-digit artifact of compound HALF_EVEN passes.
-            var total_drop = digits_removed + (
-                final_scale - Decimal128.MAX_SCALE
-            )
-            prod = decimo.decimal128.utility.round_coefficient(
-                prod_orig, ndigits_to_remove=total_drop
-            )
-            final_scale = Decimal128.MAX_SCALE
-            # Rare boundary: rounding up may push past MAX_COEF.
-            if prod > Decimal128.MAX_AS_UINT128:
-                total_drop += 1
-                prod = decimo.decimal128.utility.round_coefficient(
-                    prod_orig, ndigits_to_remove=total_drop
+        var rounded = decimo.decimal128.utility.round_coefficient[
+            skip_digit_check=True
+        ](prod, ndigits_to_remove=drop)
+        # Rounding-up may carry into a new most-significant digit, pushing
+        # the result past MAX_AS_UINT128. Drop one more digit if so.
+        if rounded > Decimal128.MAX_AS_UINT128:
+            drop += 1
+            if drop > Int(combined_scale):
+                raise OverflowError(
+                    message="Decimal128 overflow in multiplication.",
+                    function="multiply()",
                 )
-                final_scale = Decimal128.MAX_SCALE - 1
+            rounded = decimo.decimal128.utility.round_coefficient[
+                skip_digit_check=True
+            ](prod, ndigits_to_remove=drop)
 
-        return Decimal128.from_uint128(prod, UInt32(final_scale), is_negative)
+        var final_scale = Int(combined_scale) - drop
+        return Decimal128.from_uint128(
+            rounded, UInt32(final_scale), is_negative
+        )
 
     # REMAINING CASES: Both operands are big
     # The bits of the product will not exceed 192 bits
@@ -722,44 +736,51 @@ def multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
     # Or truncates the product to fit into Decimal128's capacity
 
     var prod: UInt256 = UInt256(x1_coef) * UInt256(x2_coef)
-    var prod_orig = prod  # preserve full precision for single-step round
 
-    # Use fit_to_max_coefficient to handle the try-29/try-28 pattern.
-    var fitted = decimo.decimal128.utility.fit_to_max_coefficient(prod)
-    var digits_removed = fitted[1]
+    # Single-pass rounding: compute the total digits to drop so that
+    # both the coefficient (≤ MAX_AS_UINT128) and the scale (≤ MAX_SCALE)
+    # constraints are satisfied in one `round_coefficient` call. Saves
+    # the extra UInt256 division that the old `fit_to_max_coefficient`
+    # + re-round pattern incurred.
+    var ndigits = decimo.decimal128.utility.number_of_digits(prod)
+    var drop_for_scale = Int(combined_scale) - Decimal128.MAX_SCALE
+    var drop_for_fit: Int
+    if prod > UInt256(Decimal128.MAX_AS_UINT128):
+        drop_for_fit = max(1, ndigits - Decimal128.MAX_NUM_DIGITS)
+    else:
+        drop_for_fit = 0
 
-    if digits_removed > combined_scale:
+    var drop = max(drop_for_scale, drop_for_fit)
+    if drop > Int(combined_scale):
         raise OverflowError(
             message="Decimal128 overflow in multiplication.",
             function="multiply()",
         )
 
-    prod = fitted[0]
-    var final_scale = combined_scale - digits_removed
-
-    if final_scale > Decimal128.MAX_SCALE:
-        # Single-step rounding fix (rust_decimal / System.Decimal parity):
-        # re-round the original full-precision product with the total
-        # number of digits to drop, instead of rounding the already-rounded
-        # `prod` a second time. Avoids the off-by-1 last-digit artifact of
-        # compound HALF_EVEN passes.
-        var total_drop = digits_removed + (final_scale - Decimal128.MAX_SCALE)
-        prod = decimo.decimal128.utility.round_coefficient(
-            prod_orig, ndigits_to_remove=total_drop
-        )
-        final_scale = Decimal128.MAX_SCALE
-        # Rare boundary: rounding up may push past MAX_COEF.
-        if prod > Decimal128.MAX_AS_UINT256:
-            total_drop += 1
-            prod = decimo.decimal128.utility.round_coefficient(
-                prod_orig, ndigits_to_remove=total_drop
+    var rounded = decimo.decimal128.utility.round_coefficient[
+        skip_digit_check=True
+    ](prod, ndigits_to_remove=drop)
+    # Rounding-up may carry into a new most-significant digit, pushing
+    # the result past MAX_AS_UINT128. Re-round the ORIGINAL `prod` (not
+    # the already-rounded value) with one more digit dropped to avoid
+    # double-rounding artifacts.
+    if rounded > UInt256(Decimal128.MAX_AS_UINT128):
+        drop += 1
+        if drop > Int(combined_scale):
+            raise OverflowError(
+                message="Decimal128 overflow in multiplication.",
+                function="multiply()",
             )
-            final_scale = Decimal128.MAX_SCALE - 1
+        rounded = decimo.decimal128.utility.round_coefficient[
+            skip_digit_check=True
+        ](prod, ndigits_to_remove=drop)
+
+    var final_scale = Int(combined_scale) - drop
 
     # Extract the 32-bit components from the UInt256 product
-    var low = UInt32(prod & 0xFFFFFFFF)
-    var mid = UInt32((prod >> 32) & 0xFFFFFFFF)
-    var high = UInt32((prod >> 64) & 0xFFFFFFFF)
+    var low = UInt32(rounded & 0xFFFFFFFF)
+    var mid = UInt32((rounded >> 32) & 0xFFFFFFFF)
+    var high = UInt32((rounded >> 64) & 0xFFFFFFFF)
 
     return Decimal128(low, mid, high, UInt32(final_scale), is_negative)
 

--- a/src/decimo/decimal128/comparison.mojo
+++ b/src/decimo/decimal128/comparison.mojo
@@ -104,70 +104,60 @@ def compare_absolute(x: Decimal128, y: Decimal128) -> Int8:
     var x_scale: Int = x.scale()
     var y_scale: Int = y.scale()
 
-    # CASE: The scales are the same
-    # Compare the coefficients directly
-    if x_scale == y_scale and x_coef == y_coef:
-        return 0
+    # CASE: same scale -> direct UInt128 compare.
     if x_scale == y_scale:
-        return Int8((Int(x_coef > y_coef)) - (Int(x_coef < y_coef)))
+        if x_coef == y_coef:
+            return 0
+        return Int8(1) if x_coef > y_coef else Int8(-1)
 
-    # CASE: The scales are different
-    # Compare the integral part first
-    # If the integral part is the same, compare the fractional part
-    else:
-        # Early return if integer parts have different lengths
-        # Get number of integer digits
-        var x_int_digits = (
-            decimo.decimal128.utility.number_of_digits(x_coef) - x_scale
-        )
-        var y_int_digits = (
-            decimo.decimal128.utility.number_of_digits(y_coef) - y_scale
-        )
-        if x_int_digits > y_int_digits:
-            return 1
-        if x_int_digits < y_int_digits:
-            return -1
-
-        # If interger parts have the same length, compare the integer parts
-        var x_scale_power = decimo.decimal128.utility.power_of_10_unsafe[
-            DType.uint128
-        ](Int(x_scale))
-        var y_scale_power = decimo.decimal128.utility.power_of_10_unsafe[
-            DType.uint128
-        ](Int(y_scale))
-        var x_int = x_coef // x_scale_power
-        var y_int = y_coef // y_scale_power
-
-        if x_int > y_int:
-            return 1
-        elif x_int < y_int:
-            return -1
-        else:
-            var x_frac = x_coef % x_scale_power
-            var y_frac = y_coef % y_scale_power
-
-            # Adjust the fractional part to have the same scale.
-            # Bounds: `x_frac < 10^x_scale` and `y_frac < 10^y_scale`, both
-            # ≤ 10^28. After scaling the smaller-scale fraction by
-            # `10^|scale_diff|` (≤ 10^28), the result is still
-            # < 10^max(x_scale, y_scale) ≤ 10^28, well within UInt128
-            # (max ≈ 3.4 × 10^38). No widening required.
-            var scale_diff = x_scale - y_scale
-            if scale_diff > 0:
-                y_frac *= decimo.decimal128.utility.power_of_10_unsafe[
-                    DType.uint128
-                ](Int(scale_diff))
-            else:
-                x_frac *= decimo.decimal128.utility.power_of_10_unsafe[
-                    DType.uint128
-                ](Int(-scale_diff))
-
-            if x_frac > y_frac:
-                return 1
-            elif x_frac < y_frac:
-                return -1
-            else:
+    # CASE: different scales -> scale up the smaller-scale side and
+    # compare. One multiply + one compare beats the previous
+    # number_of_digits / integer-and-fraction split (which spent 2
+    # `number_of_digits`, 4 `power_of_10_unsafe`, 2 wide divisions and
+    # 2 wide modulos before any compare).
+    #
+    # Fast path (scale_diff <= 9): 10^9 < 2^30; coefficient < 2^96, so
+    # the product fits in UInt128.
+    # Wider path: 10^28 < 2^94, max coefficient < 2^96, so the product
+    # is at most ~2^190 and we widen to UInt256.
+    if x_scale > y_scale:
+        var scale_diff = x_scale - y_scale
+        if scale_diff <= 9:
+            var y_scaled = (
+                y_coef
+                * decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
+                    scale_diff
+                )
+            )
+            if x_coef == y_scaled:
                 return 0
+            return Int8(1) if x_coef > y_scaled else Int8(-1)
+        var y_scaled_w = UInt256(
+            y_coef
+        ) * decimo.decimal128.utility.power_of_10_unsafe[DType.uint256](
+            scale_diff
+        )
+        var x_wide = UInt256(x_coef)
+        if x_wide == y_scaled_w:
+            return 0
+        return Int8(1) if x_wide > y_scaled_w else Int8(-1)
+
+    # x_scale < y_scale: scale up x.
+    var scale_diff = y_scale - x_scale
+    if scale_diff <= 9:
+        var x_scaled = x_coef * decimo.decimal128.utility.power_of_10_unsafe[
+            DType.uint128
+        ](scale_diff)
+        if x_scaled == y_coef:
+            return 0
+        return Int8(1) if x_scaled > y_coef else Int8(-1)
+    var x_scaled_w = UInt256(
+        x_coef
+    ) * decimo.decimal128.utility.power_of_10_unsafe[DType.uint256](scale_diff)
+    var y_wide = UInt256(y_coef)
+    if x_scaled_w == y_wide:
+        return 0
+    return Int8(1) if x_scaled_w > y_wide else Int8(-1)
 
 
 def greater(a: Decimal128, b: Decimal128) -> Bool:

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -596,15 +596,11 @@ struct Decimal128(
         if value_bytes_len == 0:
             return Decimal128.ZERO()
 
-        # Check for non-ASCII characters (each non-ASCII char is multi-byte)
-        for byte in value_bytes:
-            if byte > 127:
-                raise ValueError(
-                    message=String(
-                        "Invalid characters in decimal128 string: {}"
-                    ).format(value),
-                    function="Decimal128.from_string()",
-                )
+        # NOTE: A previous version did a separate full-input pass to reject
+        # non-ASCII bytes. That pre-scan is now folded into the main loop
+        # (any byte that doesn't match a recognized ASCII char ends up in
+        # the catch-all `else` branch, which raises ValueError). Saves a
+        # full ~N-byte loop on every parse.
 
         # Yuhao's notes:
         # We scan each char in the string input.
@@ -625,12 +621,67 @@ struct Decimal128(
         var num_mantissa_digits: UInt32 = 0
 
         for code in value_bytes:
+            # HOT PATH: digit '0'-'9' (ASCII 48-57). Checked first so the
+            # common case takes one branch.
+            if code >= 48 and code <= 57:
+                unexpected_end_char = False
+                var d = Int(code) - 48
+
+                # Exponent part
+                if exponent_notation_read:
+                    # Raise / skip if exponent overflows. Use `>=` (not
+                    # `>`) so that we catch the digit *before* the
+                    # multiply pushes `raw_exponent` past the cap.
+                    if raw_exponent >= UInt32(Decimal128.MAX_NUM_DIGITS * 2):
+                        if not exponent_sign:
+                            raise OverflowError(
+                                message=String(
+                                    "Exponent part is too large: {}"
+                                ).format(raw_exponent),
+                                function="Decimal128.from_string()",
+                            )
+                        # Negative exponent past the cap → safely ignored.
+                        continue
+                    raw_exponent = raw_exponent * 10 + UInt32(d)
+                    exponent_sign_read = True
+                    continue
+
+                # Mantissa part
+                # Skip the digit if mantissa is too long.
+                if num_mantissa_digits > Decimal128.MAX_NUM_DIGITS + 8:  # 37
+                    continue
+
+                mantissa_sign_read = True
+                mantissa_start = True
+
+                # Leading zeros before the first significant digit do not
+                # contribute to `coef` / `num_mantissa_digits` (mirrors the
+                # previous separate '0' branch). Trailing zeros after a
+                # significant digit do (e.g. "123.45000").
+                if d != 0 or mantissa_significant_start:
+                    num_mantissa_digits += 1
+                    coef = coef * 10 + UInt128(d)
+                    mantissa_significant_start = True
+
+                if decimal_point_read:
+                    scale += 1
             # If the char is " ", skip it
-            if code == 32:
+            elif code == 32:
                 pass
             # If the char is "," or "_", skip it
             elif code == 44 or code == 95:
                 unexpected_end_char = True
+            # If the char is "."
+            elif code == 46:
+                unexpected_end_char = False
+                if decimal_point_read:
+                    raise ValueError(
+                        message="Decimal point can only appear once.",
+                        function="Decimal128.from_string()",
+                    )
+                else:
+                    decimal_point_read = True
+                    mantissa_sign_read = True
             # If the char is "-"
             elif code == 45:
                 unexpected_end_char = True
@@ -671,17 +722,6 @@ struct Decimal128(
                     )
                 else:
                     mantissa_sign_read = True
-            # If the char is "."
-            elif code == 46:
-                unexpected_end_char = False
-                if decimal_point_read:
-                    raise ValueError(
-                        message="Decimal point can only appear once.",
-                        function="Decimal128.from_string()",
-                    )
-                else:
-                    decimal_point_read = True
-                    mantissa_sign_read = True
             # If the char is "e" or "E"
             elif code == 101 or code == 69:
                 unexpected_end_char = True
@@ -697,84 +737,6 @@ struct Decimal128(
                     )
                 else:
                     exponent_notation_read = True
-            # If the char is a digit 0
-            elif code == 48:
-                unexpected_end_char = False
-
-                # Exponent part
-                if exponent_notation_read:
-                    exponent_sign_read = True
-                    # exponent_start = True
-                    raw_exponent = raw_exponent * 10
-
-                # Mantissa part
-                else:
-                    # Skip the digit if mantissa is too long
-                    if (
-                        num_mantissa_digits > Decimal128.MAX_NUM_DIGITS + 8
-                    ):  # 37
-                        continue
-
-                    mantissa_sign_read = True
-                    mantissa_start = True
-
-                    if mantissa_significant_start:
-                        num_mantissa_digits += 1
-                        coef = coef * 10
-
-                    if decimal_point_read:
-                        scale += 1
-
-            # If the char is a digit 1 - 9
-            elif code >= 49 and code <= 57:
-                unexpected_end_char = False
-
-                # Exponent part
-                if exponent_notation_read:
-                    # Raise an error if the exponent part is too large.
-                    # Use `>=` (not `>`) so that we catch the digit *before*
-                    # the multiply pushes `raw_exponent` past the cap. With
-                    # `>` and a current cap of 58, a string like "1e589"
-                    # would slip through (58 > 58 is False) and let
-                    # `raw_exponent` grow to 589, ultimately reaching
-                    # `power_of_10_unsafe` with an out-of-range index.
-                    if (not exponent_sign) and (
-                        raw_exponent >= Decimal128.MAX_NUM_DIGITS * 2
-                    ):
-                        raise OverflowError(
-                            message=String(
-                                "Exponent part is too large: {}"
-                            ).format(raw_exponent),
-                            function="Decimal128.from_string()",
-                        )
-
-                    # Skip the digit if exponent is negatively too large
-                    elif (exponent_sign) and (
-                        raw_exponent >= Decimal128.MAX_NUM_DIGITS * 2
-                    ):
-                        continue
-
-                    else:
-                        # exponent_start = True
-                        raw_exponent = raw_exponent * 10 + UInt32(code - 48)
-
-                # Mantissa part
-                else:
-                    # Skip the digit if mantissa is too long
-                    if (
-                        num_mantissa_digits > Decimal128.MAX_NUM_DIGITS + 8
-                    ):  # 37
-                        continue
-
-                    mantissa_significant_start = True
-                    mantissa_start = True
-
-                    num_mantissa_digits += 1
-                    coef = coef * 10 + UInt128(code - 48)
-
-                    if decimal_point_read:
-                        scale += 1
-
             else:
                 raise ValueError(
                     message=String(
@@ -1050,7 +1012,7 @@ struct Decimal128(
         Args:
             writer: The writer instance.
         """
-        writer.write('Decimal128("', self.to_str(), '")')
+        writer.write('Decimal128("', String(self), '")')
 
     # ===------------------------------------------------------------------=== #
     # Type-transfer or output methods that are not dunders
@@ -1066,7 +1028,97 @@ struct Decimal128(
         Args:
             writer: The writer instance.
         """
-        writer.write(self.to_str())
+        var coef = self.coefficient()
+        var scale = self.scale()
+        var is_neg = self.is_negative()
+
+        # Special-case zero (preserves trailing zero digits per scale).
+        if coef == 0:
+            if is_neg:
+                writer.write("-")
+            if scale == 0:
+                writer.write("0")
+            else:
+                writer.write("0.")
+                for _ in range(scale):
+                    writer.write("0")
+            return
+
+        # Extract decimal digits into a right-aligned stack buffer. The
+        # Decimal128 coefficient is at most 96 bits (~7.92e28), i.e. at
+        # most 29 digits, so 32 bytes is plenty.
+        #
+        # Speed trick: split off 9-digit chunks at a time via a single
+        # UInt128 division by 10^9 (a 30-bit divisor), then format the
+        # 9-digit chunk with cheap UInt32 divisions. A 28-digit
+        # coefficient costs only ~3 wide divisions instead of 28.
+        comptime BUF_SIZE = 32
+        comptime ZERO_ASCII = UInt8(48)
+        comptime TEN9: UInt128 = 1_000_000_000
+        var buf = InlineArray[UInt8, BUF_SIZE](uninitialized=True)
+        var pos = BUF_SIZE
+
+        while coef >= TEN9:
+            var q = coef // TEN9
+            var r32 = UInt32(coef - q * TEN9)
+            coef = q
+            # Always emit 9 digits because there are more above.
+            for _ in range(9):
+                pos -= 1
+                buf.unsafe_ptr()[pos] = UInt8(r32 % UInt32(10)) + ZERO_ASCII
+                r32 //= UInt32(10)
+
+        var top = UInt32(coef)
+        while top > 0:
+            pos -= 1
+            buf.unsafe_ptr()[pos] = UInt8(top % UInt32(10)) + ZERO_ASCII
+            top //= UInt32(10)
+
+        var n_digits = BUF_SIZE - pos
+
+        if is_neg:
+            writer.write("-")
+
+        if scale == 0:
+            writer.write(
+                StringSlice(
+                    ptr=buf.unsafe_ptr() + pos,
+                    length=n_digits,
+                )
+            )
+        elif scale >= n_digits:
+            # Pre-fill the (scale - n_digits) leading zeros directly into
+            # the buffer, just before the existing digits, so we can
+            # write the entire fractional component in a single
+            # StringSlice instead of a per-byte loop. (scale ≤ 28 and
+            # BUF_SIZE = 32, so the prefix always fits.)
+            var zeros_count = scale - n_digits
+            var frac_start = pos - zeros_count
+            var p = buf.unsafe_ptr() + frac_start
+            for i in range(zeros_count):
+                p[i] = ZERO_ASCII
+            writer.write("0.")
+            writer.write(
+                StringSlice(
+                    ptr=buf.unsafe_ptr() + frac_start,
+                    length=scale,
+                )
+            )
+        else:
+            var int_len = n_digits - scale
+            writer.write(
+                StringSlice(
+                    ptr=buf.unsafe_ptr() + pos,
+                    length=int_len,
+                )
+            )
+            writer.write(".")
+            writer.write(
+                StringSlice(
+                    ptr=buf.unsafe_ptr() + pos + int_len,
+                    length=scale,
+                )
+            )
 
     def repr_words(self) -> String:
         """Returns a string representation of the Decimal128's internal words.
@@ -1197,52 +1249,18 @@ struct Decimal128(
 
         return res
 
-    def to_str(self) -> String:
+    def to_string(self) -> String:
         """Returns string representation of the Decimal128.
         Preserves trailing zeros after decimal128 point to match the scale.
 
         Returns:
             The string representation of this `Decimal128`.
         """
-        # Get the coefficient as a string (absolute value)
-        var coef = String(self.coefficient())
-        var scale = self.scale()
-        var result: String
+        var out = String()
+        self.write_to(out)
+        return out^
 
-        # Handle zero as a special case
-        if coef == "0":
-            if scale == 0:
-                result = "0"
-            else:
-                result = "0." + "0" * scale
-
-        # For non-zero values, format according to scale
-        elif scale == 0:
-            # No decimal128 places needed
-            result = coef
-        elif scale >= len(coef):
-            # Need leading zeros after decimal128 point
-            result = "0." + "0" * (scale - len(coef)) + coef
-        else:
-            # Insert decimal128 point at appropriate position
-            var insert_pos = len(coef) - scale
-            result = coef[byte=:insert_pos] + "." + coef[byte=insert_pos:]
-
-            # Ensure we have exactly 'scale' digits after decimal128 point
-            var decimal_point_pos = result.find(".")
-            var current_decimals = len(result) - decimal_point_pos - 1
-
-            if current_decimals < scale:
-                # Add trailing zeros if needed
-                result += "0" * (scale - current_decimals)
-
-        # Add negative sign if needed
-        if self.is_negative():
-            result = "-" + result
-
-        return result
-
-    def to_str_scientific(self) raises -> String:
+    def to_string_scientific(self) raises -> String:
         """Returns a string representation of this Decimal128 in scientific notation.
 
         Returns:
@@ -2100,7 +2118,7 @@ struct Decimal128(
 
         var result = String("\nInternal Representation Details of Decimal128\n")
         result += sep_line + "\n"
-        result += pad("Decimal128:") + self.to_str() + "\n"
+        result += pad("Decimal128:") + String(self) + "\n"
         result += pad("coefficient:") + String(self.coefficient()) + "\n"
         result += pad("scale:") + String(self.scale()) + "\n"
         result += pad("is negative:") + String(self.is_negative()) + "\n"

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -597,10 +597,11 @@ struct Decimal128(
             return Decimal128.ZERO()
 
         # NOTE: A previous version did a separate full-input pass to reject
-        # non-ASCII bytes. That pre-scan is now folded into the main loop
-        # (any byte that doesn't match a recognized ASCII char ends up in
-        # the catch-all `else` branch, which raises ValueError). Saves a
-        # full ~N-byte loop on every parse.
+        # non-ASCII bytes. That pre-scan is now folded into the main loop:
+        # any unrecognised byte ends up in the catch-all `else` branch,
+        # which raises ValueError. Non-ASCII bytes (`code > 127`) are
+        # special-cased there to include the offending byte value and the
+        # original input string in the error message.
 
         # Yuhao's notes:
         # We scan each char in the string input.
@@ -738,6 +739,18 @@ struct Decimal128(
                 else:
                     exponent_notation_read = True
             else:
+                # Non-ASCII bytes (>127) are typically a stray UTF-8 lead/
+                # continuation byte; surfacing the raw byte via `chr()` is
+                # garbled and not actionable. Include the offending byte
+                # value AND the original input so users can diagnose
+                # encoding issues without us reintroducing a full pre-scan.
+                if code > 127:
+                    raise ValueError(
+                        message=String(
+                            "Invalid non-ASCII byte {} in decimal128 string: {}"
+                        ).format(hex(Int(code)), value),
+                        function="Decimal128.from_string()",
+                    )
                 raise ValueError(
                     message=String(
                         "Invalid character in decimal128 string: {}"
@@ -1012,7 +1025,11 @@ struct Decimal128(
         Args:
             writer: The writer instance.
         """
-        writer.write('Decimal128("', String(self), '")')
+        # Stream the value directly through `write_to` to avoid materialising
+        # an intermediate `String(self)` allocation.
+        writer.write('Decimal128("')
+        self.write_to(writer)
+        writer.write('")')
 
     # ===------------------------------------------------------------------=== #
     # Type-transfer or output methods that are not dunders


### PR DESCRIPTION
This PR focuses on improving Decimal128 performance in core hot paths: parsing (`from_string`), formatting (`write_to`/string conversion), absolute comparison, and multiplication rounding—along with a consolidation of the Decimal128 enhancement plan document.

**Changes:**
- Reworks `Decimal128.from_string()` inner loop to prioritize digit handling and removes a separate non-ASCII pre-scan.
- Replaces string formatting with an `InlineArray`-backed digit writer (`write_to`) and routes `to_string()` through it.
- Simplifies `compare_absolute()` by scaling the smaller-scale operand (UInt128 fast path for small diffs, UInt256 otherwise) and updates multiplication rounding to compute a single total drop count.