### PR TITLE
[dec128] Improve `divide()` by dropping a redundant rounding-digit padding step

### DIFF
--- a/docs/plans/decimal128_enhancement.md
+++ b/docs/plans/decimal128_enhancement.md
@@ -153,6 +153,22 @@ value before the fact and §2.4 / §2.5 for end-to-end snapshots.
 |          | `lower > upper`. 8 new tests in `test_decimal128_comparison.mojo` cover              |
 |          | positives/negatives, tie-preserves-scale, signed zeros, in-range / below /           |
 |          | above / boundary clamps, and invalid-bounds raise.                                   |
+| 20260502 | **`divide` long-division refactor (P1 of §5.1).** Three independent changes in the   |
+|          | UInt128 sub-case: (a) dropped the `+1` rounding-digit padding from `max_steps`, so   |
+|          | the long division produces exactly the final coefficient and the post-divide         |
+|          | `round_coefficient` overflow fix-up is no longer triggered for results that fit      |
+|          | `MAX_AS_UINT128`; (b) replaced the `UInt256` `combined = quot * 10^k + quot_added`   |
+|          | fold with a `UInt128` multiply (post-bulk total digits ≤ 29 → < 2^97 fits UInt128);  |
+|          | (c) replaced the OLD "+1 padding then `round_coefficient` (banker's) with override   |
+|          | `if digit == 5 and rem != 0: quot += 1`" pattern with a direct three-branch          |
+|          | banker's test on the residual rem (`2*rem > x2`/`==`/`<`), eliminating the wide      |
+|          | divide that `round_coefficient` performed at the boundary. Behaviour preserved:      |
+|          | banker's (round-half-to-even) at exact half; round-up at "5 with non-zero tail"      |
+|          | (mathematically > half, not a banker's tie). Added `test_divide_bankers_rounding_at` |
+|          | `_boundary` (5 cases) pinning all four arms (even-keeps, odd-bumps, 5+tail,          |
+|          | below-half) cross-checked against Python `decimal` ROUND_HALF_EVEN. Bench best-of-3  |
+|          | UInt128 path: `Repeating decimal` 47 → 36 ns, `High precision division` 47–61 →      |
+|          | 33–39 ns, `Large coprime quotient` 42–54 → 29–35 ns. UInt256 sub-case unchanged.     |
 
 ### 2.5 Performance tracking — absolute decimo median ns/iter
 
@@ -301,18 +317,20 @@ context. All P1/P2 items have landed; P3 items are tracked in §5.
 These are the residual gaps after this PR. Each requires algorithmic
 work, not micro-optimisation.
 
-| Op          | Worst case                      | decimo |  rust | dm/rs | Likely root cause                                                                                            |
-| ----------- | ------------------------------- | -----: | ----: | ----: | ------------------------------------------------------------------------------------------------------------ |
-| multiply    | High precision multiplication   |   13.0 |  6.50 |  2.0× | UInt128 path: 17×17-digit prod, mandatory `round_coefficient` work                                           |
-| multiply    | Multiplication by zero          |    4.0 |  1.38 |  2.9× | Per-call dispatch overhead (raises + special-case tree)                                                      |
-| multiply    | Negative numbers                |    4.0 |  1.08 |  3.7× | Same                                                                                                         |
-| multiply    | e * e^0.5                       |   23.0 | 27.79 |  0.8× | UInt256 path; *faster* than rust                                                                             |
-| divide      | Division with repeating decimal |   47.0 | 12.12 |  3.9× | Rust uses a `div_internal` magic-multiply trick; decimo's two-phase loop still pays 28 digits' worth of bulk |
-| divide      | High precision division         |   48.0 | 19.21 |  2.5× | Same                                                                                                         |
-| divide      | Large coprime quotient          |   43.0 | 16.88 |  2.5× | Same                                                                                                         |
-| from_string | Long integer part (20 digits)   |   24.7 | 11.52 |  2.1× | UInt128 multiply-by-10 per digit; could batch into u64 chunks                                                |
-| from_string | Long fractional (28 digits)     |   46.2 | 27.12 |  1.7× | Same                                                                                                         |
-| from_string | Zero value                      |    4.3 |  1.79 |  2.4× | Per-call dispatch; rust has a 2-byte fast path                                                               |
+| Op          | Worst case                    | decimo |  rust | dm/rs | Likely root cause                                                  |
+| ----------- | ----------------------------- | -----: | ----: | ----: | ------------------------------------------------------------------ |
+| multiply    | High precision mul            |   13.0 |  6.50 |  2.0× | UInt128 path: 17×17-digit prod, mandatory `round_coefficient` work |
+| multiply    | Multiplication by zero        |    4.0 |  1.38 |  2.9× | Per-call dispatch overhead (raises + special-case tree)            |
+| multiply    | Negative numbers              |    4.0 |  1.08 |  3.7× | Same                                                               |
+| multiply    | e * e^0.5                     |   23.0 | 27.79 |  0.8× | UInt256 path; *faster* than rust                                   |
+| divide      | Div with repeating decimal    |   36.0 | 12.04 |  3.0× | One bulk wide-divide + post-divide overhead. After 20260502        |
+|             |                               |        |       |       | refactor (§2.4); rust_decimal still uses a `div_internal` magic-   |
+|             |                               |        |       |       | multiply trick. Closing the rest needs reciprocal multiplication.  |
+| divide      | High precision division       |   37.0 | 18.67 |  2.0× | Same                                                               |
+| divide      | Large coprime quotient        |   30.0 | 16.67 |  1.8× | Same                                                               |
+| from_string | Long integer part (20 digits) |   24.7 | 11.52 |  2.1× | UInt128 multiply-by-10 per digit; could batch into u64 chunks      |
+| from_string | Long fractional (28 digits)   |   46.2 | 27.12 |  1.7× | Same                                                               |
+| from_string | Zero value                    |    4.3 |  1.79 |  2.4× | Per-call dispatch; rust has a 2-byte fast path                     |
 
 **Possible follow-ups** (none committed):
 
@@ -399,6 +417,41 @@ It is a long-term proposal; not on the active roadmap.
 
 See git history (pre-2026-04-23) for the full analysis.
 
+### 5.6 Per-op `RoundingMode` parameter on `Decimal128` arithmetic — REJECTED
+
+**Considered 2026-05-02.** Question: should `Decimal128.divide` (and by
+extension `multiply`, etc.) accept a `RoundingMode` argument so callers
+can override the default banker's rounding without a follow-up
+`.round(...)` call?
+
+Cross-language survey of fixed-precision decimal types:
+
+| Library                 | `/` rounding             | Per-op `mode` arg?   |
+| ----------------------- | ------------------------ | -------------------- |
+| C# `System.Decimal`     | banker's                 | No                   |
+| Rust `rust_decimal`     | banker's                 | No                   |
+| Apache Arrow Decimal128 | banker's                 | No                   |
+| Go `govalues/decimal`   | banker's                 | No                   |
+| Python `decimal`        | context-based (banker's) | No (use context)     |
+| Java `BigDecimal`       | must specify or throws   | Yes (arbitrary-prec) |
+| decimo `BigDecimal`     | must specify or default  | Yes (arbitrary-prec) |
+
+**Verdict: REJECTED.** The industry pattern for fixed-precision decimal
+types is "implicit banker's on arithmetic, explicit `.round(scale, mode)`
+for adjustment". Decimo already provides `Decimal128.round(scale, RoundingMode)`,
+so consumers needing a different mode can chain. Adding a per-op
+parameter to arithmetic would diverge from C#/Rust without a clear
+use-case, complicate the hot-path signature, and risk silent
+inconsistency between the rounding applied by the operator and any
+follow-up call. Banker's-only matches the IEEE 754-2008 default
+(round-nearest-even) and is what users coming from `System.Decimal` /
+`rust_decimal` expect.
+
+For per-op rounding control, callers should write
+`x.divide(y).round(scale, RoundingMode.half_up())` or use
+`BigDecimal` (which is the arbitrary-precision type and does take a
+mode parameter, matching Java `BigDecimal`). No code change required.
+
 ---
 
 ## 6. Result-Equivalence vs `rust_decimal` / .NET (3 vs 1 verdict)
@@ -429,11 +482,12 @@ Part II → "A note on result exponents (`Decimal` and `Dec128`)".
 
 Open items, in priority order:
 
-| #   | Issue                                             | Effort | Priority |
-| --- | ------------------------------------------------- | ------ | -------- |
-| 5.1 | divide repeating-decimal long tail (47 → ≤ 19 ns) | Large  | P1       |
-| 5.1 | from_string digit batching                        | Medium | P2       |
-| 5.2 | `normalize()`                                     | Small  | P3       |
-| 5.2 | `__hash__` (depends on `normalize()`)             | Small  | P3       |
-| 5.3 | `exp()` sub-unit chunk constants (`exp(π)`)       | Medium | P4       |
-| 5.5 | Steal flag bits → 32-digit coefficient            | Large  | P4       |
+| #   | Issue                                            | Effort | Priority |
+| --- | ------------------------------------------------ | ------ | -------- |
+| 5.1 | divide reciprocal-multiply (36 → ≤ 19 ns target) | Large  | P2       |
+| 5.1 | from_string digit batching                       | Medium | P2       |
+| 5.2 | `normalize()`                                    | Small  | P3       |
+| 5.2 | `__hash__` (depends on `normalize()`)            | Small  | P3       |
+| 5.6 | Per-op `RoundingMode` on Decimal128 arithmetic   | —      | REJECTED |
+| 5.3 | `exp()` sub-unit chunk constants (`exp(π)`)      | Medium | P4       |
+| 5.5 | Steal flag bits → 32-digit coefficient           | Large  | P4       |

--- a/docs/plans/decimal128_enhancement.md
+++ b/docs/plans/decimal128_enhancement.md
@@ -87,7 +87,7 @@ value before the fact and §2.4 / §2.5 for end-to-end snapshots.
 | 20260422 | H#14 `power_of_10_unsafe` sweep + `from_uint128` `@always_inline` with `raises`      |
 |          | extracted into `@no_inline` helpers. add dm/rs 1.2→0.8; divide dm/rs 2.2→1.0         |
 
-### 2.4 Performance — comparison / format / parse (this PR)
+### 2.4 Performance — comparison / format / parse
 
 | Date     | Item                                                                                 |
 | -------- | ------------------------------------------------------------------------------------ |
@@ -169,6 +169,16 @@ value before the fact and §2.4 / §2.5 for end-to-end snapshots.
 |          | below-half) cross-checked against Python `decimal` ROUND_HALF_EVEN. Bench best-of-3  |
 |          | UInt128 path: `Repeating decimal` 47 → 36 ns, `High precision division` 47–61 →      |
 |          | 33–39 ns, `Large coprime quotient` 42–54 → 29–35 ns. UInt256 sub-case unchanged.     |
+|          | Negative results explored same day (none landed): (i) chunked-9 UInt128/UInt128      |
+|          | divide replacing the bulk UInt256 path regressed +10–15 ns because aarch64           |
+|          | UInt128/UInt128 falls back to libgcc `__udivti3` (~30 ns) vs the existing            |
+|          | `udiv_u256_by_u64`'s 4× hardware-favored u128/u64 divides; (ii) manually splitting   |
+|          | the probe-loop `// + %` into one divide + multiply-subtract regressed +4–5 ns        |
+|          | because LLVM already CSE-deduplicates `// + %` to a single `__udivmodti4`            |
+|          | (verified by bench, matches the existing UInt256-loop comment); (iii) full           |
+|          | rust_decimal `partial_divide_64`-style port is the only remaining algorithmic        |
+|          | win but requires Granlund-Möller shift-normalize that Mojo cannot express            |
+|          | without inline asm or LLVM intrinsics, deferred to §7 P2.                            |
 
 ### 2.5 Performance tracking — absolute decimo median ns/iter
 
@@ -229,7 +239,7 @@ context. All P1/P2 items have landed; P3 items are tracked in §5.
 | 4   | UInt256 promotion in `mul` when product fits UInt128       | DEPRIORITISED — bench cases all have `combined_num_bits ≥ 186`, mandatory UInt256                     |
 | 4.1 | `is_integer` branch in `multiply()`                        | DONE — removed; 548→5 ns on `Both integer`                                                            |
 | 5   | divide long-division loop                                  | DONE — two-phase probe + UInt256/u64 schoolbook                                                       |
-| 6   | `to_string` per-call allocation                            | DONE (this PR) — `write_to` writes digits via 32-byte `InlineArray` + single `StringSlice`            |
+| 6   | `to_string` per-call allocation                            | DONE — `write_to` writes digits via 32-byte `InlineArray` + single `StringSlice`                      |
 | 7   | bitcast 4×UInt32 → single UInt128 in `coefficient()`       | DISPROVEN                                                                                             |
 | 8   | `from_uint128()` raises overhead                           | DISPROVEN initially, but H#14 found it once `from_uint128` is `@always_inline`                        |
 | 9   | Power-of-10 LUT vs if/elif tree                            | LANDED bisect tree; LUT regressed when `debug_assert .format` was eager                               |
@@ -238,9 +248,9 @@ context. All P1/P2 items have landed; P3 items are tracked in §5.
 | 12  | `subtract` diff-scale: inline vs `add(x1, negative(x2))`   | DONE — saves ~3 ns / op                                                                               |
 | 13  | divide two-phase: probe + bulk finish                      | DONE — divide max 287→56 ns                                                                           |
 | 14  | `power_of_10_unsafe` sweep + `from_uint128` always-inline  | DONE — divide median 8→6 ns; raises extracted to `@no_inline` helpers                                 |
-| 15  | `compare_absolute` rewrite                                 | DONE (this PR) — worst case 13.6→3.8 ns                                                               |
-| 16  | `multiply` single-pass rounding (saves second wide divide) | DONE (this PR) — High-precision 19→13 ns                                                              |
-| 17  | `from_string` per-byte switch reorder + branch merge       | DONE (this PR) — Long integer 41→22 ns                                                                |
+| 15  | `compare_absolute` rewrite                                 | DONE — worst case 13.6→3.8 ns                                                                         |
+| 16  | `multiply` single-pass rounding (saves second wide divide) | DONE — High-precision 19→13 ns                                                                        |
+| 17  | `from_string` per-byte switch reorder + branch merge       | DONE — Long integer 41→22 ns                                                                          |
 | 18  | `Decimal128.from_string` call `str.parse_numeric_string`   | DISPROVEN — Output-shape mismatch: `parse_numeric_string` returns `List[UInt8]` digit bytes           |
 |     |                                                            | (right for arbitrary-precision `BigInt`/`BigUInt`/`BigDecimal`), `Decimal128.from_string` accumulates |
 |     |                                                            | straight into `UInt128` in-loop. Routing Decimal128 through the shared parser would add               |
@@ -314,8 +324,8 @@ context. All P1/P2 items have landed; P3 items are tracked in §5.
 
 ### 5.1 Worst-case ratios still > 1.5× rust
 
-These are the residual gaps after this PR. Each requires algorithmic
-work, not micro-optimisation.
+These are the residual gaps. Each requires algorithmic work, not 
+micro-optimisation.
 
 | Op          | Worst case                    | decimo |  rust | dm/rs | Likely root cause                                                  |
 | ----------- | ----------------------------- | -----: | ----: | ----: | ------------------------------------------------------------------ |
@@ -334,9 +344,15 @@ work, not micro-optimisation.
 
 **Possible follow-ups** (none committed):
 
-- *divide* (highest impact): adopt rust_decimal's reciprocal-multiplication
-  approach. Pre-compute reciprocals of common divisors or use a single
-  hardware `__udivti3` + correction, instead of the per-digit loop.
+- *divide* — REJECTED 2026-05-02. Adopting rust_decimal's
+  reciprocal-multiplication / `partial_divide_64` approach was
+  investigated and rejected: the win in rust comes from inlined
+  shift-normalize Granlund-Möller code that LLVM emits for u128/u64,
+  which Mojo cannot express in pure source (the `UInt128/UInt128`
+  operator lowers through libgcc `__udivti3` regardless). All explored
+  pure-Mojo variants (chunked-9, manual divmod split) regressed; see
+  the 2026-05-02 §2.4 entry for measurements. Revisit only if Mojo
+  gains inline-asm or a dedicated `divrem_2by1` intrinsic.
 - *from_string*: digit batching — accumulate up to 19 digits in a `UInt64`,
   then `coef = coef * 10^k + batch` once per chunk. ~5–7× reduction on the
   inner-loop multiplies. Targeted estimate: 24 → ~14 ns on `Long integer`.
@@ -419,38 +435,14 @@ See git history (pre-2026-04-23) for the full analysis.
 
 ### 5.6 Per-op `RoundingMode` parameter on `Decimal128` arithmetic — REJECTED
 
-**Considered 2026-05-02.** Question: should `Decimal128.divide` (and by
-extension `multiply`, etc.) accept a `RoundingMode` argument so callers
-can override the default banker's rounding without a follow-up
-`.round(...)` call?
-
-Cross-language survey of fixed-precision decimal types:
-
-| Library                 | `/` rounding             | Per-op `mode` arg?   |
-| ----------------------- | ------------------------ | -------------------- |
-| C# `System.Decimal`     | banker's                 | No                   |
-| Rust `rust_decimal`     | banker's                 | No                   |
-| Apache Arrow Decimal128 | banker's                 | No                   |
-| Go `govalues/decimal`   | banker's                 | No                   |
-| Python `decimal`        | context-based (banker's) | No (use context)     |
-| Java `BigDecimal`       | must specify or throws   | Yes (arbitrary-prec) |
-| decimo `BigDecimal`     | must specify or default  | Yes (arbitrary-prec) |
-
-**Verdict: REJECTED.** The industry pattern for fixed-precision decimal
-types is "implicit banker's on arithmetic, explicit `.round(scale, mode)`
-for adjustment". Decimo already provides `Decimal128.round(scale, RoundingMode)`,
-so consumers needing a different mode can chain. Adding a per-op
-parameter to arithmetic would diverge from C#/Rust without a clear
-use-case, complicate the hot-path signature, and risk silent
-inconsistency between the rounding applied by the operator and any
-follow-up call. Banker's-only matches the IEEE 754-2008 default
-(round-nearest-even) and is what users coming from `System.Decimal` /
-`rust_decimal` expect.
-
-For per-op rounding control, callers should write
-`x.divide(y).round(scale, RoundingMode.half_up())` or use
-`BigDecimal` (which is the arbitrary-precision type and does take a
-mode parameter, matching Java `BigDecimal`). No code change required.
+**Considered 2026-05-02.** Cross-language survey of fixed-precision
+decimal `/`: C# `System.Decimal`, `rust_decimal`, Apache Arrow Decimal128,
+Go `govalues/decimal`, Python `decimal` — *none* take a per-op rounding
+mode; all use implicit banker's. Only arbitrary-precision types (Java /
+decimo `BigDecimal`) take one. **Verdict: REJECTED** to match the
+fixed-precision convention. Decimo already exposes
+`Decimal128.round(scale, RoundingMode)` for follow-up adjustment, and
+`BigDecimal` for callers needing per-op control.
 
 ---
 
@@ -482,12 +474,12 @@ Part II → "A note on result exponents (`Decimal` and `Dec128`)".
 
 Open items, in priority order:
 
-| #   | Issue                                            | Effort | Priority |
-| --- | ------------------------------------------------ | ------ | -------- |
-| 5.1 | divide reciprocal-multiply (36 → ≤ 19 ns target) | Large  | P2       |
-| 5.1 | from_string digit batching                       | Medium | P2       |
-| 5.2 | `normalize()`                                    | Small  | P3       |
-| 5.2 | `__hash__` (depends on `normalize()`)            | Small  | P3       |
-| 5.6 | Per-op `RoundingMode` on Decimal128 arithmetic   | —      | REJECTED |
-| 5.3 | `exp()` sub-unit chunk constants (`exp(π)`)      | Medium | P4       |
-| 5.5 | Steal flag bits → 32-digit coefficient           | Large  | P4       |
+| #   | Issue                                          | Effort | Priority |
+| --- | ---------------------------------------------- | ------ | -------- |
+| 5.1 | from_string digit batching                     | Medium | P2       |
+| 5.2 | `normalize()`                                  | Small  | P3       |
+| 5.2 | `__hash__` (depends on `normalize()`)          | Small  | P3       |
+| 5.6 | Per-op `RoundingMode` on Decimal128 arithmetic | —      | REJECTED |
+| 5.1 | divide reciprocal-multiply (rust_decimal port) | —      | REJECTED |
+| 5.3 | `exp()` sub-unit chunk constants (`exp(π)`)    | Medium | P4       |
+| 5.5 | Steal flag bits → 32-digit coefficient         | Large  | P4       |

--- a/src/decimo/decimal128/arithmetics.mojo
+++ b/src/decimo/decimal128/arithmetics.mojo
@@ -1039,15 +1039,16 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         rem = x1_coef % x2_coef
 
     if is_use_uint128:
-        # Maximum number of steps is minimum of the following two values:
-        # - MAX_NUM_DIGITS - ndigits_initial_quot + 1
-        # - Decimal128.MAX_SCALE - diff_scale - adjusted_scale + 1 (significant digits be rounded off)
-        # ndigits_initial_quot is the number of digits of the quotient before using long division
-        # The extra digit is used for rounding up when it is 5 and not exact division
+        # Long division producing exactly the final coefficient
+        # (no extra +1 "rounding digit" padding). Total digits is
+        # bounded by `MAX_NUM_DIGITS = 29`, scale by `MAX_SCALE = 28`.
+        # Rounding is decided directly from the final remainder via
+        # the round-half-up signal `(rem << 1) >= x2_coef` — equivalent
+        # to "the next-digit (uncomputed) is >= 5", with any non-zero
+        # rem treated as inexact (decimo's policy: round up at exact-5
+        # when there is more after).
 
-        # digit is the tempory quotient digit
-        var digit = UInt128(0)
-        # The final step counter stands for the number of dicimal points
+        # The final step counter stands for the number of decimal points.
         var step_counter = 0
         var ndigits_initial_quot = decimo.decimal128.utility.number_of_digits(
             quot
@@ -1066,9 +1067,11 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         # full UInt256/UInt256 software fallback). This collapses ~25
         # iterations of the per-digit loop into one division.
         comptime PROBE_STEPS = 2
+        # No `+1` padding here: we compute the exact final digit count
+        # and recover the rounding signal from the remainder.
         var max_steps = min(
-            Decimal128.MAX_NUM_DIGITS - ndigits_initial_quot + 1,
-            Decimal128.MAX_SCALE - diff_scale - adjusted_scale + 1,
+            Decimal128.MAX_NUM_DIGITS - ndigits_initial_quot,
+            Decimal128.MAX_SCALE - diff_scale - adjusted_scale,
         )
         while (
             (rem != 0)
@@ -1076,63 +1079,65 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             and (step_counter < max_steps)
         ):
             rem *= 10
-            digit = rem // x2_coef
-            quot = quot * 10 + digit
+            quot = quot * 10 + (rem // x2_coef)
             rem = rem % x2_coef
             step_counter += 1
 
         if (rem != 0) and (step_counter < max_steps):
             var bulk_steps = max_steps - step_counter
-            # bulk_steps bound: max_steps ≤ MAX_NUM_DIGITS + 1 = 30 (the
-            # `+1` is the rounding digit; reached when
-            # `ndigits_initial_quot == 0`, which happens when the initial
-            # `x1_coef // x2_coef == 0`, e.g. 1/3). Entry to this arm
-            # requires the probe loop to have exited via
+            # bulk_steps bound: max_steps ≤ MAX_NUM_DIGITS = 29. Entry
+            # to this arm requires the probe loop to have exited via
             # `step_counter >= PROBE_STEPS = 2`, so in practice
-            # `bulk_steps ≤ 30 - 2 = 28`, comfortably within
+            # `bulk_steps ≤ 29 - 2 = 27`, well within
             # `power_of_10_unsafe`'s `0 ≤ n ≤ 29` range for `uint128`.
             var scale_factor = decimo.decimal128.utility.power_of_10_unsafe[
                 DType.uint128
             ](bulk_steps)
-            var scale_factor_256 = UInt256(scale_factor)
             # `rem * 10^bulk_steps` always fits in UInt256: rem < x2_coef
-            # ≤ 2^96 and bulk_steps ≤ 28 so 10^bulk_steps < 2^94, giving
-            # rem * 10^bulk_steps < 2^190.
+            # ≤ 2^96 and bulk_steps ≤ 27 so 10^bulk_steps < 2^90, giving
+            # rem * 10^bulk_steps < 2^186.
+            var rem_scaled: UInt256 = UInt256(rem) * UInt256(scale_factor)
 
-            var rem_scaled: UInt256 = UInt256(rem) * scale_factor_256
-            var x2_256 = UInt256(x2_coef)
-
-            var quot_added: UInt256
-            var rem_after: UInt256
+            var quot_added_u128: UInt128
+            var rem_after_u128: UInt128
             if x2_coef <= UInt128(0xFFFF_FFFF_FFFF_FFFF):
                 # Fast path: 4-step schoolbook over u64 limbs.
                 var pair = decimo.decimal128.utility.udiv_u256_by_u64(
                     rem_scaled, UInt64(x2_coef)
                 )
-                quot_added = pair[0]
-                rem_after = UInt256(pair[1])
+                # `quot_added < 10^bulk_steps ≤ 10^27 < 2^90`, fits UInt128.
+                quot_added_u128 = UInt128(
+                    pair[0] & UInt256(0xFFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF)
+                )
+                rem_after_u128 = UInt128(pair[1])
             else:
                 # Rare 96-bit-divisor fallback: software UInt256 divide.
-                quot_added = rem_scaled // x2_256
-                rem_after = rem_scaled - quot_added * x2_256
+                var x2_256 = UInt256(x2_coef)
+                var quot_added_256 = rem_scaled // x2_256
+                var rem_after_256 = rem_scaled - quot_added_256 * x2_256
+                quot_added_u128 = UInt128(
+                    quot_added_256
+                    & UInt256(0xFFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF)
+                )
+                rem_after_u128 = UInt128(
+                    rem_after_256
+                    & UInt256(0xFFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF)
+                )
 
-            var combined: UInt256 = (
-                UInt256(quot) * scale_factor_256
-            ) + quot_added
-            # `combined` fits in UInt128: total decimal digits is at
-            # most `ndigits_initial_quot + step_counter + bulk_steps =
-            # ndigits_initial_quot + max_steps ≤ MAX_NUM_DIGITS + 1 = 30`.
-            quot = UInt128(
-                combined & UInt256(0xFFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF)
-            )
+            # UInt128 fold (was UInt256 in the previous design).
+            # `quot * 10^bulk_steps` fits UInt128: post-bulk total
+            # digits = ndigits_initial_quot + step_counter + bulk_steps
+            # = ndigits_initial_quot + max_steps ≤ MAX_NUM_DIGITS = 29,
+            # so the product is < 10^29 < 2^97. Adding `quot_added_u128`
+            # (< 10^27) keeps it < 2 * 10^29 < 2^98, well below 2^128.
+            quot = quot * scale_factor + quot_added_u128
             step_counter = max_steps
 
-            if rem_after == 0:
+            if rem_after_u128 == 0:
                 # Exact division. The per-digit loop would have stopped
                 # at the first zero remainder, so its `quot` carries no
                 # trailing zeros from beyond that point. Bisect-strip
                 # the equivalent zeros so the final scale matches.
-                digit = 0
                 rem = 0
                 var pow16 = UInt128(10000000000000000)
                 while (step_counter >= 16) and (quot % pow16 == 0):
@@ -1154,22 +1159,45 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
                     quot = quot // 10
                     step_counter -= 1
             else:
-                # Inexact: the bottom digit of `quot` is the +1 extra
-                # rounding digit (`max_steps` includes it by construction).
-                # The `digit == 5 and rem != 0` patch below uses it.
-                digit = quot % 10
-                rem = UInt128(1)
+                # Inexact: forward the bulk-divide remainder for the
+                # unified rounding step below.
+                rem = rem_after_u128
 
-        # Yuhao's notes: When the remainder is non-zero at the end and the the digit to round is 5
-        # we always round up, even if the rounding mode is round half to even
-        # 朱宇浩注: 捨去項爲5時,其後方的數字可能會影響捨去項,但後方數字可能是無限位,所以無法確定
-        # 比如: 1.0000000000000000000000000000_5 可能是 1.0000000000000000000000000000_5{100 zeros}1
-        # 但我們只能算到 1.0000000000000000000000000000_5,
-        # 在銀行家捨去法中,我們將捨去項爲5時,向上捨去, 保留28位後爲1.0000000000000000000000000000
-        # 這樣的捨去法是不準確的,所以我們一律在到達餘數非零且捨去項爲5時,向上捨去
-        if (digit == 5) and (rem != 0):
-            # Not exact division, round up the last digit
-            quot += 1
+        # Banker's rounding (round-half-to-even) derived directly from
+        # the residual remainder, matching the .NET / rust_decimal
+        # convention for fixed-precision decimal divide.
+        #
+        # Compare `2*rem` against the divisor `x2_coef`:
+        #   2*rem  > x2_coef  → next-digit > 5             → round up
+        #   2*rem == x2_coef  → next-digit == 5, exact tail → banker's
+        #   2*rem  < x2_coef  → next-digit < 5             → drop
+        #
+        # Why the equality test really is "exact half (no further tail)":
+        # `2*rem == x2_coef` ⇒ `rem*10 == 5*x2_coef`, so
+        # `next_digit = (rem*10) // x2_coef == 5` and
+        # `next_rem    = (rem*10) %  x2_coef == 0` — i.e. the exact
+        # value is `quot.5` with all-zeros after, the textbook midpoint.
+        # Banker's rounds to the nearest even (round up only if the kept
+        # last digit `quot & 1` is odd).
+        #
+        # The strict `2*rem > x2_coef` arm covers the "5 with non-zero
+        # tail" case (e.g. 1/7 truncated at 28 frac digits → next is 5
+        # but the true value is strictly > .5 of the unit), which is
+        # *not* a banker's tie — rounding up is mathematically required.
+        #
+        # 朱宇浩注: 採用銀行家捨去法 (四捨六入五成雙)。
+        # 當餘數的兩倍嚴格大於除數時,下一位數字大於 5 (或等於 5 但其後仍有非零尾,
+        # 如 1/7 在第 28 位之後),四捨五入向上;當餘數的兩倍等於除數時,下一位
+        # 數字恰爲 5 且其後全爲零 (即恰好爲半),依銀行家法捨入到偶數;當餘數的
+        # 兩倍小於除數時,直接捨去。此實作與 .NET System.Decimal、rust_decimal
+        # 的除法默認捨入規則一致。
+        if rem != 0:
+            var double_rem = rem << 1
+            if double_rem > x2_coef:
+                quot += 1
+            elif (double_rem == x2_coef) and ((quot & 1) == 1):
+                # Exact half + last-kept-digit odd → bump to even.
+                quot += 1
 
         var scale_of_quot = step_counter + diff_scale + adjusted_scale
 

--- a/src/decimo/decimal128/arithmetics.mojo
+++ b/src/decimo/decimal128/arithmetics.mojo
@@ -1042,11 +1042,14 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         # Long division producing exactly the final coefficient
         # (no extra +1 "rounding digit" padding). Total digits is
         # bounded by `MAX_NUM_DIGITS = 29`, scale by `MAX_SCALE = 28`.
-        # Rounding is decided directly from the final remainder via
-        # the round-half-up signal `(rem << 1) >= x2_coef` — equivalent
-        # to "the next-digit (uncomputed) is >= 5", with any non-zero
-        # rem treated as inexact (decimo's policy: round up at exact-5
-        # when there is more after).
+        # Rounding (banker's, round-half-to-even) is decided directly
+        # from the final residual remainder via a three-branch test on
+        # `2 * rem` against `x2_coef`:
+        #   2*rem  > x2_coef  → next-digit > 5 (or 5+nonzero-tail) → up
+        #   2*rem == x2_coef  → exact half       → bump only if `quot`
+        #                                          last-kept digit odd
+        #   2*rem  < x2_coef  → next-digit < 5                     → drop
+        # See the detailed derivation just before the rounding block.
 
         # The final step counter stands for the number of decimal points.
         var step_counter = 0

--- a/tests/decimal128/test_decimal128_arithmetics.mojo
+++ b/tests/decimal128/test_decimal128_arithmetics.mojo
@@ -386,6 +386,71 @@ def test_divide_repeating_decimals() raises:
     )
 
 
+def test_divide_bankers_rounding_at_boundary() raises:
+    """Banker's (round-half-to-even) at the MAX_SCALE+1 cutoff.
+
+    Discriminating cases between banker's and round-half-up, all
+    exercising the post-bulk rounding branch in `divide()`'s UInt128
+    path. Reference values cross-checked with Python's `decimal`:
+
+        from decimal import Decimal, ROUND_HALF_EVEN
+        (Decimal(k) / Decimal(2**29)).quantize(
+            Decimal('1E-28'), rounding=ROUND_HALF_EVEN
+        )
+    """
+
+    # 1) Exact-half terminator with EVEN last-kept digit.
+    #    1 / 2^29 = 0.00000000186264514923095703125 (29 frac digits).
+    #    Cut at 28 frac → drop "5" with rem == 0; 28th digit = 2 (even).
+    #    Banker's: keep, no round-up → "...0312".
+    #    Half-up   would give "...0313" (regression marker).
+    testing.assert_equal(
+        Decimal128(1) / Decimal128(536870912),  # 2^29
+        Decimal128("0.0000000018626451492309570312"),
+        "Banker's: exact half, even kept → drop",
+    )
+
+    # 2) Exact-half terminator with EVEN last-kept digit (second
+    #    exemplar to confirm the pattern).
+    #    5 / 2^29 = 0.0000000093132257461547851562**5**.
+    #    Cut at 28 → 28th digit = 2 (even); banker's drops 5.
+    #    Half-up   would give "...1563".
+    testing.assert_equal(
+        Decimal128(5) / Decimal128(536870912),
+        Decimal128("0.0000000093132257461547851562"),
+        "Banker's: exact half, even kept → drop (case 2)",
+    )
+
+    # 3) Exact-half terminator with ODD last-kept digit.
+    #    3 / 2^29 = 0.0000000055879354476928710937**5**.
+    #    Cut at 28 → 28th digit = 7 (odd); banker's bumps to 8.
+    #    Half-up coincidentally agrees here (both round up).
+    testing.assert_equal(
+        Decimal128(3) / Decimal128(536870912),
+        Decimal128("0.0000000055879354476928710938"),
+        "Banker's: exact half, odd kept → bump to even",
+    )
+
+    # 4) "5 with non-zero tail" — NOT a banker's tie.
+    #    1 / 7 = 0.142857142857142857142857142857...  (non-terminating)
+    #    Cut at 28 → 28th = 8, 29th = 5, 30th = 7 (and so on).
+    #    True value strictly > .5 of the unit, so banker's and half-up
+    #    agree: round up. Last kept digit becomes 9.
+    testing.assert_equal(
+        Decimal128(1) / Decimal128(7),
+        Decimal128("0.1428571428571428571428571429"),
+        "5-with-tail: round up regardless of mode",
+    )
+
+    # 5) Below-half repeating: 1/3 ends in all 3s. 28th = 3, 29th = 3.
+    #    Drop. Result has 28 trailing 3s.
+    testing.assert_equal(
+        Decimal128(1) / Decimal128(3),
+        Decimal128("0.3333333333333333333333333333"),
+        "Below-half: drop",
+    )
+
+
 def test_divide_properties_and_edge() raises:
     """Scale property checks, edge cases with comparisons and overflow."""
     var a25 = Decimal128(1) / Decimal128(81)


### PR DESCRIPTION
This PR optimizes `Decimal128.divide()` for repeating-decimal cases in the UInt128 long-division path by reducing per-digit work and avoiding an extra “rounding digit” step, while preserving fixed-precision rounding behavior.

**Changes:**
- Refactors the UInt128 long-division path to compute exactly the final coefficient (no `+1` padding digit) and derive rounding directly from the final remainder.
- Replaces a previous UInt256 fold (`quot * 10^k + added`) with a UInt128-only fold where bounds guarantee it fits.
- Adds targeted tests to pin banker’s rounding behavior at the MAX_SCALE boundary; updates the enhancement plan/perf notes accordingly.