### PR TITLE
[dec128] Add `max`, `min`, `clamp`

### DIFF
--- a/docs/plans/decimal128_enhancement.md
+++ b/docs/plans/decimal128_enhancement.md
@@ -146,6 +146,13 @@ value before the fact and §2.4 / §2.5 for end-to-end snapshots.
 |          | three disputed cases vs rust_decimal: `123.45 × 0 → "0.00"`, `10.5 / 2.5 → "4.2"`,   |
 |          | `123.45 / -2 → "-61.725"`, plus zero-with-various-scales and ideal-exponent          |
 |          | rules per IEEE 754-2008 §3.3 / IBM GDA §4.1.                                         |
+| 20260427 | **`Decimal128.min` / `max` / `clamp`** (P3 of §5.2). Added free functions in         |
+|          | `comparison.mojo` and `@always_inline` methods on `Decimal128`. `max(a,b)` /         |
+|          | `min(a,b)` return the first argument on tie (preserving its scale, matching          |
+|          | rust_decimal `Ord::max` / `min`). `clamp(x, lower, upper)` raises if                 |
+|          | `lower > upper`. 8 new tests in `test_decimal128_comparison.mojo` cover              |
+|          | positives/negatives, tie-preserves-scale, signed zeros, in-range / below /           |
+|          | above / boundary clamps, and invalid-bounds raise.                                   |
 
 ### 2.5 Performance tracking — absolute decimo median ns/iter
 
@@ -294,18 +301,18 @@ context. All P1/P2 items have landed; P3 items are tracked in §5.
 These are the residual gaps after this PR. Each requires algorithmic
 work, not micro-optimisation.
 
-| Op       | Worst case                      | decimo |  rust | dm/rs | Likely root cause                                                                                            |
-| -------- | ------------------------------- | -----: | ----: | ----: | ------------------------------------------------------------------------------------------------------------ |
-| multiply | High precision multiplication   |   13.0 |  6.50 |  2.0× | UInt128 path: 17×17-digit prod, mandatory `round_coefficient` work                                           |
-| multiply | Multiplication by zero          |    4.0 |  1.38 |  2.9× | Per-call dispatch overhead (raises + special-case tree)                                                      |
-| multiply | Negative numbers                |    4.0 |  1.08 |  3.7× | Same                                                                                                         |
-| multiply | e * e^0.5                       |   23.0 | 27.79 |  0.8× | UInt256 path; *faster* than rust                                                                             |
-| divide   | Division with repeating decimal |   47.0 | 12.12 |  3.9× | Rust uses a `div_internal` magic-multiply trick; decimo's two-phase loop still pays 28 digits' worth of bulk |
-| divide   | High precision division         |   48.0 | 19.21 |  2.5× | Same                                                                                                         |
-| divide   | Large coprime quotient          |   43.0 | 16.88 |  2.5× | Same                                                                                                         |
-| from_str | Long integer part (20 digits)   |   24.7 | 11.52 |  2.1× | UInt128 multiply-by-10 per digit; could batch into u64 chunks                                                |
-| from_str | Long fractional (28 digits)     |   46.2 | 27.12 |  1.7× | Same                                                                                                         |
-| from_str | Zero value                      |    4.3 |  1.79 |  2.4× | Per-call dispatch; rust has a 2-byte fast path                                                               |
+| Op          | Worst case                      | decimo |  rust | dm/rs | Likely root cause                                                                                            |
+| ----------- | ------------------------------- | -----: | ----: | ----: | ------------------------------------------------------------------------------------------------------------ |
+| multiply    | High precision multiplication   |   13.0 |  6.50 |  2.0× | UInt128 path: 17×17-digit prod, mandatory `round_coefficient` work                                           |
+| multiply    | Multiplication by zero          |    4.0 |  1.38 |  2.9× | Per-call dispatch overhead (raises + special-case tree)                                                      |
+| multiply    | Negative numbers                |    4.0 |  1.08 |  3.7× | Same                                                                                                         |
+| multiply    | e * e^0.5                       |   23.0 | 27.79 |  0.8× | UInt256 path; *faster* than rust                                                                             |
+| divide      | Division with repeating decimal |   47.0 | 12.12 |  3.9× | Rust uses a `div_internal` magic-multiply trick; decimo's two-phase loop still pays 28 digits' worth of bulk |
+| divide      | High precision division         |   48.0 | 19.21 |  2.5× | Same                                                                                                         |
+| divide      | Large coprime quotient          |   43.0 | 16.88 |  2.5× | Same                                                                                                         |
+| from_string | Long integer part (20 digits)   |   24.7 | 11.52 |  2.1× | UInt128 multiply-by-10 per digit; could batch into u64 chunks                                                |
+| from_string | Long fractional (28 digits)     |   46.2 | 27.12 |  1.7× | Same                                                                                                         |
+| from_string | Zero value                      |    4.3 |  1.79 |  2.4× | Per-call dispatch; rust has a 2-byte fast path                                                               |
 
 **Possible follow-ups** (none committed):
 
