### PR TITLE
[decimal] Round +/-/* to default precision; add methods that conduct exact add/subtract/multiply

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,6 +28,14 @@ This is a list of changes for the Decimo package (formerly DeciMojo).
 1. Mark `number_of_bits()` as `@always_inline` to remove the call frame on `multiply()`'s critical path.
 1. **`exp()` / `ln()` / `log10()` range reduction:** rewrite Taylor and range-reduction loops so that worst-case ratios drop to **≤ 1.0× rust_decimal** across all 42 bench cases (previously up to 1.7×). `exp_series()` now uses precomputed factorial reciprocals (two multiplies per term instead of one multiply + one divide), `ln()` reads the decade exponent `q` directly from the input scale instead of looping divisions/multiplications by 10, and `log10()`'s integer-power-of-10 fast path uses `number_of_digits` (O(1)) instead of a per-digit `% 10 / //= 10` loop. Adds new bench harnesses `cases/{ln,log10,exp}.toml` and wires `ln`/`log10`/`exp` into `run_all.sh` and the Rust harness (via the `maths` feature).
 
+**BigDecimal:**
+
+1. **Operator semantics aligned with Python `decimal.Decimal`:** the `+` / `-` / `*` operators (and their reflected and augmented variants `__radd__` / `__rsub__` / `__rmul__` / `__iadd__` / `__isub__` / `__imul__`) now round HALF_EVEN to the default precision (`PRECISION = 28` significant digits), instead of returning an exact unrounded result. This matches Python `decimal.Decimal` default-context behavior.
+1. **New exact methods with explicit precision:** `BigDecimal.add(other, precision=0)`, `subtract(other, precision=0)`, and `multiply(other, precision=0)` give callers an explicit choice — `precision=0` (default) returns the exact unrounded result, `precision > 0` rounds HALF_EVEN to that many significant digits. Use these methods (instead of operators) whenever exact intermediate arithmetic matters.
+1. **New in-place exact methods:** `BigDecimal.add_inplace(other, precision=0)`, `subtract_inplace(other, precision=0)`, and `multiply_inplace(other, precision=0)`, mirroring the precision-aware non-inplace methods. Use these in tight loops to replace `+= / -= / *=` when exact intermediate arithmetic matters. The free functions `arithmetics.add_inplace` / `subtract_inplace` / `multiply_inplace` also gain the same `precision` parameter.
+1. **Internal call sites migrated:** `pi_machin` (`constants.mojo`), Newton iterations and Taylor series in `exponential.mojo`, and range-reduction loops in `trigonometric.mojo` now use the exact `*_inplace` methods so high-precision π / `ln` / `exp` / trig results are no longer silently capped at 28 digits.
+1. **CLI calculator:** the RPN evaluator (`src/cli/calculator/evaluator.mojo`) now drives `+` / `-` / `*` through `.add(b, working_precision)` / `.subtract(...)` / `.multiply(...)` so the user-requested `--precision` is honored end to end (previously results were silently capped at PRECISION = 28).
+
 ## 20260323 (v0.9.0)
 
 Decimo v0.9.0 updates the codebase to **Mojo v0.26.2** and marks the **"make it useful"** phase. This release introduces three major additions:

--- a/docs/plans/bigdecimal_enhancement.md
+++ b/docs/plans/bigdecimal_enhancement.md
@@ -287,22 +287,23 @@ lessons in §4. All borrow patterns proven on the Decimal128 hot path.
 
 P0 — Structural API change (foundation for most P1 wins)
 
-- **T-API1 — DONE.** Added `precision: Int = 0` to `add`,
-  `subtract`, `multiply` (the `__add__`/`__sub__`/`__mul__`
-  overloads keep `precision=0`, unchanged). When `precision > 0` the
+- **T-API1 — DONE.** Added `precision: Int = 0` to the free
+  functions `add`, `subtract`, `multiply`. When `precision > 0` the
   function computes the **exact** result and rounds HALF_EVEN. The
-  upfront-operand-truncation strategy that motivated the API is
-  tracked separately as T-API3.
+  Python-facing surface follows `decimal.Decimal`:
+  `__add__`/`__sub__`/`__mul__` (and the reflected variants) round to
+  `PRECISION` (28) significant digits, while the explicit
+  `BigDecimal.add` / `subtract` / `multiply` methods default to
+  `precision=0` (exact) so callers can opt out of rounding without
+  reaching for the free function. The upfront-operand-truncation
+  strategy that originally motivated the API is tracked separately
+  as T-API3.
 
 - **T-API2 — Zero-copy scale alignment for add/sub/mul.**
   Disproven as the performance gain is limited.
 
 - **T-API3 — `add`/`sub`/`multiply` with `precision > 0`: correct
-  pre-truncation.** The naive "drop low words of the longer operand"
-  heuristic fails for similar-length operands. Strategies to
-  prototype:
-
-  Disproven as it is trivial.
+  pre-truncation.** Disproven as it is trivial.
 
 P1 — Add/Sub small-precision target (currently 4.7× / 3.6× py → target ≤2×)
 

--- a/docs/plans/bigdecimal_enhancement.md
+++ b/docs/plans/bigdecimal_enhancement.md
@@ -163,7 +163,7 @@ kernels (parse/render are precision-insensitive ops).
 | 19  | `precision` arg on `add`/`sub`/`multiply`                     | DONE (PR #233) — see T-API3                                         |
 | 20  | Private functions with `_`; Replace raises with debug asserts | OPEN — improves runtime performance by avoiding unnecessary checks  |
 | 21  | More inplace variants for `BigUInt` and `BigDecimal`          | OPEN — further reduces allocations and improves performance         |
-| 22  | Zero-copy scale alignment via word-offset add/sub             | OPEN — see T-API2                                                   |
+| 22  | Zero-copy scale alignment via word-offset add/sub             | DISPROVEN — see T-API2                                              |
 | 23  | Drop multiply pre-scaling; adjust scale on result             | OPEN — see T-API2.M                                                 |
 | 24  | `round_to_precision` in-place audit                           | OPEN — see T-R2                                                     |
 
@@ -295,54 +295,14 @@ P0 — Structural API change (foundation for most P1 wins)
   tracked separately as T-API3.
 
 - **T-API2 — Zero-copy scale alignment for add/sub/mul.**
-  Today every cross-scale `add`/`subtract` calls
-  `coef.multiply_by_power_of_ten(scale_factor)` on **both** operands
-  (two allocs + two copies + a per-word multiply pass) before a third
-  alloc for the sum. When `scale_diff % 9 == 0` the multiplication is
-  conceptually a left-shift by `k` words and the whole "scale + add"
-  can be one pass into one buffer. `BigUInt.add_slices` (already used
-  by Karatsuba/Toom-3, see `src/decimo/biguint/arithmetics.mojo:207`)
-  is *almost* the right tool but does not handle a word-offset
-  between the two slices. Sub-tasks:
-
-  - **A.** New BigUInt primitive
-    `add_with_word_offsets(x, y, x_off, y_off) -> BigUInt` computing
-    `x·BASE^x_off + y·BASE^y_off` in one alloc.
-  - **B.** Sibling `subtract_with_word_offsets` with cancellation.
-  - **C.** Wire BigDecimal `add`/`subtract` to call A/B when
-    `scale_diff % 9 == 0` (the vast majority path).
-  - **D.** Sub-word residual: when `scale_diff % 9 ∈ {1..8}`, use a
-    new `multiply_by_uint32_into(dst, src, factor)` (sibling of the
-    existing `_inplace`) writing into a pre-allocated buffer, then
-    call A/B.
-  - **M.** Drop multiply pre-scaling entirely:
-    `multiply(x·10^a, y·10^b) = multiply(x, y) · 10^(a+b)`. The
-    `multiply_by_power_of_ten` calls in `multiply` are pure waste.
-    Independent of A–D and worth landing first.
-
-  **Estimated:** 30–50% on add/sub short-to-medium operands; M alone
-  removes 2 allocs + 2 copies per `multiply` with mixed scales.
+  Disproven as the performance gain is limited.
 
 - **T-API3 — `add`/`sub`/`multiply` with `precision > 0`: correct
   pre-truncation.** The naive "drop low words of the longer operand"
   heuristic fails for similar-length operands. Strategies to
   prototype:
 
-  - **S1.** Split the total drop budget (`excess // 9` words) across
-    both operands proportionally to length so neither falls below the
-    buffer-digit floor.
-  - **S2.** Slice-aware kernels: pass tighter `bounds_x`/`bounds_y`
-    to a slice-aware multiplier (`multiply_slices_school`) for `mul`,
-    or to T-API2's offset-add for `add`/`sub`, so the bottom `excess`
-    words are never computed. Pairs naturally with T-API2.
-
-  Property tests must include similar-length-operand multiply.
-  Extend
-  `test_bigdecimal_arithmetics_with_precision` once the new path
-  lands.
-
-  **Estimated:** target add/sub/mul medians of roughly half the
-  current exact-then-round cost without sacrificing precision.
+  Disproven as it is trivial.
 
 P1 — Add/Sub small-precision target (currently 4.7× / 3.6× py → target ≤2×)
 
@@ -543,31 +503,29 @@ binary splitting). All implementable in base-10^9.
 Open items in priority order (target: dm/py ≤ 1.5× across the board,
 some ops < 1.0×):
 
-| #      | Issue                                              | Effort | Priority | Target gain                                         |
-| ------ | -------------------------------------------------- | ------ | -------- | --------------------------------------------------- |
-| T-API1 | `precision` arg on `add`/`sub`/`multiply`          | S      | **DONE** | exact-then-round; foundation for T-API2/T-API3      |
-| T-API2 | Zero-copy scale alignment for add/sub/mul          | L      | **P0**   | 30–50% add/sub; remove 2 allocs/copies per mul      |
-| T-API3 | Correct precision-arg pre-truncation               | M      | **P0**   | restore add/sub/mul speedups without precision loss |
-| T-R2   | `round_to_precision_inplace` audit                 | S      | P7       | 5–15% on precision-arg ops                          |
-| T-A1   | `debug_assert .format` sweep across BigDecimal     | S      | **P1**   | 10–30% all ops                                      |
-| T-A2   | `multiply_by_power_of_ten` audit + inplace variant | M      | **P1**   | 30–50% long-dec add/sub                             |
-| T-A3   | Hot-path-first switch in `add`/`sub`               | S      | **P1**   | 1–3 ns / call                                       |
-| T-A4   | `@no_inline` raise helpers in BigDecimal/BigUInt   | S      | **P1**   | unblocks always-inline                              |
-| T-A5   | `is_zero`/`is_integer` branch audit                | S      | P2       | small                                               |
-| T-M1   | Small-coefficient mul fast path                    | M      | **P1**   | 50–70% small-mul                                    |
-| T-M2   | Single-pass rounding in `multiply`                 | S      | P2       | ~5 ns / call                                        |
-| T-D1   | Short-divisor fast path in `divide`                | M      | **P1**   | 3–10× short-divisor                                 |
-| T-D2   | Trailing-zero strip allocation in divide           | S      | P2       | 5–15%                                               |
-| T-D3   | Reciprocal-Newton divide (legacy Task 2)           | XL     | P3       | 2× large balanced                                   |
-| T-S1   | Small-coef short-circuit in `sqrt` p=100           | S      | P2       | ~50% at p=100                                       |
-| T-L1   | atanh reformulation for ln (T3f)                   | M      | **P1**   | 3× ln near-1                                        |
-| T-L2   | Process-wide ln(10) cache recipe                   | S      | P3       | doc                                                 |
-| T-L3   | AGM ln for p ≥ 1000 (T3g)                          | XL     | P4       | 10–50× p≥1000                                       |
-| T-IO1  | `from_string` digit batching                       | M      | P2       | 30–50%                                              |
-| T-IO2  | `to_string` right-aligned InlineArray              | M      | P2       | 20–40%                                              |
-| T-R1   | `round` `.format` sweep                            | S      | P2       | small                                               |
-| T-7b   | Reciprocal-Newton nth root                         | M      | P3       | 1.5–2×                                              |
-| T-7c   | Rational $x^{a/b}$ decomposition                   | S      | P2       | 5–10× frac roots                                    |
-| T-5    | NTT multiplication                                 | XL     | P4       | 2–10×                                               |
-| T-9    | SIMD schoolbook mul base                           | M      | P3       | 1.5–2×                                              |
-| T-3e   | Binary splitting for ln Taylor                     | L      | P4       | 2–4× p≥500                                          |
+| #      | Issue                                              | Effort | Priority | Target gain                                    |
+| ------ | -------------------------------------------------- | ------ | -------- | ---------------------------------------------- |
+| T-API1 | `precision` arg on `add`/`sub`/`multiply`          | S      | **DONE** | exact-then-round; foundation for T-API2/T-API3 |
+| T-R2   | `round_to_precision_inplace` audit                 | S      | P7       | 5–15% on precision-arg ops                     |
+| T-A1   | `debug_assert .format` sweep across BigDecimal     | S      | **P1**   | 10–30% all ops                                 |
+| T-A2   | `multiply_by_power_of_ten` audit + inplace variant | M      | **P1**   | 30–50% long-dec add/sub                        |
+| T-A3   | Hot-path-first switch in `add`/`sub`               | S      | **P1**   | 1–3 ns / call                                  |
+| T-A4   | `@no_inline` raise helpers in BigDecimal/BigUInt   | S      | **P1**   | unblocks always-inline                         |
+| T-A5   | `is_zero`/`is_integer` branch audit                | S      | P2       | small                                          |
+| T-M1   | Small-coefficient mul fast path                    | M      | **P1**   | 50–70% small-mul                               |
+| T-M2   | Single-pass rounding in `multiply`                 | S      | P2       | ~5 ns / call                                   |
+| T-D1   | Short-divisor fast path in `divide`                | M      | **P1**   | 3–10× short-divisor                            |
+| T-D2   | Trailing-zero strip allocation in divide           | S      | P2       | 5–15%                                          |
+| T-D3   | Reciprocal-Newton divide (legacy Task 2)           | XL     | P3       | 2× large balanced                              |
+| T-S1   | Small-coef short-circuit in `sqrt` p=100           | S      | P2       | ~50% at p=100                                  |
+| T-L1   | atanh reformulation for ln (T3f)                   | M      | **P1**   | 3× ln near-1                                   |
+| T-L2   | Process-wide ln(10) cache recipe                   | S      | P3       | doc                                            |
+| T-L3   | AGM ln for p ≥ 1000 (T3g)                          | XL     | P4       | 10–50× p≥1000                                  |
+| T-IO1  | `from_string` digit batching                       | M      | P2       | 30–50%                                         |
+| T-IO2  | `to_string` right-aligned InlineArray              | M      | P2       | 20–40%                                         |
+| T-R1   | `round` `.format` sweep                            | S      | P2       | small                                          |
+| T-7b   | Reciprocal-Newton nth root                         | M      | P3       | 1.5–2×                                         |
+| T-7c   | Rational $x^{a/b}$ decomposition                   | S      | P2       | 5–10× frac roots                               |
+| T-5    | NTT multiplication                                 | XL     | P4       | 2–10×                                          |
+| T-9    | SIMD schoolbook mul base                           | M      | P3       | 1.5–2×                                         |
+| T-3e   | Binary splitting for ln Taylor                     | L      | P4       | 2–4× p≥500                                     |

--- a/docs/readme_unreleased.md
+++ b/docs/readme_unreleased.md
@@ -7,6 +7,7 @@ Comes with `decimo`, an interactive arbitrary-precision calculator (REPL + one-s
 [![Version](https://img.shields.io/badge/version-v0.10.0-blue)](https://github.com/forfudan/decimo/releases/tag/v0.10.0)
 [![Mojo](https://img.shields.io/badge/mojo-0.26.2-orange)](https://docs.modular.com/mojo/manual/)
 [![pixi](https://img.shields.io/badge/pixi%20add-decimo-purple)](https://prefix.dev/channels/modular-community/packages/decimo)
+[![CI](https://img.shields.io/github/actions/workflow/status/forfudan/decimo/run_tests.yaml?branch=main&label=tests)](https://github.com/forfudan/decimo/actions/workflows/run_tests.yaml)
 
 <!-- 
 [![License](https://img.shields.io/github/license/forfudan/decimo)](LICENSE)
@@ -21,7 +22,6 @@ Comes with `decimo`, an interactive arbitrary-precision calculator (REPL + one-s
 [![Changelog](https://img.shields.io/badge/change-log-yellow)](https://github.com/forfudan/decimo/blob/main/docs/changelog.md)
 [![Repository on GitHub](https://img.shields.io/badge/repo-GitHub-black)](https://github.com/forfudan/decimo)
 [![Discord](https://img.shields.io/badge/discord-join-darkblue)](https://discord.gg/3rGH87uZTk)
-[![CI](https://img.shields.io/github/actions/workflow/status/forfudan/decimo/run_tests.yaml?branch=main&label=tests)](https://github.com/forfudan/decimo/actions/workflows/run_tests.yaml)
 -->
 
 ## Overview

--- a/docs/readme_unreleased.md
+++ b/docs/readme_unreleased.md
@@ -7,7 +7,6 @@ Comes with `decimo`, an interactive arbitrary-precision calculator (REPL + one-s
 [![Version](https://img.shields.io/badge/version-v0.10.0-blue)](https://github.com/forfudan/decimo/releases/tag/v0.10.0)
 [![Mojo](https://img.shields.io/badge/mojo-0.26.2-orange)](https://docs.modular.com/mojo/manual/)
 [![pixi](https://img.shields.io/badge/pixi%20add-decimo-purple)](https://prefix.dev/channels/modular-community/packages/decimo)
-[![CI](https://img.shields.io/github/actions/workflow/status/forfudan/decimo/run_tests.yaml?branch=main&label=tests)](https://github.com/forfudan/decimo/actions/workflows/run_tests.yaml)
 
 <!-- 
 [![License](https://img.shields.io/github/license/forfudan/decimo)](LICENSE)
@@ -22,6 +21,7 @@ Comes with `decimo`, an interactive arbitrary-precision calculator (REPL + one-s
 [![Changelog](https://img.shields.io/badge/change-log-yellow)](https://github.com/forfudan/decimo/blob/main/docs/changelog.md)
 [![Repository on GitHub](https://img.shields.io/badge/repo-GitHub-black)](https://github.com/forfudan/decimo)
 [![Discord](https://img.shields.io/badge/discord-join-darkblue)](https://discord.gg/3rGH87uZTk)
+[![CI](https://img.shields.io/github/actions/workflow/status/forfudan/decimo/run_tests.yaml?branch=main&label=tests)](https://github.com/forfudan/decimo/actions/workflows/run_tests.yaml)
 -->
 
 ## Overview
@@ -30,13 +30,13 @@ Comes with `decimo`, an interactive arbitrary-precision calculator (REPL + one-s
 
 Decimo provides an arbitrary-precision integer and decimal library for Mojo. It delivers exact calculations for financial modeling, scientific computing, and applications where floating-point approximation errors are unacceptable. Beyond basic arithmetic, the library includes advanced mathematical functions with guaranteed precision.
 
-For Pythonistas, `decimo.Integer` to Mojo is like `int` to Python, and `decimo.Decimal` to Mojo is like `decimal.Decimal` to Python.
+For Pythonistas, `decimo.Integer` to Mojo is like `int` to Python, and `decimo.Decimal` to Mojo is like `decimal.Decimal` to Python. `decimo.Dec128` to Mojo is like `System.Decimal` to C# or `rust_decimal` to Rust.
 
 The core types are[^auxiliary]:
 
 - An arbitrary-precision signed integer type `Integer`[^bigint], which is a Mojo-native equivalent of Python's `int`.
 - An arbitrary-precision decimal implementation (`Decimal`) allowing for calculations with unlimited digits and decimal places[^arbitrary], which is a Mojo-native equivalent of Python's `decimal.Decimal`.
-- A 128-bit fixed-point decimal implementation (`Dec128`) supporting up to 29 significant digits with a maximum of 28 decimal places[^fixed].
+- A 128-bit fixed-point decimal implementation (`Dec128`) supporting up to 29 significant digits with a maximum of 28 decimal places[^fixed], which is a Mojo-native equivalent of C#'s `System.Decimal` or Rust's `rust_decimal`.
 - An arbitrary-precision floating-point implementation (`Float`) backed by the GNU MPFR library, supporting computations with configurable precision and a wide exponent range. Unlike `Decimal`, which uses base-10 arithmetic, `Float` uses binary floating-point internally. This type is optional and requires MPFR/GMP to be installed on the user's system.
 - An arbitrary-precision exact rational number type (`Rational`) represented as a reduced fraction of two `Integer`s (numerator and denominator). It supports exact arithmetic and comparisons without any loss of precision, making it ideal for applications that require precise fractional calculations.
 
@@ -452,8 +452,8 @@ This repository and its contributions are licensed under the Apache License v2.0
 
 The `BigFloat` type optionally uses the [GNU MPFR Library](https://www.mpfr.org/) (LGPLv3+) and [GMP](https://gmplib.org/) (LGPLv3+ or GPLv2+) at runtime. Decimo does not include or distribute any MPFR/GMP source code or binaries — they are loaded via `dlopen` only if the user has independently installed them. All other Decimo types work without any external dependencies. See the [NOTICE](./NOTICE) file for details.
 
-[^fixed]: The `Decimal128` type can represent values with up to 29 significant digits and a maximum of 28 digits after the decimal point. When a value exceeds the maximum representable value (`2^96 - 1`), Decimo either raises an error or rounds the value to fit within these constraints. For example, the significant digits of `8.8888888888888888888888888888` (29 eights total with 28 after the decimal point) exceeds the maximum representable value (`2^96 - 1`) and is automatically rounded to `8.888888888888888888888888889` (28 eights total with 27 after the decimal point). Decimo's `Decimal128` type is similar to `System.Decimal` (C#/.NET), `rust_decimal` in Rust, `DECIMAL/NUMERIC` in SQL Server, etc.
-[^bigint]: The `BigInt` implementation uses a base-2^32 representation with a little-endian format, where the least significant word is stored at index 0. Each word is a `UInt32`, allowing for efficient storage and arithmetic operations on large integers. This design choice optimizes performance for binary computations while still supporting arbitrary precision.
+[^fixed]: The `Dec128` type can represent values with up to 29 significant digits and a maximum of 28 digits after the decimal point. When a value exceeds the maximum representable value (`2^96 - 1`), Decimo either raises an error or rounds the value to fit within these constraints. For example, the significant digits of `8.8888888888888888888888888888` (29 eights total with 28 after the decimal point) exceeds the maximum representable value (`2^96 - 1`) and is automatically rounded to `8.888888888888888888888888889` (28 eights total with 27 after the decimal point). Decimo's `Dec128` type is similar to `System.Decimal` (C#/.NET), `rust_decimal` in Rust, `DECIMAL/NUMERIC` in SQL Server, etc.
+[^bigint]: The `Integer` implementation uses a base-2^32 representation with a little-endian format, where the least significant word is stored at index 0. Each word is a `UInt32`, allowing for efficient storage and arithmetic operations on large integers. This design choice optimizes performance for binary computations while still supporting arbitrary precision.
 [^auxiliary]: The auxiliary types include a base-10 arbitrary-precision signed integer type (`BigInt10`) and a base-10 arbitrary-precision unsigned integer type (`BigUInt`) supporting unlimited digits[^bigint10]. `BigUInt` is used as the internal representation for `BigInt10` and `Decimal`.
 [^bigint10]: The BigInt10 implementation uses a base-10 representation for users (maintaining decimal semantics), while internally using an optimized base-10^9 storage system for efficient calculations. This approach balances human-readable decimal operations with high-performance computing. It provides both floor division (round toward negative infinity) and truncate division (round toward zero) semantics, enabling precise handling of division operations with correct mathematical behavior regardless of operand signs.
 [^arbitrary]: Built on top of our completed BigInt10 implementation, Decimal supports arbitrary precision for both the integer and fractional parts, similar to `decimal` and `mpmath` in Python, `java.math.BigDecimal` in Java, etc.

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -435,9 +435,25 @@ print(x.is_positive())      # True
 
 ### How Precision Works
 
-- **Addition, subtraction, multiplication** are always **exact** — no precision loss.
-- **Division** and **mathematical functions** (`sqrt`, `ln`, `exp`, etc.) accept an optional `precision` parameter specifying the number of **significant digits** in the result.
 - The default precision is **28** significant digits, matching Python's `decimal` module.
+- **Operators** `+` `-` `*` `+=` `-=` `*=` (and reflected `__radd__` / `__rsub__` / `__rmul__`) round their result HALF_EVEN to the default precision (28 significant digits), matching Python `decimal.Decimal` default-context arithmetic.
+- **Methods** `.add(other)` / `.subtract(other)` / `.multiply(other)` (and the in-place variants `.add_inplace(other)` / `.subtract_inplace(other)` / `.multiply_inplace(other)`) take an optional `precision: Int = 0` argument. The default `precision=0` returns the **exact, unrounded** result; passing `precision > 0` rounds HALF_EVEN to that many significant digits.
+- **Division** and **mathematical functions** (`sqrt`, `ln`, `exp`, etc.) accept an optional `precision` parameter specifying the number of **significant digits** in the result.
+
+```mojo
+var a = Decimal("999999999999999999999999999999")  # 30 nines
+var b = Decimal("1")
+
+# Operators round to 28 digits (matches Python decimal default context)
+print(a + b)             # 1.000000000000000000000000000E+30
+
+# Methods at precision=0 (default) are exact
+print(a.add(b))          # 1000000000000000000000000000000
+
+# Methods accept an explicit precision
+print(a.add(b, 50))      # 1000000000000000000000000000000 (exact, fits)
+print(a.multiply(a, 40)) # 40-significant-digit rounded product
+```
 
 ```mojo
 var x = Decimal("2")

--- a/src/cli/calculator/evaluator.mojo
+++ b/src/cli/calculator/evaluator.mojo
@@ -256,7 +256,7 @@ def evaluate_rpn(
                 )
             var b = stack.pop()
             var a = stack.pop()
-            stack.append(a + b)
+            stack.append(a.add(b, working_precision))
 
         elif kind == TOKEN_MINUS:
             if len(stack) < 2:
@@ -267,7 +267,7 @@ def evaluate_rpn(
                 )
             var b = stack.pop()
             var a = stack.pop()
-            stack.append(a - b)
+            stack.append(a.subtract(b, working_precision))
 
         elif kind == TOKEN_STAR:
             if len(stack) < 2:
@@ -278,12 +278,7 @@ def evaluate_rpn(
                 )
             var b = stack.pop()
             var a = stack.pop()
-            var product = a * b
-            # Multiplication can grow digits unboundedly; trim to
-            # working precision to prevent intermediate blowup.
-            product.round_to_precision(
-                working_precision, RoundingMode.half_even(), False, False
-            )
+            var product = a.multiply(b, working_precision)
             stack.append(product^)
 
         elif kind == TOKEN_SLASH:

--- a/src/decimo/bigdecimal/arithmetics.mojo
+++ b/src/decimo/bigdecimal/arithmetics.mojo
@@ -240,7 +240,9 @@ def multiply(
     )
 
 
-def multiply_inplace(mut x1: BigDecimal, x2: BigDecimal):
+def multiply_inplace(
+    mut x1: BigDecimal, x2: BigDecimal, precision: Int = 0
+) raises:
     """Multiplies x1 by x2 in place, avoiding full BigDecimal construction.
 
     This computes the product and moves the result words into x1,
@@ -249,6 +251,10 @@ def multiply_inplace(mut x1: BigDecimal, x2: BigDecimal):
     Args:
         x1: The first operand (modified in place to hold the result).
         x2: The second operand (multiplier).
+        precision: Optional target significant-digit precision for the
+            result. When `0` (default) the in-place product is exact.
+            When `>0` the exact product is computed and then rounded
+            in place to `precision` significant digits via HALF_EVEN.
     """
     if x1.coefficient.is_zero() or x2.coefficient.is_zero():
         x1.coefficient = BigUInt.zero()
@@ -260,8 +266,17 @@ def multiply_inplace(mut x1: BigDecimal, x2: BigDecimal):
     x1.scale = x1.scale + x2.scale
     x1.sign = x1.sign != x2.sign
 
+    if precision > 0:
+        round_to_precision(
+            x1,
+            precision,
+            RoundingMode.ROUND_HALF_EVEN,
+            remove_extra_digit_due_to_rounding=False,
+            fill_zeros_to_precision=False,
+        )
 
-def add_inplace(mut x1: BigDecimal, x2: BigDecimal) raises:
+
+def add_inplace(mut x1: BigDecimal, x2: BigDecimal, precision: Int = 0) raises:
     """Adds x2 to x1 in place.
 
     This avoids constructing a new BigDecimal for the result.
@@ -270,6 +285,10 @@ def add_inplace(mut x1: BigDecimal, x2: BigDecimal) raises:
     Args:
         x1: The accumulator (modified in place to hold x1 + x2).
         x2: The value to add.
+        precision: Optional target significant-digit precision for the
+            result. When `0` (default) the in-place sum is exact.
+            When `>0` the exact sum is computed and then rounded in
+            place to `precision` significant digits via HALF_EVEN.
     """
     var max_scale = max(x1.scale, x2.scale)
     var scale_factor1 = (max_scale - x1.scale) if x1.scale < max_scale else 0
@@ -280,58 +299,72 @@ def add_inplace(mut x1: BigDecimal, x2: BigDecimal) raises:
         if x2.coefficient.is_zero():
             x1.scale = max_scale
             x1.sign = False
-            return
         else:
             x1.coefficient = x2.coefficient.multiply_by_power_of_ten(
                 scale_factor2
             )
             x1.scale = max_scale
             x1.sign = x2.sign
-            return
-    if x2.coefficient.is_zero():
+    elif x2.coefficient.is_zero():
         if scale_factor1 > 0:
             x1.coefficient.multiply_by_power_of_ten_inplace(scale_factor1)
         x1.scale = max_scale
-        return
-
-    # Scale x1 in place if needed
-    if scale_factor1 > 0:
-        x1.coefficient.multiply_by_power_of_ten_inplace(scale_factor1)
-
-    if x1.sign == x2.sign:
-        # Same sign: add magnitudes (use inplace add on x1's coefficient)
-        if scale_factor2 == 0:
-            decimo.biguint.arithmetics.add_inplace(
-                x1.coefficient, x2.coefficient
-            )
-        else:
-            var coef2 = x2.coefficient.multiply_by_power_of_ten(scale_factor2)
-            decimo.biguint.arithmetics.add_inplace(x1.coefficient, coef2)
-        x1.scale = max_scale
     else:
-        # Different signs: subtract magnitudes
-        var coef2 = (
-            x2.coefficient.multiply_by_power_of_ten(
-                scale_factor2
-            ) if scale_factor2
-            > 0 else x2.coefficient.copy()
+        # Scale x1 in place if needed
+        if scale_factor1 > 0:
+            x1.coefficient.multiply_by_power_of_ten_inplace(scale_factor1)
+
+        if x1.sign == x2.sign:
+            # Same sign: add magnitudes (use inplace add on x1's coefficient)
+            if scale_factor2 == 0:
+                decimo.biguint.arithmetics.add_inplace(
+                    x1.coefficient, x2.coefficient
+                )
+            else:
+                var coef2 = x2.coefficient.multiply_by_power_of_ten(
+                    scale_factor2
+                )
+                decimo.biguint.arithmetics.add_inplace(x1.coefficient, coef2)
+            x1.scale = max_scale
+        else:
+            # Different signs: subtract magnitudes
+            var coef2 = (
+                x2.coefficient.multiply_by_power_of_ten(
+                    scale_factor2
+                ) if scale_factor2
+                > 0 else x2.coefficient.copy()
+            )
+
+            if x1.coefficient > coef2:
+                decimo.biguint.arithmetics.subtract_inplace(
+                    x1.coefficient, coef2
+                )
+                x1.scale = max_scale
+            elif coef2 > x1.coefficient:
+                decimo.biguint.arithmetics.subtract_inplace(
+                    coef2, x1.coefficient
+                )
+                x1.coefficient = coef2^
+                x1.scale = max_scale
+                x1.sign = x2.sign
+            else:
+                x1.coefficient = BigUInt.zero()
+                x1.scale = max_scale
+                x1.sign = False
+
+    if precision > 0:
+        round_to_precision(
+            x1,
+            precision,
+            RoundingMode.ROUND_HALF_EVEN,
+            remove_extra_digit_due_to_rounding=False,
+            fill_zeros_to_precision=False,
         )
 
-        if x1.coefficient > coef2:
-            decimo.biguint.arithmetics.subtract_inplace(x1.coefficient, coef2)
-            x1.scale = max_scale
-        elif coef2 > x1.coefficient:
-            decimo.biguint.arithmetics.subtract_inplace(coef2, x1.coefficient)
-            x1.coefficient = coef2^
-            x1.scale = max_scale
-            x1.sign = x2.sign
-        else:
-            x1.coefficient = BigUInt.zero()
-            x1.scale = max_scale
-            x1.sign = False
 
-
-def subtract_inplace(mut x1: BigDecimal, x2: BigDecimal) raises:
+def subtract_inplace(
+    mut x1: BigDecimal, x2: BigDecimal, precision: Int = 0
+) raises:
     """Subtracts x2 from x1 in place.
 
     This avoids constructing a new BigDecimal for the result.
@@ -339,6 +372,11 @@ def subtract_inplace(mut x1: BigDecimal, x2: BigDecimal) raises:
     Args:
         x1: The accumulator (modified in place to hold x1 - x2).
         x2: The value to subtract.
+        precision: Optional target significant-digit precision for the
+            result. When `0` (default) the in-place difference is
+            exact. When `>0` the exact difference is computed and
+            then rounded in place to `precision` significant digits
+            via HALF_EVEN.
     """
     # Create a negated view of x2 and use add_inplace
     var neg_x2 = BigDecimal(
@@ -346,7 +384,7 @@ def subtract_inplace(mut x1: BigDecimal, x2: BigDecimal) raises:
         scale=x2.scale,
         sign=not x2.sign,
     )
-    add_inplace(x1, neg_x2)
+    add_inplace(x1, neg_x2, precision)
 
 
 def true_divide(

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -1070,6 +1070,7 @@ struct BigDecimal(
             self, exponent, precision=PRECISION
         )
 
+    @always_inline
     def __divmod__(self, other: Self) raises -> Tuple[Self, Self]:
         """Returns `(self // other, self % other)`.
 
@@ -1096,6 +1097,7 @@ struct BigDecimal(
         )
         return (quotient^, remainder^)
 
+    @always_inline
     def __rdivmod__(self, other: Self) raises -> Tuple[Self, Self]:
         """Returns `divmod(other, self)` for right-side divmod.
 
@@ -1113,6 +1115,73 @@ struct BigDecimal(
             decimo.bigdecimal.arithmetics.multiply(quotient, self),
         )
         return (quotient^, remainder^)
+
+    # ===------------------------------------------------------------------=== #
+    # Basic binary arithmetic operation without dunders
+    # These methods allow users to set the precision explicitly
+    # ===------------------------------------------------------------------=== #
+
+    @always_inline
+    def add(self, other: Self, precision: Int = PRECISION) raises -> Self:
+        """Adds two values with explicit precision.
+
+        Args:
+            other: The right-hand side operand.
+            precision: The precision to use for the operation.
+
+        Returns:
+            The sum of the two values.
+        """
+        return decimo.bigdecimal.arithmetics.add(
+            self, other, precision=precision
+        )
+
+    @always_inline
+    def subtract(self, other: Self, precision: Int = PRECISION) raises -> Self:
+        """Subtracts two values with explicit precision.
+
+        Args:
+            other: The right-hand side operand.
+            precision: The precision to use for the operation.
+
+        Returns:
+            The difference of the two values.
+        """
+        return decimo.bigdecimal.arithmetics.subtract(
+            self, other, precision=precision
+        )
+
+    @always_inline
+    def multiply(self, other: Self, precision: Int = PRECISION) raises -> Self:
+        """Multiplies two values with explicit precision.
+
+        Args:
+            other: The right-hand side operand.
+            precision: The precision to use for the operation.
+
+        Returns:
+            The product of the two values.
+        """
+        return decimo.bigdecimal.arithmetics.multiply(
+            self, other, precision=precision
+        )
+
+    @always_inline
+    def true_divide(
+        self, other: Self, precision: Int = PRECISION
+    ) raises -> Self:
+        """Divides two values using true division with explicit precision.
+
+        Args:
+            other: The right-hand side operand.
+            precision: The precision to use for the operation.
+
+        Returns:
+            The quotient of the two values.
+        """
+        return decimo.bigdecimal.arithmetics.true_divide(
+            self, other, precision=precision
+        )
 
     # ===------------------------------------------------------------------=== #
     # Basic binary right-side arithmetic operation dunders

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -1133,84 +1133,6 @@ struct BigDecimal(
         return (quotient^, remainder^)
 
     # ===------------------------------------------------------------------=== #
-    # Basic binary arithmetic operation without dunders
-    # These methods allow users to set the precision explicitly
-    # ===------------------------------------------------------------------=== #
-
-    @always_inline
-    def add(self, other: Self, precision: Int = 0) raises -> Self:
-        """Adds two values with explicit precision.
-
-        Args:
-            other: The right-hand side operand.
-            precision: Target significant-digit precision for the result.
-                When `0` (default) the exact sum is returned, matching the
-                `+` operator. When `> 0` the exact sum is computed and
-                then rounded HALF_EVEN to `precision` significant digits.
-
-        Returns:
-            The sum of the two values.
-        """
-        return decimo.bigdecimal.arithmetics.add(
-            self, other, precision=precision
-        )
-
-    @always_inline
-    def subtract(self, other: Self, precision: Int = 0) raises -> Self:
-        """Subtracts two values with explicit precision.
-
-        Args:
-            other: The right-hand side operand.
-            precision: Target significant-digit precision for the result.
-                When `0` (default) the exact difference is returned,
-                matching the `-` operator. When `> 0` the exact
-                difference is computed and then rounded HALF_EVEN to
-                `precision` significant digits.
-
-        Returns:
-            The difference of the two values.
-        """
-        return decimo.bigdecimal.arithmetics.subtract(
-            self, other, precision=precision
-        )
-
-    @always_inline
-    def multiply(self, other: Self, precision: Int = 0) raises -> Self:
-        """Multiplies two values with explicit precision.
-
-        Args:
-            other: The right-hand side operand.
-            precision: Target significant-digit precision for the result.
-                When `0` (default) the exact product is returned,
-                matching the `*` operator. When `> 0` the exact product
-                is computed and then rounded HALF_EVEN to `precision`
-                significant digits.
-
-        Returns:
-            The product of the two values.
-        """
-        return decimo.bigdecimal.arithmetics.multiply(
-            self, other, precision=precision
-        )
-
-    @always_inline
-    def true_divide(
-        self, other: Self, precision: Int = PRECISION
-    ) raises -> Self:
-        """Divides two values using true division with explicit precision.
-
-        Args:
-            other: The right-hand side operand.
-            precision: The precision to use for the operation.
-
-        Returns:
-            The quotient of the two values.
-        """
-        return decimo.bigdecimal.arithmetics.true_divide(
-            self, other, precision=precision
-        )
-
-    # ===------------------------------------------------------------------=== #
     # Basic binary right-side arithmetic operation dunders
     # These methods are called to implement the binary arithmetic operations
     # (+, -, *, @, /, //, %, divmod(), pow(), **, <<, >>, &, ^, |)
@@ -1324,30 +1246,45 @@ struct BigDecimal(
 
     @always_inline
     def __iadd__(mut self, other: Self) raises:
-        """Adds in place.
+        """Adds in place, rounding to `PRECISION` significant digits
+        (HALF_EVEN), matching Python `decimal.Decimal`.
+        Use `self.add_inplace(other)` to add in place exactly without
+        rounding.
 
         Args:
             other: The right-hand side operand.
         """
-        decimo.bigdecimal.arithmetics.add_inplace(self, other)
+        decimo.bigdecimal.arithmetics.add_inplace(
+            self, other, precision=PRECISION
+        )
 
     @always_inline
     def __isub__(mut self, other: Self) raises:
-        """Subtracts in place.
+        """Subtracts in place, rounding to `PRECISION` significant digits
+        (HALF_EVEN), matching Python `decimal.Decimal`.
+        Use `self.subtract_inplace(other)` to subtract in place exactly
+        without rounding.
 
         Args:
             other: The right-hand side operand.
         """
-        decimo.bigdecimal.arithmetics.subtract_inplace(self, other)
+        decimo.bigdecimal.arithmetics.subtract_inplace(
+            self, other, precision=PRECISION
+        )
 
     @always_inline
     def __imul__(mut self, other: Self) raises:
-        """Multiplies in place.
+        """Multiplies in place, rounding to `PRECISION` significant digits
+        (HALF_EVEN), matching Python `decimal.Decimal`.
+        Use `self.multiply_inplace(other)` to multiply in place exactly
+        without rounding.
 
         Args:
             other: The right-hand side operand.
         """
-        decimo.bigdecimal.arithmetics.multiply_inplace(self, other)
+        decimo.bigdecimal.arithmetics.multiply_inplace(
+            self, other, precision=PRECISION
+        )
 
     @always_inline
     def __itruediv__(mut self, other: Self) raises:
@@ -1555,6 +1492,135 @@ struct BigDecimal(
         return decimo.bigdecimal.rounding.round(
             self, ndigits=0, rounding_mode=RoundingMode.down()
         )
+
+    # ===------------------------------------------------------------------=== #
+    # Basic arithmetic operation without dunders
+    # These methods allow users to set the precision explicitly
+    # ===------------------------------------------------------------------=== #
+
+    @always_inline
+    def add(self, other: Self, precision: Int = 0) raises -> Self:
+        """Adds two values with explicit precision.
+
+        Args:
+            other: The right-hand side operand.
+            precision: Target significant-digit precision for the result.
+                When `0` (default) the exact, unrounded sum is returned.
+                When `> 0` the exact sum is computed and then rounded
+                HALF_EVEN to `precision` significant digits.
+                Note: this differs from the `+` operator which always
+                rounds to `PRECISION` (matching Python `decimal.Decimal`).
+
+        Returns:
+            The sum of the two values.
+        """
+        return decimo.bigdecimal.arithmetics.add(
+            self, other, precision=precision
+        )
+
+    @always_inline
+    def subtract(self, other: Self, precision: Int = 0) raises -> Self:
+        """Subtracts two values with explicit precision.
+
+        Args:
+            other: The right-hand side operand.
+            precision: Target significant-digit precision for the result.
+                When `0` (default) the exact, unrounded difference is
+                returned. When `> 0` the exact difference is computed
+                and then rounded HALF_EVEN to `precision` significant
+                digits.
+                Note: this differs from the `-` operator which always
+                rounds to `PRECISION` (matching Python `decimal.Decimal`).
+
+        Returns:
+            The difference of the two values.
+        """
+        return decimo.bigdecimal.arithmetics.subtract(
+            self, other, precision=precision
+        )
+
+    @always_inline
+    def multiply(self, other: Self, precision: Int = 0) raises -> Self:
+        """Multiplies two values with explicit precision.
+
+        Args:
+            other: The right-hand side operand.
+            precision: Target significant-digit precision for the result.
+                When `0` (default) the exact, unrounded product is
+                returned. When `> 0` the exact product is computed and
+                then rounded HALF_EVEN to `precision` significant digits.
+                Note: this differs from the `*` operator which always
+                rounds to `PRECISION` (matching Python `decimal.Decimal`).
+
+        Returns:
+            The product of the two values.
+        """
+        return decimo.bigdecimal.arithmetics.multiply(
+            self, other, precision=precision
+        )
+
+    @always_inline
+    def true_divide(
+        self, other: Self, precision: Int = PRECISION
+    ) raises -> Self:
+        """Divides two values using true division with explicit precision.
+
+        Args:
+            other: The right-hand side operand.
+            precision: The precision to use for the operation.
+
+        Returns:
+            The quotient of the two values.
+        """
+        return decimo.bigdecimal.arithmetics.true_divide(
+            self, other, precision=precision
+        )
+
+    @always_inline
+    def add_inplace(mut self, other: Self, precision: Int = 0) raises:
+        """Adds `other` to `self` in place with explicit precision.
+
+        Args:
+            other: The right-hand side operand.
+            precision: Target significant-digit precision for the result.
+                When `0` (default) the exact, unrounded sum is stored in
+                `self`. When `> 0` the exact sum is computed and then
+                rounded HALF_EVEN to `precision` significant digits.
+                Note: this differs from the `+=` operator which always
+                rounds to `PRECISION` (matching Python `decimal.Decimal`).
+        """
+        decimo.bigdecimal.arithmetics.add_inplace(self, other, precision)
+
+    @always_inline
+    def subtract_inplace(mut self, other: Self, precision: Int = 0) raises:
+        """Subtracts `other` from `self` in place with explicit precision.
+
+        Args:
+            other: The right-hand side operand.
+            precision: Target significant-digit precision for the result.
+                When `0` (default) the exact, unrounded difference is
+                stored in `self`. When `> 0` the exact difference is
+                computed and then rounded HALF_EVEN to `precision`
+                significant digits.
+                Note: this differs from the `-=` operator which always
+                rounds to `PRECISION` (matching Python `decimal.Decimal`).
+        """
+        decimo.bigdecimal.arithmetics.subtract_inplace(self, other, precision)
+
+    @always_inline
+    def multiply_inplace(mut self, other: Self, precision: Int = 0) raises:
+        """Multiplies `self` by `other` in place with explicit precision.
+
+        Args:
+            other: The right-hand side operand.
+            precision: Target significant-digit precision for the result.
+                When `0` (default) the exact, unrounded product is stored
+                in `self`. When `> 0` the exact product is computed and
+                then rounded HALF_EVEN to `precision` significant digits.
+                Note: this differs from the `*=` operator which always
+                rounds to `PRECISION` (matching Python `decimal.Decimal`).
+        """
+        decimo.bigdecimal.arithmetics.multiply_inplace(self, other, precision)
 
     # ===------------------------------------------------------------------=== #
     # Mathematical methods that do not implement a trait (not a dunder)

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -39,30 +39,30 @@ import decimo.str
 comptime Decimal = BigDecimal
 """An arbitrary-precision decimal, similar to Python's `decimal.Decimal`.
 
-Notes:
+Examples:
 
-Internal Representation:
+```mojo
+from decimo.prelude import *
+print(Decimal("123.456"))  # Normal string representation
+print(Decimal("1.23E+5"))  # Scientific notation
+print(Decimal("-0.00100e-2"))  # Negative number with exponent
+print(Decimal("12_345.678_9"))  # Underscores for readability
+```
 
-- A base-10 unsigned integer (BigUInt) for coefficient.
-- A Int value for the scale
-- A Bool value for the sign.
-
-Final value:
-(-1)**sign * coefficient * 10^(-scale)
 """
 comptime BDec = BigDecimal
 """An arbitrary-precision decimal, similar to Python's `decimal.Decimal`.
 
-Notes:
+Examples:
 
-Internal Representation:
+```mojo
+from decimo.prelude import *
+print(Decimal("123.456"))  # Normal string representation
+print(Decimal("1.23E+5"))  # Scientific notation
+print(Decimal("-0.00100e-2"))  # Negative number with exponent
+print(Decimal("12_345.678_9"))  # Underscores for readability
+```
 
-- A base-10 unsigned integer (BigUInt) for coefficient.
-- A Int value for the scale
-- A Bool value for the sign.
-
-Final value:
-(-1)**sign * coefficient * 10^(-scale)
 """
 
 comptime PRECISION = 28  # Same as Python's decimal module default precision of 28 places.
@@ -105,18 +105,26 @@ struct BigDecimal(
 ):
     """An arbitrary-precision decimal, similar to Python's `decimal.Decimal`.
 
-    Notes:
+    Examples:
 
-    Internal Representation:
+    ```mojo
+    from decimo.prelude import *
+    print(Decimal("123.456"))  # Normal string representation
+    print(Decimal("1.23E+5"))  # Scientific notation
+    print(Decimal("-0.00100e-2"))  # Negative number with exponent
+    print(Decimal("12_345.678_9"))  # Underscores for readability
+    ```
 
-    - A base-10 unsigned integer (BigUInt) for coefficient.
-    - A Int value for the scale
-    - A Bool value for the sign.
-
-    Final value:
-    (-1)**sign * coefficient * 10^(-scale)
     """
 
+    # NOTE:
+    # Internal Representation:
+    # - A base-10 unsigned integer (BigUInt) for coefficient.
+    # - A Int value for the scale
+    # - A Bool value for the sign.
+    # Final value:
+    # (-1)**sign * coefficient * 10^(-scale)
+    #
     # ===------------------------------------------------------------------=== #
     # Organization of fields and methods:
     # - Internal representation fields

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -1815,22 +1815,6 @@ struct BigDecimal(
     # === Arithmetic operations === #
 
     @always_inline
-    def true_divide(
-        self, other: Self, precision: Int = PRECISION
-    ) raises -> Self:
-        """Returns the result of true division of two BigDecimal numbers.
-        See `arithmetics.true_divide()` for more information.
-
-        Args:
-            other: The divisor.
-            precision: The number of significant digits for the result.
-
-        Returns:
-            The quotient of the division.
-        """
-        return decimo.bigdecimal.arithmetics.true_divide(self, other, precision)
-
-    @always_inline
     def true_divide_inexact(
         self, other: Self, number_of_significant_digits: Int
     ) raises -> Self:

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -124,7 +124,7 @@ struct BigDecimal(
     # - A Bool value for the sign.
     # Final value:
     # (-1)**sign * coefficient * 10^(-scale)
-    #
+
     # ===------------------------------------------------------------------=== #
     # Organization of fields and methods:
     # - Internal representation fields
@@ -980,39 +980,55 @@ struct BigDecimal(
 
     @always_inline
     def __add__(self, other: Self) raises -> Self:
-        """Adds two values.
+        """Adds two values, rounding the result to `PRECISION` significant
+        digits (HALF_EVEN), matching Python `decimal.Decimal`.
+        Use `self.add(other)` to get the exact, unrounded sum.
 
         Args:
             other: The right-hand side operand.
 
         Returns:
-            The sum of the two values.
+            The sum of the two values, rounded to `PRECISION` digits.
         """
-        return decimo.bigdecimal.arithmetics.add(self, other)
+        return decimo.bigdecimal.arithmetics.add(
+            self, other, precision=PRECISION
+        )
 
     @always_inline
     def __sub__(self, other: Self) raises -> Self:
-        """Subtracts two values.
+        """Subtracts two values, rounding the result to `PRECISION`
+        significant digits (HALF_EVEN), matching Python
+        `decimal.Decimal`.
+        Use `self.subtract(other)` to get the exact, unrounded difference.
 
         Args:
             other: The right-hand side operand.
 
         Returns:
-            The difference of the two values.
+            The difference of the two values, rounded to `PRECISION`
+            digits.
         """
-        return decimo.bigdecimal.arithmetics.subtract(self, other)
+        return decimo.bigdecimal.arithmetics.subtract(
+            self, other, precision=PRECISION
+        )
 
     @always_inline
     def __mul__(self, other: Self) raises -> Self:
-        """Multiplies two values.
+        """Multiplies two values, rounding the result to `PRECISION`
+        significant digits (HALF_EVEN), matching Python
+        `decimal.Decimal`.
+        Use `self.multiply(other)` to get the exact, unrounded product.
 
         Args:
             other: The right-hand side operand.
 
         Returns:
-            The product of the two values.
+            The product of the two values, rounded to `PRECISION`
+            digits.
         """
-        return decimo.bigdecimal.arithmetics.multiply(self, other)
+        return decimo.bigdecimal.arithmetics.multiply(
+            self, other, precision=PRECISION
+        )
 
     @always_inline
     def __truediv__(self, other: Self) raises -> Self:
@@ -1122,12 +1138,15 @@ struct BigDecimal(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    def add(self, other: Self, precision: Int = PRECISION) raises -> Self:
+    def add(self, other: Self, precision: Int = 0) raises -> Self:
         """Adds two values with explicit precision.
 
         Args:
             other: The right-hand side operand.
-            precision: The precision to use for the operation.
+            precision: Target significant-digit precision for the result.
+                When `0` (default) the exact sum is returned, matching the
+                `+` operator. When `> 0` the exact sum is computed and
+                then rounded HALF_EVEN to `precision` significant digits.
 
         Returns:
             The sum of the two values.
@@ -1137,12 +1156,16 @@ struct BigDecimal(
         )
 
     @always_inline
-    def subtract(self, other: Self, precision: Int = PRECISION) raises -> Self:
+    def subtract(self, other: Self, precision: Int = 0) raises -> Self:
         """Subtracts two values with explicit precision.
 
         Args:
             other: The right-hand side operand.
-            precision: The precision to use for the operation.
+            precision: Target significant-digit precision for the result.
+                When `0` (default) the exact difference is returned,
+                matching the `-` operator. When `> 0` the exact
+                difference is computed and then rounded HALF_EVEN to
+                `precision` significant digits.
 
         Returns:
             The difference of the two values.
@@ -1152,12 +1175,16 @@ struct BigDecimal(
         )
 
     @always_inline
-    def multiply(self, other: Self, precision: Int = PRECISION) raises -> Self:
+    def multiply(self, other: Self, precision: Int = 0) raises -> Self:
         """Multiplies two values with explicit precision.
 
         Args:
             other: The right-hand side operand.
-            precision: The precision to use for the operation.
+            precision: Target significant-digit precision for the result.
+                When `0` (default) the exact product is returned,
+                matching the `*` operator. When `> 0` the exact product
+                is computed and then rounded HALF_EVEN to `precision`
+                significant digits.
 
         Returns:
             The product of the two values.
@@ -1191,7 +1218,8 @@ struct BigDecimal(
 
     @always_inline
     def __radd__(self, other: Self) raises -> Self:
-        """Adds two values (reflected).
+        """Adds two values (reflected). Rounds to `PRECISION` digits
+        (HALF_EVEN), matching `__add__`.
 
         Args:
             other: The left-hand side operand.
@@ -1199,11 +1227,14 @@ struct BigDecimal(
         Returns:
             The sum of the two values.
         """
-        return decimo.bigdecimal.arithmetics.add(self, other)
+        return decimo.bigdecimal.arithmetics.add(
+            self, other, precision=PRECISION
+        )
 
     @always_inline
     def __rsub__(self, other: Self) raises -> Self:
-        """Subtracts two values (reflected).
+        """Subtracts two values (reflected). Rounds to `PRECISION` digits
+        (HALF_EVEN), matching `__sub__`.
 
         Args:
             other: The left-hand side operand.
@@ -1211,11 +1242,14 @@ struct BigDecimal(
         Returns:
             The difference `other - self`.
         """
-        return decimo.bigdecimal.arithmetics.subtract(other, self)
+        return decimo.bigdecimal.arithmetics.subtract(
+            other, self, precision=PRECISION
+        )
 
     @always_inline
     def __rmul__(self, other: Self) raises -> Self:
-        """Multiplies two values (reflected).
+        """Multiplies two values (reflected). Rounds to `PRECISION`
+        digits (HALF_EVEN), matching `__mul__`.
 
         Args:
             other: The left-hand side operand.
@@ -1223,7 +1257,9 @@ struct BigDecimal(
         Returns:
             The product of the two values.
         """
-        return decimo.bigdecimal.arithmetics.multiply(self, other)
+        return decimo.bigdecimal.arithmetics.multiply(
+            self, other, precision=PRECISION
+        )
 
     @always_inline
     def __rfloordiv__(self, other: Self) raises -> Self:

--- a/src/decimo/bigdecimal/constants.mojo
+++ b/src/decimo/bigdecimal/constants.mojo
@@ -248,7 +248,9 @@ def pi_chudnovsky_binary_split(precision: Int) raises -> BigDecimal:
     )
 
     # Final formula: π = 426880 * √10005 / sum_series
-    var result = bdec_426880 * bdec_10005.sqrt(working_precision) * sum_series
+    var result = bdec_426880.multiply(
+        bdec_10005.sqrt(working_precision)
+    ).multiply(sum_series)
 
     result.round_to_precision(
         precision,

--- a/src/decimo/bigdecimal/constants.mojo
+++ b/src/decimo/bigdecimal/constants.mojo
@@ -366,8 +366,10 @@ def pi_machin(precision: Int) raises -> BigDecimal:
 
     # Calculate 4 * arctan(1/5)
     var one_fifth = bdec_1.true_divide(bdec_5, working_precision)
-    var term1 = bdec_4 * decimo.bigdecimal.trigonometric.arctan_taylor_series(
-        one_fifth, working_precision
+    var term1 = bdec_4.multiply(
+        decimo.bigdecimal.trigonometric.arctan_taylor_series(
+            one_fifth, working_precision
+        )
     )
 
     # Calculate arctan(1/239)
@@ -377,8 +379,8 @@ def pi_machin(precision: Int) raises -> BigDecimal:
     )
 
     # π/4 = 4*arctan(1/5) - arctan(1/239)
-    var pi_over_4 = term1 - term2
-    var result = bdec_4 * pi_over_4
+    var pi_over_4 = term1.subtract(term2)
+    var result = bdec_4.multiply(pi_over_4)
 
     result.round_to_precision(
         precision,

--- a/src/decimo/bigdecimal/exponential.mojo
+++ b/src/decimo/bigdecimal/exponential.mojo
@@ -1937,7 +1937,7 @@ def exp_taylor_series(
         n += 1
 
         # Add term to result
-        result += term
+        result.add_inplace(term)
 
         # print("DEUBG: round {}, term {}, result {}".format(n, term, result))
 
@@ -2065,10 +2065,14 @@ def ln(
     var combined_ln1d25_factor = adj_power_of_5 + power_of_10
     if combined_ln2_factor != 0:
         var ln2 = cache.get_ln2(working_precision)
-        result += ln2.multiply(BigDecimal.from_int(combined_ln2_factor))
+        result.add_inplace(
+            ln2.multiply(BigDecimal.from_int(combined_ln2_factor))
+        )
     if combined_ln1d25_factor != 0:
         var ln1d25 = cache.get_ln1d25(working_precision)
-        result += ln1d25.multiply(BigDecimal.from_int(combined_ln1d25_factor))
+        result.add_inplace(
+            ln1d25.multiply(BigDecimal.from_int(combined_ln1d25_factor))
+        )
 
     # Round to final precision
     result.round_to_precision(
@@ -2257,7 +2261,7 @@ def ln_series_expansion(
         var k: UInt32 = 1
 
         # ln(1+z) = z - z²/2 + z³/3 - z⁴/4 + ...
-        result += term  # first term is z
+        result.add_inplace(term)  # first term is z
 
         for _ in range(2, max_terms):
             decimo.bigdecimal.arithmetics.multiply_inplace(term, z)
@@ -2283,9 +2287,9 @@ def ln_series_expansion(
             )
 
             if is_even:
-                result -= next_term
+                result.subtract_inplace(next_term)
             else:
-                result += next_term
+                result.add_inplace(next_term)
 
             if next_term.adjusted() < -working_precision:
                 break
@@ -2338,7 +2342,7 @@ def ln_series_expansion(
         # Step 3: Divide by (2k+1) — also truncates to working_precision
         term = term.true_divide_inexact_by_uint32(new_denom, working_precision)
 
-        result += term
+        result.add_inplace(term)
 
         if term.adjusted() < -working_precision:
             break
@@ -2425,7 +2429,7 @@ def compute_ln2(working_precision: Int) raises -> BigDecimal:
     # Series: term_k = 2 * x^(2k-1) * 1 * 3 * 5 * ... * (2k-3) / (1 * 3 * 5 * ... * (2k-1))
     # Recurrence: term_{k+1} = term_k * x² * k / (k+2)
     for _ in range(1, max_terms):
-        result += term
+        result.add_inplace(term)
         var new_k = k + 2
         # Use O(n) single-word division instead of full BigDecimal div
         # Use cached x_squared with inplace multiply, and uint32 multiply for k

--- a/src/decimo/bigdecimal/exponential.mojo
+++ b/src/decimo/bigdecimal/exponential.mojo
@@ -189,7 +189,7 @@ struct MathCache:
         var extra = precision + 9
         var ln2 = self.get_ln2(extra)
         var ln1d25 = self.get_ln1d25(extra)
-        self._ln10 = ln2 * BigDecimal.from_int(3) + ln1d25
+        self._ln10 = ln2.multiply(BigDecimal(3)).add(ln1d25)
         self._ln10.round_to_precision(
             precision=precision,
             rounding_mode=RoundingMode.down(),
@@ -284,7 +284,7 @@ def power(
     # Need to be careful with negative base
     var abs_base = abs(base)
     var ln_result = ln(abs_base, working_precision)
-    var product = ln_result * exponent
+    var product = ln_result.multiply(exponent)
     var exp_result = exp(product, working_precision)
 
     # Handle sign for negative base with odd integer exponents
@@ -349,7 +349,7 @@ def integer_power(
 
         # Use inplace multiply for squaring is not beneficial
         # because we need to copy first — just use regular multiply
-        current_power = current_power * current_power
+        current_power = current_power.multiply(current_power)
         # Round to avoid coefficient explosion
         current_power.round_to_precision(
             working_precision,
@@ -720,11 +720,11 @@ def integer_root(
 
         var numerator: BigDecimal
         if n_minus_1_int == 1:
-            numerator = r + x_div_r_pow
+            numerator = r.add(x_div_r_pow)
         elif n_minus_1_int == 2:
-            numerator = r + r + x_div_r_pow
+            numerator = r.add(r).add(x_div_r_pow)
         else:
-            numerator = r * n_minus_1_bd + x_div_r_pow
+            numerator = r.multiply(n_minus_1_bd).add(x_div_r_pow)
 
         var r_new: BigDecimal
         if n_int <= Int(UInt32.MAX):
@@ -1094,7 +1094,7 @@ def fast_isqrt(c: BigUInt, working_digits: Int) raises -> BigUInt:
     for i in range(len(prec_schedule) - 1, -1, -1):
         var ip = prec_schedule[i] + 10
 
-        var r_sq = r * r
+        var r_sq = r.multiply(r)
         r_sq.round_to_precision(
             precision=ip,
             rounding_mode=RoundingMode.half_up(),
@@ -1110,7 +1110,7 @@ def fast_isqrt(c: BigUInt, working_digits: Int) raises -> BigUInt:
             fill_zeros_to_precision=False,
         )
 
-        var correction = three - r_sq
+        var correction = three.subtract(r_sq)
 
         decimo.bigdecimal.arithmetics.multiply_inplace(r, correction)
         r.round_to_precision(
@@ -1123,7 +1123,7 @@ def fast_isqrt(c: BigUInt, working_digits: Int) raises -> BigUInt:
         r = r.true_divide_inexact_by_uint32(UInt32(2), ip)
 
     # --- Compute sqrt(c) = c_norm * r * 10^(norm_shift/2) ---
-    var result_bd = c_norm * r
+    var result_bd = c_norm.multiply(r)
     result_bd.scale -= norm_shift // 2
 
     # Round to enough digits to get an accurate integer
@@ -1413,7 +1413,7 @@ def sqrt_reciprocal(x: BigDecimal, precision: Int) raises -> BigDecimal:
         var ip = prec_schedule[i] + 10  # iteration precision with guard
 
         # r^2 (self-squaring, cannot use multiply_inplace)
-        var r_sq = r * r
+        var r_sq = r.multiply(r)
         r_sq.round_to_precision(
             precision=ip,
             rounding_mode=RoundingMode.half_up(),
@@ -1431,7 +1431,7 @@ def sqrt_reciprocal(x: BigDecimal, precision: Int) raises -> BigDecimal:
         )
 
         # 3 - x_norm * r^2 (should be close to 2 when converged)
-        var correction = three - r_sq
+        var correction = three.subtract(r_sq)
 
         # r * (3 - x_norm * r^2) (inplace)
         decimo.bigdecimal.arithmetics.multiply_inplace(r, correction)
@@ -1446,7 +1446,7 @@ def sqrt_reciprocal(x: BigDecimal, precision: Int) raises -> BigDecimal:
         r = r.true_divide_inexact_by_uint32(UInt32(2), ip)
 
     # --- Final: sqrt(x_norm) = x_norm * r ---
-    var result = x_norm * r
+    var result = x_norm.multiply(r)
 
     # --- Un-normalize: sqrt(x) = sqrt(x_norm) * 10^(shift/2) ---
     result.scale -= shift // 2
@@ -1471,7 +1471,7 @@ def sqrt_reciprocal(x: BigDecimal, precision: Int) raises -> BigDecimal:
         var stripped_scale = result.scale - n_trailing
         var candidate = BigDecimal(stripped_coef^, stripped_scale, False)
         # Verify: candidate * candidate == x?
-        var check = candidate * candidate
+        var check = candidate.multiply(candidate)
         if check == x:
             # If the scale went negative but the input had non-negative scale,
             # normalize back to scale=0 to preserve integer representation.
@@ -1691,7 +1691,7 @@ def sqrt_decimal_approach(x: BigDecimal, precision: Int) raises -> BigDecimal:
     while guess != prev_guess and iteration_count < 100:
         prev_guess = guess.copy()
         var quotient = x.true_divide_inexact(guess, working_precision)
-        var sum_val = guess + quotient
+        var sum_val = guess.add(quotient)
         # Use O(n) uint32 division instead of full BigDecimal divide-by-2
         guess = sum_val.true_divide_inexact_by_uint32(2, working_precision)
         iteration_count += 1
@@ -1859,7 +1859,7 @@ def exp(x: BigDecimal, precision: Int) raises -> BigDecimal:
 
         # Square result M times: exp(x) = exp(x/2^M)^(2^M)
         for _ in range(m):
-            result = result * result
+            result = result.multiply(result)
             result.round_to_precision(
                 precision=working_precision,
                 rounding_mode=RoundingMode.half_up(),
@@ -2038,17 +2038,17 @@ def ln(
     elif m < BigDecimal(BigUInt(raw_words=[275]), 3, False):
         # [0.135, 0.275) * 5 -> [0.675, 1.375)]
         adj_power_of_5 = -1
-        m = m * BigDecimal(BigUInt(raw_words=[5]), 0, False)
+        m = m.multiply(BigDecimal(BigUInt(raw_words=[5]), 0, False))
     elif m < BigDecimal(BigUInt(raw_words=[65]), 2, False):
         # [0.275, 0.65) * 2 -> [0.55, 1.3)]
         adj_power_of_2 = -1
-        m = m * BigDecimal(BigUInt(raw_words=[2]), 0, False)
+        m = m.multiply(BigDecimal(BigUInt(raw_words=[2]), 0, False))
     else:  # [0.65, 1) -> no change
         pass
 
     # Use series expansion for ln(m) = ln(1+z) = z - z²/2 + z³/3 - ...
     var result = ln_series_expansion(
-        m - BigDecimal(BigUInt.one(), 0, False), working_precision
+        m.subtract(BigDecimal(BigUInt.one(), 0, False)), working_precision
     )
 
     # Apply range reduction adjustments
@@ -2065,10 +2065,10 @@ def ln(
     var combined_ln1d25_factor = adj_power_of_5 + power_of_10
     if combined_ln2_factor != 0:
         var ln2 = cache.get_ln2(working_precision)
-        result += ln2 * BigDecimal.from_int(combined_ln2_factor)
+        result += ln2.multiply(BigDecimal.from_int(combined_ln2_factor))
     if combined_ln1d25_factor != 0:
         var ln1d25 = cache.get_ln1d25(working_precision)
-        result += ln1d25 * BigDecimal.from_int(combined_ln1d25_factor)
+        result += ln1d25.multiply(BigDecimal.from_int(combined_ln1d25_factor))
 
     # Round to final precision
     result.round_to_precision(
@@ -2301,11 +2301,11 @@ def ln_series_expansion(
     # ---- atanh path (optimal for larger z with many digits) ----
     # Compute u = z / (2 + z)
     var two = BigDecimal(BigUInt(raw_words=[2]), 0, False)
-    var two_plus_z = z + two
+    var two_plus_z = z.add(two)
     var u = z.true_divide(two_plus_z, working_precision)
 
     # Compute u² (cached for the recurrence)
-    var u_squared = u * u
+    var u_squared = u.multiply(u)
     u_squared.round_to_precision(
         working_precision,
         RoundingMode.down(),
@@ -2413,13 +2413,13 @@ def compute_ln2(working_precision: Int) raises -> BigDecimal:
     )  # x = 1/3
 
     var result = BigDecimal(BigUInt.zero(), 0, False)
-    var term = x * BigDecimal(
-        BigUInt(raw_words=[2]), 0, False
+    var term = x.multiply(
+        BigDecimal(BigUInt(raw_words=[2]), 0, False)
     )  # First term: 2*(1/3)
     var k: UInt32 = 1
 
     # Cache x² to avoid recomputing each iteration (was term * x * x)
-    var x_squared = x * x
+    var x_squared = x.multiply(x)
 
     # Add terms: 2*(x + x³/3 + x⁵/5 + ...)
     # Series: term_k = 2 * x^(2k-1) * 1 * 3 * 5 * ... * (2k-3) / (1 * 3 * 5 * ... * (2k-1))

--- a/src/decimo/bigdecimal/rounding.mojo
+++ b/src/decimo/bigdecimal/rounding.mojo
@@ -147,25 +147,21 @@ def round_to_precision(
         else:
             return
 
-    number.coefficient = (
-        number.coefficient.remove_trailing_digits_with_rounding(
-            ndigits=ndigits_to_remove,
-            rounding_mode=rounding_mode,
-            remove_extra_digit_due_to_rounding=False,
-            sign=number.sign,
-        )
+    number.coefficient.remove_trailing_digits_with_rounding_inplace(
+        ndigits=ndigits_to_remove,
+        rounding_mode=rounding_mode,
+        remove_extra_digit_due_to_rounding=False,
+        sign=number.sign,
     )
     number.scale -= ndigits_to_remove
 
     if remove_extra_digit_due_to_rounding and (
         number.coefficient.number_of_digits() > precision
     ):
-        number.coefficient = (
-            number.coefficient.remove_trailing_digits_with_rounding(
-                ndigits=1,
-                rounding_mode=RoundingMode.down(),
-                remove_extra_digit_due_to_rounding=False,
-            )
+        number.coefficient.remove_trailing_digits_with_rounding_inplace(
+            ndigits=1,
+            rounding_mode=RoundingMode.down(),
+            remove_extra_digit_due_to_rounding=False,
         )
         number.scale -= 1
 

--- a/src/decimo/bigdecimal/trigonometric.mojo
+++ b/src/decimo/bigdecimal/trigonometric.mojo
@@ -64,7 +64,7 @@ def sin(x: BigDecimal, precision: Int) raises -> BigDecimal:
     var bdec_4 = BigDecimal.from_raw_components(UInt32(4), scale=0, sign=False)
     var bdec_6 = BigDecimal.from_raw_components(UInt32(6), scale=0, sign=False)
     var bdec_pi = decimo.bigdecimal.constants.pi(precision=working_precision)
-    var bdec_2pi = bdec_2 * bdec_pi
+    var bdec_2pi = bdec_2.multiply(bdec_pi)
     var bdec_pi_div_2 = bdec_pi.true_divide(bdec_2, precision=working_precision)
     var bdec_1d6 = BigDecimal.from_raw_components(
         UInt32(16), scale=1, sign=False
@@ -116,7 +116,7 @@ def sin(x: BigDecimal, precision: Int) raises -> BigDecimal:
     # To avoid infinite recursion, we use 1.6 as a threshold.
     # π/4 < |x| ≤ 1.6
     elif x_reduced.compare_absolute(bdec_1d6) <= 0:
-        x_reduced = bdec_pi_div_2 - x_reduced
+        x_reduced = bdec_pi_div_2.subtract(x_reduced)
         result = cos_taylor_series(
             x_reduced, minimum_precision=working_precision
         )
@@ -127,14 +127,14 @@ def sin(x: BigDecimal, precision: Int) raises -> BigDecimal:
     # π/2 < 1.6 < |x| ≤ π
     # 0 ≤ (π - x) < π - 1.6 < π/2
     elif x_reduced.compare_absolute(bdec_pi) <= 0:
-        x_reduced = bdec_pi - x_reduced
+        x_reduced = bdec_pi.subtract(x_reduced)
         result = sin(x_reduced, precision=precision)
 
     # π < |x| < 2π: Use identity sin(x) = -sin(x - π)
     # 0 < (x - π) < π
     # Note tha the acutal range is (π, 6), so it is reduced to (0, 6 - π).
     else:
-        x_reduced = x_reduced - bdec_pi
+        x_reduced = x_reduced.subtract(bdec_pi)
         result = -sin(x_reduced, precision=precision)
 
     if is_negative:
@@ -177,7 +177,7 @@ def sin_taylor_series(
 
     var term = x.copy()  # x^n / n!
     var result = x.copy()
-    var x_squared = x * x
+    var x_squared = x.multiply(x)
     var n = 1
     var sign = -1
 
@@ -234,7 +234,7 @@ def cos(x: BigDecimal, precision: Int) raises -> BigDecimal:
     # cos(x) = sin(π/2 - x)
     var pi = decimo.bigdecimal.constants.pi(precision=working_precision)
     var pi_div_2 = pi.true_divide(2, precision=working_precision)
-    var result = sin(pi_div_2 - x, precision=precision)
+    var result = sin(pi_div_2.subtract(x), precision=precision)
     return result^
 
 
@@ -268,7 +268,7 @@ def cos_taylor_series(
     var bdec_1 = BigDecimal.from_raw_components(UInt32(1), scale=0, sign=False)
     var term = bdec_1.copy()  # Current term: x^n / n!
     var result = bdec_1.copy()  # Start with 1
-    var x_squared = x * x
+    var x_squared = x.multiply(x)
     var n = 0  # Current power (0, 2, 4, 6, ...)
     var sign = -1  # Alternating sign
 
@@ -373,7 +373,7 @@ def tan_cot(x: BigDecimal, precision: Int, is_tan: Bool) raises -> BigDecimal:
 
     var pi = decimo.bigdecimal.constants.pi(precision=working_precision_pi)
     var bdec_2 = BigDecimal.from_raw_components(UInt32(2), scale=0, sign=False)
-    var two_pi = bdec_2 * pi
+    var two_pi = bdec_2.multiply(pi)
     var pi_div_2 = pi.true_divide(bdec_2, precision=working_precision_pi)
 
     var x_reduced = x.copy()
@@ -516,13 +516,13 @@ def arctan(x: BigDecimal, precision: Int) raises -> BigDecimal:
         # Use sqrt_reciprocal for speed — exact perfect square detection is
         # unnecessary since this is an intermediate computation.
         var sqrt_term = decimo.bigdecimal.exponential.sqrt_reciprocal(
-            bdec_1 + x * x, working_precision
+            bdec_1.add(x.multiply(x)), working_precision
         )
         var x_divided = x.true_divide(
-            bdec_1 + sqrt_term, precision=working_precision
+            bdec_1.add(sqrt_term), precision=working_precision
         )
-        result = bdec_2 * arctan_taylor_series(
-            x_divided, minimum_precision=precision
+        result = bdec_2.multiply(
+            arctan_taylor_series(x_divided, minimum_precision=precision)
         )
 
     else:  # x.compare_absolute(bdec_1) > 0
@@ -540,9 +540,9 @@ def arctan(x: BigDecimal, precision: Int) raises -> BigDecimal:
         )
 
         if x.sign:
-            result = -half_pi - arctan_reciprocal
+            result = (-half_pi).subtract(arctan_reciprocal)
         else:
-            result = half_pi - arctan_reciprocal
+            result = half_pi.subtract(arctan_reciprocal)
 
     result.round_to_precision(
         precision,
@@ -584,7 +584,7 @@ def arctan_taylor_series(
     var term = x.copy()  # x^n
     var term_divided = x.copy()  # x^n / n
     var result = x.copy()
-    var x_squared = x * x
+    var x_squared = x.multiply(x)
     var n = 1
     var sign = -1
 

--- a/src/decimo/bigdecimal/trigonometric.mojo
+++ b/src/decimo/bigdecimal/trigonometric.mojo
@@ -88,10 +88,10 @@ def sin(x: BigDecimal, precision: Int) raises -> BigDecimal:
     if x_reduced.compare_absolute(bdec_6) >= 0:
         if x_reduced.sign:
             # x in [-2π, -6], reduce to [0, 2π-6]
-            x_reduced += bdec_2pi
+            x_reduced.add_inplace(bdec_2pi)
         else:
             # x in [6, 2π], reduce to [0, 2π-6]
-            x_reduced -= bdec_2pi
+            x_reduced.subtract_inplace(bdec_2pi)
 
     # Step 2: Reduce to [0, 2π) using symmetry
     # At this stage, the value should be in the range [0, 6].
@@ -188,16 +188,16 @@ def sin_taylor_series(
         # x^n = x^(n-2) * x^2 / ((n-1)(n))
         n += 2
         # Use inplace multiply to avoid BigDecimal allocation
-        term *= x_squared
+        term.multiply_inplace(x_squared)
         # Use O(n) uint32 division instead of full BigDecimal divide
         # n*(n-1) fits in UInt32 for any practical Taylor series iteration count
         term = term.true_divide_inexact_by_uint32(
             UInt32(n * (n - 1)), working_precision
         )
         if sign == 1:
-            result += term
+            result.add_inplace(term)
         else:
-            result -= term
+            result.subtract_inplace(term)
         sign *= -1
 
         # Ensure that the result will not explode in size
@@ -277,16 +277,16 @@ def cos_taylor_series(
     while term.compare_absolute(epsilon) > 0:
         n += 2  # Next even power: 2, 4, 6, 8, ...
         # Use inplace multiply to avoid BigDecimal allocation
-        term *= x_squared
+        term.multiply_inplace(x_squared)
         # Use O(n) uint32 division instead of full BigDecimal divide
         term = term.true_divide_inexact_by_uint32(
             UInt32(n * (n - 1)), working_precision
         )
 
         if sign == 1:
-            result += term
+            result.add_inplace(term)
         else:
-            result -= term
+            result.subtract_inplace(term)
 
         sign *= -1
 
@@ -383,16 +383,16 @@ def tan_cot(x: BigDecimal, precision: Int, is_tan: Bool) raises -> BigDecimal:
         # Adjust to (-π, π) range
         if x_reduced.compare_absolute(pi) > 0:
             if x_reduced.sign:
-                x_reduced += two_pi
+                x_reduced.add_inplace(two_pi)
             else:
-                x_reduced -= two_pi
+                x_reduced.subtract_inplace(two_pi)
 
     # Now reduce to (-π/2, π/2) using tan(x + π) = tan(x)
     if x_reduced.compare_absolute(pi_div_2) > 0:
         if x_reduced.sign:
-            x_reduced += pi
+            x_reduced.add_inplace(pi)
         else:
-            x_reduced -= pi
+            x_reduced.subtract_inplace(pi)
 
     # Calculate
     # tan(x) = sin(x) / cos(x)
@@ -594,15 +594,15 @@ def arctan_taylor_series(
     while term_divided.compare_absolute(epsilon) > 0:
         n += 2
         # Use inplace multiply to avoid BigDecimal allocation
-        term *= x_squared  # x^n = x^(n-2) * x^2
+        term.multiply_inplace(x_squared)  # x^n = x^(n-2) * x^2
         # Use O(n) uint32 division instead of full BigDecimal divide
         term_divided = term.true_divide_inexact_by_uint32(
             UInt32(n), working_precision
         )  # x^n / n
         if sign == 1:
-            result += term_divided
+            result.add_inplace(term_divided)
         else:
-            result -= term_divided
+            result.subtract_inplace(term_divided)
         sign *= -1
         # Ensure that the result will not explode in size
         result.round_to_precision(

--- a/src/decimo/biguint/biguint.mojo
+++ b/src/decimo/biguint/biguint.mojo
@@ -2290,3 +2290,122 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
                         )
                     )
         return result^
+
+    @always_inline
+    def remove_trailing_digits_with_rounding_inplace(
+        mut self,
+        ndigits: Int,
+        rounding_mode: RoundingMode,
+        remove_extra_digit_due_to_rounding: Bool,
+        sign: Bool = False,
+    ) raises:
+        """In-place sibling of `remove_trailing_digits_with_rounding`.
+
+        Drops the lowest `ndigits` decimal digits of `self`, applying the
+        same rounding rules, but reuses the existing `words` storage via
+        `floor_divide_by_power_of_ten_inplace` instead of allocating a
+        fresh coefficient buffer. Saves one alloc and one full-buffer
+        copy per call, which compounds across every `precision > 0`
+        invocation of `add` / `subtract` / `multiply` (each ends in a
+        `round_to_precision` call).
+
+        Args:
+            ndigits: The number of digits to remove.
+            rounding_mode: The rounding mode to use. See
+                `remove_trailing_digits_with_rounding` for the full list.
+            remove_extra_digit_due_to_rounding: If True, also drop one
+                more trailing digit when rounding produces an extra
+                leading digit (e.g. 999 → 1000 → 100).
+            sign: The sign of the original number (True = negative).
+                Only consulted for CEILING / FLOOR modes.
+
+        Raises:
+            ValueError: If `ndigits` is negative or exceeds the digit
+                count of `self`.
+        """
+        if ndigits < 0:
+            raise ValueError(
+                function=(
+                    "BigUInt.remove_trailing_digits_with_rounding_inplace()"
+                ),
+                message=(
+                    "The number of digits to remove is negative: "
+                    + String(ndigits)
+                ),
+            )
+        if ndigits == 0:
+            return
+        var ndigits_self = self.number_of_digits()
+        if ndigits > ndigits_self:
+            raise ValueError(
+                function=(
+                    "BigUInt.remove_trailing_digits_with_rounding_inplace()"
+                ),
+                message=(
+                    "The number of digits to remove is larger than the "
+                    "number of digits in the BigUInt: "
+                    + String(ndigits)
+                    + " > "
+                    + String(ndigits_self)
+                ),
+            )
+
+        # Resolve the rounding decision against the *pre-truncation*
+        # digits of `self`, mirroring the out-of-place variant.
+        var effective_mode = rounding_mode
+        if rounding_mode == RoundingMode.ceiling():
+            effective_mode = (
+                RoundingMode.up() if not sign else RoundingMode.down()
+            )
+        elif rounding_mode == RoundingMode.floor():
+            effective_mode = (
+                RoundingMode.down() if not sign else RoundingMode.up()
+            )
+
+        var round_up: Bool = False
+        if effective_mode == RoundingMode.down():
+            pass
+        elif effective_mode == RoundingMode.up():
+            if self.number_of_trailing_zeros() < ndigits:
+                round_up = True
+        elif effective_mode == RoundingMode.half_up():
+            if self.ith_digit(ndigits - 1) >= 5:
+                round_up = True
+        elif effective_mode == RoundingMode.half_down():
+            var cut_off_digit = self.ith_digit(ndigits - 1)
+            if cut_off_digit > 5:
+                round_up = True
+            elif cut_off_digit == 5:
+                if self.number_of_trailing_zeros() < ndigits - 1:
+                    round_up = True
+        elif effective_mode == RoundingMode.half_even():
+            var cut_off_digit = self.ith_digit(ndigits - 1)
+            if cut_off_digit > 5:
+                round_up = True
+            elif cut_off_digit < 5:
+                pass
+            else:  # cut_off_digit == 5
+                if self.number_of_trailing_zeros() < ndigits - 1:
+                    round_up = True
+                else:
+                    round_up = self.ith_digit(ndigits) % 2 == 1
+        # TODO: Remove this fallback once Mojo has proper enum support.
+        else:
+            raise ValueError(
+                function=(
+                    "BigUInt.remove_trailing_digits_with_rounding_inplace()"
+                ),
+                message=("Unknown rounding mode: " + String(rounding_mode)),
+            )
+
+        # Drop the digits in place, then apply the carry from rounding.
+        decimo.biguint.arithmetics.floor_divide_by_power_of_ten_inplace(
+            self, ndigits
+        )
+        if round_up:
+            decimo.biguint.arithmetics.add_by_uint32_inplace(self, UInt32(1))
+            if self.is_power_of_10():
+                if remove_extra_digit_due_to_rounding:
+                    decimo.biguint.arithmetics.floor_divide_by_power_of_ten_inplace(
+                        self, 1
+                    )

--- a/tests/bigdecimal/test_bigdecimal_arithmetics.mojo
+++ b/tests/bigdecimal/test_bigdecimal_arithmetics.mojo
@@ -25,8 +25,11 @@ def test_bigdecimal_arithmetics() raises:
     var toml = parse_file(file_path)
     var test_cases: List[TestCase]
 
-    # BigDecimal add/sub/mul are exact (unlimited precision).
-    # Set Python context precision high so Python doesn't round.
+    # BigDecimal `.add` / `.subtract` / `.multiply` methods are exact
+    # (precision=0 by default). The operators `+ - *` round to PRECISION
+    # (28) like Python `decimal.Decimal`. We exercise the exact paths
+    # here, so set Python context precision high enough that Python
+    # also returns the exact result.
     pydecimal.getcontext().prec = 500
 
     # -------------------------------------------------------
@@ -36,7 +39,7 @@ def test_bigdecimal_arithmetics() raises:
     test_cases = load_test_cases(toml, "addition_tests")
     count_wrong = 0
     for test_case in test_cases:
-        var result = BDec(test_case.a) + BDec(test_case.b)
+        var result = BDec(test_case.a).add(BDec(test_case.b))
         var mojo_str = String(result)
         var py_str = String(
             pydecimal.Decimal(test_case.a) + pydecimal.Decimal(test_case.b)
@@ -64,7 +67,7 @@ def test_bigdecimal_arithmetics() raises:
     test_cases = load_test_cases(toml, "subtraction_tests")
     count_wrong = 0
     for test_case in test_cases:
-        var result = BDec(test_case.a) - BDec(test_case.b)
+        var result = BDec(test_case.a).subtract(BDec(test_case.b))
         var mojo_str = String(result)
         var py_str = String(
             pydecimal.Decimal(test_case.a) - pydecimal.Decimal(test_case.b)
@@ -92,7 +95,7 @@ def test_bigdecimal_arithmetics() raises:
     test_cases = load_test_cases(toml, "multiplication_tests")
     count_wrong = 0
     for test_case in test_cases:
-        var result = BDec(test_case.a) * BDec(test_case.b)
+        var result = BDec(test_case.a).multiply(BDec(test_case.b))
         var mojo_str = String(result)
         var py_str = String(
             pydecimal.Decimal(test_case.a) * pydecimal.Decimal(test_case.b)

--- a/tests/bigdecimal/test_bigdecimal_arithmetics.mojo
+++ b/tests/bigdecimal/test_bigdecimal_arithmetics.mojo
@@ -384,9 +384,8 @@ def test_bigdecimal_operators_round_to_precision() raises:
             )
             count_wrong += 1
 
-        # __radd__ (BigDecimal does not promote ints automatically here,
-        # but reflected on BigDecimal is exercised by `mb + ma`)
-        var radd_op = mb + ma
+        # __radd__
+        var radd_op = ma.__radd__(mb)
         var radd_py = String(pb + pa)
         if String(radd_op) != radd_py:
             print(

--- a/tests/bigdecimal/test_bigdecimal_arithmetics.mojo
+++ b/tests/bigdecimal/test_bigdecimal_arithmetics.mojo
@@ -308,6 +308,174 @@ def test_bigdecimal_arithmetics_with_precision() raises:
     )
 
 
+def test_bigdecimal_operators_round_to_precision() raises:
+    """Tests that `+`, `-`, `*` (and reflected and augmented variants)
+    round HALF_EVEN to `PRECISION` (28) significant digits, matching
+    Python `decimal.Decimal` default-context behavior.
+    """
+    var pydecimal = Python.import_module("decimal")
+    pydecimal.getcontext().prec = 28
+
+    # Pairs chosen so the exact result has > 28 digits, forcing the
+    # operator to actually round (rather than returning an exact answer
+    # that already fits in 28 digits).
+    var pairs = List[Tuple[String, String, String]]()
+    pairs.append(
+        Tuple[String, String, String](
+            "1.234567890123456789012345678",
+            "9.876543210987654321098765432",
+            "mul_long_long",
+        )
+    )
+    pairs.append(
+        Tuple[String, String, String](
+            "1.234567890123456789012345678",
+            "0.876543210987654321098765432",
+            "add_long_long",
+        )
+    )
+    pairs.append(
+        Tuple[String, String, String](
+            "1.000000000000000000000000001",
+            "1.000000000000000000000000002",
+            "sub_close_carry",
+        )
+    )
+    pairs.append(
+        Tuple[String, String, String](
+            "9.999999999999999999999999995",
+            "0.000000000000000000000000005",
+            "add_carry_to_extra_digit",
+        )
+    )
+    pairs.append(
+        Tuple[String, String, String](
+            "12345678901234567890123456785",
+            "1",
+            "add_half_even_round_down",
+        )
+    )
+    pairs.append(
+        Tuple[String, String, String](
+            "12345678901234567890123456795",
+            "1",
+            "add_half_even_round_up",
+        )
+    )
+
+    var count_wrong = 0
+    for p in pairs:
+        var ma = BDec(p[0])
+        var mb = BDec(p[1])
+        var pa = pydecimal.Decimal(p[0])
+        var pb = pydecimal.Decimal(p[1])
+
+        # __add__
+        var add_op = ma + mb
+        var add_py = String(pa + pb)
+        if String(add_op) != add_py:
+            print(
+                "op + (",
+                p[2],
+                "):\n  Mojo: ",
+                String(add_op),
+                "\n  Py:   ",
+                add_py,
+            )
+            count_wrong += 1
+
+        # __radd__ (BigDecimal does not promote ints automatically here,
+        # but reflected on BigDecimal is exercised by `mb + ma`)
+        var radd_op = mb + ma
+        var radd_py = String(pb + pa)
+        if String(radd_op) != radd_py:
+            print(
+                "op + reflected (",
+                p[2],
+                "):\n  Mojo: ",
+                String(radd_op),
+                "\n  Py:   ",
+                radd_py,
+            )
+            count_wrong += 1
+
+        # __sub__
+        var sub_op = ma - mb
+        var sub_py = String(pa - pb)
+        if String(sub_op) != sub_py:
+            print(
+                "op - (",
+                p[2],
+                "):\n  Mojo: ",
+                String(sub_op),
+                "\n  Py:   ",
+                sub_py,
+            )
+            count_wrong += 1
+
+        # __mul__
+        var mul_op = ma * mb
+        var mul_py = String(pa * pb)
+        if String(mul_op) != mul_py:
+            print(
+                "op * (",
+                p[2],
+                "):\n  Mojo: ",
+                String(mul_op),
+                "\n  Py:   ",
+                mul_py,
+            )
+            count_wrong += 1
+
+        # __iadd__
+        var iadd_val = ma.copy()
+        iadd_val += mb
+        if String(iadd_val) != add_py:
+            print(
+                "op += (",
+                p[2],
+                "):\n  Mojo: ",
+                String(iadd_val),
+                "\n  Py:   ",
+                add_py,
+            )
+            count_wrong += 1
+
+        # __isub__
+        var isub_val = ma.copy()
+        isub_val -= mb
+        if String(isub_val) != sub_py:
+            print(
+                "op -= (",
+                p[2],
+                "):\n  Mojo: ",
+                String(isub_val),
+                "\n  Py:   ",
+                sub_py,
+            )
+            count_wrong += 1
+
+        # __imul__
+        var imul_val = ma.copy()
+        imul_val *= mb
+        if String(imul_val) != mul_py:
+            print(
+                "op *= (",
+                p[2],
+                "):\n  Mojo: ",
+                String(imul_val),
+                "\n  Py:   ",
+                mul_py,
+            )
+            count_wrong += 1
+
+    testing.assert_equal(
+        count_wrong,
+        0,
+        "Operators must round HALF_EVEN to PRECISION matching Python decimal.",
+    )
+
+
 def main() raises:
     # print("Running BigDecimal arithmetic tests")
 


### PR DESCRIPTION
This PR adds round +/-/* to default precision and add methods that allow users to set the precision. Adds an in-place BigUInt rounding/truncation primitive and wires it into BigDecimal’s precision-rounding path to reduce allocations in hot arithmetic flows.