### PR TITLE
[decimal] Add `precision` argument to `add`/`subtract`/`multiply`

### DIFF
--- a/benches/bigdecimal/README.md
+++ b/benches/bigdecimal/README.md
@@ -17,7 +17,7 @@ Each op is exercised at multiple working precisions (default **100, 1000,
     cases/            # source-of-truth TOML test cases (one file per op)
     mojo/   bench.mojo   +  bench   (release-built binary)
     python/ bench.py
-    aggregate.py      # logs/*.csv  ->  reports/bigdec_report_<ts>.md
+    aggregate.py      # logs/*.csv  ->  reports/bigdecimal_report_<ts>.md
     run_all.sh        # build all available, run all (op, precision), aggregate
     logs/             # per-language CSV bench logs (generated)
     reports/          # generated markdown reports

--- a/benches/bigdecimal/aggregate.py
+++ b/benches/bigdecimal/aggregate.py
@@ -328,7 +328,7 @@ def main() -> int:
     offset = now_local.strftime("%z")
     offset_str = f"UTC{offset[:3]}:{offset[3:]}" if len(offset) == 5 else "UTC"
     header_ts = f"{now_local.strftime('%Y-%m-%d %H:%M:%S')} ({offset_str})"
-    out_path = args.out or os.path.join(args.reports_dir, f"bigdec_report_{ts}.md")
+    out_path = args.out or os.path.join(args.reports_dir, f"bigdecimal_report_{ts}.md")
 
     log_index = discover_logs(args.logs_dir)
     records: dict[str, dict[int, dict[str, dict[str, dict[str, str]]]]] = {}

--- a/benches/bigdecimal/mojo/bench.mojo
+++ b/benches/bigdecimal/mojo/bench.mojo
@@ -14,7 +14,7 @@
 #                from_string, to_string, sqrt, exp, ln, root, round.
 
 from decimo import BigDecimal
-from decimo.bigdecimal.arithmetics import true_divide
+from decimo.bigdecimal.arithmetics import add, multiply, subtract, true_divide
 from decimo.bigdecimal.exponential import sqrt as bd_sqrt
 from decimo.bigdecimal.exponential import exp as bd_exp
 from decimo.bigdecimal.exponential import ln as bd_ln
@@ -142,11 +142,11 @@ fn _result_for(
     Never call this inside a timing loop — use `_time_kernel` instead.
     """
     if op == "add":
-        return _emit(_round_to_prec(a + b, precision))
+        return _emit(add(a, b, precision))
     if op == "subtract":
-        return _emit(_round_to_prec(a - b, precision))
+        return _emit(subtract(a, b, precision))
     if op == "multiply":
-        return _emit(_round_to_prec(a * b, precision))
+        return _emit(multiply(a, b, precision))
     if op == "divide":
         return _emit(true_divide(a, b, precision))
     if op == "comparison":
@@ -194,17 +194,17 @@ fn _time_kernel(
     deep copy of the heap-backed BigUInt occurs.
     """
     if op == "add":
-        var r = _round_to_prec(a + b, precision)
+        var r = add(a, b, precision)
         keep(r.scale)
         keep(len(r.coefficient.words))
         return
     if op == "subtract":
-        var r = _round_to_prec(a - b, precision)
+        var r = subtract(a, b, precision)
         keep(r.scale)
         keep(len(r.coefficient.words))
         return
     if op == "multiply":
-        var r = _round_to_prec(a * b, precision)
+        var r = multiply(a, b, precision)
         keep(r.scale)
         keep(len(r.coefficient.words))
         return

--- a/benches/bigdecimal/run_all.sh
+++ b/benches/bigdecimal/run_all.sh
@@ -3,7 +3,7 @@
 # then write a timestamped markdown report under reports/.
 #
 # Raw per-language CSV logs land in   logs/{lang}_{op}_p{prec}_{ts}.csv
-# Aggregated markdown report lands in reports/bigdec_report_{ts}.md
+# Aggregated markdown report lands in reports/bigdecimal_report_{ts}.md
 #
 # Usage:
 #   ./run_all.sh                               # all default ops + per-op precs

--- a/docs/plans/bigdecimal_enhancement.md
+++ b/docs/plans/bigdecimal_enhancement.md
@@ -79,60 +79,49 @@ Dated by report file under `benches/bigdecimal/reports/`. Append-only.
 Best-of-5, `-D ASSERT=none`. Append-only. Where a precision is omitted
 the operation only runs at p=100 in that snapshot.
 
-| Date      | op   | p=100 | p=1000 | p=10000 | p=100000 | note                                         |
-| --------- | ---- | ----: | -----: | ------: | -------: | -------------------------------------------- |
-| 20260221  | div  |   ~7M |    ~6M |   ~480M |   444M\* | pre-T1 asymmetric (\*65536w/32768w)          |
-| 20260221  | div  |   614 |   3.2k |     25k |     245k | post-T1 asymmetric (614 ns at 32768/65536)   |
-| 20260224  | sqrt |  8.6k |   166k |      7M |        — | post-T4 reciprocal-Newton                    |
-| 20260224  | exp  |   24k |   1.7M |       — |        — | post-T3d aggressive halving                  |
-| 20260224  | ln   |  104k |    38M |       — |        — | post-T3a/b/c (far-from-1 still slow)         |
-| 20260430  | add  |   276 |    280 |     290 |      269 | latest 60-case sweep                         |
-| 20260430  | sub  |   211 |    203 |     220 |      210 | latest 50-case sweep                         |
-| 20260430  | mul  |   140 |    140 |     140 |      130 | latest 50-case sweep                         |
-| 20260430  | div  |   805 |   3.2k |     25k |     245k | latest 64-case sweep                         |
-| 20260430  | cmp  |   9.4 |    8.7 |     9.5 |        — | independent of precision                     |
-| 20260430b | add  |   134 |    126 |     142 |        — | post-T-API1: −50% / −55% / −51% vs row above |
-| 20260430b | sub  |   137 |    138 |     136 |        — | post-T-API1: −35% / −32% / −38% vs row above |
-| 20260430b | mul  |    90 |    105 |      80 |        — | post-T-API1: −36% / −25% / −43% vs row above |
+| Date     | op   | p=100 | p=1000 | p=10000 | p=100000 | note                                       |
+| -------- | ---- | ----: | -----: | ------: | -------: | ------------------------------------------ |
+| 20260221 | div  |   ~7M |    ~6M |   ~480M |   444M\* | pre-T1 asymmetric (\*65536w/32768w)        |
+| 20260221 | div  |   614 |   3.2k |     25k |     245k | post-T1 asymmetric (614 ns at 32768/65536) |
+| 20260224 | sqrt |  8.6k |   166k |      7M |        — | post-T4 reciprocal-Newton                  |
+| 20260224 | exp  |   24k |   1.7M |       — |        — | post-T3d aggressive halving                |
+| 20260224 | ln   |  104k |    38M |       — |        — | post-T3a/b/c (far-from-1 still slow)       |
+| 20260430 | add  |   276 |    280 |     290 |      269 | latest 60-case sweep                       |
+| 20260430 | sub  |   211 |    203 |     220 |      210 | latest 50-case sweep                       |
+| 20260430 | mul  |   140 |    140 |     140 |      130 | latest 50-case sweep                       |
+| 20260430 | div  |   805 |   3.2k |     25k |     245k | latest 64-case sweep                       |
+| 20260430 | cmp  |   9.4 |    8.7 |     9.5 |        — | independent of precision                   |
 
 ### 2.5 Performance tracking — decimo / python ratio (>1 = decimo slower)
 
-| Date      | op     | p=100 | p=1000 | p=10000 | Comments      |
-| --------- | ------ | ----: | -----: | ------: | ------------- |
-| 20260224  | add    |  4.7× |   4.9× |    4.9× |               |
-| 20260224  | sub    |  3.6× |   3.5× |    3.8× |               |
-| 20260224  | mul    |  2.3× |   2.4× |    2.4× |               |
-| 20260224  | div    |  5.4× |   5.8× |    5.0× |               |
-| 20260224  | cmp    |  0.2× |      — |       — |               |
-| 20260224  | sqrt   |  2.1× |   0.7× |    0.3× |               |
-| 20260224  | exp    |  1.8× |   0.4× |       — |               |
-| 20260224  | ln     |  4.6× |   9.2× |       — |               |
-| 20260224  | root   |  0.3× |   0.0× |       — |               |
-| 20260224  | frmstr |  1.2× |   1.2× |    1.2× |               |
-| 20260224  | tostr  |  1.3× |   1.3× |    1.2× |               |
-| 20260224  | round  |  1.9× |   2.1× |    2.2× |               |
-| 20260430  | add    |  4.9× |   5.4× |    5.0× |               |
-| 20260430  | sub    |  3.7× |   3.7× |    3.3× |               |
-| 20260430  | mul    |  2.6× |   2.3× |    2.4× |               |
-| 20260430  | div    |  6.5× |   5.3× |    5.1× |               |
-| 20260430b | add    |  2.2× |   2.1× |    2.4× | (post-T-API1) |
-| 20260430b | sub    |  2.3× |   2.3× |    2.3× | (post-T-API1) |
-| 20260430b | mul    |  1.7× |   2.0× |    1.6× | (post-T-API1) |
-| 20260430  | cmp    |  0.2× |      — |       — |               |
-| 20260430  | sqrt   |  2.1× |   0.7× |    0.3× |               |
-| 20260430  | exp    |  1.6× |   0.4× |       — |               |
-| 20260430  | ln     |  4.3× |   8.9× |       — |               |
-| 20260430  | root   |  0.2× |   0.0× |       — |               |
-| 20260430  | frmstr |  1.4× |      — |       — |               |
-| 20260430  | tostr  |  1.0× |      — |       — |               |
-| 20260430  | round  |  2.2× |   2.2× |    2.3× |               |
+| Date     | op     | p=100 | p=1000 | p=10000 | Comments |
+| -------- | ------ | ----: | -----: | ------: | -------- |
+| 20260224 | add    |  4.7× |   4.9× |    4.9× |          |
+| 20260224 | sub    |  3.6× |   3.5× |    3.8× |          |
+| 20260224 | mul    |  2.3× |   2.4× |    2.4× |          |
+| 20260224 | div    |  5.4× |   5.8× |    5.0× |          |
+| 20260224 | cmp    |  0.2× |      — |       — |          |
+| 20260224 | sqrt   |  2.1× |   0.7× |    0.3× |          |
+| 20260224 | exp    |  1.8× |   0.4× |       — |          |
+| 20260224 | ln     |  4.6× |   9.2× |       — |          |
+| 20260224 | root   |  0.3× |   0.0× |       — |          |
+| 20260224 | frmstr |  1.2× |   1.2× |    1.2× |          |
+| 20260224 | tostr  |  1.3× |   1.3× |    1.2× |          |
+| 20260224 | round  |  1.9× |   2.1× |    2.2× |          |
+| 20260430 | add    |  4.9× |   5.4× |    5.0× |          |
+| 20260430 | sub    |  3.7× |   3.7× |    3.3× |          |
+| 20260430 | mul    |  2.6× |   2.3× |    2.4× |          |
+| 20260430 | div    |  6.5× |   5.3× |    5.1× |          |
+| 20260430 | cmp    |  0.2× |      — |       — |          |
+| 20260430 | sqrt   |  2.1× |   0.7× |    0.3× |          |
+| 20260430 | exp    |  1.6× |   0.4× |       — |          |
+| 20260430 | ln     |  4.3× |   8.9× |       — |          |
+| 20260430 | root   |  0.2× |   0.0× |       — |          |
+| 20260430 | frmstr |  1.4× |      — |       — |          |
+| 20260430 | tostr  |  1.0× |      — |       — |          |
+| 20260430 | round  |  2.2× |   2.2× |    2.3× |          |
 
-Latest sweep (2026-05-01, `bigdecimal_report_20260501_115440.md`,
-add/sub/mul only — post-T-API1 with style cleanup; baseline
-`bigdecimal_report_20260430_192858.md`). Re-measured after the
-in-place truncation rewrite; numbers within ±5% of the first
-post-T-API1 sweep `bigdecimal_report_20260430_211128.md` and slightly
-better for short-precision cases.
+Baseline sweep `bigdecimal_report_20260430_192858.md`.
 **Note (2026-04-30):** the cross-language harness was simplified to
 `decimo` vs `python` only. The previous Rust `bigdecimal` reference was
 dropped — it lacked `exp`/`ln`/`root`/`round`, used naive long-division,
@@ -143,37 +132,40 @@ kernels (parse/render are precision-insensitive ops).
 
 ## 3. Hypothesis Ledger
 
-| H#  | Hypothesis                                                       | Outcome                                                             |
-| --- | ---------------------------------------------------------------- | ------------------------------------------------------------------- |
-| 1   | Asymmetric divide pads quotient unnecessarily                    | DONE (T1) — 0.11→76× py at 65536w/32768w                            |
-| 2   | Balanced divide also wastes work for high-precision req          | DONE (T2) — quotient near-constant time (8–915× py)                 |
-| 3a  | `ln(2)`/`ln(1.25)` recomputed per call                           | DONE (T3a) — `MathCache`; 3×–4.5× speedup for repeated `ln()`       |
-| 3b  | Per-Taylor-term BigDecimal divide is wasteful                    | DONE (T3b) — UInt32 divide path; +20–130% near-1 ln                 |
-| 3c  | `log10()`/`log()` re-compute `ln(10)`                            | DONE (T3c) — cached via `MathCache`                                 |
-| 3d  | exp Taylor series too long; weak halving                         | DONE (T3d) — $M=\sqrt{3.322p}$; exp 0.4×→2.6× py at p=1000          |
-| 3e  | Binary splitting for ln Taylor series                            | OPEN — diminishing returns for exp post-T3d; ln still O(p) terms    |
-| 3f  | `atanh` reformulation for ln (3× fewer terms)                    | OPEN — easy win; estimated 3× near-1                                |
-| 3g  | AGM-based ln for very high precision                             | OPEN — long-term, complex                                           |
-| 4   | sqrt via Newton-with-division is slow                            | DONE (T4) — reciprocal-Newton + precision doubling; 20× improvement |
-| 5   | NTT multiplication for n ≥ 1024 words                            | OPEN — single biggest long-term gap vs libmpdec                     |
-| 6   | Toom-3 between Karatsuba and NTT                                 | DONE (T6) — +14–29% for ≥256w                                       |
-| 7a  | `integer_root` via direct Newton (was exp(ln(x)/n))              | DONE (T7a) — 0.14×→25× py at p=1000 for cbrt                        |
-| 7b  | Reciprocal-Newton for nth root (no divide)                       | OPEN — estimated 1.5–2×                                             |
-| 7c  | Rational decomposition $x^{a/b}$ → root then power               | OPEN — fractional roots still 0.2–0.4× py                           |
-| 8   | BigDecimal-level inplace ops in Taylor loops                     | DONE (T8) — +15–27% exp/ln, +9% sqrt                                |
-| 9   | SIMD schoolbook multiply base                                    | OPEN — 1.5–2× constant-factor                                       |
-| 10  | `debug_assert(..., "{}".format(...))` eager allocation           | OPEN — sweep BigUInt + BigDecimal hot paths (Lesson #7)             |
-| 11  | Hot-path-first switch reorder in BigDecimal `add`/`sub`          | OPEN — same-scale & same-sign branch first (Lesson #12)             |
-| 12  | `@no_inline` raise helpers in BigDecimal/BigUInt                 | OPEN — sweep `from_string`, `from_uint32`, etc. (Lesson #10)        |
-| 13  | `from_string` digit batching (UInt64 chunks of 9 or 19)          | OPEN — borrowed from decimal128 H#17 follow-up                      |
-| 14  | `to_string` `InlineArray` right-aligned chunked emit             | OPEN — borrowed from decimal128 §2.4                                |
-| 15  | Single-pass rounding in BigDecimal `multiply` / `divide`         | OPEN — borrowed from decimal128 H#16                                |
-| 16  | Short-divisor fast path in `divide` (single-word loop)           | OPEN — `BigUInt.floor_divide_by_uint32` exists; lift to BigDecimal  |
-| 17  | Add/sub `multiply_by_power_of_ten` allocates oversized           | OPEN — root cause of 4.7× py on small-precision add                 |
-| 18  | Small-coefficient mul fast path (bypass Karatsuba dispatch)      | OPEN — borrowed from decimal128 H#4 dispatch-overhead lesson        |
-| 19  | `precision` arg on `add`/`sub`/`multiply` (truncate ops upfront) | DONE (T-API1, 2026-04-30b)                                          |
-| 20  | Private functions with `_`; Replace raises with debug asserts    | OPEN — improves runtime performance by avoiding unnecessary checks  |
-| 21  | More inplace variants for `BigUInt` and `BigDecimal`             | OPEN — further reduces allocations and improves performance         |
+| H#  | Hypothesis                                                    | Outcome                                                             |
+| --- | ------------------------------------------------------------- | ------------------------------------------------------------------- |
+| 1   | Asymmetric divide pads quotient unnecessarily                 | DONE (T1) — 0.11→76× py at 65536w/32768w                            |
+| 2   | Balanced divide also wastes work for high-precision req       | DONE (T2) — quotient near-constant time (8–915× py)                 |
+| 3a  | `ln(2)`/`ln(1.25)` recomputed per call                        | DONE (T3a) — `MathCache`; 3×–4.5× speedup for repeated `ln()`       |
+| 3b  | Per-Taylor-term BigDecimal divide is wasteful                 | DONE (T3b) — UInt32 divide path; +20–130% near-1 ln                 |
+| 3c  | `log10()`/`log()` re-compute `ln(10)`                         | DONE (T3c) — cached via `MathCache`                                 |
+| 3d  | exp Taylor series too long; weak halving                      | DONE (T3d) — $M=\sqrt{3.322p}$; exp 0.4×→2.6× py at p=1000          |
+| 3e  | Binary splitting for ln Taylor series                         | OPEN — diminishing returns for exp post-T3d; ln still O(p) terms    |
+| 3f  | `atanh` reformulation for ln (3× fewer terms)                 | OPEN — easy win; estimated 3× near-1                                |
+| 3g  | AGM-based ln for very high precision                          | OPEN — long-term, complex                                           |
+| 4   | sqrt via Newton-with-division is slow                         | DONE (T4) — reciprocal-Newton + precision doubling; 20× improvement |
+| 5   | NTT multiplication for n ≥ 1024 words                         | OPEN — single biggest long-term gap vs libmpdec                     |
+| 6   | Toom-3 between Karatsuba and NTT                              | DONE (T6) — +14–29% for ≥256w                                       |
+| 7a  | `integer_root` via direct Newton (was exp(ln(x)/n))           | DONE (T7a) — 0.14×→25× py at p=1000 for cbrt                        |
+| 7b  | Reciprocal-Newton for nth root (no divide)                    | OPEN — estimated 1.5–2×                                             |
+| 7c  | Rational decomposition $x^{a/b}$ → root then power            | OPEN — fractional roots still 0.2–0.4× py                           |
+| 8   | BigDecimal-level inplace ops in Taylor loops                  | DONE (T8) — +15–27% exp/ln, +9% sqrt                                |
+| 9   | SIMD schoolbook multiply base                                 | OPEN — 1.5–2× constant-factor                                       |
+| 10  | `debug_assert(..., "{}".format(...))` eager allocation        | OPEN — sweep BigUInt + BigDecimal hot paths (Lesson #7)             |
+| 11  | Hot-path-first switch reorder in BigDecimal `add`/`sub`       | OPEN — same-scale & same-sign branch first (Lesson #12)             |
+| 12  | `@no_inline` raise helpers in BigDecimal/BigUInt              | OPEN — sweep `from_string`, `from_uint32`, etc. (Lesson #10)        |
+| 13  | `from_string` digit batching (UInt64 chunks of 9 or 19)       | OPEN — borrowed from decimal128 H#17 follow-up                      |
+| 14  | `to_string` `InlineArray` right-aligned chunked emit          | OPEN — borrowed from decimal128 §2.4                                |
+| 15  | Single-pass rounding in BigDecimal `multiply` / `divide`      | OPEN — borrowed from decimal128 H#16                                |
+| 16  | Short-divisor fast path in `divide` (single-word loop)        | OPEN — `BigUInt.floor_divide_by_uint32` exists; lift to BigDecimal  |
+| 17  | Add/sub `multiply_by_power_of_ten` allocates oversized        | OPEN — root cause of 4.7× py on small-precision add                 |
+| 18  | Small-coefficient mul fast path (bypass Karatsuba dispatch)   | OPEN — borrowed from decimal128 H#4 dispatch-overhead lesson        |
+| 19  | `precision` arg on `add`/`sub`/`multiply`                     | DONE (PR #233) — see T-API3                                         |
+| 20  | Private functions with `_`; Replace raises with debug asserts | OPEN — improves runtime performance by avoiding unnecessary checks  |
+| 21  | More inplace variants for `BigUInt` and `BigDecimal`          | OPEN — further reduces allocations and improves performance         |
+| 22  | Zero-copy scale alignment via word-offset add/sub             | OPEN — see T-API2                                                   |
+| 23  | Drop multiply pre-scaling; adjust scale on result             | OPEN — see T-API2.M                                                 |
+| 24  | `round_to_precision` in-place audit                           | OPEN — see T-R2                                                     |
 
 ## 4. Lessons Learnt (the reusable bits)
 
@@ -295,39 +287,62 @@ lessons in §4. All borrow patterns proven on the Decimal128 hot path.
 
 P0 — Structural API change (foundation for most P1 wins)
 
-- **T-API1 — DONE (2026-04-30b).** Added `precision: Int = 0` argument
-  to `add`, `subtract`, `multiply` (existing `__add__`/`__sub__`/`__mul__`
-  overloads keep `precision=0` and so are unchanged). When `precision
-  > 0`:
+- **T-API1 — DONE.** Added `precision: Int = 0` to `add`,
+  `subtract`, `multiply` (the `__add__`/`__sub__`/`__mul__`
+  overloads keep `precision=0`, unchanged). When `precision > 0` the
+  function computes the **exact** result and rounds HALF_EVEN. The
+  upfront-operand-truncation strategy that motivated the API is
+  tracked separately as T-API3.
 
-  - **add/sub:** estimate the result's leading exponent, then for each
-    operand drop the low base-10^9 words that fall below
-    `result_max_exp - precision - 18` guard digits. A *cancellation
-    guard* skips the truncation when signs would subtract AND the two
-    leading exponents are within `precision + 18` of each other,
-    preserving correctness when the leading digits cancel into the
-    precision window. Final result rounded HALF_EVEN.
-  - **multiply:** when `digits(a) + digits(b) > precision + 18`, the
-    longer operand is truncated by `(excess // 9)` low words upfront,
-    bringing the Karatsuba/Toom-3 width down to the precision window.
+- **T-API2 — Zero-copy scale alignment for add/sub/mul.**
+  Today every cross-scale `add`/`subtract` calls
+  `coef.multiply_by_power_of_ten(scale_factor)` on **both** operands
+  (two allocs + two copies + a per-word multiply pass) before a third
+  alloc for the sum. When `scale_diff % 9 == 0` the multiplication is
+  conceptually a left-shift by `k` words and the whole "scale + add"
+  can be one pass into one buffer. `BigUInt.add_slices` (already used
+  by Karatsuba/Toom-3, see `src/decimo/biguint/arithmetics.mojo:207`)
+  is *almost* the right tool but does not handle a word-offset
+  between the two slices. Sub-tasks:
 
-  Result (sweep `bigdecimal_report_20260501_115440.md`, all 460 cases
-  match python oracle 100%):
+  - **A.** New BigUInt primitive
+    `add_with_word_offsets(x, y, x_off, y_off) -> BigUInt` computing
+    `x·BASE^x_off + y·BASE^y_off` in one alloc.
+  - **B.** Sibling `subtract_with_word_offsets` with cancellation.
+  - **C.** Wire BigDecimal `add`/`subtract` to call A/B when
+    `scale_diff % 9 == 0` (the vast majority path).
+  - **D.** Sub-word residual: when `scale_diff % 9 ∈ {1..8}`, use a
+    new `multiply_by_uint32_into(dst, src, factor)` (sibling of the
+    existing `_inplace`) writing into a pre-allocated buffer, then
+    call A/B.
+  - **M.** Drop multiply pre-scaling entirely:
+    `multiply(x·10^a, y·10^b) = multiply(x, y) · 10^(a+b)`. The
+    `multiply_by_power_of_ten` calls in `multiply` are pure waste.
+    Independent of A–D and worth landing first.
 
-  - add: median ns/iter 276/280/290 → 134/126/142 (−50% / −55% / −51%);
-    worst-case dm/py ratio 14× → 4.7×.
-  - sub: 211/203/220 → 137/138/136 (−35% / −32% / −38%);
-    worst case dm/py ~14× → ~3×.
-  - mul: 140/140/140 → 90/105/80 (−36% / −25% / −43%); worst case
-    dm/py 2.3× → 2.0×.
+  **Estimated:** 30–50% on add/sub short-to-medium operands; M alone
+  removes 2 allocs + 2 copies per `multiply` with mixed scales.
 
-  Within the 30–70% estimate at the median; exceeds it on the long-
-  decimal worst cases (e.g. "Add of 2000-d with carries" 3115 → 644 ns,
-  −79%; "Extreme scale diff with large dec (3000+ d)" 4803 → 739 ns,
-  −85%).
+- **T-API3 — `add`/`sub`/`multiply` with `precision > 0`: correct
+  pre-truncation.** The naive "drop low words of the longer operand"
+  heuristic fails for similar-length operands. Strategies to
+  prototype:
 
-  Foundation in place for T-A2 (multiply_by_power_of_ten alloc audit)
-  and T-M1 to push the small-precision residual gap toward ≤2× py.
+  - **S1.** Split the total drop budget (`excess // 9` words) across
+    both operands proportionally to length so neither falls below the
+    buffer-digit floor.
+  - **S2.** Slice-aware kernels: pass tighter `bounds_x`/`bounds_y`
+    to a slice-aware multiplier (`multiply_slices_school`) for `mul`,
+    or to T-API2's offset-add for `add`/`sub`, so the bottom `excess`
+    words are never computed. Pairs naturally with T-API2.
+
+  Property tests must include similar-length-operand multiply.
+  Extend
+  `test_bigdecimal_arithmetics_with_precision` once the new path
+  lands.
+
+  **Estimated:** target add/sub/mul medians of roughly half the
+  current exact-then-round cost without sacrificing precision.
 
 P1 — Add/Sub small-precision target (currently 4.7× / 3.6× py → target ≤2×)
 
@@ -444,6 +459,19 @@ P7 — `round` (2× py → target ≤1.0×)
 - **T-R1: `debug_assert .format` sweep specific to rounding modes.**
   The round dispatcher likely has one assert per mode branch.
 
+- **T-R2: `round_to_precision_inplace` variant.** Today
+  `round_to_precision(result, precision, …)` already mutates its
+  argument in place at the BigDecimal level (`result` is `mut`), but
+  audit whether the inner BigUInt path
+  (`remove_trailing_digits_with_rounding`) allocates a fresh
+  coefficient buffer and copies back. If so, add a true-in-place
+  variant that operates on `coefficient.words` directly. Every
+  `precision > 0` call to `add` / `subtract` / `multiply` (and after
+  T-API3, the multiply pre-truncation path too) ends in a
+  `round_to_precision` call, so the saving compounds across all
+  precision-arg ops. **Estimated:** 5–15% on the precision-arg fast
+  paths; small-coefficient cases benefit most.
+
 ### 5.3 Long-term tasks not on the active roadmap
 
 | #   | Task                                                                                                                                                                 | Effort |
@@ -515,28 +543,31 @@ binary splitting). All implementable in base-10^9.
 Open items in priority order (target: dm/py ≤ 1.5× across the board,
 some ops < 1.0×):
 
-| #      | Issue                                              | Effort | Priority | Target gain                                                   |
-| ------ | -------------------------------------------------- | ------ | -------- | ------------------------------------------------------------- |
-| T-API1 | `precision` arg on `add`/`sub`/`multiply`          | M      | **DONE** | −25–55% median; −70–85% on long-dec worst cases (2026-04-30b) |
-| T-A1   | `debug_assert .format` sweep across BigDecimal     | S      | **P1**   | 10–30% all ops                                                |
-| T-A2   | `multiply_by_power_of_ten` audit + inplace variant | M      | **P1**   | 30–50% long-dec add/sub                                       |
-| T-A3   | Hot-path-first switch in `add`/`sub`               | S      | **P1**   | 1–3 ns / call                                                 |
-| T-A4   | `@no_inline` raise helpers in BigDecimal/BigUInt   | S      | **P1**   | unblocks always-inline                                        |
-| T-A5   | `is_zero`/`is_integer` branch audit                | S      | P2       | small                                                         |
-| T-M1   | Small-coefficient mul fast path                    | M      | **P1**   | 50–70% small-mul                                              |
-| T-M2   | Single-pass rounding in `multiply`                 | S      | P2       | ~5 ns / call                                                  |
-| T-D1   | Short-divisor fast path in `divide`                | M      | **P1**   | 3–10× short-divisor                                           |
-| T-D2   | Trailing-zero strip allocation in divide           | S      | P2       | 5–15%                                                         |
-| T-D3   | Reciprocal-Newton divide (legacy Task 2)           | XL     | P3       | 2× large balanced                                             |
-| T-S1   | Small-coef short-circuit in `sqrt` p=100           | S      | P2       | ~50% at p=100                                                 |
-| T-L1   | atanh reformulation for ln (T3f)                   | M      | **P1**   | 3× ln near-1                                                  |
-| T-L2   | Process-wide ln(10) cache recipe                   | S      | P3       | doc                                                           |
-| T-L3   | AGM ln for p ≥ 1000 (T3g)                          | XL     | P4       | 10–50× p≥1000                                                 |
-| T-IO1  | `from_string` digit batching                       | M      | P2       | 30–50%                                                        |
-| T-IO2  | `to_string` right-aligned InlineArray              | M      | P2       | 20–40%                                                        |
-| T-R1   | `round` `.format` sweep                            | S      | P2       | small                                                         |
-| T-7b   | Reciprocal-Newton nth root                         | M      | P3       | 1.5–2×                                                        |
-| T-7c   | Rational $x^{a/b}$ decomposition                   | S      | P2       | 5–10× frac roots                                              |
-| T-5    | NTT multiplication                                 | XL     | P4       | 2–10×                                                         |
-| T-9    | SIMD schoolbook mul base                           | M      | P3       | 1.5–2×                                                        |
-| T-3e   | Binary splitting for ln Taylor                     | L      | P4       | 2–4× p≥500                                                    |
+| #      | Issue                                              | Effort | Priority | Target gain                                         |
+| ------ | -------------------------------------------------- | ------ | -------- | --------------------------------------------------- |
+| T-API1 | `precision` arg on `add`/`sub`/`multiply`          | S      | **DONE** | exact-then-round; foundation for T-API2/T-API3      |
+| T-API2 | Zero-copy scale alignment for add/sub/mul          | L      | **P0**   | 30–50% add/sub; remove 2 allocs/copies per mul      |
+| T-API3 | Correct precision-arg pre-truncation               | M      | **P0**   | restore add/sub/mul speedups without precision loss |
+| T-R2   | `round_to_precision_inplace` audit                 | S      | P7       | 5–15% on precision-arg ops                          |
+| T-A1   | `debug_assert .format` sweep across BigDecimal     | S      | **P1**   | 10–30% all ops                                      |
+| T-A2   | `multiply_by_power_of_ten` audit + inplace variant | M      | **P1**   | 30–50% long-dec add/sub                             |
+| T-A3   | Hot-path-first switch in `add`/`sub`               | S      | **P1**   | 1–3 ns / call                                       |
+| T-A4   | `@no_inline` raise helpers in BigDecimal/BigUInt   | S      | **P1**   | unblocks always-inline                              |
+| T-A5   | `is_zero`/`is_integer` branch audit                | S      | P2       | small                                               |
+| T-M1   | Small-coefficient mul fast path                    | M      | **P1**   | 50–70% small-mul                                    |
+| T-M2   | Single-pass rounding in `multiply`                 | S      | P2       | ~5 ns / call                                        |
+| T-D1   | Short-divisor fast path in `divide`                | M      | **P1**   | 3–10× short-divisor                                 |
+| T-D2   | Trailing-zero strip allocation in divide           | S      | P2       | 5–15%                                               |
+| T-D3   | Reciprocal-Newton divide (legacy Task 2)           | XL     | P3       | 2× large balanced                                   |
+| T-S1   | Small-coef short-circuit in `sqrt` p=100           | S      | P2       | ~50% at p=100                                       |
+| T-L1   | atanh reformulation for ln (T3f)                   | M      | **P1**   | 3× ln near-1                                        |
+| T-L2   | Process-wide ln(10) cache recipe                   | S      | P3       | doc                                                 |
+| T-L3   | AGM ln for p ≥ 1000 (T3g)                          | XL     | P4       | 10–50× p≥1000                                       |
+| T-IO1  | `from_string` digit batching                       | M      | P2       | 30–50%                                              |
+| T-IO2  | `to_string` right-aligned InlineArray              | M      | P2       | 20–40%                                              |
+| T-R1   | `round` `.format` sweep                            | S      | P2       | small                                               |
+| T-7b   | Reciprocal-Newton nth root                         | M      | P3       | 1.5–2×                                              |
+| T-7c   | Rational $x^{a/b}$ decomposition                   | S      | P2       | 5–10× frac roots                                    |
+| T-5    | NTT multiplication                                 | XL     | P4       | 2–10×                                               |
+| T-9    | SIMD schoolbook mul base                           | M      | P3       | 1.5–2×                                              |
+| T-3e   | Binary splitting for ln Taylor                     | L      | P4       | 2–4× p≥500                                          |

--- a/docs/plans/bigdecimal_enhancement.md
+++ b/docs/plans/bigdecimal_enhancement.md
@@ -79,49 +79,60 @@ Dated by report file under `benches/bigdecimal/reports/`. Append-only.
 Best-of-5, `-D ASSERT=none`. Append-only. Where a precision is omitted
 the operation only runs at p=100 in that snapshot.
 
-| Date     | op   | p=100 | p=1000 | p=10000 | p=100000 | note                                       |
-| -------- | ---- | ----: | -----: | ------: | -------: | ------------------------------------------ |
-| 20260221 | div  |   ~7M |    ~6M |   ~480M |   444M\* | pre-T1 asymmetric (\*65536w/32768w)        |
-| 20260221 | div  |   614 |   3.2k |     25k |     245k | post-T1 asymmetric (614 ns at 32768/65536) |
-| 20260224 | sqrt |  8.6k |   166k |      7M |        — | post-T4 reciprocal-Newton                  |
-| 20260224 | exp  |   24k |   1.7M |       — |        — | post-T3d aggressive halving                |
-| 20260224 | ln   |  104k |    38M |       — |        — | post-T3a/b/c (far-from-1 still slow)       |
-| 20260430 | add  |   276 |    280 |     290 |      269 | latest 60-case sweep                       |
-| 20260430 | sub  |   211 |    203 |     220 |      210 | latest 50-case sweep                       |
-| 20260430 | mul  |   140 |    140 |     140 |      130 | latest 50-case sweep                       |
-| 20260430 | div  |   805 |   3.2k |     25k |     245k | latest 64-case sweep                       |
-| 20260430 | cmp  |   9.4 |    8.7 |     9.5 |        — | independent of precision                   |
+| Date      | op   | p=100 | p=1000 | p=10000 | p=100000 | note                                         |
+| --------- | ---- | ----: | -----: | ------: | -------: | -------------------------------------------- |
+| 20260221  | div  |   ~7M |    ~6M |   ~480M |   444M\* | pre-T1 asymmetric (\*65536w/32768w)          |
+| 20260221  | div  |   614 |   3.2k |     25k |     245k | post-T1 asymmetric (614 ns at 32768/65536)   |
+| 20260224  | sqrt |  8.6k |   166k |      7M |        — | post-T4 reciprocal-Newton                    |
+| 20260224  | exp  |   24k |   1.7M |       — |        — | post-T3d aggressive halving                  |
+| 20260224  | ln   |  104k |    38M |       — |        — | post-T3a/b/c (far-from-1 still slow)         |
+| 20260430  | add  |   276 |    280 |     290 |      269 | latest 60-case sweep                         |
+| 20260430  | sub  |   211 |    203 |     220 |      210 | latest 50-case sweep                         |
+| 20260430  | mul  |   140 |    140 |     140 |      130 | latest 50-case sweep                         |
+| 20260430  | div  |   805 |   3.2k |     25k |     245k | latest 64-case sweep                         |
+| 20260430  | cmp  |   9.4 |    8.7 |     9.5 |        — | independent of precision                     |
+| 20260430b | add  |   134 |    126 |     142 |        — | post-T-API1: −50% / −55% / −51% vs row above |
+| 20260430b | sub  |   137 |    138 |     136 |        — | post-T-API1: −35% / −32% / −38% vs row above |
+| 20260430b | mul  |    90 |    105 |      80 |        — | post-T-API1: −36% / −25% / −43% vs row above |
 
 ### 2.5 Performance tracking — decimo / python ratio (>1 = decimo slower)
 
-| Date     | op     | p=100 | p=1000 | p=10000 |
-| -------- | ------ | ----: | -----: | ------: |
-| 20260224 | add    |  4.7× |   4.9× |    4.9× |
-| 20260224 | sub    |  3.6× |   3.5× |    3.8× |
-| 20260224 | mul    |  2.3× |   2.4× |    2.4× |
-| 20260224 | div    |  5.4× |   5.8× |    5.0× |
-| 20260224 | cmp    |  0.2× |      — |       — |
-| 20260224 | sqrt   |  2.1× |   0.7× |    0.3× |
-| 20260224 | exp    |  1.8× |   0.4× |       — |
-| 20260224 | ln     |  4.6× |   9.2× |       — |
-| 20260224 | root   |  0.3× |   0.0× |       — |
-| 20260224 | frmstr |  1.2× |   1.2× |    1.2× |
-| 20260224 | tostr  |  1.3× |   1.3× |    1.2× |
-| 20260224 | round  |  1.9× |   2.1× |    2.2× |
-| 20260430 | add    |  4.9× |   5.4× |    5.0× |
-| 20260430 | sub    |  3.7× |   3.7× |    3.3× |
-| 20260430 | mul    |  2.6× |   2.3× |    2.4× |
-| 20260430 | div    |  6.5× |   5.3× |    5.1× |
-| 20260430 | cmp    |  0.2× |      — |       — |
-| 20260430 | sqrt   |  2.1× |   0.7× |    0.3× |
-| 20260430 | exp    |  1.6× |   0.4× |       — |
-| 20260430 | ln     |  4.3× |   8.9× |       — |
-| 20260430 | root   |  0.2× |   0.0× |       — |
-| 20260430 | frmstr |  1.4× |      — |       — |
-| 20260430 | tostr  |  1.0× |      — |       — |
-| 20260430 | round  |  2.2× |   2.2× |    2.3× |
+| Date      | op     | p=100 | p=1000 | p=10000 | Comments      |
+| --------- | ------ | ----: | -----: | ------: | ------------- |
+| 20260224  | add    |  4.7× |   4.9× |    4.9× |               |
+| 20260224  | sub    |  3.6× |   3.5× |    3.8× |               |
+| 20260224  | mul    |  2.3× |   2.4× |    2.4× |               |
+| 20260224  | div    |  5.4× |   5.8× |    5.0× |               |
+| 20260224  | cmp    |  0.2× |      — |       — |               |
+| 20260224  | sqrt   |  2.1× |   0.7× |    0.3× |               |
+| 20260224  | exp    |  1.8× |   0.4× |       — |               |
+| 20260224  | ln     |  4.6× |   9.2× |       — |               |
+| 20260224  | root   |  0.3× |   0.0× |       — |               |
+| 20260224  | frmstr |  1.2× |   1.2× |    1.2× |               |
+| 20260224  | tostr  |  1.3× |   1.3× |    1.2× |               |
+| 20260224  | round  |  1.9× |   2.1× |    2.2× |               |
+| 20260430  | add    |  4.9× |   5.4× |    5.0× |               |
+| 20260430  | sub    |  3.7× |   3.7× |    3.3× |               |
+| 20260430  | mul    |  2.6× |   2.3× |    2.4× |               |
+| 20260430  | div    |  6.5× |   5.3× |    5.1× |               |
+| 20260430b | add    |  2.2× |   2.1× |    2.4× | (post-T-API1) |
+| 20260430b | sub    |  2.3× |   2.3× |    2.3× | (post-T-API1) |
+| 20260430b | mul    |  1.7× |   2.0× |    1.6× | (post-T-API1) |
+| 20260430  | cmp    |  0.2× |      — |       — |               |
+| 20260430  | sqrt   |  2.1× |   0.7× |    0.3× |               |
+| 20260430  | exp    |  1.6× |   0.4× |       — |               |
+| 20260430  | ln     |  4.3× |   8.9× |       — |               |
+| 20260430  | root   |  0.2× |   0.0× |       — |               |
+| 20260430  | frmstr |  1.4× |      — |       — |               |
+| 20260430  | tostr  |  1.0× |      — |       — |               |
+| 20260430  | round  |  2.2× |   2.2× |    2.3× |               |
 
-Latest sweep (2026-04-30, `bigdec_report_20260430_192858.md`).
+Latest sweep (2026-05-01, `bigdecimal_report_20260501_115440.md`,
+add/sub/mul only — post-T-API1 with style cleanup; baseline
+`bigdecimal_report_20260430_192858.md`). Re-measured after the
+in-place truncation rewrite; numbers within ±5% of the first
+post-T-API1 sweep `bigdecimal_report_20260430_211128.md` and slightly
+better for short-precision cases.
 **Note (2026-04-30):** the cross-language harness was simplified to
 `decimo` vs `python` only. The previous Rust `bigdecimal` reference was
 dropped — it lacked `exp`/`ln`/`root`/`round`, used naive long-division,
@@ -160,7 +171,9 @@ kernels (parse/render are precision-insensitive ops).
 | 16  | Short-divisor fast path in `divide` (single-word loop)           | OPEN — `BigUInt.floor_divide_by_uint32` exists; lift to BigDecimal  |
 | 17  | Add/sub `multiply_by_power_of_ten` allocates oversized           | OPEN — root cause of 4.7× py on small-precision add                 |
 | 18  | Small-coefficient mul fast path (bypass Karatsuba dispatch)      | OPEN — borrowed from decimal128 H#4 dispatch-overhead lesson        |
-| 19  | `precision` arg on `add`/`sub`/`multiply` (truncate ops upfront) | OPEN — structural; foundation for T-A2/T-M1 (see T-API1)            |
+| 19  | `precision` arg on `add`/`sub`/`multiply` (truncate ops upfront) | DONE (T-API1, 2026-04-30b)                                          |
+| 20  | Private functions with `_`; Replace raises with debug asserts    | OPEN — improves runtime performance by avoiding unnecessary checks  |
+| 21  | More inplace variants for `BigUInt` and `BigDecimal`             | OPEN — further reduces allocations and improves performance         |
 
 ## 4. Lessons Learnt (the reusable bits)
 
@@ -247,19 +260,20 @@ because the lesson generalises to the variable-length case unchanged.
 
 ## 5. Open Items / Future Improvements
 
-### 5.1 Worst-case ratios still > 1.5× python (latest sweep 2026-04-30)
+### 5.1 Worst-case ratios still > 1.5× python (latest sweep 2026-05-01, post-T-API1)
 
-The new bench harness exposes that **all small-to-medium-precision
-arithmetic ops sit at 2–6× python**, not the previously reported 2–4×
-on a smaller corpus. Closing these is the path to the ≤1.5× target.
+The T-API1 sweep (`bigdecimal_report_20260501_115440.md`) shows the
+add/sub/mul kernels are now within ~2–3× python on every case;
+long-decimal add/sub worst cases dropped from 10–15× py down to
+1.4–4× py.
 
 | Op          | Worst case (p=100)                     | decimo | python | dm/py | Likely cause                                    |
 | ----------- | -------------------------------------- | -----: | -----: | ----: | ----------------------------------------------- |
-| add         | Add of 2000-digit dec with carries     |   3116 |    222 | 14.0× | scale-align + per-call overhead                 |
-| add         | Fib-like large dec add (1100 d)        |   2021 |    128 | 15.8× | same                                            |
-| add         | Addition at precision boundary         |    524 |   57.5 |  9.1× | over-allocation at boundary                     |
-| sub         | (similar long-decimal cases)           |  ~2000 |   ~120 |  ~14× | same                                            |
-| mul         | High precision multiply small operands |    140 |     61 |  2.3× | dispatch overhead, no small-coef fast path      |
+| add         | Add of 1000-digit decimals             |    660 |    140 |  4.7× | residual scale-align overhead post-truncation   |
+| add         | Fib-like large dec add (1100 d)        |    662 |    147 |  4.5× | same                                            |
+| add         | Add of 2000-digit dec with carries     |    644 |    215 |  3.0× | exact path retained for cancellation guard      |
+| sub         | (similar long-decimal cases)           |   ~650 |   ~200 |   ~3× | same                                            |
+| mul         | High precision multiply small operands |    105 |     51 |  2.0× | dispatch overhead, no small-coef fast path      |
 | div         | Repeating-decimal div                  |    805 |  149.6 |  5.4× | full Burnikel-Ziegler even for short divisor    |
 | div (p=10k) | Long decimal divide                    |    25k |   5.0k |  5.0× | same                                            |
 | sqrt(p=100) | √(small irrational)                    |   8.6k |   4.1k |  2.1× | reciprocal-Newton overhead at tiny size         |
@@ -281,32 +295,39 @@ lessons in §4. All borrow patterns proven on the Decimal128 hot path.
 
 P0 — Structural API change (foundation for most P1 wins)
 
-- **T-API1: Add `precision: Int = 0` argument to `add`, `subtract`,
-  `multiply`** (and the `__add__`/`__sub__`/`__mul__` overloads).
-  Today these ops produce the full exact result regardless of how many
-  digits the user actually wants. Python `decimal` and Java
-  `BigDecimal` round to context precision after every op; that is a
-  large part of why Python is 4.7× / 3.6× / 2.3× faster on add/sub/mul
-  at p=100. With a precision hint:
+- **T-API1 — DONE (2026-04-30b).** Added `precision: Int = 0` argument
+  to `add`, `subtract`, `multiply` (existing `__add__`/`__sub__`/`__mul__`
+  overloads keep `precision=0` and so are unchanged). When `precision
+  > 0`:
 
-  - **add/sub:** when one operand's scale is so small relative to the
-    other that its low-order digits would round away (the 14× py
-    "Add of 2000-digit dec with carries" worst case), truncate it via
-    `floor_divide_by_power_of_billion()` *before* the SIMD addition.
-    Same trick that drove T1 (asymmetric divide) to 76× py.
-  - **multiply:** when `digits(a) + digits(b) > precision + guard`,
-    truncate the longer operand by `excess` words upfront. The product
-    of two 1000-digit operands at p=100 currently does the full
-    2000-digit Karatsuba then discards 1900 digits.
-  - **divide:** already takes precision; no change.
-  - **comparison / from_string / to_string:** unaffected.
+  - **add/sub:** estimate the result's leading exponent, then for each
+    operand drop the low base-10^9 words that fall below
+    `result_max_exp - precision - 18` guard digits. A *cancellation
+    guard* skips the truncation when signs would subtract AND the two
+    leading exponents are within `precision + 18` of each other,
+    preserving correctness when the leading digits cancel into the
+    precision window. Final result rounded HALF_EVEN.
+  - **multiply:** when `digits(a) + digits(b) > precision + 18`, the
+    longer operand is truncated by `(excess // 9)` low words upfront,
+    bringing the Karatsuba/Toom-3 width down to the precision window.
 
-  **Default `precision=0` preserves current exact-result behaviour for
-  back-compat.** When non-zero it acts as the rounding context for the
-  return value *and* as a hint for upfront operand truncation.
-  **Estimated:** 30–70% on every long-decimal arithmetic case; the
-  single highest-leverage change open today. Foundation that T-A2,
-  T-M1, T-D1 plug into.
+  Result (sweep `bigdecimal_report_20260501_115440.md`, all 460 cases
+  match python oracle 100%):
+
+  - add: median ns/iter 276/280/290 → 134/126/142 (−50% / −55% / −51%);
+    worst-case dm/py ratio 14× → 4.7×.
+  - sub: 211/203/220 → 137/138/136 (−35% / −32% / −38%);
+    worst case dm/py ~14× → ~3×.
+  - mul: 140/140/140 → 90/105/80 (−36% / −25% / −43%); worst case
+    dm/py 2.3× → 2.0×.
+
+  Within the 30–70% estimate at the median; exceeds it on the long-
+  decimal worst cases (e.g. "Add of 2000-d with carries" 3115 → 644 ns,
+  −79%; "Extreme scale diff with large dec (3000+ d)" 4803 → 739 ns,
+  −85%).
+
+  Foundation in place for T-A2 (multiply_by_power_of_ten alloc audit)
+  and T-M1 to push the small-precision residual gap toward ≤2× py.
 
 P1 — Add/Sub small-precision target (currently 4.7× / 3.6× py → target ≤2×)
 
@@ -425,14 +446,15 @@ P7 — `round` (2× py → target ≤1.0×)
 
 ### 5.3 Long-term tasks not on the active roadmap
 
-| #   | Task                                                           | Effort |
-| --- | -------------------------------------------------------------- | ------ |
-| 5   | NTT multiplication (≥1024 words). Closes the gap with libmpdec | XL     |
-| 9   | SIMD-optimised schoolbook mul kernel                           | M      |
-| 3e  | Binary splitting for ln Taylor series                          | L      |
-| 3g  | AGM-based ln for p ≥ 1000                                      | XL     |
-| 7b  | Reciprocal-Newton for nth root                                 | M      |
-| 7c  | Rational $x^{a/b}$ decomposition                               | S      |
+| #   | Task                                                                                                                                                                 | Effort |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| 5   | NTT multiplication (≥1024 words). Closes the gap with libmpdec                                                                                                       | XL     |
+| 9   | SIMD-optimised schoolbook mul kernel                                                                                                                                 | M      |
+| 3e  | Binary splitting for ln Taylor series                                                                                                                                | L      |
+| 3g  | AGM-based ln for p ≥ 1000                                                                                                                                            | XL     |
+| 7b  | Reciprocal-Newton for nth root                                                                                                                                       | M      |
+| 7c  | Rational $x^{a/b}$ decomposition                                                                                                                                     | S      |
+| 11  | Make `BigUInt.remove_trailing_digits_with_rounding` private and replace its runtime `raise` with a debug assert (saves one `raises` propagation across all callers). | S      |
 
 ## 6. Result-Equivalence vs Python
 
@@ -493,28 +515,28 @@ binary splitting). All implementable in base-10^9.
 Open items in priority order (target: dm/py ≤ 1.5× across the board,
 some ops < 1.0×):
 
-| #      | Issue                                              | Effort | Priority | Target gain             |
-| ------ | -------------------------------------------------- | ------ | -------- | ----------------------- |
-| T-API1 | `precision` arg on `add`/`sub`/`multiply`          | M      | **P0**   | 30–70% long-dec arith   |
-| T-A1   | `debug_assert .format` sweep across BigDecimal     | S      | **P1**   | 10–30% all ops          |
-| T-A2   | `multiply_by_power_of_ten` audit + inplace variant | M      | **P1**   | 30–50% long-dec add/sub |
-| T-A3   | Hot-path-first switch in `add`/`sub`               | S      | **P1**   | 1–3 ns / call           |
-| T-A4   | `@no_inline` raise helpers in BigDecimal/BigUInt   | S      | **P1**   | unblocks always-inline  |
-| T-A5   | `is_zero`/`is_integer` branch audit                | S      | P2       | small                   |
-| T-M1   | Small-coefficient mul fast path                    | M      | **P1**   | 50–70% small-mul        |
-| T-M2   | Single-pass rounding in `multiply`                 | S      | P2       | ~5 ns / call            |
-| T-D1   | Short-divisor fast path in `divide`                | M      | **P1**   | 3–10× short-divisor     |
-| T-D2   | Trailing-zero strip allocation in divide           | S      | P2       | 5–15%                   |
-| T-D3   | Reciprocal-Newton divide (legacy Task 2)           | XL     | P3       | 2× large balanced       |
-| T-S1   | Small-coef short-circuit in `sqrt` p=100           | S      | P2       | ~50% at p=100           |
-| T-L1   | atanh reformulation for ln (T3f)                   | M      | **P1**   | 3× ln near-1            |
-| T-L2   | Process-wide ln(10) cache recipe                   | S      | P3       | doc                     |
-| T-L3   | AGM ln for p ≥ 1000 (T3g)                          | XL     | P4       | 10–50× p≥1000           |
-| T-IO1  | `from_string` digit batching                       | M      | P2       | 30–50%                  |
-| T-IO2  | `to_string` right-aligned InlineArray              | M      | P2       | 20–40%                  |
-| T-R1   | `round` `.format` sweep                            | S      | P2       | small                   |
-| T-7b   | Reciprocal-Newton nth root                         | M      | P3       | 1.5–2×                  |
-| T-7c   | Rational $x^{a/b}$ decomposition                   | S      | P2       | 5–10× frac roots        |
-| T-5    | NTT multiplication                                 | XL     | P4       | 2–10×                   |
-| T-9    | SIMD schoolbook mul base                           | M      | P3       | 1.5–2×                  |
-| T-3e   | Binary splitting for ln Taylor                     | L      | P4       | 2–4× p≥500              |
+| #      | Issue                                              | Effort | Priority | Target gain                                                   |
+| ------ | -------------------------------------------------- | ------ | -------- | ------------------------------------------------------------- |
+| T-API1 | `precision` arg on `add`/`sub`/`multiply`          | M      | **DONE** | −25–55% median; −70–85% on long-dec worst cases (2026-04-30b) |
+| T-A1   | `debug_assert .format` sweep across BigDecimal     | S      | **P1**   | 10–30% all ops                                                |
+| T-A2   | `multiply_by_power_of_ten` audit + inplace variant | M      | **P1**   | 30–50% long-dec add/sub                                       |
+| T-A3   | Hot-path-first switch in `add`/`sub`               | S      | **P1**   | 1–3 ns / call                                                 |
+| T-A4   | `@no_inline` raise helpers in BigDecimal/BigUInt   | S      | **P1**   | unblocks always-inline                                        |
+| T-A5   | `is_zero`/`is_integer` branch audit                | S      | P2       | small                                                         |
+| T-M1   | Small-coefficient mul fast path                    | M      | **P1**   | 50–70% small-mul                                              |
+| T-M2   | Single-pass rounding in `multiply`                 | S      | P2       | ~5 ns / call                                                  |
+| T-D1   | Short-divisor fast path in `divide`                | M      | **P1**   | 3–10× short-divisor                                           |
+| T-D2   | Trailing-zero strip allocation in divide           | S      | P2       | 5–15%                                                         |
+| T-D3   | Reciprocal-Newton divide (legacy Task 2)           | XL     | P3       | 2× large balanced                                             |
+| T-S1   | Small-coef short-circuit in `sqrt` p=100           | S      | P2       | ~50% at p=100                                                 |
+| T-L1   | atanh reformulation for ln (T3f)                   | M      | **P1**   | 3× ln near-1                                                  |
+| T-L2   | Process-wide ln(10) cache recipe                   | S      | P3       | doc                                                           |
+| T-L3   | AGM ln for p ≥ 1000 (T3g)                          | XL     | P4       | 10–50× p≥1000                                                 |
+| T-IO1  | `from_string` digit batching                       | M      | P2       | 30–50%                                                        |
+| T-IO2  | `to_string` right-aligned InlineArray              | M      | P2       | 20–40%                                                        |
+| T-R1   | `round` `.format` sweep                            | S      | P2       | small                                                         |
+| T-7b   | Reciprocal-Newton nth root                         | M      | P3       | 1.5–2×                                                        |
+| T-7c   | Rational $x^{a/b}$ decomposition                   | S      | P2       | 5–10× frac roots                                              |
+| T-5    | NTT multiplication                                 | XL     | P4       | 2–10×                                                         |
+| T-9    | SIMD schoolbook mul base                           | M      | P3       | 1.5–2×                                                        |
+| T-3e   | Binary splitting for ln Taylor                     | L      | P4       | 2–4× p≥500                                                    |

--- a/src/decimo/bigdecimal/arithmetics.mojo
+++ b/src/decimo/bigdecimal/arithmetics.mojo
@@ -21,10 +21,6 @@ Implements functions for mathematical operations on BigDecimal objects.
 from std import math
 
 from decimo.bigdecimal.rounding import round_to_precision
-from decimo.biguint.arithmetics import (
-    floor_divide_by_power_of_billion,
-    floor_divide_by_power_of_billion_inplace,
-)
 from decimo.errors import ZeroDivisionError
 from decimo.rounding_mode import RoundingMode
 
@@ -48,12 +44,8 @@ def add(
         x2: The second operand.
         precision: Optional target significant-digit precision for the
             result. When `0` (default) the function returns the exact
-            sum (current behaviour). When `>0` the function truncates
-            each operand at word granularity to the smallest range
-            that still feeds `precision + 18` guard digits into the
-            sum, then rounds the result to `precision` significant
-            digits via HALF_EVEN. This avoids materialising the full
-            exact sum when only the leading `precision` digits matter.
+            sum. When `>0` the exact sum is computed and then rounded
+            to `precision` significant digits via HALF_EVEN.
 
     Returns:
         The sum of x1 and x2 (exact when `precision == 0`, otherwise
@@ -71,64 +63,6 @@ def add(
         and not x1.coefficient.is_zero()
         and not x2.coefficient.is_zero()
     ):
-        comptime BUFFER_DIGITS = 18  # 2 base-10^9 words, word-aligned
-        var ndigits1 = x1.coefficient.number_of_digits()
-        var ndigits2 = x2.coefficient.number_of_digits()
-        var leading_exp1 = ndigits1 - 1 - x1.scale
-        var leading_exp2 = ndigits2 - 1 - x2.scale
-        var result_leading_exp = max(leading_exp1, leading_exp2) + 1
-        var lowest_kept_exp = result_leading_exp - precision - BUFFER_DIGITS
-        # Cancellation guard: opposite signs make this an effective
-        # subtraction; if the leading exponents are within the
-        # precision window, the leading digits may cancel and the
-        # surviving digits would be those we are about to truncate.
-        # The guard is intentionally conservative — it triggers as
-        # soon as the leading exponents fall within the window even
-        # when the leading digits themselves obviously cannot cancel
-        # (e.g. 1.0e100 + (-9.5e100)). The check is O(1) and always
-        # correct; an exact pre-check would cost a comparison of
-        # leading digits and rarely pays off.
-        var drop1 = 0
-        var drop2 = 0
-        var cancellation_possible = (
-            x1.sign != x2.sign
-            and abs(leading_exp1 - leading_exp2) <= precision + BUFFER_DIGITS
-        )
-        if not cancellation_possible:
-            drop1 = (lowest_kept_exp + x1.scale) // 9
-            if drop1 < 0:
-                drop1 = 0
-            elif drop1 > (ndigits1 - 1) // 9:
-                drop1 = (ndigits1 - 1) // 9
-            drop2 = (lowest_kept_exp + x2.scale) // 9
-            if drop2 < 0:
-                drop2 = 0
-            elif drop2 > (ndigits2 - 1) // 9:
-                drop2 = (ndigits2 - 1) // 9
-        if drop1 > 0 or drop2 > 0:
-            var x1_truncated = x1.copy()
-            if drop1 > 0:
-                floor_divide_by_power_of_billion_inplace(
-                    x1_truncated.coefficient, drop1
-                )
-                x1_truncated.scale -= 9 * drop1
-            var x2_truncated = x2.copy()
-            if drop2 > 0:
-                floor_divide_by_power_of_billion_inplace(
-                    x2_truncated.coefficient, drop2
-                )
-                x2_truncated.scale -= 9 * drop2
-            var result = add(x1_truncated, x2_truncated, precision=0)
-            round_to_precision(
-                result,
-                precision,
-                RoundingMode.ROUND_HALF_EVEN,
-                remove_extra_digit_due_to_rounding=False,
-                fill_zeros_to_precision=False,
-            )
-            return result^
-        # Operands are already inside the precision window; just round
-        # the exact sum.
         var result = add(x1, x2, precision=0)
         round_to_precision(
             result,
@@ -191,10 +125,8 @@ def subtract(
         x2: The second operand (subtrahend).
         precision: Optional target significant-digit precision for the
             result. When `0` (default) the function returns the exact
-            difference. When `>0` the function truncates each operand
-            at word granularity to the smallest range that still feeds
-            `precision + 18` guard digits into the subtraction, then
-            rounds the result to `precision` significant digits via
+            difference. When `>0` the exact difference is computed
+            and then rounded to `precision` significant digits via
             HALF_EVEN.
 
     Returns:
@@ -212,64 +144,6 @@ def subtract(
         and not x1.coefficient.is_zero()
         and not x2.coefficient.is_zero()
     ):
-        comptime BUFFER_DIGITS = 18  # 2 base-10^9 words, word-aligned
-        var ndigits1 = x1.coefficient.number_of_digits()
-        var ndigits2 = x2.coefficient.number_of_digits()
-        var leading_exp1 = ndigits1 - 1 - x1.scale
-        var leading_exp2 = ndigits2 - 1 - x2.scale
-        var result_leading_exp = max(leading_exp1, leading_exp2) + 1
-        var lowest_kept_exp = result_leading_exp - precision - BUFFER_DIGITS
-        # Cancellation guard: same signs make this an effective
-        # subtraction of magnitudes; if the leading exponents are
-        # within the precision window, the leading digits may cancel
-        # and the surviving digits would be those we are about to
-        # truncate. The guard is intentionally conservative — it
-        # triggers as soon as the leading exponents fall within the
-        # window even when the leading digits themselves obviously
-        # cannot cancel (e.g. 9.5e100 - 1.0e100). The check is O(1)
-        # and always correct; an exact pre-check would cost a
-        # comparison of leading digits and rarely pays off.
-        var drop1 = 0
-        var drop2 = 0
-        var cancellation_possible = (
-            x1.sign == x2.sign
-            and abs(leading_exp1 - leading_exp2) <= precision + BUFFER_DIGITS
-        )
-        if not cancellation_possible:
-            drop1 = (lowest_kept_exp + x1.scale) // 9
-            if drop1 < 0:
-                drop1 = 0
-            elif drop1 > (ndigits1 - 1) // 9:
-                drop1 = (ndigits1 - 1) // 9
-            drop2 = (lowest_kept_exp + x2.scale) // 9
-            if drop2 < 0:
-                drop2 = 0
-            elif drop2 > (ndigits2 - 1) // 9:
-                drop2 = (ndigits2 - 1) // 9
-        if drop1 > 0 or drop2 > 0:
-            var x1_truncated = x1.copy()
-            if drop1 > 0:
-                floor_divide_by_power_of_billion_inplace(
-                    x1_truncated.coefficient, drop1
-                )
-                x1_truncated.scale -= 9 * drop1
-            var x2_truncated = x2.copy()
-            if drop2 > 0:
-                floor_divide_by_power_of_billion_inplace(
-                    x2_truncated.coefficient, drop2
-                )
-                x2_truncated.scale -= 9 * drop2
-            var result = subtract(x1_truncated, x2_truncated, precision=0)
-            round_to_precision(
-                result,
-                precision,
-                RoundingMode.ROUND_HALF_EVEN,
-                remove_extra_digit_due_to_rounding=False,
-                fill_zeros_to_precision=False,
-            )
-            return result^
-        # Operands are already inside the precision window; just round
-        # the exact difference.
         var result = subtract(x1, x2, precision=0)
         round_to_precision(
             result,
@@ -335,13 +209,8 @@ def multiply(
         x2: The second operand (multiplier).
         precision: Optional target significant-digit precision for the
             result. When `0` (default) the function returns the exact
-            product. When `>0` and the combined operand digit count
-            exceeds `precision + 18`, the longer operand is truncated
-            at word granularity to bring the product width down to
-            `precision + 18` guard digits, after which the result is
+            product. When `>0` the exact product is computed and then
             rounded to `precision` significant digits via HALF_EVEN.
-            This skips the work of materialising digits that would be
-            rounded away.
 
     Returns:
         The product of x1 and x2. Exact when `precision == 0`,
@@ -358,59 +227,6 @@ def multiply(
         and not x1.coefficient.is_zero()
         and not x2.coefficient.is_zero()
     ):
-        comptime BUFFER_DIGITS = 18  # 2 base-10^9 words, word-aligned
-        var ndigits1 = x1.coefficient.number_of_digits()
-        var ndigits2 = x2.coefficient.number_of_digits()
-        var product_ndigits = ndigits1 + ndigits2
-        var product_budget = precision + BUFFER_DIGITS
-        if product_ndigits > product_budget:
-            var excess = product_ndigits - product_budget
-            # Truncate the LONGER operand: dropping its low base-10^9
-            # words shrinks the product width by the same amount of
-            # digits, but only loses information well below the
-            # precision window (kept >= BUFFER_DIGITS guard).
-            if ndigits1 >= ndigits2:
-                var drop1 = excess // 9
-                if drop1 > (ndigits1 - 1) // 9:
-                    drop1 = (ndigits1 - 1) // 9
-                var x1_truncated = BigDecimal(
-                    coefficient=floor_divide_by_power_of_billion(
-                        x1.coefficient, drop1
-                    ),
-                    scale=x1.scale - 9 * drop1,
-                    sign=x1.sign,
-                )
-                var result = multiply(x1_truncated, x2, precision=0)
-                round_to_precision(
-                    result,
-                    precision,
-                    RoundingMode.ROUND_HALF_EVEN,
-                    remove_extra_digit_due_to_rounding=False,
-                    fill_zeros_to_precision=False,
-                )
-                return result^
-            else:
-                var drop2 = excess // 9
-                if drop2 > (ndigits2 - 1) // 9:
-                    drop2 = (ndigits2 - 1) // 9
-                var x2_truncated = BigDecimal(
-                    coefficient=floor_divide_by_power_of_billion(
-                        x2.coefficient, drop2
-                    ),
-                    scale=x2.scale - 9 * drop2,
-                    sign=x2.sign,
-                )
-                var result = multiply(x1, x2_truncated, precision=0)
-                round_to_precision(
-                    result,
-                    precision,
-                    RoundingMode.ROUND_HALF_EVEN,
-                    remove_extra_digit_due_to_rounding=False,
-                    fill_zeros_to_precision=False,
-                )
-                return result^
-        # Operands are already inside the precision window; just round
-        # the exact product.
         var result = multiply(x1, x2, precision=0)
         round_to_precision(
             result,

--- a/src/decimo/bigdecimal/arithmetics.mojo
+++ b/src/decimo/bigdecimal/arithmetics.mojo
@@ -58,11 +58,7 @@ def add(
       maximum of the two operands' scales.
     - The result's sign is determined by the signs of the operands.
     """
-    if (
-        precision > 0
-        and not x1.coefficient.is_zero()
-        and not x2.coefficient.is_zero()
-    ):
+    if precision > 0:
         var result = add(x1, x2, precision=0)
         round_to_precision(
             result,
@@ -139,11 +135,7 @@ def subtract(
       maximum of the two operands' scales.
     - The result's sign is determined by the signs of the operands.
     """
-    if (
-        precision > 0
-        and not x1.coefficient.is_zero()
-        and not x2.coefficient.is_zero()
-    ):
+    if precision > 0:
         var result = subtract(x1, x2, precision=0)
         round_to_precision(
             result,
@@ -222,11 +214,7 @@ def multiply(
       sum of the two operands' scales (except for zero).
     - The result's sign follows the standard sign rules for multiplication.
     """
-    if (
-        precision > 0
-        and not x1.coefficient.is_zero()
-        and not x2.coefficient.is_zero()
-    ):
+    if precision > 0:
         var result = multiply(x1, x2, precision=0)
         round_to_precision(
             result,

--- a/src/decimo/bigdecimal/arithmetics.mojo
+++ b/src/decimo/bigdecimal/arithmetics.mojo
@@ -20,36 +20,125 @@ Implements functions for mathematical operations on BigDecimal objects.
 
 from std import math
 
+from decimo.bigdecimal.rounding import round_to_precision
+from decimo.biguint.arithmetics import (
+    floor_divide_by_power_of_billion,
+    floor_divide_by_power_of_billion_inplace,
+)
 from decimo.errors import ZeroDivisionError
 from decimo.rounding_mode import RoundingMode
 
 # ===----------------------------------------------------------------------=== #
 # Arithmetic operations on BigDecimal objects
-# add(x1, x2)
-# subtract(x1, x2)
-# multiply(x1, x2)
+# add(x1, x2, precision=0)
+# subtract(x1, x2, precision=0)
+# multiply(x1, x2, precision=0)
 # true_divide(x1, x2, precision)
 # true_divide_inexact(x1, x2, number_of_significant_digits)
 # ===----------------------------------------------------------------------=== #
 
 
-def add(x1: BigDecimal, x2: BigDecimal) raises -> BigDecimal:
+def add(
+    x1: BigDecimal, x2: BigDecimal, precision: Int = 0
+) raises -> BigDecimal:
     """Returns the sum of two numbers.
 
     Args:
         x1: The first operand.
         x2: The second operand.
+        precision: Optional target significant-digit precision for the
+            result. When `0` (default) the function returns the exact
+            sum (current behaviour). When `>0` the function truncates
+            each operand at word granularity to the smallest range
+            that still feeds `precision + 18` guard digits into the
+            sum, then rounds the result to `precision` significant
+            digits via HALF_EVEN. This avoids materialising the full
+            exact sum when only the leading `precision` digits matter.
 
     Returns:
-        The sum of x1 and x2.
+        The sum of x1 and x2 (exact when `precision == 0`, otherwise
+        rounded to `precision` significant digits).
 
     Notes:
 
     Rules for addition:
-    - This function always return the exact result of the addition.
-    - The result's scale is the maximum of the two operands' scales.
+    - When `precision == 0`, the result is exact and its scale is the
+      maximum of the two operands' scales.
     - The result's sign is determined by the signs of the operands.
     """
+    if (
+        precision > 0
+        and not x1.coefficient.is_zero()
+        and not x2.coefficient.is_zero()
+    ):
+        comptime BUFFER_DIGITS = 18  # 2 base-10^9 words, word-aligned
+        var ndigits1 = x1.coefficient.number_of_digits()
+        var ndigits2 = x2.coefficient.number_of_digits()
+        var leading_exp1 = ndigits1 - 1 - x1.scale
+        var leading_exp2 = ndigits2 - 1 - x2.scale
+        var result_leading_exp = max(leading_exp1, leading_exp2) + 1
+        var lowest_kept_exp = result_leading_exp - precision - BUFFER_DIGITS
+        # Cancellation guard: opposite signs make this an effective
+        # subtraction; if the leading exponents are within the
+        # precision window, the leading digits may cancel and the
+        # surviving digits would be those we are about to truncate.
+        # The guard is intentionally conservative — it triggers as
+        # soon as the leading exponents fall within the window even
+        # when the leading digits themselves obviously cannot cancel
+        # (e.g. 1.0e100 + (-9.5e100)). The check is O(1) and always
+        # correct; an exact pre-check would cost a comparison of
+        # leading digits and rarely pays off.
+        var drop1 = 0
+        var drop2 = 0
+        var cancellation_possible = (
+            x1.sign != x2.sign
+            and abs(leading_exp1 - leading_exp2) <= precision + BUFFER_DIGITS
+        )
+        if not cancellation_possible:
+            drop1 = (lowest_kept_exp + x1.scale) // 9
+            if drop1 < 0:
+                drop1 = 0
+            elif drop1 > (ndigits1 - 1) // 9:
+                drop1 = (ndigits1 - 1) // 9
+            drop2 = (lowest_kept_exp + x2.scale) // 9
+            if drop2 < 0:
+                drop2 = 0
+            elif drop2 > (ndigits2 - 1) // 9:
+                drop2 = (ndigits2 - 1) // 9
+        if drop1 > 0 or drop2 > 0:
+            var x1_truncated = x1.copy()
+            if drop1 > 0:
+                floor_divide_by_power_of_billion_inplace(
+                    x1_truncated.coefficient, drop1
+                )
+                x1_truncated.scale -= 9 * drop1
+            var x2_truncated = x2.copy()
+            if drop2 > 0:
+                floor_divide_by_power_of_billion_inplace(
+                    x2_truncated.coefficient, drop2
+                )
+                x2_truncated.scale -= 9 * drop2
+            var result = add(x1_truncated, x2_truncated, precision=0)
+            round_to_precision(
+                result,
+                precision,
+                RoundingMode.ROUND_HALF_EVEN,
+                remove_extra_digit_due_to_rounding=False,
+                fill_zeros_to_precision=False,
+            )
+            return result^
+        # Operands are already inside the precision window; just round
+        # the exact sum.
+        var result = add(x1, x2, precision=0)
+        round_to_precision(
+            result,
+            precision,
+            RoundingMode.ROUND_HALF_EVEN,
+            remove_extra_digit_due_to_rounding=False,
+            fill_zeros_to_precision=False,
+        )
+        return result^
+
     var max_scale = max(x1.scale, x2.scale)
     var scale_factor1 = (max_scale - x1.scale) if x1.scale < max_scale else 0
     var scale_factor2 = (max_scale - x2.scale) if x2.scale < max_scale else 0
@@ -92,22 +181,104 @@ def add(x1: BigDecimal, x2: BigDecimal) raises -> BigDecimal:
         )
 
 
-def subtract(x1: BigDecimal, x2: BigDecimal) raises -> BigDecimal:
+def subtract(
+    x1: BigDecimal, x2: BigDecimal, precision: Int = 0
+) raises -> BigDecimal:
     """Returns the difference of two numbers.
 
     Args:
         x1: The first operand (minuend).
         x2: The second operand (subtrahend).
+        precision: Optional target significant-digit precision for the
+            result. When `0` (default) the function returns the exact
+            difference. When `>0` the function truncates each operand
+            at word granularity to the smallest range that still feeds
+            `precision + 18` guard digits into the subtraction, then
+            rounds the result to `precision` significant digits via
+            HALF_EVEN.
 
     Returns:
-        The difference of x1 and x2 (x1 - x2).
+        The difference of x1 and x2 (x1 - x2). Exact when
+        `precision == 0`, otherwise rounded to `precision` digits.
 
     Notes:
 
-    - This function always return the exact result of the subtraction.
-    - The result's scale is the maximum of the two operands' scales.
+    - When `precision == 0`, the result is exact and its scale is the
+      maximum of the two operands' scales.
     - The result's sign is determined by the signs of the operands.
     """
+    if (
+        precision > 0
+        and not x1.coefficient.is_zero()
+        and not x2.coefficient.is_zero()
+    ):
+        comptime BUFFER_DIGITS = 18  # 2 base-10^9 words, word-aligned
+        var ndigits1 = x1.coefficient.number_of_digits()
+        var ndigits2 = x2.coefficient.number_of_digits()
+        var leading_exp1 = ndigits1 - 1 - x1.scale
+        var leading_exp2 = ndigits2 - 1 - x2.scale
+        var result_leading_exp = max(leading_exp1, leading_exp2) + 1
+        var lowest_kept_exp = result_leading_exp - precision - BUFFER_DIGITS
+        # Cancellation guard: same signs make this an effective
+        # subtraction of magnitudes; if the leading exponents are
+        # within the precision window, the leading digits may cancel
+        # and the surviving digits would be those we are about to
+        # truncate. The guard is intentionally conservative — it
+        # triggers as soon as the leading exponents fall within the
+        # window even when the leading digits themselves obviously
+        # cannot cancel (e.g. 9.5e100 - 1.0e100). The check is O(1)
+        # and always correct; an exact pre-check would cost a
+        # comparison of leading digits and rarely pays off.
+        var drop1 = 0
+        var drop2 = 0
+        var cancellation_possible = (
+            x1.sign == x2.sign
+            and abs(leading_exp1 - leading_exp2) <= precision + BUFFER_DIGITS
+        )
+        if not cancellation_possible:
+            drop1 = (lowest_kept_exp + x1.scale) // 9
+            if drop1 < 0:
+                drop1 = 0
+            elif drop1 > (ndigits1 - 1) // 9:
+                drop1 = (ndigits1 - 1) // 9
+            drop2 = (lowest_kept_exp + x2.scale) // 9
+            if drop2 < 0:
+                drop2 = 0
+            elif drop2 > (ndigits2 - 1) // 9:
+                drop2 = (ndigits2 - 1) // 9
+        if drop1 > 0 or drop2 > 0:
+            var x1_truncated = x1.copy()
+            if drop1 > 0:
+                floor_divide_by_power_of_billion_inplace(
+                    x1_truncated.coefficient, drop1
+                )
+                x1_truncated.scale -= 9 * drop1
+            var x2_truncated = x2.copy()
+            if drop2 > 0:
+                floor_divide_by_power_of_billion_inplace(
+                    x2_truncated.coefficient, drop2
+                )
+                x2_truncated.scale -= 9 * drop2
+            var result = subtract(x1_truncated, x2_truncated, precision=0)
+            round_to_precision(
+                result,
+                precision,
+                RoundingMode.ROUND_HALF_EVEN,
+                remove_extra_digit_due_to_rounding=False,
+                fill_zeros_to_precision=False,
+            )
+            return result^
+        # Operands are already inside the precision window; just round
+        # the exact difference.
+        var result = subtract(x1, x2, precision=0)
+        round_to_precision(
+            result,
+            precision,
+            RoundingMode.ROUND_HALF_EVEN,
+            remove_extra_digit_due_to_rounding=False,
+            fill_zeros_to_precision=False,
+        )
+        return result^
 
     var max_scale = max(x1.scale, x2.scale)
     var scale_factor1 = (max_scale - x1.scale) if x1.scale < max_scale else 0
@@ -154,22 +325,102 @@ def subtract(x1: BigDecimal, x2: BigDecimal) raises -> BigDecimal:
         )
 
 
-def multiply(x1: BigDecimal, x2: BigDecimal) -> BigDecimal:
+def multiply(
+    x1: BigDecimal, x2: BigDecimal, precision: Int = 0
+) raises -> BigDecimal:
     """Returns the product of two numbers.
 
     Args:
         x1: The first operand (multiplicand).
         x2: The second operand (multiplier).
+        precision: Optional target significant-digit precision for the
+            result. When `0` (default) the function returns the exact
+            product. When `>0` and the combined operand digit count
+            exceeds `precision + 18`, the longer operand is truncated
+            at word granularity to bring the product width down to
+            `precision + 18` guard digits, after which the result is
+            rounded to `precision` significant digits via HALF_EVEN.
+            This skips the work of materialising digits that would be
+            rounded away.
 
     Returns:
-        The product of x1 and x2.
+        The product of x1 and x2. Exact when `precision == 0`,
+        otherwise rounded to `precision` digits.
 
     Notes:
 
-    - This function always returns the exact result of the multiplication.
-    - The result's scale is the sum of the two operands' scales (except for zero).
+    - When `precision == 0`, the result is exact and its scale is the
+      sum of the two operands' scales (except for zero).
     - The result's sign follows the standard sign rules for multiplication.
     """
+    if (
+        precision > 0
+        and not x1.coefficient.is_zero()
+        and not x2.coefficient.is_zero()
+    ):
+        comptime BUFFER_DIGITS = 18  # 2 base-10^9 words, word-aligned
+        var ndigits1 = x1.coefficient.number_of_digits()
+        var ndigits2 = x2.coefficient.number_of_digits()
+        var product_ndigits = ndigits1 + ndigits2
+        var product_budget = precision + BUFFER_DIGITS
+        if product_ndigits > product_budget:
+            var excess = product_ndigits - product_budget
+            # Truncate the LONGER operand: dropping its low base-10^9
+            # words shrinks the product width by the same amount of
+            # digits, but only loses information well below the
+            # precision window (kept >= BUFFER_DIGITS guard).
+            if ndigits1 >= ndigits2:
+                var drop1 = excess // 9
+                if drop1 > (ndigits1 - 1) // 9:
+                    drop1 = (ndigits1 - 1) // 9
+                var x1_truncated = BigDecimal(
+                    coefficient=floor_divide_by_power_of_billion(
+                        x1.coefficient, drop1
+                    ),
+                    scale=x1.scale - 9 * drop1,
+                    sign=x1.sign,
+                )
+                var result = multiply(x1_truncated, x2, precision=0)
+                round_to_precision(
+                    result,
+                    precision,
+                    RoundingMode.ROUND_HALF_EVEN,
+                    remove_extra_digit_due_to_rounding=False,
+                    fill_zeros_to_precision=False,
+                )
+                return result^
+            else:
+                var drop2 = excess // 9
+                if drop2 > (ndigits2 - 1) // 9:
+                    drop2 = (ndigits2 - 1) // 9
+                var x2_truncated = BigDecimal(
+                    coefficient=floor_divide_by_power_of_billion(
+                        x2.coefficient, drop2
+                    ),
+                    scale=x2.scale - 9 * drop2,
+                    sign=x2.sign,
+                )
+                var result = multiply(x1, x2_truncated, precision=0)
+                round_to_precision(
+                    result,
+                    precision,
+                    RoundingMode.ROUND_HALF_EVEN,
+                    remove_extra_digit_due_to_rounding=False,
+                    fill_zeros_to_precision=False,
+                )
+                return result^
+        # Operands are already inside the precision window; just round
+        # the exact product.
+        var result = multiply(x1, x2, precision=0)
+        round_to_precision(
+            result,
+            precision,
+            RoundingMode.ROUND_HALF_EVEN,
+            remove_extra_digit_due_to_rounding=False,
+            fill_zeros_to_precision=False,
+        )
+        return result^
+
     # Handle zero operands as special cases for efficiency
     if x1.coefficient.is_zero() or x2.coefficient.is_zero():
         return BigDecimal(
@@ -235,13 +486,13 @@ def add_inplace(mut x1: BigDecimal, x2: BigDecimal) raises:
             return
     if x2.coefficient.is_zero():
         if scale_factor1 > 0:
-            x1.coefficient.multiply_inplace_by_power_of_ten(scale_factor1)
+            x1.coefficient.multiply_by_power_of_ten_inplace(scale_factor1)
         x1.scale = max_scale
         return
 
     # Scale x1 in place if needed
     if scale_factor1 > 0:
-        x1.coefficient.multiply_inplace_by_power_of_ten(scale_factor1)
+        x1.coefficient.multiply_by_power_of_ten_inplace(scale_factor1)
 
     if x1.sign == x2.sign:
         # Same sign: add magnitudes (use inplace add on x1's coefficient)
@@ -740,7 +991,7 @@ def true_divide_inexact(
     # Scale up the dividend to ensure sufficient precision
     var scaled_x1 = x1.coefficient.copy()
     if buffer_digits > 0:
-        scaled_x1.multiply_inplace_by_power_of_ten(buffer_digits)
+        scaled_x1.multiply_by_power_of_ten_inplace(buffer_digits)
 
     # Perform division
     var quotient: BigUInt = scaled_x1 // x2.coefficient
@@ -802,7 +1053,7 @@ def _true_divide_inexact_truncated(
 
     var scaled_x1 = x1_coef_tr^
     if buffer_digits > 0:
-        scaled_x1.multiply_inplace_by_power_of_ten(buffer_digits)
+        scaled_x1.multiply_by_power_of_ten_inplace(buffer_digits)
 
     var quotient: BigUInt = scaled_x1 // x2_coef_tr
     var result_scale = buffer_digits + scale_adjust_digits + x1.scale - x2.scale
@@ -874,7 +1125,7 @@ def true_divide_inexact_by_uint32(
     # Scale up the dividend to ensure sufficient precision
     var scaled_x1 = x1.coefficient.copy()
     if buffer_digits > 0:
-        scaled_x1.multiply_inplace_by_power_of_ten(buffer_digits)
+        scaled_x1.multiply_by_power_of_ten_inplace(buffer_digits)
 
     # O(n) division by single word — the key speedup
     var quotient = decimo.biguint.arithmetics.floor_divide_by_uint32(

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -995,7 +995,7 @@ struct BigDecimal(
         return decimo.bigdecimal.arithmetics.subtract(self, other)
 
     @always_inline
-    def __mul__(self, other: Self) -> Self:
+    def __mul__(self, other: Self) raises -> Self:
         """Multiplies two values.
 
         Args:
@@ -2195,7 +2195,7 @@ struct BigDecimal(
         if precision_diff <= 0:
             return
 
-        decimo.biguint.arithmetics.multiply_inplace_by_power_of_ten(
+        decimo.biguint.arithmetics.multiply_by_power_of_ten_inplace(
             self.coefficient, precision_diff
         )
         self.scale += precision_diff

--- a/src/decimo/bigdecimal/exponential.mojo
+++ b/src/decimo/bigdecimal/exponential.mojo
@@ -358,7 +358,7 @@ def integer_power(
             fill_zeros_to_precision=False,
         )
 
-        decimo.biguint.arithmetics.floor_divide_inplace_by_2(exp_value)
+        decimo.biguint.arithmetics.floor_divide_by_2_inplace(exp_value)
 
     # For negative exponents, compute reciprocal
     if is_negative_exponent:
@@ -1162,7 +1162,7 @@ def fast_isqrt(c: BigUInt, working_digits: Int) raises -> BigUInt:
         # Newton step: n = (n + c/n) / 2
         var q = c.floor_divide(n)
         n += q
-        decimo.biguint.arithmetics.floor_divide_inplace_by_2(n)
+        decimo.biguint.arithmetics.floor_divide_by_2_inplace(n)
         if n == prev_n:
             break
         if prev_n == n + BigUInt.one():
@@ -1295,7 +1295,7 @@ def sqrt_exact(x: BigDecimal, precision: Int) raises -> BigDecimal:
         # Check: n % 5 == 0
         # Since our BigUInt base is 10^9, n % 5 == (last_word % 5)
         if n.words[0] % 5 == 0:
-            decimo.biguint.arithmetics.add_inplace_by_uint32(n, 1)
+            decimo.biguint.arithmetics.add_by_uint32_inplace(n, 1)
 
     # Construct result: coefficient=n, scale=-e (since exponent=e means *10^e)
     var result = BigDecimal(n^, -e, False)
@@ -1849,7 +1849,7 @@ def exp(x: BigDecimal, precision: Int) raises -> BigDecimal:
         # This is exact — no rounding needed.
         var reduced_coeff = x.coefficient.copy()
         for _ in range(m):
-            decimo.biguint.arithmetics.multiply_inplace_by_uint32(
+            decimo.biguint.arithmetics.multiply_by_uint32_inplace(
                 reduced_coeff, 5
             )
         var reduced_x = BigDecimal(reduced_coeff^, x.scale + m, False)
@@ -2330,7 +2330,7 @@ def ln_series_expansion(
         # Step 1: Undo previous denominator: multiply by (2k-1).
         # Note: when k=1, old_denom=1, so this is a no-op by design;
         # the first term (k=0) has denominator 1, which needs no undoing.
-        decimo.biguint.arithmetics.multiply_inplace_by_uint32(
+        decimo.biguint.arithmetics.multiply_by_uint32_inplace(
             term.coefficient, old_denom
         )
         # Step 2: Multiply by u²
@@ -2432,7 +2432,7 @@ def compute_ln2(working_precision: Int) raises -> BigDecimal:
         decimo.bigdecimal.arithmetics.multiply_inplace(term, x_squared)
         term = term.true_divide_inexact_by_uint32(new_k, working_precision)
         # Multiply by k using coefficient-level UInt32 multiply (avoids BigDecimal alloc)
-        decimo.biguint.arithmetics.multiply_inplace_by_uint32(
+        decimo.biguint.arithmetics.multiply_by_uint32_inplace(
             term.coefficient, k
         )
         k = new_k

--- a/src/decimo/bigint/arithmetics.mojo
+++ b/src/decimo/bigint/arithmetics.mojo
@@ -1738,7 +1738,7 @@ def add_inplace(mut x: BigInt, read other: BigInt):
             x.sign = other.sign
 
 
-def add_inplace_int(mut x: BigInt, value: Int):
+def add_int_inplace(mut x: BigInt, value: Int):
     """Performs x += value (Int) by mutating x.words directly.
 
     Optimized for adding a small integer: avoids constructing a full BigInt.

--- a/src/decimo/bigint/bigint.mojo
+++ b/src/decimo/bigint/bigint.mojo
@@ -1221,7 +1221,7 @@ struct BigInt(
         Args:
             other: The right-hand side operand.
         """
-        decimo.bigint.arithmetics.add_inplace_int(self, other)
+        decimo.bigint.arithmetics.add_int_inplace(self, other)
 
     @always_inline
     def __isub__(mut self, other: Self):
@@ -2003,7 +2003,7 @@ struct BigInt(
 # ===----------------------------------------------------------------------=== #
 
 
-def _multiply_inplace_by_uint32(mut x: BigInt, y: UInt32):
+def _multiply_by_uint32_inplace(mut x: BigInt, y: UInt32):
     """Multiplies a BigInt magnitude by a UInt32 scalar in-place.
 
     This is used internally by from_string() during base conversion.
@@ -2029,7 +2029,7 @@ def _multiply_inplace_by_uint32(mut x: BigInt, y: UInt32):
         x.words.append(UInt32(carry))
 
 
-def _add_inplace_by_uint32(mut x: BigInt, y: UInt32):
+def _add_by_uint32_inplace(mut x: BigInt, y: UInt32):
     """Adds a UInt32 value to a BigInt magnitude in-place.
 
     This is used internally by from_string() during base conversion.

--- a/src/decimo/bigint10/arithmetics.mojo
+++ b/src/decimo/bigint10/arithmetics.mojo
@@ -118,7 +118,7 @@ def subtract(x1: BigInt10, x2: BigInt10) -> BigInt10:
     if comparison_result > 0:  # |x1| > |x2|
         # Subtract smaller from larger
         magnitude = x1.magnitude.copy()
-        decimo.biguint.arithmetics.subtract_inplace_no_check(
+        decimo.biguint.arithmetics.subtract_no_check_inplace(
             magnitude, x2.magnitude
         )
         sign = x1.sign
@@ -126,7 +126,7 @@ def subtract(x1: BigInt10, x2: BigInt10) -> BigInt10:
     else:  # |x1| < |x2|
         # Subtract larger from smaller and negate the result
         magnitude = x2.magnitude.copy()
-        decimo.biguint.arithmetics.subtract_inplace_no_check(
+        decimo.biguint.arithmetics.subtract_no_check_inplace(
             magnitude, x1.magnitude
         )
         sign = not x1.sign

--- a/src/decimo/bigint10/bigint10.mojo
+++ b/src/decimo/bigint10/bigint10.mojo
@@ -796,7 +796,7 @@ struct BigInt10(
         """
         # Optimize the case `i += 1`
         if (self >= 0) and (other >= 0) and (other <= 999_999_999):
-            decimo.biguint.arithmetics.add_inplace_by_uint32(
+            decimo.biguint.arithmetics.add_by_uint32_inplace(
                 self.magnitude, UInt32(other)
             )
         else:

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -70,14 +70,14 @@ comptime CUTOFF_BURNIKEL_ZIEGLER = 32
 # floor_divide_estimate_quotient(x1: BigUInt, x2: BigUInt, j: Int, m: Int) -> UInt64
 # floor_divide_by_single_word_inplace(x1: BigUInt, x2: BigUInt) -> None
 # floor_divide_by_double_words_inplace(x1: BigUInt, x2: BigUInt) -> None
-# floor_divide_by_2_inplace(x: BigUInt) -> Nonet, x2: BigUInt) -> BigUInt
+# floor_divide_by_2_inplace(x: BigUInt) -> None
 # floor_divide_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt
 # floor_divide_by_power_of_ten_inplace(x: BigUInt, n: Int) -> None
 # floor_divide_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt
 # floor_divide_by_power_of_billion_inplace(x: BigUInt, n: Int) -> None
 #
 # truncate_divide(x1: BigUInt, x2: BigUInt) -> BigUInt
-# ceil_divide(x1: BigUInt, x2: BigUInt) -> BigUIntulo(x1: BigUIn# floor_divide_school(x1: BigUInt, x2: BigUInt) -> BigUInt
+# ceil_divide(x1: BigUInt, x2: BigUInt) -> BigUInt
 #
 # floor_modulo(x1: BigUInt, x2: BigUInt) -> BigUInt
 # ceil_modulo(x1: BigUInt, x2: BigUInt) -> BigUInt
@@ -2302,7 +2302,11 @@ def floor_divide_by_uint32_inplace(mut x: BigUInt, y: UInt32) -> None:
     It is not intended for public use. You need to ensure that y is non-zero.
     """
     debug_assert[assert_mode="none"](
-        y != 0, "biguint.arithmetics.floor_divide_by_uint32(): Division by zero"
+        y != 0,
+        (
+            "biguint.arithmetics.floor_divide_by_uint32_inplace(): Division by"
+            " zero"
+        ),
     )
 
     # Most significant word of the dividend
@@ -2333,7 +2337,7 @@ def floor_divide_by_uint64(x: BigUInt, y: UInt64) -> BigUInt:
     """
     debug_assert[assert_mode="none"](
         y != 0,
-        "biguint.arithmetics.floor_divide_by_uint64_inplace(): ",
+        "biguint.arithmetics.floor_divide_by_uint64(): ",
         "Division by zero.",
     )
 
@@ -2411,7 +2415,7 @@ def floor_divide_by_uint128(x: BigUInt, y: UInt128) -> BigUInt:
     """
     debug_assert[assert_mode="none"](
         y != 0,
-        "biguint.arithmetics.floor_divide_by_uint128_inplace(): ",
+        "biguint.arithmetics.floor_divide_by_uint128(): ",
         "Division by zero.",
     )
 
@@ -2503,9 +2507,8 @@ def floor_divide_by_2_inplace(mut x: BigUInt) -> None:
     x.remove_leading_empty_words()
 
 
-# TODO: Implement a in-place version of this function
-# TODO: If n % 9 == 0, we can optimize by just calling the
-# `floor_divide_by_power_of_billion_inplace` function.
+# TODO: If n % 9 == 0, the in-place version can be optimized by
+# delegating to `floor_divide_by_power_of_billion_inplace` directly.
 def floor_divide_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt:
     """Floor divides a BigUInt by 10^n (n>=0).
     It is equal to removing the last n digits of the number.
@@ -2614,8 +2617,7 @@ fn _shift_right_by_decimal_digits_inplace(mut x: BigUInt, digit_shift: Int):
     """Divides `x` in place by `10^digit_shift`, where
     `1 <= digit_shift <= 8`. Assumes any whole-word shift has already
     been applied; this only performs the sub-word digit shift and
-    canonicalises the result. The `mut x` signature makes the in-place
-    semantics explicit, so no `_inplace` suffix is needed.
+    canonicalises the result.
     """
     debug_assert[assert_mode="none"](
         digit_shift >= 1 and digit_shift <= 8,

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -48,30 +48,33 @@ comptime CUTOFF_BURNIKEL_ZIEGLER = 32
 # add_slices_simd(x: BigUInt, y: BigUInt) -> BigUInt
 # add_slices(x: BigUInt, y: BigUInt, start_x: Int, end_x: Int, start_y: Int, end_y: Int) -> BigUInt
 # add_inplace(x1: BigUInt, x2: BigUInt)
-# add_inplace_by_uint32(x: BigUInt, y: UInt32) -> None
+# add_by_uint32_inplace(x: BigUInt, y: UInt32) -> None
 #
 # subtract(x1: BigUInt, x2: BigUInt) -> BigUInt
 # subtract_inplace(x1: BigUInt, x2: BigUInt) -> None
-# subtract_inplace_no_check(x1: BigUInt, x2: BigUInt) -> None
-# subtract_inplace_by_uint32(x: BigUInt, y: UInt32) -> None
+# subtract_no_check_inplace(x1: BigUInt, x2: BigUInt) -> None
+# subtract_by_uint32_inplace(x: BigUInt, y: UInt32) -> None
 #
 # multiply(x1: BigUInt, x2: BigUInt) -> BigUInt
 # multiply_slices_school(x: BigUInt, y: BigUInt, start_x: Int, end_x: Int, start_y: Int, end_y: Int) -> BigUInt
 # multiply_slices_karatsuba(x: BigUInt, y: BigUInt, start_x: Int, end_x: Int, start_y: Int, end_y: Int, cutoff_number_of_words: Int) -> BigUInt
 # multiply_slices_toom3(x: BigUInt, y: BigUInt, bounds_x: Tuple[Int, Int], bounds_y: Tuple[Int, Int]) -> BigUInt
-# multiply_inplace_by_uint32(x: BigUInt, y: UInt32) -> None
+# multiply_by_uint32_inplace(x: BigUInt, y: UInt32) -> None
 # multiply_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt
-# multiply_inplace_by_power_of_billion(mut x: BigUInt, n: Int)
+# multiply_by_power_of_billion_inplace(mut x: BigUInt, n: Int)
 # exact_divide_by_2_inplace(mut x: BigUInt)
 # exact_divide_by_3_inplace(mut x: BigUInt)
 #
 # floor_divide(x1: BigUInt, x2: BigUInt) -> BigUInt
 # floor_divide_school(x1: BigUInt, x2: BigUInt) -> BigUInt
 # floor_divide_estimate_quotient(x1: BigUInt, x2: BigUInt, j: Int, m: Int) -> UInt64
-# floor_divide_inplace_by_single_word(x1: BigUInt, x2: BigUInt) -> None
-# floor_divide_inplace_by_double_words(x1: BigUInt, x2: BigUInt) -> None
-# floor_divide_inplace_by_2(x: BigUInt) -> Nonet, x2: BigUInt) -> BigUInt
+# floor_divide_by_single_word_inplace(x1: BigUInt, x2: BigUInt) -> None
+# floor_divide_by_double_words_inplace(x1: BigUInt, x2: BigUInt) -> None
+# floor_divide_by_2_inplace(x: BigUInt) -> Nonet, x2: BigUInt) -> BigUInt
 # floor_divide_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt
+# floor_divide_by_power_of_ten_inplace(x: BigUInt, n: Int) -> None
+# floor_divide_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt
+# floor_divide_by_power_of_billion_inplace(x: BigUInt, n: Int) -> None
 #
 # truncate_divide(x1: BigUInt, x2: BigUInt) -> BigUInt
 # ceil_divide(x1: BigUInt, x2: BigUInt) -> BigUIntulo(x1: BigUIn# floor_divide_school(x1: BigUInt, x2: BigUInt) -> BigUInt
@@ -128,7 +131,7 @@ def absolute(x: BigUInt) -> BigUInt:
 
 # ===----------------------------------------------------------------------=== #
 # Addition algorithms
-# add, add_inplace, add_inplace_by_uint32
+# add, add_inplace, add_by_uint32_inplace
 # ===----------------------------------------------------------------------=== #
 
 
@@ -174,13 +177,13 @@ def add(x: BigUInt, y: BigUInt) -> BigUInt:
             )
         else:  # If x is single-word, we can handle it with UInt32
             var result = y.copy()
-            add_inplace_by_uint32(result, x.words[0])
+            add_by_uint32_inplace(result, x.words[0])
             return result^
 
     if len(y.words) == 1:
         # If y is single-word, we can handle it with UInt32
         var result = x.copy()
-        add_inplace_by_uint32(result, y.words[0])
+        add_by_uint32_inplace(result, y.words[0])
         return result^
 
     # If both numbers are double-word, we can handle them with UInt64
@@ -237,7 +240,7 @@ def add_slices(
         else:
             # If y slice is longer
             var result = BigUInt.from_slice(y, bounds_y)
-            add_inplace_by_uint32(result, x.words[bounds_x[0]])
+            add_by_uint32_inplace(result, x.words[bounds_x[0]])
             return result^
     if n_words_y_slice == 1:
         if y.words[bounds_y[0]] == 0:
@@ -245,7 +248,7 @@ def add_slices(
         else:
             # If x slice is longer
             var result = BigUInt.from_slice(x, bounds_x)
-            add_inplace_by_uint32(result, y.words[bounds_y[0]])
+            add_by_uint32_inplace(result, y.words[bounds_y[0]])
             return result^
 
     # Normal cases
@@ -376,7 +379,7 @@ def add_inplace(mut x: BigUInt, y: BigUInt) -> None:
         return
 
     if len(y.words) == 1:
-        add_inplace_by_uint32(x, y.words[0])
+        add_by_uint32_inplace(x, y.words[0])
         return
 
     # Normal cases
@@ -400,7 +403,7 @@ def add_inplace(mut x: BigUInt, y: BigUInt) -> None:
     return
 
 
-def add_inplace_by_slice(
+def add_by_slice_inplace(
     mut x: BigUInt, y: BigUInt, bounds_y: Tuple[Int, Int]
 ) -> None:
     """Increments a BigUInt number in-place by another BigUInt slice.
@@ -414,7 +417,7 @@ def add_inplace_by_slice(
     # Short circuit cases
     if x.is_zero():
         debug_assert[assert_mode="none"](
-            len(x.words) == 1, "add_inplace_by_slice(): leading zero words in x"
+            len(x.words) == 1, "add_by_slice_inplace(): leading zero words in x"
         )
         x = BigUInt.from_slice(
             y, bounds=(bounds_y[0], bounds_y[1])
@@ -427,7 +430,7 @@ def add_inplace_by_slice(
     var n_words_y_slice = bounds_y[1] - bounds_y[0]
 
     if n_words_y_slice == 1:
-        add_inplace_by_uint32(x, y.words[bounds_y[0]])
+        add_by_uint32_inplace(x, y.words[bounds_y[0]])
         return
 
     # Normal cases
@@ -452,7 +455,7 @@ def add_inplace_by_slice(
     return
 
 
-def add_inplace_by_uint32(mut x: BigUInt, y: UInt32) -> None:
+def add_by_uint32_inplace(mut x: BigUInt, y: UInt32) -> None:
     """Increments a BigUInt number by a UInt32 value.
 
     Args:
@@ -711,7 +714,7 @@ def subtract_inplace(mut x: BigUInt, y: BigUInt) raises -> None:
 
     # If y is a single-word number, we can handle it with UInt32
     if len(y.words) == 1:
-        subtract_inplace_by_uint32(x, y.words[0])
+        subtract_by_uint32_inplace(x, y.words[0])
         return
 
     # Note that len(x.words) >= len(y.words) here
@@ -733,7 +736,7 @@ def subtract_inplace(mut x: BigUInt, y: BigUInt) raises -> None:
     return
 
 
-def subtract_inplace_no_check(mut x: BigUInt, y: BigUInt) -> None:
+def subtract_no_check_inplace(mut x: BigUInt, y: BigUInt) -> None:
     """Subtracts y from x in-place without checking for underflow.
 
     Notes:
@@ -750,7 +753,7 @@ def subtract_inplace_no_check(mut x: BigUInt, y: BigUInt) -> None:
     # If the subtrahend is zero, return the minuend
     if y.is_zero():
         debug_assert[assert_mode="none"](
-            len(y.words) == 1, "subtract_inplace_no_check(): leading zero words"
+            len(y.words) == 1, "subtract_no_check_inplace(): leading zero words"
         )
         return
 
@@ -774,7 +777,7 @@ def subtract_inplace_no_check(mut x: BigUInt, y: BigUInt) -> None:
     return
 
 
-def subtract_inplace_by_uint32(mut x: BigUInt, y: UInt32) -> None:
+def subtract_by_uint32_inplace(mut x: BigUInt, y: UInt32) -> None:
     """Subtracts a UInt32 value from a BigUInt number in-place.
 
     Args:
@@ -789,7 +792,7 @@ def subtract_inplace_by_uint32(mut x: BigUInt, y: UInt32) -> None:
 
     debug_assert[assert_mode="none"](
         (len(x.words) > 1) or (x.words[0] >= y),
-        "subtract_inplace_by_uint32(): Underflow due to x < y.",
+        "subtract_by_uint32_inplace(): Underflow due to x < y.",
     )
 
     x.words[0] -= y
@@ -850,7 +853,7 @@ def multiply(x: BigUInt, y: BigUInt) -> BigUInt:
 
     # SPECIAL CASES
     # If x or y is a single-word number
-    # We can use `multiply_inplace_by_uint32` because this is only one loop
+    # We can use `multiply_by_uint32_inplace` because this is only one loop
     # No need to split the long number into two parts
     if len(x.words) == 1:
         var x_word = x.words[0]
@@ -860,7 +863,7 @@ def multiply(x: BigUInt, y: BigUInt) -> BigUInt:
             return y.copy()
         else:
             var result = y.copy()
-            multiply_inplace_by_uint32(result, x_word)
+            multiply_by_uint32_inplace(result, x_word)
             return result^
 
     if len(y.words) == 1:
@@ -871,7 +874,7 @@ def multiply(x: BigUInt, y: BigUInt) -> BigUInt:
             return x.copy()
         else:
             var result = x.copy()
-            multiply_inplace_by_uint32(result, y_word)
+            multiply_by_uint32_inplace(result, y_word)
             return result^
 
     # CASE 1
@@ -976,7 +979,7 @@ def multiply_slices_school(
             return BigUInt.from_slice(y, (bounds_y[0], bounds_y[1]))
         else:
             var result = BigUInt.from_slice(y, (bounds_y[0], bounds_y[1]))
-            multiply_inplace_by_uint32(result, x_word)
+            multiply_by_uint32_inplace(result, x_word)
             return result^
     if n_words_y_slice == 1:
         var y_word = y.words[bounds_y[0]]
@@ -986,7 +989,7 @@ def multiply_slices_school(
             return BigUInt.from_slice(x, (bounds_x[0], bounds_x[1]))
         else:
             var result = BigUInt.from_slice(x, (bounds_x[0], bounds_x[1]))
-            multiply_inplace_by_uint32(result, y_word)
+            multiply_by_uint32_inplace(result, y_word)
             return result^
 
     # The max number of words in the result is the sum of the words in the operands
@@ -1122,7 +1125,7 @@ def multiply_slices_karatsuba(
         )
         # z2 = 0
 
-        z1.multiply_inplace_by_power_of_billion(m)
+        z1.multiply_by_power_of_billion_inplace(m)
         z1 += z0
         z1.remove_leading_empty_words()
         return z1^
@@ -1150,7 +1153,7 @@ def multiply_slices_karatsuba(
             cutoff_number_of_words,
         )
         # z2 = 0
-        z1.multiply_inplace_by_power_of_billion(m)
+        z1.multiply_by_power_of_billion_inplace(m)
         z1 += z0
         z1.remove_leading_empty_words()
         return z1^
@@ -1203,12 +1206,12 @@ def multiply_slices_karatsuba(
         )
 
         # z1 >= z2 + z0 by construction
-        subtract_inplace_no_check(z1, z2)
-        subtract_inplace_no_check(z1, z0)
+        subtract_no_check_inplace(z1, z2)
+        subtract_no_check_inplace(z1, z0)
 
         # z2*9^(m * 2) + z1*9^m + z0
-        z2.multiply_inplace_by_power_of_billion(2 * m)
-        z1.multiply_inplace_by_power_of_billion(m)
+        z2.multiply_by_power_of_billion_inplace(2 * m)
+        z1.multiply_by_power_of_billion_inplace(m)
         z2 += z1
         z2 += z0
 
@@ -1329,11 +1332,11 @@ def multiply_slices_toom3(
         var cmp = decimo.biguint.comparison.compare(x0_plus_x2, x1_val)
         if cmp >= 0:
             pxm1 = x0_plus_x2.copy()
-            subtract_inplace_no_check(pxm1, x1_val)
+            subtract_no_check_inplace(pxm1, x1_val)
             pxm1_neg = False
         else:
             pxm1 = x1_val^
-            subtract_inplace_no_check(pxm1, x0_plus_x2)
+            subtract_no_check_inplace(pxm1, x0_plus_x2)
             pxm1_neg = True
     else:
         pxm1 = x0_plus_x2.copy()
@@ -1347,11 +1350,11 @@ def multiply_slices_toom3(
         var cmp = decimo.biguint.comparison.compare(y0_plus_y2, y1_val)
         if cmp >= 0:
             qym1 = y0_plus_y2.copy()
-            subtract_inplace_no_check(qym1, y1_val)
+            subtract_no_check_inplace(qym1, y1_val)
             qym1_neg = False
         else:
             qym1 = y1_val^
-            subtract_inplace_no_check(qym1, y0_plus_y2)
+            subtract_no_check_inplace(qym1, y0_plus_y2)
             qym1_neg = True
     else:
         qym1 = y0_plus_y2.copy()
@@ -1361,13 +1364,13 @@ def multiply_slices_toom3(
     var px2: BigUInt
     if has_x2:
         px2 = BigUInt.from_slice(x, (sx2_start, sx2_end))
-        multiply_inplace_by_uint32(px2, UInt32(2))
+        multiply_by_uint32_inplace(px2, UInt32(2))
     else:
         px2 = BigUInt.zero()
     if has_x1:
         var x1_slice = BigUInt.from_slice(x, (sx1_start, sx1_end))
         add_inplace(px2, x1_slice)
-    multiply_inplace_by_uint32(px2, UInt32(2))
+    multiply_by_uint32_inplace(px2, UInt32(2))
     var x0_slice = BigUInt.from_slice(x, (sx0_start, sx0_end))
     add_inplace(px2, x0_slice)
 
@@ -1375,13 +1378,13 @@ def multiply_slices_toom3(
     var qy2: BigUInt
     if has_y2:
         qy2 = BigUInt.from_slice(y, (sy2_start, sy2_end))
-        multiply_inplace_by_uint32(qy2, UInt32(2))
+        multiply_by_uint32_inplace(qy2, UInt32(2))
     else:
         qy2 = BigUInt.zero()
     if has_y1:
         var y1_slice = BigUInt.from_slice(y, (sy1_start, sy1_end))
         add_inplace(qy2, y1_slice)
-    multiply_inplace_by_uint32(qy2, UInt32(2))
+    multiply_by_uint32_inplace(qy2, UInt32(2))
     var y0_slice = BigUInt.from_slice(y, (sy0_start, sy0_end))
     add_inplace(qy2, y0_slice)
 
@@ -1447,7 +1450,7 @@ def multiply_slices_toom3(
     else:
         # v1 - vm1 = 2*(w1 + w3) >= 0
         t1 = v1.copy()
-        subtract_inplace_no_check(t1, vm1)
+        subtract_no_check_inplace(t1, vm1)
     exact_divide_by_2_inplace(t1)
 
     # --- Compute w2 = (v1 + vm1_signed) / 2 - w0 - w4 ---
@@ -1457,34 +1460,34 @@ def multiply_slices_toom3(
     var w2: BigUInt
     if vm1_neg:
         w2 = v1.copy()
-        subtract_inplace_no_check(w2, vm1)
+        subtract_no_check_inplace(w2, vm1)
     else:
         w2 = add(v1, vm1)
     exact_divide_by_2_inplace(w2)
     # w2 = w2 - w0 - w4 (both subtractions are safe: result = w2 >= 0)
-    subtract_inplace_no_check(w2, v0)
-    subtract_inplace_no_check(w2, vinf)
+    subtract_no_check_inplace(w2, v0)
+    subtract_no_check_inplace(w2, vinf)
 
     # --- Compute t3 = (v2 - w0 - 16*w4) / 2 = w1 + 2*w2 + 4*w3 ---
     var t3 = v2^  # move v2, no longer needed
-    subtract_inplace_no_check(t3, v0)
+    subtract_no_check_inplace(t3, v0)
     # Subtract 16 * vinf
     if not vinf.is_zero():
         var vinf_16 = vinf.copy()
-        multiply_inplace_by_uint32(vinf_16, UInt32(16))
-        subtract_inplace_no_check(t3, vinf_16)
+        multiply_by_uint32_inplace(vinf_16, UInt32(16))
+        subtract_no_check_inplace(t3, vinf_16)
     exact_divide_by_2_inplace(t3)
 
     # --- Compute w3 = (t3 - 2*w2 - t1) / 3 ---
     # Avoid copy: subtract w2 twice instead of creating w2*2
-    subtract_inplace_no_check(t3, w2)
-    subtract_inplace_no_check(t3, w2)
-    subtract_inplace_no_check(t3, t1)
+    subtract_no_check_inplace(t3, w2)
+    subtract_no_check_inplace(t3, w2)
+    subtract_no_check_inplace(t3, t1)
     exact_divide_by_3_inplace(t3)
     # t3 now holds w3
 
     # --- Compute w1 = t1 - w3 ---
-    subtract_inplace_no_check(t1, t3)
+    subtract_no_check_inplace(t1, t3)
     # t1 now holds w1
 
     # ===================================================================
@@ -1529,7 +1532,7 @@ def multiply_slices_toom3(
     return result^
 
 
-def multiply_inplace_by_uint32(mut x: BigUInt, y: UInt32):
+def multiply_by_uint32_inplace(mut x: BigUInt, y: UInt32):
     """Multiplies in-place a BigUInt by a UInt32 value.
 
     Args:
@@ -1537,10 +1540,10 @@ def multiply_inplace_by_uint32(mut x: BigUInt, y: UInt32):
         y: The single word to multiply by.
     """
     # Short circuit cases when y is between 0 and 4
-    # See `multiply_inplace_by_uint32_le_4()` for details
+    # See `multiply_by_uint32_le_4_inplace()` for details
     # The performance is the best when `y <= 2`
     if y <= 2:
-        multiply_inplace_by_uint32_le_4(x, y)
+        multiply_by_uint32_le_4_inplace(x, y)
         return
 
     var y_as_uint64 = UInt64(y)
@@ -1556,7 +1559,7 @@ def multiply_inplace_by_uint32(mut x: BigUInt, y: UInt32):
         x.words.append(UInt32(carry))
 
 
-def multiply_inplace_by_uint32_le_4(mut x: BigUInt, y: UInt32):
+def multiply_by_uint32_le_4_inplace(mut x: BigUInt, y: UInt32):
     """Multiplies in-place a BigUInt by a UInt32 value which is between 0 and 4.
 
     Args:
@@ -1565,7 +1568,7 @@ def multiply_inplace_by_uint32_le_4(mut x: BigUInt, y: UInt32):
 
     Notes:
 
-    This function will be used in the `multiply_inplace_by_uint32()` function.
+    This function will be used in the `multiply_by_uint32_inplace()` function.
     It is optimized for the case where y is between 0 and 4.
 
     When a valid word times 2, 3, or 4, the result is no larger than 4*10^9,
@@ -1702,7 +1705,7 @@ def multiply_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt:
     return result^
 
 
-def multiply_inplace_by_power_of_ten(mut x: BigUInt, n: Int):
+def multiply_by_power_of_ten_inplace(mut x: BigUInt, n: Int):
     """Multiplies a BigUInt in-place by 10^n (n >= 0).
 
     Args:
@@ -1716,7 +1719,7 @@ def multiply_inplace_by_power_of_ten(mut x: BigUInt, n: Int):
     """
     debug_assert[assert_mode="none"](
         n >= 0,
-        "multiply_inplace_by_power_of_ten(): n must be non-negative, got ",
+        "multiply_by_power_of_ten_inplace(): n must be non-negative, got ",
         n,
     )
 
@@ -1726,7 +1729,7 @@ def multiply_inplace_by_power_of_ten(mut x: BigUInt, n: Int):
     if x.is_zero():
         debug_assert[assert_mode="none"](
             len(x.words) == 1,
-            "multiply_inplace_by_power_of_ten(): leading zero words",
+            "multiply_by_power_of_ten_inplace(): leading zero words",
         )
         # If x is zero, we can just return
         # No need to add zeros, it will still be zero
@@ -1738,7 +1741,7 @@ def multiply_inplace_by_power_of_ten(mut x: BigUInt, n: Int):
     # SPECIAL CASE: If n is a multiple of 9
     if number_of_remaining_digits == 0:
         # If n is a multiple of 9, we just need to add zero words
-        x.multiply_inplace_by_power_of_billion(number_of_zero_words)
+        x.multiply_by_power_of_billion_inplace(number_of_zero_words)
         return
 
     else:  # number_of_remaining_digits > 0
@@ -1821,7 +1824,7 @@ def multiply_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt:
     if x.is_zero():
         debug_assert[assert_mode="none"](
             len(x.words) == 1,
-            "multiply_inplace_by_power_of_billion(): leading zero words",
+            "multiply_by_power_of_billion_inplace(): leading zero words",
         )
         # If x is zero, we can just return
         # No need to add zeros, it will still be zero
@@ -1837,7 +1840,7 @@ def multiply_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt:
     return res^
 
 
-def multiply_inplace_by_power_of_billion(mut x: BigUInt, n: Int):
+def multiply_by_power_of_billion_inplace(mut x: BigUInt, n: Int):
     """Multiplies a BigUInt in-place by (10^9)^n (n >= 0).
     This equals to adding 9n zeros (n words) to the end of the number.
 
@@ -1852,7 +1855,7 @@ def multiply_inplace_by_power_of_billion(mut x: BigUInt, n: Int):
     """
     debug_assert[assert_mode="none"](
         n >= 0,
-        "multiply_inplace_by_power_of_billion(): n must be non-negative, got ",
+        "multiply_by_power_of_billion_inplace(): n must be non-negative, got ",
         n,
     )
 
@@ -1862,7 +1865,7 @@ def multiply_inplace_by_power_of_billion(mut x: BigUInt, n: Int):
     if x.is_zero():
         debug_assert[assert_mode="none"](
             len(x.words) == 1,
-            "multiply_inplace_by_power_of_billion(): leading zero words",
+            "multiply_by_power_of_billion_inplace(): leading zero words",
         )
         # If x is zero, we can just return
         # No need to add zeros, it will still be zero
@@ -2137,8 +2140,8 @@ def floor_divide_school(x: BigUInt, y: BigUInt) raises -> BigUInt:
 
         # Calculate trial product
         trial_product = y.copy()
-        multiply_inplace_by_uint32(trial_product, quotient)
-        multiply_inplace_by_power_of_billion(trial_product, index_of_word)
+        multiply_by_uint32_inplace(trial_product, quotient)
+        multiply_by_power_of_billion_inplace(trial_product, index_of_word)
 
         # By construction, no correction is needed
         # Add correction attempts counter to avoid infinite loop
@@ -2154,7 +2157,7 @@ def floor_divide_school(x: BigUInt, y: BigUInt) raises -> BigUInt:
         # Store the quotient word
         result.words[index_of_word] = quotient
         # By construction, trial_product <= remainder
-        subtract_inplace_no_check(remainder, trial_product)
+        subtract_no_check_inplace(remainder, trial_product)
         index_of_word -= 1
 
     result.remove_leading_empty_words()
@@ -2286,7 +2289,7 @@ def floor_divide_by_uint32(x: BigUInt, y: UInt32) -> BigUInt:
     return result^
 
 
-def floor_divide_inplace_by_uint32(mut x: BigUInt, y: UInt32) -> None:
+def floor_divide_by_uint32_inplace(mut x: BigUInt, y: UInt32) -> None:
     """Divides a BigUInt by a UInt32 divisor in-place.
 
     Args:
@@ -2330,7 +2333,7 @@ def floor_divide_by_uint64(x: BigUInt, y: UInt64) -> BigUInt:
     """
     debug_assert[assert_mode="none"](
         y != 0,
-        "biguint.arithmetics.floor_divide_inplace_by_uint64(): ",
+        "biguint.arithmetics.floor_divide_by_uint64_inplace(): ",
         "Division by zero.",
     )
 
@@ -2360,7 +2363,7 @@ def floor_divide_by_uint64(x: BigUInt, y: UInt64) -> BigUInt:
     return result^
 
 
-def floor_divide_inplace_by_uint64(mut x: BigUInt, y: UInt64) -> None:
+def floor_divide_by_uint64_inplace(mut x: BigUInt, y: UInt64) -> None:
     """Divides a BigUInt by UInt64 in-place.
 
     Args:
@@ -2369,7 +2372,7 @@ def floor_divide_inplace_by_uint64(mut x: BigUInt, y: UInt64) -> None:
     """
     debug_assert[assert_mode="none"](
         y != 0,
-        "biguint.arithmetics.floor_divide_inplace_by_uint64(): ",
+        "biguint.arithmetics.floor_divide_by_uint64_inplace(): ",
         "Division by zero.",
     )
 
@@ -2408,7 +2411,7 @@ def floor_divide_by_uint128(x: BigUInt, y: UInt128) -> BigUInt:
     """
     debug_assert[assert_mode="none"](
         y != 0,
-        "biguint.arithmetics.floor_divide_inplace_by_uint128(): ",
+        "biguint.arithmetics.floor_divide_by_uint128_inplace(): ",
         "Division by zero.",
     )
 
@@ -2474,7 +2477,7 @@ def floor_divide_by_uint128(x: BigUInt, y: UInt128) -> BigUInt:
     return result^
 
 
-def floor_divide_inplace_by_2(mut x: BigUInt) -> None:
+def floor_divide_by_2_inplace(mut x: BigUInt) -> None:
     """Divides a BigUInt by 2 in-place.
 
     Args:
@@ -2482,7 +2485,7 @@ def floor_divide_inplace_by_2(mut x: BigUInt) -> None:
     """
     if x.is_zero():
         debug_assert[assert_mode="none"](
-            len(x.words) == 1, "floor_divide_inplace_by_2(): leading zero words"
+            len(x.words) == 1, "floor_divide_by_2_inplace(): leading zero words"
         )
         return
 
@@ -2501,6 +2504,8 @@ def floor_divide_inplace_by_2(mut x: BigUInt) -> None:
 
 
 # TODO: Implement a in-place version of this function
+# TODO: If n % 9 == 0, we can optimize by just calling the
+# `floor_divide_by_power_of_billion_inplace` function.
 def floor_divide_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt:
     """Floor divides a BigUInt by 10^n (n>=0).
     It is equal to removing the last n digits of the number.
@@ -2510,7 +2515,7 @@ def floor_divide_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt:
         n: The power of 10 to divide by. Should be non-negative.
 
     Returns:
-        A new BigUInt containing the result of the multiplication.
+        A new BigUInt containing the result of the division.
 
     Notes:
 
@@ -2529,30 +2534,98 @@ def floor_divide_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt:
     if n <= 0:
         return x.copy()
 
-    # First remove the last words (10^9)
-    var result: BigUInt
-    if len(x.words) == 1:
-        result = x.copy()
-    else:
-        var word_shift = n // 9
-        # If we need to drop more words than exists, result is zero
-        if word_shift >= len(x.words):
-            return BigUInt.zero()
-        # Create result with the remaining words
-        result = BigUInt(uninitialized_capacity=len(x.words) - word_shift)
-        for i in range(word_shift, len(x.words)):
-            result.words.append(x.words[i])
-
-    # Then shift the remaining words right
-    # Get the last word of the divisor
+    var word_shift = n // 9
     var digit_shift = n % 9
-    var carry = UInt32(0)
-    var divisor: UInt32
+
+    # If we need to drop more words than exists, the result is zero.
+    if word_shift >= len(x.words):
+        return BigUInt.zero()
+
+    # Whole-word divide: delegate to the cheaper specialised path.
     if digit_shift == 0:
-        # No need to shift, just return the result
-        result.remove_leading_empty_words()
-        return result^
-    elif digit_shift == 1:
+        return floor_divide_by_power_of_billion(x, word_shift)
+
+    # Drop the low `word_shift` words via memcpy, then sub-word shift.
+    var keep = len(x.words) - word_shift
+    var result = BigUInt(unsafe_uninit_length=keep)
+    memcpy(
+        dest=result.words._data,
+        src=x.words._data + word_shift,
+        count=keep,
+    )
+    _shift_right_by_decimal_digits_inplace(result, digit_shift)
+    return result^
+
+
+fn floor_divide_by_power_of_ten_inplace(mut x: BigUInt, n: Int):
+    """In-place version of `floor_divide_by_power_of_ten`. Drops the
+    `n` lowest decimal digits of `x` directly inside its `words`
+    storage, avoiding an allocation when only a sub-word shift is
+    needed.
+
+    Args:
+        x: The BigUInt value to divide in place.
+        n: The power of 10 to divide by. Should be non-negative.
+
+    Notes:
+
+    No-op when `n <= 0`. When `n` is at least the current decimal
+    width, `x` becomes the canonical zero (a single word holding 0).
+    Delegates to `floor_divide_by_power_of_billion_inplace` whenever
+    `n` is a multiple of 9, which is the common case for word-aligned
+    truncation. In debug mode, asserts that `n` is non-negative.
+    """
+    debug_assert[assert_mode="none"](
+        n >= 0,
+        (
+            "biguint.arithmetics.floor_divide_by_power_of_ten_inplace(): "
+            "n must be non-negative but got "
+            + String(n)
+        ),
+    )
+
+    if n <= 0:
+        return
+
+    var word_shift = n // 9
+    var digit_shift = n % 9
+
+    if word_shift >= len(x.words):
+        x.words.shrink(0)
+        x.words.append(UInt32(0))
+        return
+
+    if digit_shift == 0:
+        floor_divide_by_power_of_billion_inplace(x, word_shift)
+        return
+
+    if word_shift > 0:
+        # Forward shift is safe: dst index < src index, dst[i] is
+        # written before src[i+1] is read.
+        var keep = len(x.words) - word_shift
+        for i in range(keep):
+            x.words[i] = x.words[i + word_shift]
+        x.words.shrink(keep)
+
+    _shift_right_by_decimal_digits_inplace(x, digit_shift)
+
+
+fn _shift_right_by_decimal_digits_inplace(mut x: BigUInt, digit_shift: Int):
+    """Divides `x` in place by `10^digit_shift`, where
+    `1 <= digit_shift <= 8`. Assumes any whole-word shift has already
+    been applied; this only performs the sub-word digit shift and
+    canonicalises the result. The `mut x` signature makes the in-place
+    semantics explicit, so no `_inplace` suffix is needed.
+    """
+    debug_assert[assert_mode="none"](
+        digit_shift >= 1 and digit_shift <= 8,
+        (
+            "biguint.arithmetics._shift_right_by_decimal_digits_inplace(): "
+            "digit_shift must be in [1, 8]"
+        ),
+    )
+    var divisor: UInt32
+    if digit_shift == 1:
         divisor = UInt32(10)
     elif digit_shift == 2:
         divisor = UInt32(100)
@@ -2569,14 +2642,13 @@ def floor_divide_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt:
     else:  # digit_shift == 8
         divisor = UInt32(100000000)
     var power_of_carry = BigUInt.BASE // divisor
-    for i in range(len(result.words) - 1, -1, -1):
-        var quot = result.words[i] // divisor
-        var rem = result.words[i] % divisor
-        result.words[i] = quot + carry * power_of_carry
+    var carry = UInt32(0)
+    for i in range(len(x.words) - 1, -1, -1):
+        var quot = x.words[i] // divisor
+        var rem = x.words[i] % divisor
+        x.words[i] = quot + carry * power_of_carry
         carry = rem
-
-    result.remove_leading_empty_words()
-    return result^
+    x.remove_leading_empty_words()
 
 
 def floor_divide_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt:
@@ -2619,6 +2691,46 @@ def floor_divide_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt:
             count=n_words_of_result,
         )
         return result^
+
+
+fn floor_divide_by_power_of_billion_inplace(mut x: BigUInt, n: Int):
+    """In-place version of `floor_divide_by_power_of_billion`. Drops
+    the `n` lowest base-10^9 words of `x` directly inside its `words`
+    storage, avoiding an allocation.
+
+    Args:
+        x: The BigUInt value to divide in place.
+        n: The power of 10^9 to divide by. Should be non-negative.
+
+    Notes:
+
+    No-op when `n <= 0`. When `n` is at least the current word count,
+    `x` becomes the canonical zero (a single word holding 0). In
+    debug mode, asserts that `n` is non-negative.
+    """
+    debug_assert[assert_mode="none"](
+        n >= 0,
+        (
+            "biguint.arithmetics.floor_divide_by_power_of_billion_inplace(): "
+            "n must be non-negative but got "
+            + String(n)
+        ),
+    )
+
+    if n <= 0:
+        return
+
+    var keep = len(x.words) - n
+    if keep <= 0:
+        x.words.shrink(0)
+        x.words.append(UInt32(0))
+        return
+
+    # Forward shift is safe: dst index < src index, dst[i] is written
+    # before src[i+1] is read.
+    for i in range(keep):
+        x.words[i] = x.words[i + n]
+    x.words.shrink(keep)
 
 
 # FAST RUCURSIVE DIVISION ALGORITHM
@@ -2694,10 +2806,10 @@ def floor_divide_burnikel_ziegler(
         n - len(normalized_b.words)
     ) * 9 + ndigits_to_shift
 
-    decimo.biguint.arithmetics.multiply_inplace_by_power_of_ten(
+    decimo.biguint.arithmetics.multiply_by_power_of_ten_inplace(
         normalized_b, n_digits_to_scale_up
     )
-    decimo.biguint.arithmetics.multiply_inplace_by_power_of_ten(
+    decimo.biguint.arithmetics.multiply_by_power_of_ten_inplace(
         normalized_a, n_digits_to_scale_up
     )
 
@@ -2711,10 +2823,10 @@ def floor_divide_burnikel_ziegler(
         gap_ratio = BigUInt.BASE_MAX // normalized_b.words[-1]
 
     if gap_ratio >= 2:
-        decimo.biguint.arithmetics.multiply_inplace_by_uint32(
+        decimo.biguint.arithmetics.multiply_by_uint32_inplace(
             normalized_b, gap_ratio
         )
-        decimo.biguint.arithmetics.multiply_inplace_by_uint32(
+        decimo.biguint.arithmetics.multiply_by_uint32_inplace(
             normalized_a, gap_ratio
         )
 
@@ -2770,17 +2882,17 @@ def floor_divide_burnikel_ziegler(
             )
             q_i = _tuple[0].copy()
             z = _tuple[1].copy()
-            decimo.biguint.arithmetics.multiply_inplace_by_power_of_billion(
+            decimo.biguint.arithmetics.multiply_by_power_of_billion_inplace(
                 q, n
             )
             q += q_i
 
         if i > 0:
-            decimo.biguint.arithmetics.multiply_inplace_by_power_of_billion(
+            decimo.biguint.arithmetics.multiply_by_power_of_billion_inplace(
                 z, n
             )
             # z = r + a[(i - 1) * n : i * n]
-            decimo.biguint.arithmetics.add_inplace_by_slice(
+            decimo.biguint.arithmetics.add_by_slice_inplace(
                 z,
                 normalized_a,
                 bounds_y=((i - 1) * n, i * n),
@@ -2844,7 +2956,7 @@ def floor_divide_two_by_one(
         var s = _tuple[1].copy()  # s is the final remainder
 
         # q -> q1q0
-        decimo.biguint.arithmetics.multiply_inplace_by_power_of_billion(
+        decimo.biguint.arithmetics.multiply_by_power_of_billion_inplace(
             q, n // 2
         )
         q += q0
@@ -2889,19 +3001,19 @@ def floor_divide_three_by_two(
         a2a1 = a1.copy()
     else:
         a2a1 = a2.copy()
-        decimo.biguint.arithmetics.multiply_inplace_by_power_of_billion(a2a1, n)
+        decimo.biguint.arithmetics.multiply_by_power_of_billion_inplace(a2a1, n)
         a2a1 += a1
     # TODO: Refine this when Mojo support move values of unpacked tuples
     _tuple = floor_divide_two_by_one(a2a1, b1, n, cut_off)
     var q = _tuple[0].copy()
     ref c = _tuple[1]  # c is the carry
     var d = q * b0
-    decimo.biguint.arithmetics.multiply_inplace_by_power_of_billion(c, n)
+    decimo.biguint.arithmetics.multiply_by_power_of_billion_inplace(c, n)
     var r = c + a0
 
     if r < d:
         var b = b1.copy()
-        decimo.biguint.arithmetics.multiply_inplace_by_power_of_billion(b, n)
+        decimo.biguint.arithmetics.multiply_by_power_of_billion_inplace(b, n)
         b += b0
         q -= BigUInt.one()
         r += b
@@ -3002,8 +3114,8 @@ def floor_divide_slices_two_by_one(
         var q = _tuple[0].copy()  # q is q1
         ref r = _tuple[1]  # r is the carry
 
-        multiply_inplace_by_power_of_billion(r, n // 2)
-        add_inplace_by_slice(r, a, (bounds_a[0], bounds_a[0] + n // 2))
+        multiply_by_power_of_billion_inplace(r, n // 2)
+        add_by_slice_inplace(r, a, (bounds_a[0], bounds_a[0] + n // 2))
         _tuple = floor_divide_slices_three_by_two(
             r, b, (0, len(r.words)), bounds_b, n // 2, cut_off
         )
@@ -3011,7 +3123,7 @@ def floor_divide_slices_two_by_one(
         var s = _tuple[1].copy()  # s is the final remainder
 
         # q -> q1q0
-        decimo.biguint.arithmetics.multiply_inplace_by_power_of_billion(
+        decimo.biguint.arithmetics.multiply_by_power_of_billion_inplace(
             q, n // 2
         )
         q += q0
@@ -3081,17 +3193,17 @@ def floor_divide_slices_three_by_two(
     ref c = _tuple[1]  # c is the carry
 
     var d = multiply_slices(q, b, (0, len(q.words)), bounds_b0)
-    decimo.biguint.arithmetics.multiply_inplace_by_power_of_billion(c, n)
+    decimo.biguint.arithmetics.multiply_by_power_of_billion_inplace(c, n)
     var r = add_slices(c, a, bounds_x=(0, len(c.words)), bounds_y=bounds_a0)
 
     if r < d:
         q -= BigUInt.one()
         # r = r + b
-        add_inplace_by_slice(r, b, bounds_y=bounds_b)
+        add_by_slice_inplace(r, b, bounds_y=bounds_b)
         if r < d:
             q -= BigUInt.one()
             # r = r + b
-            add_inplace_by_slice(r, b, bounds_y=bounds_b)
+            add_by_slice_inplace(r, b, bounds_y=bounds_b)
 
     r -= d
     q.remove_leading_empty_words()
@@ -3271,7 +3383,7 @@ def ceil_divide(x1: BigUInt, x2: BigUInt) raises -> BigUInt:
     # Apply floor division and check if there is a remainder
     var quotient = floor_divide(x1, x2)
     if quotient * x2 < x1:
-        add_inplace_by_uint32(quotient, 1)
+        add_by_uint32_inplace(quotient, 1)
     return quotient^
 
 

--- a/src/decimo/biguint/biguint.mojo
+++ b/src/decimo/biguint/biguint.mojo
@@ -1102,7 +1102,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         """
         var result = self.copy()
         for _ in range(shift_amount):
-            decimo.biguint.arithmetics.floor_divide_inplace_by_2(result)
+            decimo.biguint.arithmetics.floor_divide_by_2_inplace(result)
         return result^
 
     # ===------------------------------------------------------------------=== #
@@ -1661,11 +1661,11 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         return decimo.biguint.arithmetics.floor_divide_modulo(self, other)
 
     @always_inline
-    def floor_divide_inplace_by_2(mut self) raises:
+    def floor_divide_by_2_inplace(mut self) raises:
         """Divides this number by 2 in place.
-        See `floor_divide_inplace_by_2()` for more information.
+        See `floor_divide_by_2_inplace()` for more information.
         """
-        decimo.biguint.arithmetics.floor_divide_inplace_by_2(self)
+        decimo.biguint.arithmetics.floor_divide_by_2_inplace(self)
 
     @always_inline
     def multiply_by_power_of_ten(self, n: Int) -> Self:
@@ -1681,14 +1681,14 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         return decimo.biguint.arithmetics.multiply_by_power_of_ten(self, n)
 
     @always_inline
-    def multiply_inplace_by_power_of_ten(mut self, n: Int):
+    def multiply_by_power_of_ten_inplace(mut self, n: Int):
         """Multiplies this number in-place by 10^n (n>=0).
-        See `multiply_inplace_by_power_of_ten()` for more information.
+        See `multiply_by_power_of_ten_inplace()` for more information.
 
         Args:
             n: The power of 10 to multiply by.
         """
-        decimo.biguint.arithmetics.multiply_inplace_by_power_of_ten(self, n)
+        decimo.biguint.arithmetics.multiply_by_power_of_ten_inplace(self, n)
 
     @always_inline
     def floor_divide_by_power_of_ten(self, n: Int) -> Self:
@@ -1705,14 +1705,14 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         return decimo.biguint.arithmetics.floor_divide_by_power_of_ten(self, n)
 
     @always_inline
-    def multiply_inplace_by_power_of_billion(mut self, n: Int):
+    def multiply_by_power_of_billion_inplace(mut self, n: Int):
         """Multiplies a BigUInt in-place by (10^9)^n if n > 0.
         This equals to adding 9n zeros (n words) to the end of the number.
 
         Args:
             n: The power of 10^9 to multiply by. Should be non-negative.
         """
-        decimo.biguint.arithmetics.multiply_inplace_by_power_of_billion(self, n)
+        decimo.biguint.arithmetics.multiply_by_power_of_billion_inplace(self, n)
 
     def power(self, exponent: Int) raises -> Self:
         """Returns the result of raising this number to the power of `exponent`.
@@ -2277,7 +2277,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             )
 
         if round_up:
-            decimo.biguint.arithmetics.add_inplace_by_uint32(result, UInt32(1))
+            decimo.biguint.arithmetics.add_by_uint32_inplace(result, UInt32(1))
             # Check whether rounding results in extra digit
             if result.is_power_of_10():
                 if remove_extra_digit_due_to_rounding:

--- a/src/decimo/biguint/biguint.mojo
+++ b/src/decimo/biguint/biguint.mojo
@@ -1663,7 +1663,8 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
     @always_inline
     def floor_divide_by_2_inplace(mut self) raises:
         """Divides this number by 2 in place.
-        See `floor_divide_by_2_inplace()` for more information.
+        See `decimo.biguint.arithmetics.floor_divide_by_2_inplace()`
+        for more information.
         """
         decimo.biguint.arithmetics.floor_divide_by_2_inplace(self)
 
@@ -1683,7 +1684,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
     @always_inline
     def multiply_by_power_of_ten_inplace(mut self, n: Int):
         """Multiplies this number in-place by 10^n (n>=0).
-        See `multiply_by_power_of_ten_inplace()` for more information.
+        See
+        `decimo.biguint.arithmetics.multiply_by_power_of_ten_inplace()`
+        for more information.
 
         Args:
             n: The power of 10 to multiply by.

--- a/src/decimo/biguint/exponential.mojo
+++ b/src/decimo/biguint/exponential.mojo
@@ -98,7 +98,7 @@ def sqrt(x: BigUInt) -> BigUInt:
                 quotient = BigUInt.one()
 
             guess += quotient
-            decimo.biguint.arithmetics.floor_divide_inplace_by_2(guess)
+            decimo.biguint.arithmetics.floor_divide_by_2_inplace(guess)
 
             if guess == prev_guess:
                 break
@@ -112,7 +112,7 @@ def sqrt(x: BigUInt) -> BigUInt:
         # var guess_squared = guess * guess
         # if guess_squared > x:
         #     # guess must be larger than 1
-        #     decimo.biguint.arithmetics.subtract_inplace_by_uint32(guess, 1)
+        #     decimo.biguint.arithmetics.subtract_by_uint32_inplace(guess, 1)
 
         return guess^
 

--- a/tests/bigdecimal/test_bigdecimal_arithmetics.mojo
+++ b/tests/bigdecimal/test_bigdecimal_arithmetics.mojo
@@ -11,6 +11,9 @@ from std.python import Python
 from std import testing
 
 from decimo import BDec
+from decimo.bigdecimal.arithmetics import add, subtract, multiply
+from decimo.bigdecimal.rounding import round_to_precision
+from decimo.rounding_mode import RoundingMode
 from decimo.tests import TestCase, parse_file, load_test_cases
 
 comptime file_path = "tests/bigdecimal/test_data/bigdecimal_arithmetics.toml"
@@ -140,6 +143,144 @@ def test_bigdecimal_arithmetics() raises:
         count_wrong,
         0,
         "Division: Mojo and Python results differ. See above.",
+    )
+
+
+def test_bigdecimal_arithmetics_with_precision() raises:
+    """Tests `add`/`subtract`/`multiply` with `precision > 0`.
+
+    Each precision-arg call must equal `op(x1, x2, precision=0)`
+    followed by an explicit `round_to_precision(..., HALF_EVEN)` on
+    every input below.
+
+    Coverage:
+    - Long, same-sign operands.
+    - Wide-exponent operands, mixed and same sign.
+    - Close-exponent operands where leading digits can cancel
+      (mixed-sign add, same-sign sub).
+    - Short operands inside the precision window.
+    - Equally-long operands at high digit count.
+    - Asymmetric (long * short, wide-exponent) operands.
+    """
+    comptime PRECISION = 50
+
+    var inputs = List[Tuple[String, String, String]]()
+    inputs.append(
+        Tuple[String, String, String](
+            "1234567890" * 30, "9876543210" * 30, "long_same_sign"
+        )
+    )
+    inputs.append(
+        Tuple[String, String, String](
+            "1.234e200", "-9.876e-50", "wide_exp_mixed_sign"
+        )
+    )
+    inputs.append(
+        Tuple[String, String, String](
+            "1.234e200", "9.876e-50", "wide_exp_same_sign"
+        )
+    )
+    inputs.append(
+        Tuple[String, String, String](
+            "1." + "1" * 200 + "e10",
+            "-1." + "1" * 199 + "0e10",
+            "cancellation_add",
+        )
+    )
+    inputs.append(
+        Tuple[String, String, String](
+            "1." + "1" * 200 + "e10",
+            "1." + "1" * 199 + "0e10",
+            "cancellation_sub",
+        )
+    )
+    inputs.append(
+        Tuple[String, String, String]("1.5", "2.5", "short_inside_window")
+    )
+    inputs.append(
+        Tuple[String, String, String](
+            "1234567890" * 30, "7", "asymmetric_long_short"
+        )
+    )
+    inputs.append(
+        Tuple[String, String, String](
+            "9.876e200", "1.234e-50", "asymmetric_wide_exp"
+        )
+    )
+
+    var count_wrong = 0
+    for ref item in inputs:
+        var a_str = item[0]
+        var b_str = item[1]
+        var desc = item[2]
+        var ma = BDec(a_str)
+        var mb = BDec(b_str)
+
+        # add: precision-arg fast path must equal exact-then-round.
+        var add_ref = add(ma, mb, precision=0)
+        round_to_precision(
+            add_ref,
+            PRECISION,
+            RoundingMode.ROUND_HALF_EVEN,
+            remove_extra_digit_due_to_rounding=False,
+            fill_zeros_to_precision=False,
+        )
+        var add_fast = add(ma, mb, precision=PRECISION)
+        if String(add_ref) != String(add_fast):
+            print(
+                "add (",
+                desc,
+                "):\n  fast: ",
+                String(add_fast),
+                "\n  ref:  ",
+                String(add_ref),
+            )
+            count_wrong += 1
+
+        var sub_ref = subtract(ma, mb, precision=0)
+        round_to_precision(
+            sub_ref,
+            PRECISION,
+            RoundingMode.ROUND_HALF_EVEN,
+            remove_extra_digit_due_to_rounding=False,
+            fill_zeros_to_precision=False,
+        )
+        var sub_fast = subtract(ma, mb, precision=PRECISION)
+        if String(sub_ref) != String(sub_fast):
+            print(
+                "sub (",
+                desc,
+                "):\n  fast: ",
+                String(sub_fast),
+                "\n  ref:  ",
+                String(sub_ref),
+            )
+            count_wrong += 1
+
+        var mul_ref = multiply(ma, mb, precision=0)
+        round_to_precision(
+            mul_ref,
+            PRECISION,
+            RoundingMode.ROUND_HALF_EVEN,
+            remove_extra_digit_due_to_rounding=False,
+            fill_zeros_to_precision=False,
+        )
+        var mul_fast = multiply(ma, mb, precision=PRECISION)
+        if String(mul_ref) != String(mul_fast):
+            print(
+                "mul (",
+                desc,
+                "):\n  fast: ",
+                String(mul_fast),
+                "\n  ref:  ",
+                String(mul_ref),
+            )
+            count_wrong += 1
+
+    testing.assert_equal(
+        count_wrong,
+        0,
+        "precision-arg add/sub/mul disagreed with exact-then-round.",
     )
 
 

--- a/tests/bigdecimal/test_bigdecimal_arithmetics.mojo
+++ b/tests/bigdecimal/test_bigdecimal_arithmetics.mojo
@@ -161,10 +161,31 @@ def test_bigdecimal_arithmetics_with_precision() raises:
     - Short operands inside the precision window.
     - Equally-long operands at high digit count.
     - Asymmetric (long * short, wide-exponent) operands.
+    - Zero on either side (must still be rounded to `precision`).
     """
     comptime PRECISION = 50
 
     var inputs = List[Tuple[String, String, String]]()
+    inputs.append(
+        Tuple[String, String, String](
+            "0", "1234567890123456789.123456789", "zero_left"
+        )
+    )
+    inputs.append(
+        Tuple[String, String, String](
+            "1234567890123456789.123456789", "0", "zero_right"
+        )
+    )
+    inputs.append(
+        Tuple[String, String, String](
+            "0", "1234567890123456789.123456789", "zero_left"
+        )
+    )
+    inputs.append(
+        Tuple[String, String, String](
+            "1234567890123456789.123456789", "0", "zero_right"
+        )
+    )
     inputs.append(
         Tuple[String, String, String](
             "1234567890" * 30, "9876543210" * 30, "long_same_sign"


### PR DESCRIPTION
This PR introduces an optional significant-digit `precision` parameter for BigDecimal add/subtract/multiply to enable rounding to precision. It also performs a broad rename/cleanup of BigUInt/BigInt “in-place” helper APIs and updates benchmarks/docs to use the new BigDecimal APIs.

**Changes:**
- Add `precision: Int = 0` to `decimo.bigdecimal.arithmetics.add/subtract/multiply` with truncation + HALF_EVEN rounding when `precision > 0`.
- Add BigUInt in-place division-by-power helpers and rename multiple BigUInt/BigInt in-place helper functions for naming consistency.