@@ -322,9 +329,8 @@ work, not micro-optimisation.
 ### 5.2 API gaps vs `rust_decimal`
 
 Landed 2026-04-23: `trunc`, `floor`, `ceil`, `fract`, `signum`, `unpack`
-(see §2.4). Still tracked:
+(see §2.4). Landed 2026-04-27: `min`, `max`, `clamp`. Still tracked:
 
-- `min` / `max` / `clamp`
 - `normalize()` (strip trailing zeros)
 - `__hash__` (depends on `normalize`)
 
@@ -423,12 +429,11 @@ Part II → "A note on result exponents (`Decimal` and `Dec128`)".
 
 Open items, in priority order:
 
-| #   | Issue                                             | Effort  | Priority |
-| --- | ------------------------------------------------- | ------- | -------- |
-| 5.1 | divide repeating-decimal long tail (47 → ≤ 19 ns) | Large   | P1       |
-| 5.1 | from_string digit batching                        | Medium  | P2       |
-| 5.2 | `min`/`max`/`clamp`                               | Trivial | P3       |
-| 5.2 | `normalize()`                                     | Small   | P3       |
-| 5.2 | `__hash__` (depends on `normalize()`)             | Small   | P3       |
-| 5.3 | `exp()` sub-unit chunk constants (`exp(π)`)       | Medium  | P4       |
-| 5.5 | Steal flag bits → 32-digit coefficient            | Large   | P4       |
+| #   | Issue                                             | Effort | Priority |
+| --- | ------------------------------------------------- | ------ | -------- |
+| 5.1 | divide repeating-decimal long tail (47 → ≤ 19 ns) | Large  | P1       |
+| 5.1 | from_string digit batching                        | Medium | P2       |
+| 5.2 | `normalize()`                                     | Small  | P3       |
+| 5.2 | `__hash__` (depends on `normalize()`)             | Small  | P3       |
+| 5.3 | `exp()` sub-unit chunk constants (`exp(π)`)       | Medium | P4       |
+| 5.5 | Steal flag bits → 32-digit coefficient            | Large  | P4       |

--- a/src/decimo/decimal128/comparison.mojo
+++ b/src/decimo/decimal128/comparison.mojo
@@ -28,6 +28,9 @@
 # less_equal(a: Decimal128, b: Decimal128) -> Bool: Returns True if a <= b
 # equal(a: Decimal128, b: Decimal128) -> Bool: Returns True if a == b
 # not_equal(a: Decimal128, b: Decimal128) -> Bool: Returns True if a != b
+# max(a: Decimal128, b: Decimal128) -> Decimal128: Returns the larger of two Decimals
+# min(a: Decimal128, b: Decimal128) -> Decimal128: Returns the smaller of two Decimals
+# clamp(x: Decimal128, lower: Decimal128, upper: Decimal128) -> Decimal128: Clamps x into [lower, upper]
 #
 # List of internal functions in this module:
 #
@@ -43,11 +46,11 @@ from std import testing
 
 from decimo.decimal128.decimal128 import Decimal128
 import decimo.decimal128.utility
+from decimo.errors import ValueError
 
 
 def compare(x: Decimal128, y: Decimal128) -> Int8:
-    """
-    Compares the values of two Decimal128 numbers and returns the result.
+    """Compares the values of two Decimal128 numbers and returns the result.
 
     Args:
         x: First Decimal128 value.
@@ -85,8 +88,7 @@ def compare(x: Decimal128, y: Decimal128) -> Int8:
 
 
 def compare_absolute(x: Decimal128, y: Decimal128) -> Int8:
-    """
-    Compares the absolute values of two Decimal128 numbers and returns the result.
+    """Compares the absolute values of two Decimal128 numbers and returns the result.
 
     Args:
         x: First Decimal128 value.
@@ -161,8 +163,7 @@ def compare_absolute(x: Decimal128, y: Decimal128) -> Int8:
 
 
 def greater(a: Decimal128, b: Decimal128) -> Bool:
-    """
-    Returns True if a > b.
+    """Returns True if a > b.
 
     Args:
         a: First Decimal128 value.
@@ -176,8 +177,7 @@ def greater(a: Decimal128, b: Decimal128) -> Bool:
 
 
 def less(a: Decimal128, b: Decimal128) -> Bool:
-    """
-    Returns True if a < b.
+    """Returns True if a < b.
 
     Args:
         a: First Decimal128 value.
@@ -191,8 +191,7 @@ def less(a: Decimal128, b: Decimal128) -> Bool:
 
 
 def greater_equal(a: Decimal128, b: Decimal128) -> Bool:
