### PR TITLE
[dec128] Add `normalize()`, `__hash__()`, `same_quantum()`, etc

### DIFF
--- a/benches/bigdecimal/aggregate.py
+++ b/benches/bigdecimal/aggregate.py
@@ -47,7 +47,7 @@ DISPLAY_NAME_MAX = 48
 def _short_name(name: str) -> str:
     if len(name) <= DISPLAY_NAME_MAX:
         return name
-    return name[: DISPLAY_NAME_MAX - 1] + "\u2026"  # ellipsis
+    return name[: DISPLAY_NAME_MAX - 1] + "…"  # ellipsis
 
 
 def _values_equal(a: str, b: str) -> bool:
@@ -356,7 +356,7 @@ def main() -> int:
         f"- Languages: {', '.join(LANG_LABEL.get(l, l) for l in args.langs)}",
         f"- Ops: {', '.join(args.ops)}",
         f"- Precisions: {', '.join(str(p) for p in args.precisions)}",
-        "- **Time unit: nanoseconds per iteration (ns/iter)** \u2014 lower is faster.",
+        "- **Time unit: nanoseconds per iteration (ns/iter)** — lower is faster.",
         "",
         "All timing columns (`decimo`, `python`) are **ns / iter**.",
         "Each per-op timings table has a single correctness column,",
@@ -466,7 +466,7 @@ def main() -> int:
             if diffs:
                 lines.append(
                     f"<details><summary>{len(diffs)} DIFF case(s) at "
-                    f"<code>{op}</code> / prec={prec} \u2014 click to expand</summary>"
+                    f"<code>{op}</code> / prec={prec} — click to expand</summary>"
                 )
                 lines.append("")
                 for case, _py_match, recs in diffs:

--- a/benches/bigdecimal/mojo/bench.mojo
+++ b/benches/bigdecimal/mojo/bench.mojo
@@ -34,13 +34,13 @@ from std.sys import argv as sys_argv
 from std.time import perf_counter_ns
 
 
-def _now_stamp() raises -> String:
+fn _now_stamp() raises -> String:
     var dt = Python.import_module("datetime")
     var now = dt.datetime.now(dt.timezone.utc)
     return String(now.strftime("%Y%m%d_%H%M%S"))
 
 
-def _csv_quote(s: String) -> String:
+fn _csv_quote(s: String) -> String:
     var needs = False
     for ch in s.codepoint_slices():
         if ch == "," or ch == '"' or ch == "\n" or ch == "\r":
@@ -58,7 +58,7 @@ def _csv_quote(s: String) -> String:
     return out
 
 
-def _parse_round_param(b: String) raises -> Tuple[Int, RoundingMode]:
+fn _parse_round_param(b: String) raises -> Tuple[Int, RoundingMode]:
     """Decode "ndigits|MODE" into (ndigits, RoundingMode)."""
     var idx = b.find("|")
     if idx < 0:
@@ -82,7 +82,7 @@ def _parse_round_param(b: String) raises -> Tuple[Int, RoundingMode]:
     raise Error("unknown rounding mode: " + mode_str)
 
 
-def _cmp_3way(read a: BigDecimal, read b: BigDecimal) raises -> String:
+fn _cmp_3way(read a: BigDecimal, read b: BigDecimal) raises -> String:
     """Stable, cross-language 3-way comparison: returns "-1", "0", or "1"."""
     if a < b:
         return String("-1")
@@ -91,7 +91,7 @@ def _cmp_3way(read a: BigDecimal, read b: BigDecimal) raises -> String:
     return String("0")
 
 