-    """
-    Returns True if a >= b.
+    """Returns True if a >= b.
 
     Args:
         a: First Decimal128 value.
@@ -206,8 +205,7 @@ def greater_equal(a: Decimal128, b: Decimal128) -> Bool:
 
 
 def less_equal(a: Decimal128, b: Decimal128) -> Bool:
-    """
-    Returns True if a <= b.
+    """Returns True if a <= b.
 
     Args:
         a: First Decimal128 value.
@@ -221,8 +219,7 @@ def less_equal(a: Decimal128, b: Decimal128) -> Bool:
 
 
 def equal(a: Decimal128, b: Decimal128) -> Bool:
-    """
-    Returns True if a == b.
+    """Returns True if a == b.
 
     Args:
         a: First Decimal128 value.
@@ -236,8 +233,7 @@ def equal(a: Decimal128, b: Decimal128) -> Bool:
 
 
 def not_equal(a: Decimal128, b: Decimal128) -> Bool:
-    """
-    Returns True if a != b.
+    """Returns True if a != b.
 
     Args:
         a: First Decimal128 value.
@@ -248,3 +244,66 @@ def not_equal(a: Decimal128, b: Decimal128) -> Bool:
     """
 
     return compare(a, b) != 0
+
+
+def max(a: Decimal128, b: Decimal128) -> Decimal128:
+    """Returns the larger of two Decimal128 values.
+
+    When the two values compare equal, `a` is returned. Sign and
+    scale follow the operand that is returned (e.g. `max(0, 0.00) == 0`).
+
+    Args:
+        a: First Decimal128 value.
+        b: Second Decimal128 value.
+
+    Returns:
+        `a` if `a >= b`, otherwise `b`.
+    """
+
+    return a if compare(a, b) >= 0 else b
+
+
+def min(a: Decimal128, b: Decimal128) -> Decimal128:
+    """Returns the smaller of two Decimal128 values.
+
+    When the two values compare equal, `a` is returned. Sign and
+    scale follow the operand that is returned.
+
+    Args:
+        a: First Decimal128 value.
+        b: Second Decimal128 value.
+
+    Returns:
+        `a` if `a <= b`, otherwise `b`.
+    """
+
+    return a if compare(a, b) <= 0 else b
+
+
+def clamp(
+    x: Decimal128, lower: Decimal128, upper: Decimal128
+) raises -> Decimal128:
+    """Clamps `x` into the closed interval `[lower, upper]`.
+
+    Args:
+        x:     The value to clamp.
+        lower: The inclusive lower bound.
+        upper: The inclusive upper bound.
+
+    Returns:
+        `lower` if `x < lower`, `upper` if `x > upper`, otherwise `x`.
+
+    Raises:
+        ValueError: If `lower > upper`.
+    """
+
+    if compare(lower, upper) > 0:
+        raise ValueError(
+            message="`lower` must be less than or equal to `upper`.",
+            function="clamp()",
+        )
+    if compare(x, lower) < 0:
+        return lower
+    if compare(x, upper) > 0:
+        return upper
+    return x

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -1827,6 +1827,53 @@ struct Decimal128(
         return decimo.decimal128.comparison.not_equal(self, other)
 
     # ===------------------------------------------------------------------=== #
+    # min / max / clamp
+    # ===------------------------------------------------------------------=== #
+
+    @always_inline
+    def max(self, other: Decimal128) -> Decimal128:
+        """Returns the larger of `self` and `other`.
+        See `max()` for more information.
+
+        Args:
+            other: The value to compare against.
+
+        Returns:
+            `self` if `self >= other`, otherwise `other`.
+        """
+        return decimo.decimal128.comparison.max(self, other)
+
+    @always_inline
+    def min(self, other: Decimal128) -> Decimal128:
+        """Returns the smaller of `self` and `other`.
+        See `min()` for more information.
+
+        Args:
+            other: The value to compare against.
+
+        Returns:
+            `self` if `self <= other`, otherwise `other`.
+        """
+        return decimo.decimal128.comparison.min(self, other)
+
+    @always_inline
+    def clamp(self, lower: Decimal128, upper: Decimal128) raises -> Decimal128:
+        """Clamps `self` into the closed interval `[lower, upper]`.
+        See `clamp()` for more information.
+
+        Args:
+            lower: The inclusive lower bound.
+            upper: The inclusive upper bound.
+
+        Returns:
+            `lower` if `self < lower`, `upper` if `self > upper`, otherwise `self`.
+
+        Raises:
+            ValueError: If `lower > upper`.
+        """
+        return decimo.decimal128.comparison.clamp(self, lower, upper)
+
+    # ===------------------------------------------------------------------=== #
     # Other dunders that implements traits
     # round
     # ===------------------------------------------------------------------=== #

--- a/tests/decimal128/test_decimal128_comparison.mojo
+++ b/tests/decimal128/test_decimal128_comparison.mojo
@@ -6,6 +6,7 @@ Test Decimal128 comparison operations including:
 3. zero comparison edge cases
 4. edge cases (transitivity, precision)
 5. exact comparison with trailing zeros
+6. min / max / clamp
 """
 
 from std import testing