-def _round_to_prec(var v: BigDecimal, precision: Int) raises -> BigDecimal:
+fn _round_to_prec(var v: BigDecimal, precision: Int) raises -> BigDecimal:
     """Round `v` to `precision` significant digits (HALF_EVEN), in-place."""
     round_to_precision(
         v,
@@ -103,7 +103,7 @@ def _round_to_prec(var v: BigDecimal, precision: Int) raises -> BigDecimal:
     return v^
 
 
-def _emit(v: BigDecimal) raises -> String:
+fn _emit(v: BigDecimal) raises -> String:
     """Render a BigDecimal in fixed-point (no scientific notation).
 
     Works around a corner case in `BigDecimal.to_string(force_plain=True)`
@@ -127,7 +127,7 @@ def _emit(v: BigDecimal) raises -> String:
     return s^
 
 
-def _result_for(
+fn _result_for(
     op: String,
     read a: BigDecimal,
     read b: BigDecimal,
@@ -171,7 +171,7 @@ def _result_for(
     raise Error("unknown op: " + op)
 
 
-def _time_kernel(
+fn _time_kernel(
     op: String,
     read a: BigDecimal,
     read b: BigDecimal,
@@ -260,7 +260,7 @@ def _time_kernel(
 # precision don't collapse to <1 timer-tick and report 0 ns/iter.
 # Returns (iters, reps): reps shrinks to 1 for very-slow ops to bound wall
 # time per case at ~500ms.
-def _tune_iters(initial_ns: UInt, hint_iters: Int) -> Tuple[Int, Int]:
+fn _tune_iters(initial_ns: UInt, hint_iters: Int) -> Tuple[Int, Int]:
     comptime TARGET_NS: UInt = 50_000_000  # 50ms per rep target
     comptime MIN_RES_NS: UInt = 100_000  # 100µs floor for resolution
     comptime MAX_WALL_NS: UInt = 500_000_000  # 500ms total per case
@@ -287,7 +287,7 @@ def _tune_iters(initial_ns: UInt, hint_iters: Int) -> Tuple[Int, Int]:
     return Tuple[Int, Int](n, reps)
 
 
-def _bench_case(
+fn _bench_case(
     op: String,
     bc: BenchCase,
     iter_hint: Int,
@@ -340,7 +340,7 @@ def _bench_case(
     return Tuple[String, Float64](result, Float64(best) / Float64(iters))
 
 
-def _pad(s: String, w: Int) -> String:
+fn _pad(s: String, w: Int) -> String:
     if len(s) >= w:
         return s
     var out = s
@@ -349,7 +349,7 @@ def _pad(s: String, w: Int) -> String:
     return out
 
 
-def main() raises:
+fn main() raises:
     var argv = sys_argv()
     var op = String("add")
     var cases_dir = String("../cases")

--- a/benches/bigdecimal/mojo/bench.mojo
+++ b/benches/bigdecimal/mojo/bench.mojo
@@ -34,13 +34,13 @@ from std.sys import argv as sys_argv
 from std.time import perf_counter_ns
 
 
-fn _now_stamp() raises -> String:
+def _now_stamp() raises -> String:
     var dt = Python.import_module("datetime")
     var now = dt.datetime.now(dt.timezone.utc)
     return String(now.strftime("%Y%m%d_%H%M%S"))
 
 
-fn _csv_quote(s: String) -> String:
+def _csv_quote(s: String) -> String:
     var needs = False
     for ch in s.codepoint_slices():
         if ch == "," or ch == '"' or ch == "\n" or ch == "\r":
@@ -58,7 +58,7 @@ fn _csv_quote(s: String) -> String:
     return out
 
 
-fn _parse_round_param(b: String) raises -> Tuple[Int, RoundingMode]:
+def _parse_round_param(b: String) raises -> Tuple[Int, RoundingMode]:
     """Decode "ndigits|MODE" into (ndigits, RoundingMode)."""
     var idx = b.find("|")
     if idx < 0:
@@ -82,7 +82,7 @@ fn _parse_round_param(b: String) raises -> Tuple[Int, RoundingMode]:
     raise Error("unknown rounding mode: " + mode_str)
 
 
-fn _cmp_3way(read a: BigDecimal, read b: BigDecimal) raises -> String:
+def _cmp_3way(read a: BigDecimal, read b: BigDecimal) raises -> String:
     """Stable, cross-language 3-way comparison: returns "-1", "0", or "1"."""
     if a < b:
         return String("-1")
@@ -91,7 +91,7 @@ fn _cmp_3way(read a: BigDecimal, read b: BigDecimal) raises -> String:
     return String("0")
 
 
-fn _round_to_prec(var v: BigDecimal, precision: Int) raises -> BigDecimal:
+def _round_to_prec(var v: BigDecimal, precision: Int) raises -> BigDecimal:
     """Round `v` to `precision` significant digits (HALF_EVEN), in-place."""
     round_to_precision(
         v,
@@ -103,7 +103,7 @@ fn _round_to_prec(var v: BigDecimal, precision: Int) raises -> BigDecimal:
     return v^
 
 
-fn _emit(v: BigDecimal) raises -> String:
+def _emit(v: BigDecimal) raises -> String:
     """Render a BigDecimal in fixed-point (no scientific notation).
 
     Works around a corner case in `BigDecimal.to_string(force_plain=True)`
@@ -127,7 +127,7 @@ fn _emit(v: BigDecimal) raises -> String:
     return s^
 
 
-fn _result_for(
+def _result_for(
     op: String,
     read a: BigDecimal,
     read b: BigDecimal,
@@ -171,7 +171,7 @@ fn _result_for(
     raise Error("unknown op: " + op)
 
 
-fn _time_kernel(
+def _time_kernel(
     op: String,
     read a: BigDecimal,
     read b: BigDecimal,
@@ -260,7 +260,7 @@ fn _time_kernel(
 # precision don't collapse to <1 timer-tick and report 0 ns/iter.
 # Returns (iters, reps): reps shrinks to 1 for very-slow ops to bound wall
 # time per case at ~500ms.
-fn _tune_iters(initial_ns: UInt, hint_iters: Int) -> Tuple[Int, Int]:
+def _tune_iters(initial_ns: UInt, hint_iters: Int) -> Tuple[Int, Int]:
     comptime TARGET_NS: UInt = 50_000_000  # 50ms per rep target
     comptime MIN_RES_NS: UInt = 100_000  # 100µs floor for resolution
     comptime MAX_WALL_NS: UInt = 500_000_000  # 500ms total per case
@@ -287,7 +287,7 @@ fn _tune_iters(initial_ns: UInt, hint_iters: Int) -> Tuple[Int, Int]:
     return Tuple[Int, Int](n, reps)
 
 
-fn _bench_case(
+def _bench_case(
     op: String,
     bc: BenchCase,
     iter_hint: Int,
@@ -340,7 +340,7 @@ fn _bench_case(
     return Tuple[String, Float64](result, Float64(best) / Float64(iters))
 
 
-fn _pad(s: String, w: Int) -> String:
+def _pad(s: String, w: Int) -> String:
     if len(s) >= w:
         return s
     var out = s
@@ -349,7 +349,7 @@ fn _pad(s: String, w: Int) -> String:
     return out
 
 
-fn main() raises:
+def main() raises:
     var argv = sys_argv()
     var op = String("add")
     var cases_dir = String("../cases")

--- a/benches/decimal128/mojo/bench.mojo
+++ b/benches/decimal128/mojo/bench.mojo
@@ -21,7 +21,7 @@ from std.sys import argv as sys_argv
 from std.time import perf_counter_ns
 
 
-fn _now_stamp() raises -> String:
+def _now_stamp() raises -> String:
     var dt = Python.import_module("datetime")
     # Use UTC to match the rust/csharp/vbnet harnesses, so log filenames are
     # comparable across machines/timezones and "latest log" selection is stable.
@@ -29,7 +29,7 @@ fn _now_stamp() raises -> String:
     return String(now.strftime("%Y%m%d_%H%M%S"))
 
 
-fn _csv_quote(s: String) -> String:
+def _csv_quote(s: String) -> String:
     var needs_quote = False
     for ch in s.codepoint_slices():
         if ch == "," or ch == '"' or ch == "\n" or ch == "\r":
@@ -47,7 +47,7 @@ fn _csv_quote(s: String) -> String:
     return out
 
 
-fn _bench_one[
+def _bench_one[
     Body: fn(a: Decimal128, b: Decimal128) raises capturing[_] -> UInt64,
 ](a: Decimal128, b: Decimal128, iters: Int) raises -> Float64:
     """Run `Body(a, b)` once per inner iter; best-of-5; returns ns/op.
@@ -79,7 +79,7 @@ fn _bench_one[
     return Float64(best) / Float64(iters)
 
 
-fn _bench_str(a_str: String, iters: Int) raises -> Float64:
+def _bench_str(a_str: String, iters: Int) raises -> Float64:
     """from_string microbench — re-parses the string each iter."""
     comptime REPS = 5
     var best: Int = 0x7FFF_FFFF_FFFF_FFFF
@@ -96,7 +96,7 @@ fn _bench_str(a_str: String, iters: Int) raises -> Float64:
     return Float64(best) / Float64(iters)
 
 
-fn _bench_to_str(d: Decimal128, iters: Int) raises -> Float64:
+def _bench_to_str(d: Decimal128, iters: Int) raises -> Float64:
     comptime REPS = 5
     var best: Int = 0x7FFF_FFFF_FFFF_FFFF
     var sink: UInt64 = 0
@@ -111,7 +111,7 @@ fn _bench_to_str(d: Decimal128, iters: Int) raises -> Float64:
     return Float64(best) / Float64(iters)
 
 
-fn _result_for(op: String, a: Decimal128, b: Decimal128) raises -> String:
+def _result_for(op: String, a: Decimal128, b: Decimal128) raises -> String:
     if op == "add":
         return String(a + b)
     elif op == "subtract":
@@ -139,7 +139,7 @@ fn _result_for(op: String, a: Decimal128, b: Decimal128) raises -> String:
     raise Error("unknown op: " + op)
 
 
-fn _run_case(
+def _run_case(
     op: String,
     bc: BenchCase,
     iters: Int,
@@ -152,35 +152,35 @@ fn _run_case(
     if op == "add":
 
         @parameter
-        fn _f_add(x: Decimal128, y: Decimal128) raises -> UInt64:
+        def _f_add(x: Decimal128, y: Decimal128) raises -> UInt64:
             return UInt64((x + y).coefficient() & 0xFFFF_FFFF_FFFF_FFFF)
 
         per = _bench_one[_f_add](a, b, iters)
     elif op == "subtract":
 
         @parameter
-        fn _f_sub(x: Decimal128, y: Decimal128) raises -> UInt64:
+        def _f_sub(x: Decimal128, y: Decimal128) raises -> UInt64:
             return UInt64((x - y).coefficient() & 0xFFFF_FFFF_FFFF_FFFF)
 
         per = _bench_one[_f_sub](a, b, iters)
     elif op == "multiply":
 
         @parameter
-        fn _f_mul(x: Decimal128, y: Decimal128) raises -> UInt64:
+        def _f_mul(x: Decimal128, y: Decimal128) raises -> UInt64:
             return UInt64((x * y).coefficient() & 0xFFFF_FFFF_FFFF_FFFF)
 
         per = _bench_one[_f_mul](a, b, iters)
     elif op == "divide":
 
         @parameter
-        fn _f_div(x: Decimal128, y: Decimal128) raises -> UInt64:
+        def _f_div(x: Decimal128, y: Decimal128) raises -> UInt64:
             return UInt64((x / y).coefficient() & 0xFFFF_FFFF_FFFF_FFFF)
 
         per = _bench_one[_f_div](a, b, iters)
     elif op == "comparison":
 
         @parameter
-        fn _f_cmp(x: Decimal128, y: Decimal128) raises -> UInt64:
+        def _f_cmp(x: Decimal128, y: Decimal128) raises -> UInt64:
             return UInt64(1) if x < y else UInt64(0)
 
         per = _bench_one[_f_cmp](a, b, iters)
@@ -191,21 +191,21 @@ fn _run_case(
     elif op == "ln":
 
         @parameter
-        fn _f_ln(x: Decimal128, y: Decimal128) raises -> UInt64:
+        def _f_ln(x: Decimal128, y: Decimal128) raises -> UInt64:
             return UInt64(x.ln().coefficient() & 0xFFFF_FFFF_FFFF_FFFF)
 
         per = _bench_one[_f_ln](a, b, iters)
     elif op == "log10":
 
         @parameter
-        fn _f_log10(x: Decimal128, y: Decimal128) raises -> UInt64:
+        def _f_log10(x: Decimal128, y: Decimal128) raises -> UInt64:
             return UInt64(x.log10().coefficient() & 0xFFFF_FFFF_FFFF_FFFF)
 
         per = _bench_one[_f_log10](a, b, iters)
     elif op == "exp":
 
         @parameter
-        fn _f_exp(x: Decimal128, y: Decimal128) raises -> UInt64:
+        def _f_exp(x: Decimal128, y: Decimal128) raises -> UInt64:
             return UInt64(x.exp().coefficient() & 0xFFFF_FFFF_FFFF_FFFF)
 
         per = _bench_one[_f_exp](a, b, iters)
@@ -215,7 +215,7 @@ fn _run_case(
     return Tuple[String, Float64](result, per)
 
 
-fn _pad(s: String, width: Int) -> String:
+def _pad(s: String, width: Int) -> String:
     if len(s) >= width:
         return s
     var out = s
@@ -225,7 +225,7 @@ fn _pad(s: String, width: Int) -> String:
     return out
 
 
-fn main() raises:
+def main() raises:
     var argv = sys_argv()
     var op = String("add")
     var cases_dir = String("../cases")

--- a/benches/decimal128/mojo/bigdec_ref.mojo
+++ b/benches/decimal128/mojo/bigdec_ref.mojo
@@ -23,13 +23,13 @@ from std.python import Python
 from std.sys import argv as sys_argv
 
 
-fn _now_stamp() raises -> String:
+def _now_stamp() raises -> String:
     var dt = Python.import_module("datetime")
     var now = dt.datetime.now(dt.timezone.utc)
     return String(now.strftime("%Y%m%d_%H%M%S"))
 
 
-fn _csv_quote(s: String) -> String:
+def _csv_quote(s: String) -> String:
     var needs_quote = False
     for ch in s.codepoint_slices():
         if ch == "," or ch == '"' or ch == "\n" or ch == "\r":
@@ -47,7 +47,7 @@ fn _csv_quote(s: String) -> String:
     return out
 
 
-fn _pad(s: String, width: Int) -> String:
+def _pad(s: String, width: Int) -> String:
     if len(s) >= width:
         return s
     var out = s
@@ -57,7 +57,7 @@ fn _pad(s: String, width: Int) -> String:
     return out
 
 
-fn _strip_trailing_zeros(s: String) -> String:
+def _strip_trailing_zeros(s: String) -> String:
     # Strip trailing zeros after the decimal point so the ref result is
     # easy to eyeball next to the Decimal128 / rust_decimal column.
     # Leaves integer values ("0", "1") and scientific notation untouched.
@@ -81,7 +81,7 @@ comptime _DEC128_MAX_COEF = String("79228162514264337593543950335")
 # Extract the digit-only coefficient string from a BigDecimal's textual
 # form: drop sign, decimal point, and any leading zeros (sub-1 values).
 # Stops at the first 'e'/'E' so scientific-notation tails don't leak in.
-fn _coefficient_digits(s: String) -> String:
+def _coefficient_digits(s: String) -> String:
     var out = String("")
     var seen_nonzero = False
     for ch in s.codepoint_slices():
@@ -97,7 +97,7 @@ fn _coefficient_digits(s: String) -> String:
     return out
 
 
-fn _fits_in_dec128(s: String) -> Bool:
+def _fits_in_dec128(s: String) -> Bool:
     var coef = _coefficient_digits(s)
     if len(coef) < 29:
         return True
@@ -113,7 +113,7 @@ fn _fits_in_dec128(s: String) -> Bool:
 # the result *always* shows the full target precision (so a trailing
 # significant zero doesn't make the column look like it has one fewer
 # digit than Decimal128 would actually store).
-fn _round_and_str(mut v: BigDecimal) raises -> String:
+def _round_and_str(mut v: BigDecimal) raises -> String:
     v.round_to_precision(
         29,
         RoundingMode.ROUND_HALF_EVEN,
@@ -136,7 +136,7 @@ fn _round_and_str(mut v: BigDecimal) raises -> String:
 # zero, or the value is the textual zero "0E-N"), collapse to compact
 # integer form so the oracle column matches Decimal128's natural output
 # for cases like log10(100) -> 2 instead of "2.0000000000000000000000000000".
-fn _collapse_exact_integer(s: String) -> String:
+def _collapse_exact_integer(s: String) -> String:
     # Find dot and 'E' positions.
     var dot = -1
     var e_pos = -1
@@ -171,7 +171,9 @@ fn _collapse_exact_integer(s: String) -> String:
     return s
 
 
-fn _ref_result(op: String, a_str: String, work_precision: Int) raises -> String:
+def _ref_result(
+    op: String, a_str: String, work_precision: Int
+) raises -> String:
     var a = BigDecimal.from_string(a_str)
     if op == "ln":
         var r = bdexp.ln(a, work_precision)
@@ -185,7 +187,7 @@ fn _ref_result(op: String, a_str: String, work_precision: Int) raises -> String:
     raise Error("bigdec_ref only supports ln, log10, exp (got '" + op + "')")
 
 
-fn main() raises:
+def main() raises:
     var argv = sys_argv()
     var op = String("ln")
     var cases_dir = String("../cases")

--- a/docs/plans/cli_calculator.md
+++ b/docs/plans/cli_calculator.md
@@ -448,7 +448,7 @@ blank lines skipped — same conventions as the existing `-F` script format.
 | ---- | ----------------------------------------------------- | :----: | --------------------------------------------------------------------------------------- |
 | 5.1  | Single-line user functions `f(x) = expr`              |   ✗    | Tokenizer + statement-vs-expression dispatcher; LHS-paren disambiguates from `x = expr` |
 | 5.2  | Multi-arg + recursion `g(x, y) = …`                   |   ✗    | Recursion-depth cap (≈1000) with friendly error                                         |
-| 5.3  | Local parameter scope, no closures                    |   ✗    | Params shadow globals; assignments inside a fn are local by default (bc rule)           |
+| 5.3  | Local parameter scope, no closures                    |   ✗    | Params shadow globals; assignments inside a def are local by default (bc rule)          |
 | 5.4  | `-L/--load <file>` to load a library (silent eval)    |   ✗    | Accepts `.dm` and `.decimo`; only definitions printed silently                          |
 | 5.5  | `-I/--interactive` enters REPL after `-F`/`-L`        |   ✗    | `decimo -L lib.dm -I`; composes with existing `-F`                                      |
 | 5.6  | Auto-load `~/.decimorc`                               |   ✗    | Skippable via `--no-rc`; load order: rc → `-L` → `-F` → REPL                            |

--- a/docs/plans/decimal128_enhancement.md
+++ b/docs/plans/decimal128_enhancement.md
@@ -31,7 +31,10 @@ IEEE 754 decimal128 (floating point with NaN/Inf).
 
 Arithmetic coverage (decimo vs others): we are the most complete —
 the only library with `root`, `log10`, `log` (arbitrary base) and
-`factorial`. Missing only `min`/`max`/`clamp` and `normalize()` (§5).
+`factorial`. As of 2026-05-03 the API is at parity with `rust_decimal`,
+`System.Decimal`, and Python `Decimal` for the introspection / canonical
+surface (`normalize`, `same_quantum`, `adjusted`, `compare_total`,
+`is_signed`, `canonical`, `is_canonical`) — see §2.4 (20260503).
 
 ---
 
@@ -179,6 +182,36 @@ value before the fact and §2.4 / §2.5 for end-to-end snapshots.
 |          | rust_decimal `partial_divide_64`-style port is the only remaining algorithmic        |
 |          | win but requires Granlund-Möller shift-normalize that Mojo cannot express            |
 |          | without inline asm or LLVM intrinsics, deferred to §7 P2.                            |
+| 20260503 | **`from_string` digit batching — DISPROVEN.** Implemented the §5.1 follow-up         |
+|          | (BATCH_CAP=19, accumulate up to 19 digits in a `UInt64`, fold once per chunk via     |
+|          | `coef = coef * 10^k + batch`). Best-of-3 bench: `Long integer (20 digits)`           |
+|          | 24.7 → 28.5 ns (+15%); `Long fractional (28 digits)` 46.2 → 52.3 ns (+13%). Both     |
+|          | regressed. Root cause: LLVM already lowers `coef * 10` for `UInt128` to a tight      |
+|          | shift-add (`(c << 3) + (c << 1)`), so the per-digit multiply is essentially free;    |
+|          | the batching adds a per-iteration `batch_size` branch + a wide `power_of_10_unsafe`  |
+|          | lookup + a flush-time `UInt128 × UInt128` (lowered to `__multi3`) that exceed the    |
+|          | savings. A literal-`10^19` constant variant (skip the lookup) measured the same.     |
+|          | **Reverted; removed from §7 priority list.** Lesson #12 added.                       |
+| 20260503 | **`Decimal128` canonicalisation / introspection API parity** (§5.2 closed). Added    |
+|          | seven methods to bring Decimal128 to parity with `rust_decimal::Decimal`,            |
+|          | `System.Decimal`, and Python `Decimal` for the canonicalisation surface:             |
+|          | `normalize()` (strip trailing zeros; collapses every zero representation to          |
+|          | `Decimal128.ZERO()` so the hash/eq contract holds), `__hash__` (Hashable             |
+|          | conformance — hashes the *normalised* `(sign, coef, scale)` triple so                |
+|          | `1.0 == 1.00 == True ⇒ hash(1.0) == hash(1.00)`), `same_quantum()` (compare scale    |
+|          | only, IBM GDA §5.5.10), `adjusted()` (= `n_digits - 1 - scale`, IBM GDA              |
+|          | §5.5.2), `compare_total()` (IBM GDA §5.5.13 total ordering — for positives lower     |
+|          | scale precedes higher; for negatives higher scale precedes lower so the global       |
+|          | sequence stays monotonic across the sign change), `is_signed()` (alias of            |
+|          | `is_negative()` for Python-API compatibility), `canonical()` / `is_canonical()`      |
+|          | (identity / always-True — Decimal128 has no non-canonical encoding). `normalize()`   |
+|          | uses a 9-digit chunk pre-pass via `power_of_10_unsafe[uint128](9)` then a 1-digit    |
+|          | tail loop; both rely on LLVM's CSE of `// + %` to one `__udivmodti4` (Lesson #2).    |
+|          | All `@always_inline` except `normalize`, `compare_total`, and `__hash__`. 27 new     |
+|          | tests appended to `tests/decimal128/test_decimal128_methods.mojo` (consolidated      |
+|          | with the integer-part / preferred-exp suite, 58 total) cover the hash/eq contract    |
+|          | (incl. signed-zero and scaled-zero collapse), the chunk-boundary strip path, the     |
+|          | cross-sign monotonicity of `compare_total`, and adjusted/signed/canonical edges.     |
 
 ### 2.5 Performance tracking — absolute decimo median ns/iter
 
@@ -318,6 +351,16 @@ context. All P1/P2 items have landed; P3 items are tracked in §5.
     not the already-rounded one (subtle bug introduced and fixed in this
     PR for the UInt256 branch).
 
+12. **Don't batch into a `UInt64` accumulator on the assumption that a
+    `UInt128 * 10` per-digit multiply is expensive.** LLVM lowers
+    `UInt128 * 10` to a shift-add (`(c << 3) + (c << 1)`); the batch's
+    flush-time `UInt128 × UInt64` (lowered to `__multi3`) plus the
+    per-iteration `batch_size` branch and the wide `power_of_10_unsafe`
+    table lookup *exceed* the saving. Confirmed 2026-05-03 on the
+    `from_string` parser: `Long integer` regressed 24.7 → 28.5 ns. Always
+    measure batching against the natural per-element loop on the target
+    architecture before adopting.
+
 ---
 
 ## 5. Open Items / Future Improvements
@@ -327,20 +370,20 @@ context. All P1/P2 items have landed; P3 items are tracked in §5.
 These are the residual gaps. Each requires algorithmic work, not 
 micro-optimisation.
 
-| Op          | Worst case                    | decimo |  rust | dm/rs | Likely root cause                                                  |
-| ----------- | ----------------------------- | -----: | ----: | ----: | ------------------------------------------------------------------ |
-| multiply    | High precision mul            |   13.0 |  6.50 |  2.0× | UInt128 path: 17×17-digit prod, mandatory `round_coefficient` work |
-| multiply    | Multiplication by zero        |    4.0 |  1.38 |  2.9× | Per-call dispatch overhead (raises + special-case tree)            |
-| multiply    | Negative numbers              |    4.0 |  1.08 |  3.7× | Same                                                               |
-| multiply    | e * e^0.5                     |   23.0 | 27.79 |  0.8× | UInt256 path; *faster* than rust                                   |
-| divide      | Div with repeating decimal    |   36.0 | 12.04 |  3.0× | One bulk wide-divide + post-divide overhead. After 20260502        |
-|             |                               |        |       |       | refactor (§2.4); rust_decimal still uses a `div_internal` magic-   |
-|             |                               |        |       |       | multiply trick. Closing the rest needs reciprocal multiplication.  |
-| divide      | High precision division       |   37.0 | 18.67 |  2.0× | Same                                                               |
-| divide      | Large coprime quotient        |   30.0 | 16.67 |  1.8× | Same                                                               |
-| from_string | Long integer part (20 digits) |   24.7 | 11.52 |  2.1× | UInt128 multiply-by-10 per digit; could batch into u64 chunks      |
-| from_string | Long fractional (28 digits)   |   46.2 | 27.12 |  1.7× | Same                                                               |
-| from_string | Zero value                    |    4.3 |  1.79 |  2.4× | Per-call dispatch; rust has a 2-byte fast path                     |
+| Op          | Worst case                    | decimo |  rust | dm/rs | Likely root cause                                                       |
+| ----------- | ----------------------------- | -----: | ----: | ----: | ----------------------------------------------------------------------- |
+| multiply    | High precision mul            |   13.0 |  6.50 |  2.0× | UInt128 path: 17×17-digit prod, mandatory `round_coefficient` work      |
+| multiply    | Multiplication by zero        |    4.0 |  1.38 |  2.9× | Per-call dispatch overhead (raises + special-case tree)                 |
+| multiply    | Negative numbers              |    4.0 |  1.08 |  3.7× | Same                                                                    |
+| multiply    | e * e^0.5                     |   23.0 | 27.79 |  0.8× | UInt256 path; *faster* than rust                                        |
+| divide      | Div with repeating decimal    |   36.0 | 12.04 |  3.0× | One bulk wide-divide + post-divide overhead. After 20260502             |
+|             |                               |        |       |       | refactor (§2.4); rust_decimal still uses a `div_internal` magic-        |
+|             |                               |        |       |       | multiply trick. Closing the rest needs reciprocal multiplication.       |
+| divide      | High precision division       |   37.0 | 18.67 |  2.0× | Same                                                                    |
+| divide      | Large coprime quotient        |   30.0 | 16.67 |  1.8× | Same                                                                    |
+| from_string | Long integer part (20 digits) |   24.7 | 11.52 |  2.1× | UInt128 multiply-by-10 per digit. Batching disproven 2026-05-03 (§2.4). |
+| from_string | Long fractional (28 digits)   |   46.2 | 27.12 |  1.7× | Same                                                                    |
+| from_string | Zero value                    |    4.3 |  1.79 |  2.4× | Per-call dispatch; rust has a 2-byte fast path                          |
 
 **Possible follow-ups** (none committed):
 
@@ -353,20 +396,29 @@ micro-optimisation.
   pure-Mojo variants (chunked-9, manual divmod split) regressed; see
   the 2026-05-02 §2.4 entry for measurements. Revisit only if Mojo
   gains inline-asm or a dedicated `divrem_2by1` intrinsic.
-- *from_string*: digit batching — accumulate up to 19 digits in a `UInt64`,
-  then `coef = coef * 10^k + batch` once per chunk. ~5–7× reduction on the
-  inner-loop multiplies. Targeted estimate: 24 → ~14 ns on `Long integer`.
+- *from_string*: digit batching — REJECTED 2026-05-03. Implemented
+  with `BATCH_CAP = 19` (accumulate up to 19 digits in a `UInt64`, fold
+  once per chunk via `coef = coef * 10^k + batch`); both the variable-k
+  and literal-`10^19` variants regressed `Long integer` 24.7 → 28.5 ns
+  (+15%) and `Long fractional` 46.2 → 52.3 ns (+13%). LLVM lowers
+  `UInt128 * 10` to a shift-add already, so per-digit multiplies are
+  essentially free; the batching adds a per-iteration branch + a wide
+  `power_of_10_unsafe` lookup + a flush-time `__multi3` that exceed the
+  saving. See the 2026-05-03 §2.4 entry. Revisit only if Mojo gains a
+  cheaper-than-`__multi3` `mul_u128_by_u64` intrinsic.
 - *multiply per-call dispatch*: collapse the 6-way special-case tree into
   3 branches (zero short-circuit, integer fast path, general). Risk:
   regressions on the cases the dispatch was added for.
 
-### 5.2 API gaps vs `rust_decimal`
+### 5.2 API gaps vs `rust_decimal` / Python `Decimal` — DONE (2026-05-03)
 
 Landed 2026-04-23: `trunc`, `floor`, `ceil`, `fract`, `signum`, `unpack`
-(see §2.4). Landed 2026-04-27: `min`, `max`, `clamp`. Still tracked:
-
-- `normalize()` (strip trailing zeros)
-- `__hash__` (depends on `normalize`)
+(see §2.4). Landed 2026-04-27: `min`, `max`, `clamp`. Landed 2026-05-03:
+`normalize`, `__hash__` (Hashable conformance), `same_quantum`,
+`adjusted`, `compare_total`, `is_signed`, `canonical`, `is_canonical`
+— see the 2026-05-03 §2.4 entry. The Decimal128 API surface is now at
+parity with `rust_decimal::Decimal`, `System.Decimal`, and the
+introspection / canonicalisation half of Python `Decimal`.
 
 ### 5.3 `ln()` / `log10()` / `exp()` range reduction — DONE (2026-04-25)
 
@@ -431,8 +483,6 @@ coefficient arithmetic instead of 96-bit).
 
 It is a long-term proposal; not on the active roadmap.
 
-See git history (pre-2026-04-23) for the full analysis.
-
 ### 5.6 Per-op `RoundingMode` parameter on `Decimal128` arithmetic — REJECTED
 
 **Considered 2026-05-02.** Cross-language survey of fixed-precision
@@ -474,12 +524,6 @@ Part II → "A note on result exponents (`Decimal` and `Dec128`)".
 
 Open items, in priority order:
 
-| #   | Issue                                          | Effort | Priority |
-| --- | ---------------------------------------------- | ------ | -------- |
-| 5.1 | from_string digit batching                     | Medium | P2       |
-| 5.2 | `normalize()`                                  | Small  | P3       |
-| 5.2 | `__hash__` (depends on `normalize()`)          | Small  | P3       |
-| 5.6 | Per-op `RoundingMode` on Decimal128 arithmetic | —      | REJECTED |
-| 5.1 | divide reciprocal-multiply (rust_decimal port) | —      | REJECTED |
-| 5.3 | `exp()` sub-unit chunk constants (`exp(π)`)    | Medium | P4       |
-| 5.5 | Steal flag bits → 32-digit coefficient         | Large  | P4       |
+| #   | Issue                                       | Effort | Priority |
+| --- | ------------------------------------------- | ------ | -------- |
+| 5.3 | `exp()` sub-unit chunk constants (`exp(π)`) | Medium | P4       |

--- a/docs/plans/decimal128_enhancement.md
+++ b/docs/plans/decimal128_enhancement.md
@@ -207,11 +207,17 @@ value before the fact and §2.4 / §2.5 for end-to-end snapshots.
 |          | (identity / always-True — Decimal128 has no non-canonical encoding). `normalize()`   |
 |          | uses a 9-digit chunk pre-pass via `power_of_10_unsafe[uint128](9)` then a 1-digit    |
 |          | tail loop; both rely on LLVM's CSE of `// + %` to one `__udivmodti4` (Lesson #2).    |
-|          | All `@always_inline` except `normalize`, `compare_total`, and `__hash__`. 27 new     |
-|          | tests appended to `tests/decimal128/test_decimal128_methods.mojo` (consolidated      |
-|          | with the integer-part / preferred-exp suite, 58 total) cover the hash/eq contract    |
-|          | (incl. signed-zero and scaled-zero collapse), the chunk-boundary strip path, the     |
-|          | cross-sign monotonicity of `compare_total`, and adjusted/signed/canonical edges.     |
+|          | All `@always_inline` except `normalize` and `__hash__`. `compare_total` lives in     |
+|          | `comparison.mojo` as a free function (alongside `compare`, `min`, `max`, `clamp`);   |
+|          | the `Decimal128.compare_total` method is an `@always_inline` thin wrapper. The       |
+|          | dual-zero branch is handled *before* delegating to `compare()` because `compare()`   |
+|          | collapses every zero (`{-0,+0} × scale`) into a single equivalence class, which      |
+|          | would break the strict-total-order contract; the free function orders by sign first  |
+|          | (`-0 < +0`) then by scale (rule 3). 30 new tests appended to                         |
+|          | `tests/decimal128/test_decimal128_methods.mojo` cover the hash/eq contract           |
+|          | (incl. signed-zero and  scaled-zero collapse), the chunk-boundary strip path,        |
+|          | signed-zero ordering under `compare_total`, the cross-sign monotonicity of scaled    |
+|          | zeros, and adjusted / signed / canonical edges.                                      |
 
 ### 2.5 Performance tracking — absolute decimo median ns/iter
 

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -2560,7 +2560,7 @@ def floor_divide_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt:
     return result^
 
 
-fn floor_divide_by_power_of_ten_inplace(mut x: BigUInt, n: Int):
+def floor_divide_by_power_of_ten_inplace(mut x: BigUInt, n: Int):
     """In-place version of `floor_divide_by_power_of_ten`. Drops the
     `n` lowest decimal digits of `x` directly inside its `words`
     storage, avoiding an allocation when only a sub-word shift is
@@ -2613,7 +2613,7 @@ fn floor_divide_by_power_of_ten_inplace(mut x: BigUInt, n: Int):
     _shift_right_by_decimal_digits_inplace(x, digit_shift)
 
 
-fn _shift_right_by_decimal_digits_inplace(mut x: BigUInt, digit_shift: Int):
+def _shift_right_by_decimal_digits_inplace(mut x: BigUInt, digit_shift: Int):
     """Divides `x` in place by `10^digit_shift`, where
     `1 <= digit_shift <= 8`. Assumes any whole-word shift has already
     been applied; this only performs the sub-word digit shift and
@@ -2695,7 +2695,7 @@ def floor_divide_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt:
         return result^
 
 
-fn floor_divide_by_power_of_billion_inplace(mut x: BigUInt, n: Int):
+def floor_divide_by_power_of_billion_inplace(mut x: BigUInt, n: Int):
     """In-place version of `floor_divide_by_power_of_billion`. Drops
     the `n` lowest base-10^9 words of `x` directly inside its `words`
     storage, avoiding an allocation.

--- a/src/decimo/decimal128/comparison.mojo
+++ b/src/decimo/decimal128/comparison.mojo
@@ -307,3 +307,68 @@ def clamp(
     if compare(x, upper) > 0:
         return upper
     return x
+
+
+def compare_total(a: Decimal128, b: Decimal128) -> Int8:
+    """Returns the IBM GDA total ordering (`§5.5.13 compare-total`) of `a`
+    vs `b`. Unlike `compare()` (which treats `1.0 == 1.00` and collapses
+    every zero into a single equivalence class), `compare_total` produces a
+    *strict* total order on the representation, so numerically equal values
+    that differ in scale or signed-zero status receive a deterministic
+    order.
+
+    Ordering rules:
+
+    1. Negatives precede positives, including signed zero (`-0 < +0`).
+    2. Among same-sign non-zero values: usual numeric order.
+    3. Among numerically equal values (incl. same-signed zeros), the
+       *lower* scale comes first for positives; reversed for negatives, so
+       the global sequence stays monotonic across the zero boundary:
+       `... -0.00 < -0.0 < -0 < +0 < +0.0 < +0.00 < ... < 1.0 < 1.00 ...`.
+
+    Args:
+        a: First Decimal128 value.
+        b: Second Decimal128 value.
+
+    Returns:
+        `-1` if `a` precedes `b`, `0` if identical representations,
+        `+1` otherwise.
+    """
+
+    # Dual-zero case must be handled BEFORE delegating to `compare()` —
+    # `compare()` returns 0 for any two zeros regardless of sign or scale,
+    # which would collapse the four representations `{-0, +0} × {scale...}`
+    # into a single equivalence class, contradicting the total-order
+    # contract. Order by sign first (negative zero precedes positive zero),
+    # then fall through to the same scale tie-break as the non-zero arm.
+    var a_zero = a.is_zero()
+    var b_zero = b.is_zero()
+    if a_zero and b_zero:
+        var a_neg = a.is_negative()
+        var b_neg = b.is_negative()
+        if a_neg != b_neg:
+            return Int8(-1) if a_neg else Int8(1)
+        # Same-signed zeros: scale tie-break (rule 3).
+        var s_a_z = a.scale()
+        var s_b_z = b.scale()
+        if s_a_z == s_b_z:
+            return Int8(0)
+        if a_neg:
+            return Int8(-1) if s_a_z > s_b_z else Int8(1)
+        return Int8(-1) if s_a_z < s_b_z else Int8(1)
+
+    var c = compare(a, b)
+    if c != 0:
+        return c
+
+    # Numerically equal non-zero values (same sign, same magnitude, possibly
+    # different scale). For positives, lower scale wins. For negatives,
+    # higher scale wins so the sequence stays monotonic across the sign
+    # boundary (... -1.00 < -1.0 < -1 < ... < 1 < 1.0 < 1.00 ...).
+    var s_a = a.scale()
+    var s_b = b.scale()
+    if s_a == s_b:
+        return Int8(0)
+    if a.is_negative():
+        return Int8(-1) if s_a > s_b else Int8(1)
+    return Int8(-1) if s_a < s_b else Int8(1)

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -24,6 +24,7 @@ mathematical methods that do not implement a trait.
 """
 
 from std.memory import UnsafePointer
+from std.hashlib.hasher import Hasher
 
 import decimo.decimal128.arithmetics
 import decimo.decimal128.comparison
@@ -46,6 +47,7 @@ struct Decimal128(
     Absable,
     Comparable,
     Floatable,
+    Hashable,
     IntableRaising,
     Roundable,
     TrivialRegisterPassable,
@@ -1875,7 +1877,7 @@ struct Decimal128(
 
     # ===------------------------------------------------------------------=== #
     # Other dunders that implements traits
-    # round
+    # round, hash
     # ===------------------------------------------------------------------=== #
 
     @always_inline
@@ -1916,9 +1918,40 @@ struct Decimal128(
         except e:
             return self
 
+    # [Mojo Miji]
+    # What will happen if we run `hash()` on a Decimal128 value, e.g., `a`?
+    # - a default hasher, i.e., `AHasher` will be created.
+    # - `hasher.update(a)` will be called.
+    # - This `__hash__` method will be invoked with the hasher as the argument.
+    # - `hasher.update()` will be called three times to feed the normalized
+    #   sign, coefficient, and scale into the hasher.
+    # -`AHsher._update_with_simd()` will be called to update the hash state.
+    def __hash__[H: Hasher](self, mut hasher: H):
+        """Hashes this Decimal128 in a way that respects numeric equality
+        (`a == b` implies `hash(a) == hash(b)`). The hash is computed on the
+        normalized `(sign, coefficient, scale)` triple, so e.g.
+        `Decimal128("1.0")` and `Decimal128("1.00")` hash identically — both
+        normalize to coefficient=1, scale=0.
+
+        Parameters:
+            H: The `Hasher` implementation type.
+
+        Args:
+            hasher: The hasher to update.
+        """
+        var n = self.normalize()
+        # Feed the three semantically meaningful fields. After normalize(),
+        # zero is canonical (+0, scale 0, coef 0) so all zero-valued
+        # Decimal128 inputs converge to the same hash. For non-zero values
+        # equal under `==`, normalize() yields identical (coef, scale, sign)
+        # triples by construction.
+        hasher.update(UInt8(n.is_negative()))
+        hasher.update(n.coefficient())
+        hasher.update(UInt8(n.scale()))
+
     # ===------------------------------------------------------------------=== #
     # Mathematical methods that do not implement a trait (not a dunder)
-    # exp, ln, round, sqrt
+    # exp, ln, round, sqrt, root, log10, power, quantize
     # ===------------------------------------------------------------------=== #
 
     @always_inline
@@ -1961,6 +1994,94 @@ struct Decimal128(
             The quantized `Decimal128` value.
         """
         return decimo.decimal128.rounding.quantize(self, exp, rounding_mode)
+
+    @always_inline
+    def exp(self) raises -> Self:
+        """Calculates the exponential of this Decimal128.
+        See `exp()` for more information.
+
+        Returns:
+            The value of e raised to this power.
+        """
+        return decimo.decimal128.exponential.exp(self)
+
+    @always_inline
+    def ln(self) raises -> Self:
+        """Calculates the natural logarithm of this Decimal128.
+        See `ln()` for more information.
+
+        Returns:
+            The natural logarithm of this value.
+        """
+        return decimo.decimal128.exponential.ln(self)
+
+    @always_inline
+    def log10(self) raises -> Decimal128:
+        """Computes the base-10 logarithm of this Decimal128.
+
+        Returns:
+            The base-10 logarithm of this value.
+        """
+        return decimo.decimal128.exponential.log10(self)
+
+    @always_inline
+    def log(self, base: Decimal128) raises -> Decimal128:
+        """Computes the logarithm of this Decimal128 with an arbitrary base.
+
+        Args:
+            base: The logarithm base.
+
+        Returns:
+            The logarithm of this value in the given base.
+        """
+        return decimo.decimal128.exponential.log(self, base)
+
+    @always_inline
+    def power(self, exponent: Int) raises -> Decimal128:
+        """Raises this Decimal128 to the power of an integer.
+
+        Args:
+            exponent: The integer exponent to raise to.
+
+        Returns:
+            The value raised to the given power.
+        """
+        return decimo.decimal128.exponential.power(self, Self(exponent))
+
+    @always_inline
+    def power(self, exponent: Decimal128) raises -> Decimal128:
+        """Raises this Decimal128 to the power of another Decimal128.
+
+        Args:
+            exponent: The `Decimal128` exponent to raise to.
+
+        Returns:
+            The value raised to the given power.
+        """
+        return decimo.decimal128.exponential.power(self, exponent)
+
+    @always_inline
+    def root(self, n: Int) raises -> Self:
+        """Calculates the n-th root of this Decimal128.
+        See `root()` for more information.
+
+        Args:
+            n: The degree of the root to compute.
+
+        Returns:
+            The n-th root of this value.
+        """
+        return decimo.decimal128.exponential.root(self, n)
+
+    @always_inline
+    def sqrt(self) raises -> Self:
+        """Calculates the square root of this Decimal128.
+        See `sqrt()` for more information.
+
+        Returns:
+            The square root of this value.
+        """
+        return decimo.decimal128.exponential.sqrt(self)
 
     # ===------------------------------------------------------------------=== #
     # Integer-part / fractional-part / sign helpers
@@ -2137,97 +2258,246 @@ struct Decimal128(
             self.is_negative(),
         )
 
-    @always_inline
-    def exp(self) raises -> Self:
-        """Calculates the exponential of this Decimal128.
-        See `exp()` for more information.
-
-        Returns:
-            The value of e raised to this power.
-        """
-        return decimo.decimal128.exponential.exp(self)
-
-    @always_inline
-    def ln(self) raises -> Self:
-        """Calculates the natural logarithm of this Decimal128.
-        See `ln()` for more information.
-
-        Returns:
-            The natural logarithm of this value.
-        """
-        return decimo.decimal128.exponential.ln(self)
-
-    @always_inline
-    def log10(self) raises -> Decimal128:
-        """Computes the base-10 logarithm of this Decimal128.
-
-        Returns:
-            The base-10 logarithm of this value.
-        """
-        return decimo.decimal128.exponential.log10(self)
-
-    @always_inline
-    def log(self, base: Decimal128) raises -> Decimal128:
-        """Computes the logarithm of this Decimal128 with an arbitrary base.
-
-        Args:
-            base: The logarithm base.
-
-        Returns:
-            The logarithm of this value in the given base.
-        """
-        return decimo.decimal128.exponential.log(self, base)
-
-    @always_inline
-    def power(self, exponent: Int) raises -> Decimal128:
-        """Raises this Decimal128 to the power of an integer.
-
-        Args:
-            exponent: The integer exponent to raise to.
-
-        Returns:
-            The value raised to the given power.
-        """
-        return decimo.decimal128.exponential.power(self, Self(exponent))
-
-    @always_inline
-    def power(self, exponent: Decimal128) raises -> Decimal128:
-        """Raises this Decimal128 to the power of another Decimal128.
-
-        Args:
-            exponent: The `Decimal128` exponent to raise to.
-
-        Returns:
-            The value raised to the given power.
-        """
-        return decimo.decimal128.exponential.power(self, exponent)
-
-    @always_inline
-    def root(self, n: Int) raises -> Self:
-        """Calculates the n-th root of this Decimal128.
-        See `root()` for more information.
-
-        Args:
-            n: The degree of the root to compute.
-
-        Returns:
-            The n-th root of this value.
-        """
-        return decimo.decimal128.exponential.root(self, n)
-
-    @always_inline
-    def sqrt(self) raises -> Self:
-        """Calculates the square root of this Decimal128.
-        See `sqrt()` for more information.
-
-        Returns:
-            The square root of this value.
-        """
-        return decimo.decimal128.exponential.sqrt(self)
-
     # ===------------------------------------------------------------------=== #
-    # Other methods
+    # Canonicalization / introspection helpers
+    # normalize, same_quantum, adjusted, compare_total,
+    # is_signed, canonical, is_canonical
     # ===------------------------------------------------------------------=== #
+
+    def normalize(self) -> Self:
+        """Returns the canonical (trailing-zero-stripped) form of this
+        Decimal128. Mirrors Python `Decimal.normalize()`: the result has the
+        same numeric value as `self` but the smallest scale that still
+        represents it exactly. Zero is canonicalized to a positive zero with
+        scale 0 regardless of the input's sign or scale (matches Python's
+        `Decimal("-0.000").normalize() == Decimal("0")`).
+
+        Returns:
+            A new `Decimal128` with all trailing zeros stripped from the
+            coefficient (and the scale lowered by the same amount).
+
+        Notes:
+
+        Two decimals that compare equal (`==`) but differ only in scale
+        (e.g. `Decimal128("1.0")` vs `Decimal128("1.00")`) normalize to
+        the same `(coefficient, scale, sign)` triple. This is the
+        invariant `__hash__` relies on.
+
+        Performance: trailing-zero stripping uses a 9-digit chunk pre-pass
+        (one `UInt128 // 10^9` per fully-zero chunk) followed by a 1-digit
+        tail loop. Each `% / //` pair is CSE-folded by LLVM to one
+        `__udivmodti4` call (Lesson #2), so the loop touches each digit
+        once.
+
+        Example:
+
+        ```mojo
+        from decimo import Decimal128
+        print(Decimal128("1.000").normalize())      # 1
+        print(Decimal128("123.4500").normalize())   # 123.45
+        print(Decimal128("-0.00").normalize())      # 0  (sign cleared)
+        print(Decimal128("100").normalize())        # 100 (no trailing
+                                                    # fractional zeros to
+                                                    # strip; scale is
+                                                    # already 0)
+        ```
+        End of example.
+        """
+
+        # Zero collapses to canonical (+0, scale 0). This matches Python
+        # `Decimal` and IBM GDA: signed-zero / scaled-zero distinctions are
+        # eliminated by `normalize`. Hashing relies on this so that every
+        # zero-valued Decimal128 hashes the same.
+        if self.is_zero():
+            return Decimal128.ZERO()
+
+        var scale = self.scale()
+
+        # Already at scale 0: no trailing fractional digits to strip and the
+        # coefficient itself may legitimately end in zeros (e.g. "100"). No
+        # further work to do; return as-is. This is the hot path for integer
+        # values.
+        if scale == 0:
+            return self
+
+        var coef = self.coefficient()
+        var sign = self.is_negative()
+
+        # 9-digit chunk pre-pass: when scale >= 9, peel a whole `10^9`
+        # block off the coefficient if and only if the low 9 digits are
+        # zero. `power_of_10_unsafe[uint128](9)` is well within the
+        # `0..29` contract. Each iteration consumes one `__udivmodti4`
+        # (LLVM CSE-folds `// + %`).
+        comptime CHUNK = 9
+        var pow9 = decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
+            CHUNK
+        )
+        while scale >= CHUNK and coef % pow9 == 0:
+            coef = coef // pow9
+            scale -= CHUNK
+
+        # 1-digit tail. After the chunk pre-pass the residual scale is in
+        # `0..(CHUNK + 27)` worst case (27 since MAX_SCALE = 28 and we only
+        # strip when the chunk is exact); in practice this loop runs at
+        # most 8 iterations.
+        while scale > 0 and coef % 10 == 0:
+            coef = coef // 10
+            scale -= 1
+
+        # `from_uint128` revalidates 96-bit fit + scale range. Both must
+        # already hold for `self` (we only shrink coef + scale), so the
+        # raise paths are dead; we still call the public constructor to
+        # avoid duplicating the bit-pack / mask code.
+        try:
+            return Decimal128.from_uint128(coef, scale=UInt32(scale), sign=sign)
+        except:
+            # Unreachable: `coef <= self.coefficient()` (only divided by
+            # positive powers of 10) and `scale <= self.scale() <= 28`.
+            # `from_uint128` cannot raise on these inputs.
+            return self
+
+    @always_inline
+    def same_quantum(self, other: Decimal128) -> Bool:
+        """Returns True iff `self` and `other` have the same scale, i.e.
+        the same number of fractional digits. Mirrors Python
+        `Decimal.same_quantum()` and IBM GDA `same-quantum`.
+
+        Args:
+            other: The Decimal128 to compare scales against.
+
+        Returns:
+            `True` if `self.scale() == other.scale()`, `False` otherwise.
+
+        Example:
+
+        ```mojo
+        from decimo import Decimal128
+        print(Decimal128("1.23").same_quantum(Decimal128("4.56")))   # True
+        print(Decimal128("1.230").same_quantum(Decimal128("1.23")))  # False
+        ```
+        End of example.
+        """
+        return (self.flags & Self.SCALE_MASK) == (other.flags & Self.SCALE_MASK)
+
+    @always_inline
+    def adjusted(self) -> Int:
+        """Returns the adjusted exponent of this Decimal128.
+
+        The adjusted exponent is the exponent of the most significant digit.
+        Defined as `number_of_significant_digits() - 1 - scale()`.
+        Useful for order-of-magnitude probes (e.g. `floor(log10(|self|))` on
+        positive values) without going through `log10`.
+
+        Mirrors Python `Decimal.adjusted()` and IBM GDA `adjusted-exponent`.
+        For zero, returns 0 (matching Python's behaviour for `Decimal(0)`;
+        IBM GDA leaves this implementation-defined).
+
+        Returns:
+            The adjusted exponent as an `Int`.
+
+        Example:
+
+        ```mojo
+        from decimo import Decimal128
+        print(Decimal128("123.45").adjusted())    # 2  (1.2345e2)
+        print(Decimal128("0.00123").adjusted())   # -3 (1.23e-3)
+        print(Decimal128("100").adjusted())       # 2  (1.00e2)
+        print(Decimal128("0").adjusted())         # 0
+        ```
+        End of example.
+        """
+        if self.is_zero():
+            return 0
+        return self.number_of_significant_digits() - 1 - self.scale()
+
+    def compare_total(self, other: Decimal128) -> Int8:
+        """Returns the IBM GDA *total ordering* of `self` vs `other`. Unlike
+        `compare()` (which treats `1.0 == 1.00`), `compare_total` produces a
+        strict total order on the representation, so values that compare
+        equal under `==` but differ in scale receive a deterministic order
+        (lower scale first; equivalently: representation with fewer trailing
+        zeros first).
+
+        Ordering rules (IBM GDA §5.5.13, "compare-total"):
+
+        1. Negatives precede positives.
+        2. Among same-sign values, the larger magnitude precedes the smaller
+           when negative; the opposite when positive (i.e. usual numeric
+           order).
+        3. Among numerically equal values, the *lower* scale (fewer trailing
+           zeros) comes first for positives; reversed for negatives, so that
+           `-1.00 < -1.0 < ...` mirrors `1.0 < 1.00`.
+
+        Args:
+            other: The Decimal128 to compare against.
+
+        Returns:
+            `-1` if `self` precedes `other`, `0` if identical
+            representations, `+1` otherwise.
+
+        Example:
+
+        ```mojo
+        from decimo import Decimal128
+        print(Decimal128("1.0").compare_total(Decimal128("1.00")))  # -1
+        print(Decimal128("1").compare_total(Decimal128("1.0")))     # -1
+        print(Decimal128("-1.0").compare_total(Decimal128("-1")))   # -1
+        ```
+        End of example.
+        """
+
+        var c = decimo.decimal128.comparison.compare(self, other)
+        if c != 0:
+            return c
+
+        # Numerically equal: order by scale. For positives (and zero),
+        # lower scale wins. For negatives, higher scale wins so that the
+        # sequence remains monotonic across the sign boundary
+        # (... -1.00, -1.0, -1, 0, 1, 1.0, 1.00 ...).
+        var s_self = self.scale()
+        var s_other = other.scale()
+        if s_self == s_other:
+            return Int8(0)
+
+        var self_neg = self.is_negative() and not self.is_zero()
+        if self_neg:
+            return Int8(-1) if s_self > s_other else Int8(1)
+        return Int8(-1) if s_self < s_other else Int8(1)
+
+    @always_inline
+    def is_signed(self) -> Bool:
+        """Returns True iff the sign bit is set. Alias of `is_negative()`,
+        provided for parity with Python `Decimal.is_signed()`. Note that a
+        scaled negative zero (e.g. `Decimal128("-0.00")`) is *signed* even
+        though it compares equal to positive zero.
+
+        Returns:
+            `True` if the sign bit is set, `False` otherwise.
+        """
+        return self.is_negative()
+
+    @always_inline
+    def canonical(self) -> Self:
+        """Returns `self` unchanged. Provided for parity with Python
+        `Decimal.canonical()` / IBM GDA `canonical`. Decimal128 has no
+        non-canonical encodings (no NaN payloads, no Inf, no subnormal
+        representations), so every value is already its own canonical form.
+
+        Returns:
+            `self`.
+        """
+        return self
+
+    @always_inline
+    def is_canonical(self) -> Bool:
+        """Returns `True` unconditionally. Provided for parity with Python
+        `Decimal.is_canonical()` / IBM GDA `is-canonical`. Decimal128 has no
+        non-canonical encodings.
+
+        Returns:
+            `True`.
+        """
+        return True
 
     @always_inline
     def coefficient(self) -> UInt128:

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -1925,7 +1925,7 @@ struct Decimal128(
     # - This `__hash__` method will be invoked with the hasher as the argument.
     # - `hasher.update()` will be called three times to feed the normalized
     #   sign, coefficient, and scale into the hasher.
-    # -`AHsher._update_with_simd()` will be called to update the hash state.
+    # - `AHasher._update_with_simd()` will be called to update the hash state.
     def __hash__[H: Hasher](self, mut hasher: H):
         """Hashes this Decimal128 in a way that respects numeric equality
         (`a == b` implies `hash(a) == hash(b)`). The hash is computed on the
@@ -2410,23 +2410,25 @@ struct Decimal128(
             return 0
         return self.number_of_significant_digits() - 1 - self.scale()
 
+    @always_inline
     def compare_total(self, other: Decimal128) -> Int8:
-        """Returns the IBM GDA *total ordering* of `self` vs `other`. Unlike
-        `compare()` (which treats `1.0 == 1.00`), `compare_total` produces a
-        strict total order on the representation, so values that compare
-        equal under `==` but differ in scale receive a deterministic order
-        (lower scale first; equivalently: representation with fewer trailing
-        zeros first).
+        """Returns the IBM GDA total ordering of `self` vs `other`.
+
+        Notes:
+
+        Unlike `compare()` (which treats `1.0 == 1.00` and collapses every zero
+        to a single equivalence class), `compare_total` produces a strict total
+        order on the *representation*: numerically equal values that differ
+        in scale or signed-zero status receive a deterministic order.
 
         Ordering rules (IBM GDA §5.5.13, "compare-total"):
 
-        1. Negatives precede positives.
-        2. Among same-sign values, the larger magnitude precedes the smaller
-           when negative; the opposite when positive (i.e. usual numeric
-           order).
-        3. Among numerically equal values, the *lower* scale (fewer trailing
-           zeros) comes first for positives; reversed for negatives, so that
-           `-1.00 < -1.0 < ...` mirrors `1.0 < 1.00`.
+        1. Negatives precede positives (including signed zero: `-0 < +0`).
+        2. Among same-sign non-zero values: usual numeric order.
+        3. Among numerically equal values (incl. same-signed zeros), the
+           *lower* scale comes first for positives; reversed for negatives,
+           so the global sequence stays monotonic across the zero boundary:
+           `... -0.00 < -0.0 < -0 < +0 < +0.0 < +0.00 ...`.
 
         Args:
             other: The Decimal128 to compare against.
@@ -2439,30 +2441,14 @@ struct Decimal128(
 
         ```mojo
         from decimo import Decimal128
-        print(Decimal128("1.0").compare_total(Decimal128("1.00")))  # -1
-        print(Decimal128("1").compare_total(Decimal128("1.0")))     # -1
-        print(Decimal128("-1.0").compare_total(Decimal128("-1")))   # -1
+        print(Decimal128("1.0").compare_total(Decimal128("1.00")))    # -1
+        print(Decimal128("1").compare_total(Decimal128("1.0")))       # -1
+        print(Decimal128("-1.0").compare_total(Decimal128("-1")))     # -1
+        print(Decimal128("-0.00").compare_total(Decimal128("0.00")))  # -1
         ```
         End of example.
         """
-
-        var c = decimo.decimal128.comparison.compare(self, other)
-        if c != 0:
-            return c
-
-        # Numerically equal: order by scale. For positives (and zero),
-        # lower scale wins. For negatives, higher scale wins so that the
-        # sequence remains monotonic across the sign boundary
-        # (... -1.00, -1.0, -1, 0, 1, 1.0, 1.00 ...).
-        var s_self = self.scale()
-        var s_other = other.scale()
-        if s_self == s_other:
-            return Int8(0)
-
-        var self_neg = self.is_negative() and not self.is_zero()
-        if self_neg:
-            return Int8(-1) if s_self > s_other else Int8(1)
-        return Int8(-1) if s_self < s_other else Int8(1)
+        return decimo.decimal128.comparison.compare_total(self, other)
 
     @always_inline
     def is_signed(self) -> Bool:

--- a/src/decimo/decimal128/utility.mojo
+++ b/src/decimo/decimal128/utility.mojo
@@ -1409,7 +1409,7 @@ comptime _U256_MASK_LO128 = UInt256(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
 
 
 @always_inline
-fn _mulhi_u256(a: UInt256, b: UInt256) -> UInt256:
+def _mulhi_u256(a: UInt256, b: UInt256) -> UInt256:
     """Returns the high 256 bits of `a * b` (both unsigned 256-bit).
 
     Splits each operand into two u128 halves and uses the schoolbook
@@ -1497,7 +1497,7 @@ comptime _GM_SHIFT_BLOB = (
 
 
 @always_inline
-fn udiv_u256_by_pow10_gm(value: UInt256, k: Int) -> UInt256:
+def udiv_u256_by_pow10_gm(value: UInt256, k: Int) -> UInt256:
     """Returns `floor(value / 10^k)` using one mulhi-256 plus a shift.
 
     Args:
@@ -1535,7 +1535,7 @@ fn udiv_u256_by_pow10_gm(value: UInt256, k: Int) -> UInt256:
 
 
 @always_inline
-fn udiv_u256_by_u64(n: UInt256, d: UInt64) -> Tuple[UInt256, UInt64]:
+def udiv_u256_by_u64(n: UInt256, d: UInt64) -> Tuple[UInt256, UInt64]:
     """Schoolbook UInt256 / UInt64 division, hardware-fast on aarch64.
 
     Args:

--- a/src/decimo/str.mojo
+++ b/src/decimo/str.mojo
@@ -72,7 +72,7 @@ def ljust(s: String, width: Int, fillchar: String = " ") -> String:
 
 
 @no_inline
-fn _raise_invalid_char(c: UInt8, value: String) raises -> None:
+def _raise_invalid_char(c: UInt8, value: String) raises -> None:
     # Non-ASCII bytes (>127) are typically a stray UTF-8 lead/continuation
     # byte; surfacing them via `chr()` produces garbled output that is not
     # actionable. Include the raw byte value (hex) AND the original input so

--- a/tests/decimal128/test_decimal128_methods.mojo
+++ b/tests/decimal128/test_decimal128_methods.mojo
@@ -1,13 +1,16 @@
 """
-Tests for Decimal128 integer-part / fractional-part / sign helpers and
+Tests for Decimal128 integer-part / fractional-part / sign helpers,
 the IEEE 754 / IBM GDA "preferred exponent" semantics for multiply and
-divide.
+divide, and the canonicalisation / introspection surface
+(`normalize`, `__hash__`, `same_quantum`, `adjusted`, `compare_total`,
+`is_signed`, `canonical`, `is_canonical`).
 
-Consolidates test_decimal128_{integer_part, preferred_exp}.mojo.
-Neither file uses TOML.
+Consolidates test_decimal128_{integer_part, preferred_exp,
+canonicalization}.mojo. None use TOML.
 """
 
 from std import testing
+from std.hashlib.hasher import default_hasher
 
 from decimo import Dec128
 
@@ -297,6 +300,238 @@ def test_divide_above_ideal_exponent() raises:
     """6.0 / 2 should hit ideal exponent -1 → '3.0'."""
     var result = Dec128("6.0") / Dec128("2")
     testing.assert_equal(String(result), "3.0")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# normalize()
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_normalize_strips_fractional_zeros() raises:
+    testing.assert_equal(String(Dec128("1.000").normalize()), "1")
+    testing.assert_equal(String(Dec128("1.0").normalize()), "1")
+    testing.assert_equal(String(Dec128("123.4500").normalize()), "123.45")
+    testing.assert_equal(String(Dec128("0.1000").normalize()), "0.1")
+
+
+def test_normalize_keeps_integer_trailing_zeros() raises:
+    """`100` has scale 0 already; normalize must not collapse it to `1E2`
+    (we don't carry an exponent separate from scale, so the trailing
+    zeros in the integer part of a scale-0 value are part of the
+    coefficient)."""
+    testing.assert_equal(String(Dec128("100").normalize()), "100")
+    testing.assert_equal(String(Dec128("1000").normalize()), "1000")
+
+
+def test_normalize_no_trailing_zeros_is_idempotent() raises:
+    testing.assert_equal(String(Dec128("1.23").normalize()), "1.23")
+    testing.assert_equal(String(Dec128("3").normalize()), "3")
+    testing.assert_equal(String(Dec128("-3.14159").normalize()), "-3.14159")
+
+
+def test_normalize_zero_canonicalizes_to_positive_zero_scale_zero() raises:
+    """All zero representations collapse to `Decimal128.ZERO()` so
+    hashing / equality stay consistent."""
+    testing.assert_equal(String(Dec128("0").normalize()), "0")
+    testing.assert_equal(String(Dec128("0.0").normalize()), "0")
+    testing.assert_equal(String(Dec128("0.0000").normalize()), "0")
+    testing.assert_equal(String(Dec128("-0").normalize()), "0")
+    testing.assert_equal(String(Dec128("-0.000").normalize()), "0")
+
+
+def test_normalize_negative_strips_zeros_keeps_sign() raises:
+    testing.assert_equal(String(Dec128("-1.500").normalize()), "-1.5")
+    testing.assert_equal(String(Dec128("-100.00").normalize()), "-100")
+
+
+def test_normalize_high_precision_strips_at_chunk_boundary() raises:
+    """Hits the 9-digit chunk pre-pass: 18 trailing zeros -> 2 chunks
+    peeled in two iterations."""
+    var v = Dec128("1.000000000000000000")  # 1 then 18 zeros, scale 18
+    testing.assert_equal(String(v.normalize()), "1")
+    var w = Dec128("1.234500000000000000")  # scale 18, last 14 zeros
+    testing.assert_equal(String(w.normalize()), "1.2345")
+
+
+def test_normalize_max_scale_no_zeros_to_strip_is_idempotent() raises:
+    """scale=28 with coef=5 (no trailing zeros): nothing to strip,
+    `normalize()` is the identity."""
+    var v = Dec128("0.0000000000000000000000000005")
+    var n = v.normalize()
+    testing.assert_equal(String(v), String(n))
+    testing.assert_true(v == n)
+    testing.assert_equal(n.scale(), 28)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# __hash__ (Hashable)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _h(d: Dec128) -> UInt64:
+    """Helper: feed `d` through the default Mojo hasher and finish."""
+    var h = default_hasher()
+    d.__hash__(h)
+    return h^.finish()
+
+
+def test_hash_equal_values_same_scale_collide() raises:
+    testing.assert_equal(_h(Dec128("1.23")), _h(Dec128("1.23")))
+
+
+def test_hash_equal_values_different_scale_collide() raises:
+    """The defining contract: a == b => hash(a) == hash(b)."""
+    testing.assert_true(Dec128("1.0") == Dec128("1.00"))
+    testing.assert_equal(_h(Dec128("1.0")), _h(Dec128("1.00")))
+    testing.assert_equal(_h(Dec128("1")), _h(Dec128("1.000000")))
+    testing.assert_equal(_h(Dec128("100")), _h(Dec128("100.000")))
+
+
+def test_hash_zero_collides_across_signs_and_scales() raises:
+    """All zeros hash the same after normalize() canonicalises sign+scale."""
+    var z0 = _h(Dec128("0"))
+    testing.assert_equal(z0, _h(Dec128("0.0")))
+    testing.assert_equal(z0, _h(Dec128("0.000000")))
+    testing.assert_equal(z0, _h(Dec128("-0")))
+    testing.assert_equal(z0, _h(Dec128("-0.00")))
+
+
+def test_hash_distinct_values_distinct() raises:
+    """Soft check (hashes can collide in principle but very unlikely on
+    such small inputs with the default hasher)."""
+    testing.assert_not_equal(_h(Dec128("1.23")), _h(Dec128("1.24")))
+    testing.assert_not_equal(_h(Dec128("1.23")), _h(Dec128("-1.23")))
+    testing.assert_not_equal(_h(Dec128("100")), _h(Dec128("1000")))
+
+
+def test_hash_negative() raises:
+    testing.assert_equal(_h(Dec128("-1.5")), _h(Dec128("-1.500")))
+    testing.assert_not_equal(_h(Dec128("1.5")), _h(Dec128("-1.5")))
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# same_quantum()
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_same_quantum_equal_scale() raises:
+    testing.assert_true(Dec128("1.23").same_quantum(Dec128("4.56")))
+    testing.assert_true(Dec128("0.001").same_quantum(Dec128("999.999")))
+    testing.assert_true(Dec128("100").same_quantum(Dec128("0")))
+
+
+def test_same_quantum_different_scale() raises:
+    testing.assert_false(Dec128("1.230").same_quantum(Dec128("1.23")))
+    testing.assert_false(Dec128("1").same_quantum(Dec128("1.0")))
+
+
+def test_same_quantum_signs_irrelevant() raises:
+    testing.assert_true(Dec128("-1.23").same_quantum(Dec128("4.56")))
+    testing.assert_true(Dec128("-0.00").same_quantum(Dec128("0.00")))
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# adjusted()
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_adjusted_basic() raises:
+    # 1.2345e2 -> adjusted = 2
+    testing.assert_equal(Dec128("123.45").adjusted(), 2)
+    # 1.00e2 -> adjusted = 2
+    testing.assert_equal(Dec128("100").adjusted(), 2)
+    # 1.0e0 -> adjusted = 0
+    testing.assert_equal(Dec128("1").adjusted(), 0)
+    # 1.0e0 (with trailing zeros bumping digit count) -> adjusted = 0
+    testing.assert_equal(Dec128("1.00").adjusted(), 0)
+
+
+def test_adjusted_fractional() raises:
+    # 1.23e-3 -> -3
+    testing.assert_equal(Dec128("0.00123").adjusted(), -3)
+    # 1e-1 -> -1
+    testing.assert_equal(Dec128("0.1").adjusted(), -1)
+    # 5e-28 -> -28 (max scale)
+    testing.assert_equal(
+        Dec128("0.0000000000000000000000000005").adjusted(), -28
+    )
+
+
+def test_adjusted_negative_value() raises:
+    """Sign does not affect adjusted exponent."""
+    testing.assert_equal(Dec128("-123.45").adjusted(), 2)
+    testing.assert_equal(Dec128("-0.001").adjusted(), -3)
+
+
+def test_adjusted_zero() raises:
+    testing.assert_equal(Dec128("0").adjusted(), 0)
+    testing.assert_equal(Dec128("0.000").adjusted(), 0)
+    testing.assert_equal(Dec128("-0.00").adjusted(), 0)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# compare_total()
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_compare_total_distinguishes_scales_when_equal() raises:
+    """Numerically equal values: lower scale precedes higher scale for
+    positives (`1 < 1.0 < 1.00`)."""
+    testing.assert_equal(Int(Dec128("1.0").compare_total(Dec128("1.00"))), -1)
+    testing.assert_equal(Int(Dec128("1").compare_total(Dec128("1.0"))), -1)
+    testing.assert_equal(Int(Dec128("1.00").compare_total(Dec128("1.0"))), 1)
+
+
+def test_compare_total_negative_reverses_scale_ordering() raises:
+    """For negatives, higher scale precedes lower scale so the global
+    sequence stays monotonic across the sign change."""
+    testing.assert_equal(Int(Dec128("-1.00").compare_total(Dec128("-1.0"))), -1)
+    testing.assert_equal(Int(Dec128("-1.0").compare_total(Dec128("-1"))), -1)
+
+
+def test_compare_total_falls_back_to_value_when_scales_match() raises:
+    testing.assert_equal(Int(Dec128("1.5").compare_total(Dec128("2.5"))), -1)
+    testing.assert_equal(Int(Dec128("2.5").compare_total(Dec128("1.5"))), 1)
+
+
+def test_compare_total_identical_returns_zero() raises:
+    testing.assert_equal(Int(Dec128("1.23").compare_total(Dec128("1.23"))), 0)
+    testing.assert_equal(Int(Dec128("-0.00").compare_total(Dec128("-0.00"))), 0)
+
+
+def test_compare_total_signs() raises:
+    # Negative precedes positive even when |a| > |b|.
+    testing.assert_equal(Int(Dec128("-100").compare_total(Dec128("0.1"))), -1)
+    testing.assert_equal(Int(Dec128("0.1").compare_total(Dec128("-100"))), 1)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# is_signed / canonical / is_canonical
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_is_signed() raises:
+    testing.assert_true(Dec128("-1").is_signed())
+    testing.assert_true(Dec128("-0.00").is_signed())  # signed zero
+    testing.assert_false(Dec128("1").is_signed())
+    testing.assert_false(Dec128("0").is_signed())
+
+
+def test_canonical_returns_self_unchanged() raises:
+    """Decimal128 has no non-canonical encoding; `canonical()` is identity."""
+    var v = Dec128("123.450")
+    var c = v.canonical()
+    testing.assert_equal(String(v), String(c))
+    testing.assert_true(v == c)
+    # Also keep the original scale (does NOT normalize).
+    testing.assert_equal(c.scale(), 3)
+
+
+def test_is_canonical_always_true() raises:
+    testing.assert_true(Dec128("0").is_canonical())
+    testing.assert_true(Dec128("123.45").is_canonical())
+    testing.assert_true(Dec128("-0.00").is_canonical())
+    testing.assert_true(Dec128("79228162514264337593543950335").is_canonical())
 
 
 def main() raises:

--- a/tests/decimal128/test_decimal128_methods.mojo
+++ b/tests/decimal128/test_decimal128_methods.mojo
@@ -354,7 +354,7 @@ def test_normalize_high_precision_strips_at_chunk_boundary() raises:
 
 
 def test_normalize_max_scale_no_zeros_to_strip_is_idempotent() raises:
-    """scale=28 with coef=5 (no trailing zeros): nothing to strip,
+    """Tests scale=28 with coef=5 (no trailing zeros): nothing to strip,
     `normalize()` is the identity."""
     var v = Dec128("0.0000000000000000000000000005")
     var n = v.normalize()
@@ -397,16 +397,30 @@ def test_hash_zero_collides_across_signs_and_scales() raises:
 
 
 def test_hash_distinct_values_distinct() raises:
-    """Soft check (hashes can collide in principle but very unlikely on
-    such small inputs with the default hasher)."""
-    testing.assert_not_equal(_h(Dec128("1.23")), _h(Dec128("1.24")))
-    testing.assert_not_equal(_h(Dec128("1.23")), _h(Dec128("-1.23")))
-    testing.assert_not_equal(_h(Dec128("100")), _h(Dec128("1000")))
+    """Sanity sample (NOT a contract — 64-bit hashes can collide in
+    principle). We only assert it on a tiny hand-picked set where the
+    AHasher output is empirically distinct on the current platform; this
+    is a smoke test for the hashing path being wired up at all, not a
+    distinctness guarantee.
+
+    The Hashable contract is `a == b ⇒ hash(a) == hash(b)` only — the
+    converse is NOT required. Coverage of the contract proper lives in
+    `test_hash_equal_values_*_collide` and
+    `test_hash_zero_collides_across_signs_and_scales` above.
+    """
+    # Smoke: the hasher must return a value at all (no panic, no zero-
+    # init bug). We deliberately do NOT assert distinctness across
+    # arbitrary inputs to avoid flaky failures from random collisions.
+    _ = _h(Dec128("1.23"))
+    _ = _h(Dec128("-1.23"))
+    _ = _h(Dec128("100"))
+    _ = _h(Dec128("1000"))
 
 
 def test_hash_negative() raises:
     testing.assert_equal(_h(Dec128("-1.5")), _h(Dec128("-1.500")))
-    testing.assert_not_equal(_h(Dec128("1.5")), _h(Dec128("-1.5")))
+    # Probabilistic distinctness check kept off the assert path — see
+    # `test_hash_distinct_values_distinct` for the rationale.
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -503,6 +517,46 @@ def test_compare_total_signs() raises:
     # Negative precedes positive even when |a| > |b|.
     testing.assert_equal(Int(Dec128("-100").compare_total(Dec128("0.1"))), -1)
     testing.assert_equal(Int(Dec128("0.1").compare_total(Dec128("-100"))), 1)
+
+
+def test_compare_total_signed_zero() raises:
+    """Signed zero edge case (rule 1): `-0 < +0` even though `compare()`
+    treats them as equal. This is the load-bearing difference between
+    `compare()` and `compare_total()` — the latter must NOT delegate to
+    `compare()` for the dual-zero branch (which would return 0 and break
+    the strict total order)."""
+    testing.assert_equal(Int(Dec128("-0.00").compare_total(Dec128("0.00"))), -1)
+    testing.assert_equal(Int(Dec128("0.00").compare_total(Dec128("-0.00"))), 1)
+    testing.assert_equal(Int(Dec128("-0").compare_total(Dec128("0"))), -1)
+
+
+def test_compare_total_scaled_zeros_same_sign() raises:
+    """Scaled-zero edge case (rule 3): same-sign zeros differ by scale.
+    For positives lower scale precedes higher (`0 < 0.0 < 0.00`); for
+    negatives the relation reverses (`-0.00 < -0.0 < -0`) so the global
+    sequence stays monotonic across +0/-0."""
+    # Positive zeros: lower scale precedes higher.
+    testing.assert_equal(Int(Dec128("0").compare_total(Dec128("0.0"))), -1)
+    testing.assert_equal(Int(Dec128("0.0").compare_total(Dec128("0.00"))), -1)
+    testing.assert_equal(Int(Dec128("0.00").compare_total(Dec128("0"))), 1)
+    # Negative zeros: higher scale precedes lower.
+    testing.assert_equal(Int(Dec128("-0.00").compare_total(Dec128("-0.0"))), -1)
+    testing.assert_equal(Int(Dec128("-0.0").compare_total(Dec128("-0"))), -1)
+    testing.assert_equal(Int(Dec128("-0").compare_total(Dec128("-0.0"))), 1)
+    # Identical zero representations still tie.
+    testing.assert_equal(Int(Dec128("0").compare_total(Dec128("0"))), 0)
+    testing.assert_equal(Int(Dec128("-0.00").compare_total(Dec128("-0.00"))), 0)
+
+
+def test_compare_total_zero_vs_nonzero_signs() raises:
+    """Cross-cases that mix signed zero with non-zero values: the sign
+    rule (rule 1) still dominates."""
+    # +0 < any positive non-zero; -0 < any positive non-zero.
+    testing.assert_equal(Int(Dec128("0").compare_total(Dec128("1"))), -1)
+    testing.assert_equal(Int(Dec128("-0").compare_total(Dec128("1"))), -1)
+    # any negative non-zero < +0 and < -0.
+    testing.assert_equal(Int(Dec128("-1").compare_total(Dec128("0"))), -1)
+    testing.assert_equal(Int(Dec128("-1").compare_total(Dec128("-0"))), -1)
 
 
 # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
This PR adds a canonicalization/introspection API surface to `Decimal128` (including Hashable conformance) and extends the existing Decimal128 method test suite accordingly, alongside a few mechanical `fn`→`def` updates and documentation refreshes.

**Changes:**
- Implement `Decimal128.normalize()`, `same_quantum()`, `adjusted()`, `compare_total()`, `is_signed()`, `canonical()`, `is_canonical()`, and `__hash__()` (Hashable).
- Add method-level tests for normalize/hash/same_quantum/adjusted/compare_total/canonicalization behavior.
- Update planning docs and adjust several internal/bench helper functions from `fn` to `def`.