@@ -19,6 +20,9 @@ from decimo.decimal128.comparison import (
     less_equal,
     equal,
     not_equal,
+    max,
+    min,
+    clamp,
 )
 
 
@@ -232,6 +236,84 @@ def test_comparison_operators() raises:
     testing.assert_true(a != b)
     testing.assert_false(a != c)
     testing.assert_false(f != g)
+
+
+# ===----------------------------------------------------------------------=== #
+# min / max / clamp
+# ===----------------------------------------------------------------------=== #
+
+
+def test_max() raises:
+    """Test max() returns the larger of two values; equal values return `a`."""
+    var a = Dec128("1.5")
+    var b = Dec128("2.25")
+    testing.assert_equal(String(max(a, b)), "2.25")
+    testing.assert_equal(String(max(b, a)), "2.25")
+    testing.assert_equal(String(a.max(b)), "2.25")
+    # negatives
+    testing.assert_equal(String(max(Dec128("-3"), Dec128("-7"))), "-3")
+    # equal values: returns first arg, preserving its scale
+    testing.assert_equal(String(max(Dec128("1.0"), Dec128("1.00"))), "1.0")
+    testing.assert_equal(String(max(Dec128("1.00"), Dec128("1.0"))), "1.00")
+
+
+def test_min() raises:
+    """Test min() returns the smaller of two values; equal values return `a`."""
+    var a = Dec128("1.5")
+    var b = Dec128("2.25")
+    testing.assert_equal(String(min(a, b)), "1.5")
+    testing.assert_equal(String(min(b, a)), "1.5")
+    testing.assert_equal(String(b.min(a)), "1.5")
+    testing.assert_equal(String(min(Dec128("-3"), Dec128("-7"))), "-7")
+    # equal values: returns first arg
+    testing.assert_equal(String(min(Dec128("1.0"), Dec128("1.00"))), "1.0")
+
+
+def test_min_max_zero() raises:
+    """Test min/max with zeros of different scales and signs."""
+    testing.assert_equal(String(max(Dec128("0"), Dec128("0.00"))), "0")
+    testing.assert_equal(String(min(Dec128("-0"), Dec128("0"))), "-0")
+
+
+def test_clamp_in_range() raises:
+    """Test clamp() returns x unchanged when lower <= x <= upper."""
+    var lo = Dec128("0")
+    var hi = Dec128("10")
+    var x = Dec128("3.14")
+    testing.assert_equal(String(clamp(x, lo, hi)), "3.14")
+    testing.assert_equal(String(x.clamp(lo, hi)), "3.14")
+
+
+def test_clamp_below() raises:
+    """Test clamp() returns lower when x < lower."""
+    var lo = Dec128("0")
+    var hi = Dec128("10")
+    testing.assert_equal(String(clamp(Dec128("-5"), lo, hi)), "0")
+
+
+def test_clamp_above() raises:
+    """Test clamp() returns upper when x > upper."""
+    var lo = Dec128("0")
+    var hi = Dec128("10")
+    testing.assert_equal(String(clamp(Dec128("99"), lo, hi)), "10")
+
+
+def test_clamp_at_boundary() raises:
+    """Test clamp() at exact boundary values."""
+    var lo = Dec128("-1.5")
+    var hi = Dec128("1.5")
+    testing.assert_equal(String(clamp(lo, lo, hi)), "-1.5")
+    testing.assert_equal(String(clamp(hi, lo, hi)), "1.5")
+
+
+def test_clamp_invalid_bounds() raises:
+    """Test clamp() raises when lower > upper."""
+    var raised = False
+    try:
+        _ = clamp(Dec128("5"), Dec128("10"), Dec128("0"))
+    except:
+        raised = True
+    testing.assert_true(raised, "clamp must raise when lower > upper")
 
 
 def main() raises:


### PR DESCRIPTION
This PR adds `min`, `max`, and `clamp` APIs for `Decimal128`, with corresponding tests and documentation updates.

**Changes:**
- Added free functions `max(a,b)`, `min(a,b)`, and `clamp(x, lower, upper)` to `src/decimo/decimal128/comparison.mojo`.
- Added `@always_inline` instance methods `Decimal128.max()`, `Decimal128.min()`, and `Decimal128.clamp()` delegating to the comparison module.
- Extended the Decimal128 comparison test suite to cover tie behavior (scale preservation), signed zeros, and clamp bounds/raising behavior; updated the enhancement plan doc.