### PR TITLE
[core][decimal] Create alias for imports + Make `round_to_precision` allocation-free

### DIFF
--- a/benches/bigdecimal/mojo/bench.mojo
+++ b/benches/bigdecimal/mojo/bench.mojo
@@ -20,7 +20,7 @@ from decimo.bigdecimal.exponential import exp as bd_exp
 from decimo.bigdecimal.exponential import ln as bd_ln
 from decimo.bigdecimal.exponential import root as bd_root
 from decimo.bigdecimal.rounding import round as bd_round
-from decimo.bigdecimal.rounding import round_to_precision
+from decimo.bigdecimal.rounding import round_to_precision_inplace
 from decimo.rounding_mode import RoundingMode
 from decimo.tests import (
     BenchCase,
@@ -93,7 +93,7 @@ def _cmp_3way(read a: BigDecimal, read b: BigDecimal) raises -> String:
 
 def _round_to_prec(var v: BigDecimal, precision: Int) raises -> BigDecimal:
     """Round `v` to `precision` significant digits (HALF_EVEN), in-place."""
-    round_to_precision(
+    round_to_precision_inplace(
         v,
         precision,
         RoundingMode.ROUND_HALF_EVEN,

--- a/benches/decimal128/.gitignore
+++ b/benches/decimal128/.gitignore
@@ -13,6 +13,7 @@ rust/Cargo.lock
 # C# build output.
 csharp/bin/
 csharp/obj/
+csharp/*.lscache
 
 # VB.NET build output.
 vbnet/bin/

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,11 +4,22 @@ This is a list of changes for the Decimo package (formerly DeciMojo).
 
 ## 20260514 (v0.10.0)
 
-Decimo v0.10.0 retargets the codebase to **Mojo v1.0.0b1** and rounds out the **Decimal128** API to feature parity with `BigDecimal` / Python `decimal.Decimal`. This release also introduces a new **`Rational`** type, a small **`limo`** line-editor package powering the REPL, and a thoroughly reworked error system with concrete error types instead of a single catch-all.
+Decimo v0.10.0 updates the codebase to **Mojo v1.0.0b1** and marks the **"polish and parity"** phase. This release introduces four major additions.
 
-The **CLI calculator** is now distributed as a self-contained binary via the `forfudan` Homebrew tap — `brew install forfudan/tap/decimo` (macOS arm64 and Linux x86_64; no Mojo or Pixi needed on the user's machine).
+First, the **`Decimal128`** API reaches feature parity with `BigDecimal` and Python's `decimal.Decimal` / IEEE 754: `fma()`, `__divmod__()`, `from_decimal(BigDecimal)`, `cbrt()`, `normalize()`, `__hash__()`, `same_quantum()`, `max` / `min` / `clamp`, `trunc` / `floor` / `ceil` / `fract` / `signum` / `unpack`, `__bool__` / `__pos__`, and a unified `to_string` family with `scientific` / `engineering` / `delimiter` keywords. The `nan` / `inf` values are removed — `Decimal128` is now a strict finite type — and the arithmetic and string hot paths are heavily optimised.
+
+Second, **`BigDecimal`** operator semantics are aligned with Python's `decimal.Decimal`: `+`, `-`, `*` now round HALF_EVEN to the default precision (`PRECISION = 28`) instead of returning unrounded results. New explicit-precision methods `add(other, precision=0)` / `subtract(...)` / `multiply(...)` (and `*_inplace` variants) let callers choose between exact and rounded arithmetic. Internal `pi_machin` / `exp` / `ln` / trig sites switch to the exact `*_inplace` path, and the **CLI calculator's RPN evaluator** now honors `--precision` end to end.
+
+Third, the **CLI calculator** is now distributed as a self-contained binary. A new `release_cli` workflow builds tarballs for **macOS arm64** and **Linux x86_64** (Mojo runtime bundled, `rpath` patched) and publishes them via the [`forfudan/tap`](https://github.com/forfudan/homebrew-tap) Homebrew tap — `brew install forfudan/tap/decimo` and Mojo / Pixi are no longer required on the user's machine. The CLI itself gains a Mojo-native line editor **`limo`** (REPL editing, history, cursor movement); pipe / stdin and file modes (`-F`); shell-completion docs for Bash / Zsh / Fish; REPL info commands (`:`, `?`, `$`, `:q`, `:info`); the `ans` variable; user-defined variables; a `:100` precision shortcut; and case-insensitive input.
+
+Fourth, the codebase gains two new core types and a reworked error system. **`BigFloat`** is an arbitrary-precision binary floating-point type backed by **GMP / MPFR** through a thin C wrapper (`src/decimo/gmp/gmp_wrapper.c`, `src/decimo/bigfloat/mpfr_wrapper.mojo`); every operation is a single MPFR call against a pooled `mpfr_t` handle, precision is in decimal digits with 64 guard bits added internally, and the type is the right choice when MPFR-quality transcendentals or a wider exponent range than `BigDecimal` are wanted. MPFR/GMP must be present at runtime (PR #190, #191). **`Rational`** is a new exact rational number type, stored as a reduced fraction of two `Integer`s (PR #214). The **error system** replaces the catch-all `DecimoError` with concrete types such as `RuntimeError`, makes `message` and `function` mandatory, and renders coloured errors with auto-inferred shortened-relative file/line info (PR #195, #196, #198, #200); `raises:` docstring sections are audited (PR #199) and every public symbol now carries a docstring (PR #194).
 
 ### ⭐️ New in v0.10.0
+
+**New core types:**
+
+1. New **`BigFloat`** type (alias `BFlt`, `Float`) — arbitrary-precision **binary floating-point** wrapping a single MPFR handle via a C wrapper. Each arithmetic and transcendental operation is a single MPFR call against a pooled `mpfr_t` handle. Precision is specified in decimal digits and converted to bits internally; 64 guard bits are added so the requested decimal digits are correct. Provides `+ - * /`, `sqrt`, `cbrt`, `root`, `pow`, `exp`, `ln`, `log`, `log10`, full trig and hyperbolic suite, comparison and rounding, plus conversion to / from `BigDecimal`. RAII destructor frees the MPFR handle. Optional — requires MPFR/GMP to be installed at runtime; the C wrapper is built via `pixi run buildgmp` (PR #190, #191).
+1. New **`Rational`** type — arbitrary-precision exact rational number, stored as a reduced fraction of two `Integer`s. Supports exact arithmetic and comparisons without precision loss (PR #214).
 
 **Decimal128 — feature parity with Python `decimal.Decimal`:**
 
@@ -28,13 +39,17 @@ The **CLI calculator** is now distributed as a self-contained binary via the `fo
 
 1. New **`limo`** package — a small Mojo-native line editor used by the REPL for line editing and history navigation (PR #212).
 1. Interactive **REPL**: `decimo` with no arguments launches a coloured `decimo>` prompt with per-line error recovery, comment/blank-line skipping, and graceful exit via `exit` / `quit` / Ctrl-D (PR #205).
-1. **REPL info commands**: `:` shows current settings, `?` shows help, `$` / `:v` / `:vars` lists variables, `:q` / `:quit` / `:exit` exits.
+1. **REPL info commands**: `:` shows current settings, `?` shows help, `$` / `:v` / `:vars` lists variables, `:q` / `:quit` / `:exit` exits (PR #210, #211).
+1. **REPL `:info` / `:about` section** — print version, author, license, and project links from inside the REPL (PR #213).
+1. **REPL configuration system** — settings commands (`:p`, `:scientific`, etc.) now print the full settings block after every change so the effect is immediately visible; multiple flags can be set on a single line (PR #208).
 1. **Variable assignment** in REPL (`x = 1+2`) plus the `ans` variable holding the last result (PR #206).
-1. **Pipe / stdin mode**: read expressions from piped stdin, one per line (e.g. `echo "1+2" | decimo`). Comments and blank lines are skipped.
-1. **File mode** (`--file` / `-F`): evaluate expressions from a file, one per line, sharing all CLI flags.
-1. **Shell completion** documentation for Bash, Zsh, and Fish (`decimo --completions bash|zsh|fish`).
-1. **Standalone-precision shortcut** in settings: `:100` is equivalent to `:p 100`.
-1. Case-insensitive REPL input (`PI`, `Sqrt(2)`, `SIN(1)` all work).
+1. **Pipe / stdin mode**: read expressions from piped stdin, one per line (e.g. `echo "1+2" | decimo`). Comments and blank lines are skipped (PR #203).
+1. **File mode** (`--file` / `-F`): evaluate expressions from a file, one per line, sharing all CLI flags (PR #203).
+1. **Negative numbers and negative expressions** as positional CLI arguments (PR #201, #202).
+1. **Argument parsing polish** — range / value-name / argument-group validation, custom usage line, all short option names upper-cased (PR #201, #203).
+1. **Shell completion** documentation for Bash, Zsh, and Fish (`decimo --completions bash|zsh|fish`) (PR #204).
+1. **Standalone-precision shortcut** in settings: `:100` is equivalent to `:p 100` (PR #211).
+1. Case-insensitive REPL input (`PI`, `Sqrt(2)`, `SIN(1)` all work) (PR #210).
 
 **Error handling:**
 
@@ -46,10 +61,6 @@ The **CLI calculator** is now distributed as a self-contained binary via the `fo
 
 1. New **`release_cli`** workflow building self-contained `decimo` CLI tarballs for **macOS arm64** and **Linux x86_64**; published via the `forfudan/tap` Homebrew tap (`brew install forfudan/tap/decimo`).
 1. Bundled third-party licenses are now documented in `NOTICE` and shipped in the source tarball (PR #231).
-
-**Core types:**
-
-1. New **`Rational`** type — arbitrary-precision exact rational number, stored as a reduced fraction of two `Integer`s. Supports exact arithmetic and comparisons without precision loss (PR #214).
 
 ### 🦋 Changed in v0.10.0
 
@@ -87,6 +98,10 @@ The **CLI calculator** is now distributed as a self-contained binary via the `fo
 1. **Removed `Decimal128.copy()` / `clone()`**: trivial and unused. `Decimal128` is `TrivialRegisterPassable`, so `var b = a` is the idiomatic copy.
 1. **Removed `Decimal128.print_internal_representation()`**: one-line wrapper, unused. Use `print(x.internal_representation())` directly.
 
+**BigInt:**
+
+1. Rewrite type conversion from all integral scalar types (`Int`, `UInt`, `IntLiteral`, `Scalar[DType.intN]`, `Scalar[DType.uintN]`) so that every integral scalar can be converted to `BigInt` / `BigUInt` correctly, including the corner case of `Int.MIN` and signed-to-unsigned narrowing (PR #189).
+
 ### 🐛 Fixed in v0.10.0
 
 1. **`BigDecimal.to_string(force_plain=True)` dropping trailing zeros for `scale < 0`**: `BigDecimal("1e40").to_string(force_plain=True)` previously returned `"1"` instead of the full 41-digit integer, silently producing a wrong value when re-parsed (e.g. via `Decimal128.from_decimal()`).
@@ -96,11 +111,13 @@ The **CLI calculator** is now distributed as a self-contained binary via the `fo
 
 1. Ensure all functions, fields, and constants have docstrings; eliminates `mojo doc` warnings (PR #194).
 1. Reorganise the `docs/` folder and update user-facing manuals (PR #207).
+1. Add planning documents `docs/plans/gmp_integration.md` (kicks off the GMP/MPFR integration that lands as `BigFloat`) and `docs/plans/decimal128_enhancement.md` (roadmap for Decimal128 parity work in this release) (PR #190, #193).
 1. Refactor the GitHub Actions unit-test workflow to use caching for faster CI (PR #234).
 1. Consolidate the Decimal128 test suites into fewer files (`test_decimal128_arithmetics.mojo`, `test_decimal128_creation.mojo`, etc.) for faster compilation (PR #228).
 1. Refactor cross-language benchmark harness to include **Rust (`rust_decimal`)**, **C# (`System.Decimal`)**, and **VB.NET** (PR #219); `BigDecimal` acts as the high-precision oracle for `ln` / `log10` / `exp` (PR #229).
 1. Add **CLI performance benchmarks** comparing correctness and timing against `bc` and `python3` across 47 cases — all results match to 15 significant digits; `decimo` is **3–4× faster than `python3 -c`** (PR #204).
 1. Refactor BigDecimal benchmark suites (PR #232); add edge-case tests for `compare_absolute()` (PR #217); refactor test files to a CLI argument style (PR #209).
+1. Document bundled third-party libraries in `NOTICE` and ship their licenses in the source tarball (PR #231).
 
 ## 20260323 (v0.9.0)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,27 @@
 
 This is a list of changes for the Decimo package (formerly DeciMojo).
 
+## Unreleased
+
+1. **Renamed `BigDecimal` rounding APIs to `*_inplace`.**
+   The free function `decimo.bigdecimal.rounding.round_to_precision` and
+   the `BigDecimal.round_to_precision` method were renamed to
+   `round_to_precision_inplace` to make their mutating semantics
+   explicit. Callers must update import and call sites. The
+   out-of-place, Python-compatible `BigDecimal.round(ndigits=...)` API
+   is unchanged. See PR #245 / roadmap task T-R2.
+1. Routed `round_to_precision` through a fully in-place path, removing
+   one `BigUInt` allocation + buffer copy from 6 call sites in
+   `bigdecimal/arithmetics.mojo` (3 × `divide`) and
+   `bigdecimal/exponential.mojo`. The out-of-place
+   `BigUInt.remove_trailing_digits_with_rounding` is now a thin
+   `copy + inplace` wrapper (~110 LOC removed). Added an optional
+   `ndigits_before_removal` hint parameter so callers that already know
+   `self.number_of_digits()` skip the redundant inner pass.
+   Measured impact on `divide` (p = 100 / 1000 / 10000) is within ±1 %
+   run-to-run noise; the cleanup is kept for code quality and will
+   compound on future rounding-dominated fast paths.
+
 ## 20260514 (v0.10.0)
 
 Decimo v0.10.0 updates the codebase to **Mojo v1.0.0b1** and marks the **"polish and parity"** phase. This release introduces four major additions.

--- a/docs/plans/bigdecimal_enhancement.md
+++ b/docs/plans/bigdecimal_enhancement.md
@@ -455,13 +455,23 @@ P7 — `round` (2× py → target ≤1.0×)
   copy each). The out-of-place
   `BigUInt.remove_trailing_digits_with_rounding` was de-duplicated
   into a thin `copy + inplace` wrapper (~110 lines removed).
-  **Measured impact on divide bench (p=100/1000/10000):** ~0%
-  (162.5→163.75, 741.9→747.3, 6717→6731 ns/iter — within noise).
-  The per-call alloc saving is real but is dominated by the cost of
-  the divide itself. The cleanup is kept for code quality and
-  because the saving will compound on future rounding-dominated
-  fast paths (e.g. small-coefficient `add`/`subtract`/`multiply`
-  with `precision > 0`).
+  Additionally, a `ndigits_before_removal: Int = -1` parameter was
+  added to the inplace path so callers that already computed
+  `number_of_digits()` (the public `round()`,
+  `round_to_precision_inplace`, all 3 divide callsites, and the 1
+  exp callsite) can skip the redundant inner `number_of_digits()`
+  pass. As part of the audit the inplace function's primary
+  parameter was also renamed from `ndigits` to `ndigits_to_remove`
+  for self-documenting clarity (the public Python-compatible
+  `round(ndigits=...)` API is unchanged).
+  **Measured impact on divide bench (p=100/1000/10000):** ~0% in
+  every run — the per-call alloc and `number_of_digits()` savings
+  are dominated by the cost of the divide itself and stay inside
+  run-to-run noise (±1%). The cleanup is kept for code quality
+  (~110 LOC removed, mutating semantics now visible in the name)
+  and because the saving will compound on future
+  rounding-dominated fast paths (e.g. small-coefficient `add` /
+  `subtract` / `multiply` with `precision > 0`).
 
 ### 5.3 Long-term tasks not on the active roadmap
 

--- a/docs/plans/bigdecimal_enhancement.md
+++ b/docs/plans/bigdecimal_enhancement.md
@@ -18,15 +18,15 @@ fuller historical view is needed.
 Scope: **arbitrary-precision** decimal types. Out of scope: 128-bit
 fixed-precision (covered by `decimal128_enhancement.md`).
 
-| Library                 | Limb base           | Mul algorithm tier               | Div algo           | Sqrt              |
-| ----------------------- | ------------------- | -------------------------------- | ------------------ | ----------------- |
-| **decimo BigDecimal**   | 10^9 (UInt32 LE)    | School → Karatsuba → Toom-3      | B-Z (Knuth-D base) | reciprocal-Newton |
-| Python `decimal`/libmpd | 10^9 / 10^19        | School → Karatsuba → **NTT**     | reciprocal-Newton  | reciprocal-Newton |
-| Rust `bigdecimal` 0.4   | 10^9 (num-bigint)   | School → Karatsuba → Toom-3      | schoolbook (slow)  | Newton with div   |
-| Java `BigDecimal`       | binary `BigInteger` | School → Kara → Toom → Schönhage | Burnikel-Ziegler   | Newton (binary)   |
-| GMP `mpz_t` / MPFR      | 2^64                | School → Kara → Toom → **FFT**   | reciprocal-Newton  | reciprocal-Newton |
-| JS `decimal.js`         | 10^7 (Number arr)   | School only                      | schoolbook         | Newton            |
-| Go `math/big.Float`     | 2^64 (binary)       | School → Karatsuba               | reciprocal-Newton  | Newton            |
+| Library             | Limb base           | Mul algorithm tier               | Div algo           | Sqrt              |
+| ------------------- | ------------------- | -------------------------------- | ------------------ | ----------------- |
+| decimo BigDecimal   | 10^9 (UInt32 LE)    | School → Karatsuba → Toom-3      | B-Z (Knuth-D base) | reciprocal-Newton |
+| Py `decimal`/libmpd | 10^9 / 10^19        | School → Karatsuba → **NTT**     | reciprocal-Newton  | reciprocal-Newton |
+| Rust `bigdecimal`   | 10^9 (num-bigint)   | School → Karatsuba → Toom-3      | schoolbook (slow)  | Newton with div   |
+| Java `BigDecimal`   | binary `BigInteger` | School → Kara → Toom → Schönhage | Burnikel-Ziegler   | Newton (binary)   |
+| GMP `mpz_t` / MPFR  | 2^64                | School → Kara → Toom → **FFT**   | reciprocal-Newton  | reciprocal-Newton |
+| JS `decimal.js`     | 10^7 (Number arr)   | School only                      | schoolbook         | Newton            |
+| Go `math/big.Float` | 2^64 (binary)       | School → Karatsuba               | reciprocal-Newton  | Newton            |
 
 **Coverage matrix.** decimo offers the broadest decimal API: `add`,
 `subtract`, `multiply`, `divide`, `sqrt`, `cbrt`, `root(x,n)`, `exp`,
@@ -61,18 +61,22 @@ Dated by report file under `benches/bigdecimal/reports/`. Append-only.
 
 ### 2.3 Performance — arithmetic & analytic ops
 
-| Date     | Tag | Item                                                                               |
-| -------- | --- | ---------------------------------------------------------------------------------- |
-| 20260221 | T1  | Asymmetric divide truncation: `extra_words = ceil(P/9)+2 - diff_n_words`           |
-| 20260223 | T2  | Balanced divide also truncates; quotient near constant time vs operand size        |
-| 20260222 | T3a | `MathCache` for `ln(2)`/`ln(1.25)` — log() shares 2 internal ln() calls            |
-| 20260222 | T3b | UInt32 division in Taylor series (was full BigDecimal divide per term)             |
-| 20260222 | T3c | `get_ln10()` in MathCache (reuses cached `ln(2)` & `ln(1.25)`)                     |
-| 20260224 | T3d | Aggressive halving range reduction for exp: $M \approx \sqrt{3.322p}$              |
-| 20260222 | T4  | sqrt via reciprocal-Newton with precision doubling at BigDecimal level (no divide) |
-| 20260222 | T7a | `integer_root` via direct Newton (was `exp(ln(x)/n)`)                              |
-| 20260223 | T8  | BigDecimal in-place ops applied across exp/ln/sin/cos/arctan Taylor loops          |
-| 20260224 | T6  | Toom-3 multiplication, cutoff 128 words; +14–29% over Karatsuba for ≥256 words     |
+| Date     | Tag  | Item                                                                               |
+| -------- | ---- | ---------------------------------------------------------------------------------- |
+| 20260221 | T1   | Asymmetric divide truncation: `extra_words = ceil(P/9)+2 - diff_n_words`           |
+| 20260223 | T2   | Balanced divide also truncates; quotient near constant time vs operand size        |
+| 20260222 | T3a  | `MathCache` for `ln(2)`/`ln(1.25)` — log() shares 2 internal ln() calls            |
+| 20260222 | T3b  | UInt32 division in Taylor series (was full BigDecimal divide per term)             |
+| 20260222 | T3c  | `get_ln10()` in MathCache (reuses cached `ln(2)` & `ln(1.25)`)                     |
+| 20260224 | T3d  | Aggressive halving range reduction for exp: $M \approx \sqrt{3.322p}$              |
+| 20260222 | T4   | sqrt via reciprocal-Newton with precision doubling at BigDecimal level (no divide) |
+| 20260222 | T7a  | `integer_root` via direct Newton (was `exp(ln(x)/n)`)                              |
+| 20260223 | T8   | BigDecimal in-place ops applied across exp/ln/sin/cos/arctan Taylor loops          |
+| 20260224 | T6   | Toom-3 multiplication, cutoff 128 words; +14–29% over Karatsuba for ≥256 words     |
+| 20260516 | T-R2 | `round_to_precision_inplace` routed through fully in-place BigUInt path;           |
+|          |      | 6 callsites converted + free function/method renamed; `round()` rewritten as       |
+|          |      | copy+inplace; `BigUInt.remove_trailing_digits_with_rounding` de-duplicated to      |
+|          |      | thin wrapper                                                                       |
 
 ### 2.4 Performance tracking — absolute decimo median ns/iter (ascending precision)
 
@@ -132,40 +136,58 @@ kernels (parse/render are precision-insensitive ops).
 
 ## 3. Hypothesis Ledger
 
-| H#  | Hypothesis                                                    | Outcome                                                             |
-| --- | ------------------------------------------------------------- | ------------------------------------------------------------------- |
-| 1   | Asymmetric divide pads quotient unnecessarily                 | DONE (T1) — 0.11→76× py at 65536w/32768w                            |
-| 2   | Balanced divide also wastes work for high-precision req       | DONE (T2) — quotient near-constant time (8–915× py)                 |
-| 3a  | `ln(2)`/`ln(1.25)` recomputed per call                        | DONE (T3a) — `MathCache`; 3×–4.5× speedup for repeated `ln()`       |
-| 3b  | Per-Taylor-term BigDecimal divide is wasteful                 | DONE (T3b) — UInt32 divide path; +20–130% near-1 ln                 |
-| 3c  | `log10()`/`log()` re-compute `ln(10)`                         | DONE (T3c) — cached via `MathCache`                                 |
-| 3d  | exp Taylor series too long; weak halving                      | DONE (T3d) — $M=\sqrt{3.322p}$; exp 0.4×→2.6× py at p=1000          |
-| 3e  | Binary splitting for ln Taylor series                         | OPEN — diminishing returns for exp post-T3d; ln still O(p) terms    |
-| 3f  | `atanh` reformulation for ln (3× fewer terms)                 | OPEN — easy win; estimated 3× near-1                                |
-| 3g  | AGM-based ln for very high precision                          | OPEN — long-term, complex                                           |
-| 4   | sqrt via Newton-with-division is slow                         | DONE (T4) — reciprocal-Newton + precision doubling; 20× improvement |
-| 5   | NTT multiplication for n ≥ 1024 words                         | OPEN — single biggest long-term gap vs libmpdec                     |
-| 6   | Toom-3 between Karatsuba and NTT                              | DONE (T6) — +14–29% for ≥256w                                       |
-| 7a  | `integer_root` via direct Newton (was exp(ln(x)/n))           | DONE (T7a) — 0.14×→25× py at p=1000 for cbrt                        |
-| 7b  | Reciprocal-Newton for nth root (no divide)                    | OPEN — estimated 1.5–2×                                             |
-| 7c  | Rational decomposition $x^{a/b}$ → root then power            | OPEN — fractional roots still 0.2–0.4× py                           |
-| 8   | BigDecimal-level inplace ops in Taylor loops                  | DONE (T8) — +15–27% exp/ln, +9% sqrt                                |
-| 9   | SIMD schoolbook multiply base                                 | OPEN — 1.5–2× constant-factor                                       |
-| 10  | `debug_assert(..., "{}".format(...))` eager allocation        | OPEN — sweep BigUInt + BigDecimal hot paths (Lesson #7)             |
-| 11  | Hot-path-first switch reorder in BigDecimal `add`/`sub`       | OPEN — same-scale & same-sign branch first (Lesson #12)             |
-| 12  | `@no_inline` raise helpers in BigDecimal/BigUInt              | OPEN — sweep `from_string`, `from_uint32`, etc. (Lesson #10)        |
-| 13  | `from_string` digit batching (UInt64 chunks of 9 or 19)       | OPEN — borrowed from decimal128 H#17 follow-up                      |
-| 14  | `to_string` `InlineArray` right-aligned chunked emit          | OPEN — borrowed from decimal128 §2.4                                |
-| 15  | Single-pass rounding in BigDecimal `multiply` / `divide`      | OPEN — borrowed from decimal128 H#16                                |
-| 16  | Short-divisor fast path in `divide` (single-word loop)        | OPEN — `BigUInt.floor_divide_by_uint32` exists; lift to BigDecimal  |
-| 17  | Add/sub `multiply_by_power_of_ten` allocates oversized        | OPEN — root cause of 4.7× py on small-precision add                 |
-| 18  | Small-coefficient mul fast path (bypass Karatsuba dispatch)   | OPEN — borrowed from decimal128 H#4 dispatch-overhead lesson        |
-| 19  | `precision` arg on `add`/`sub`/`multiply`                     | DONE (PR #233) — see T-API3                                         |
-| 20  | Private functions with `_`; Replace raises with debug asserts | OPEN — improves runtime performance by avoiding unnecessary checks  |
-| 21  | More inplace variants for `BigUInt` and `BigDecimal`          | OPEN — further reduces allocations and improves performance         |
-| 22  | Zero-copy scale alignment via word-offset add/sub             | DISPROVEN — see T-API2                                              |
-| 23  | Drop multiply pre-scaling; adjust scale on result             | OPEN — see T-API2.M                                                 |
-| 24  | `round_to_precision` in-place audit                           | OPEN — see T-R2                                                     |
+| H#  | Hypothesis                                    | Outcome                                                                                                                                               |
+| --- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Asymmetric divide pads quotient unnecessarily | DONE (T1) — 0.11→76× py at 65536w/32768w                                                                                                              |
+| 2   | Balanced divide also wastes work for          | DONE (T2) — quotient near-constant time (8–915× py)                                                                                                   |
+|     | high-precision req                            |                                                                                                                                                       |
+| 3a  | `ln(2)`/`ln(1.25)` recomputed per call        | DONE (T3a) — `MathCache`; 3×–4.5× speedup for repeated `ln()`                                                                                         |
+| 3b  | Per-Taylor-term BigDecimal divide is wasteful | DONE (T3b) — UInt32 divide path; +20–130% near-1 ln                                                                                                   |
+| 3c  | `log10()`/`log()` re-compute `ln(10)`         | DONE (T3c) — cached via `MathCache`                                                                                                                   |
+| 3d  | exp Taylor series too long; weak halving      | DONE (T3d) — $M=\sqrt{3.322p}$; exp 0.4×→2.6× py at p=1000                                                                                            |
+| 3e  | Binary splitting for ln Taylor series         | OPEN — diminishing returns for exp post-T3d;                                                                                                          |
+|     |                                               | ln still O(p) terms                                                                                                                                   |
+| 3f  | `atanh` reformulation for ln (3× fewer terms) | OPEN — easy win; estimated 3× near-1                                                                                                                  |
+| 3g  | AGM-based ln for very high precision          | OPEN — long-term, complex                                                                                                                             |
+| 4   | sqrt via Newton-with-division is slow         | DONE (T4) — reciprocal-Newton + precision doubling;                                                                                                   |
+|     |                                               | 20× improvement                                                                                                                                       |
+| 5   | NTT multiplication for n ≥ 1024 words         | OPEN — single biggest long-term gap vs libmpdec                                                                                                       |
+| 6   | Toom-3 between Karatsuba and NTT              | DONE (T6) — +14–29% for ≥256w                                                                                                                         |
+| 7a  | `integer_root` via direct Newton              | DONE (T7a) — 0.14×→25× py at p=1000 for cbrt                                                                                                          |
+|     | (was exp(ln(x)/n))                            |                                                                                                                                                       |
+| 7b  | Reciprocal-Newton for nth root (no divide)    | OPEN — estimated 1.5–2×                                                                                                                               |
+| 7c  | Rational decomposition $x^{a/b}$              | OPEN — fractional roots still 0.2–0.4× py                                                                                                             |
+|     | → root then power                             |                                                                                                                                                       |
+| 8   | BigDecimal-level inplace ops in Taylor loops  | DONE (T8) — +15–27% exp/ln, +9% sqrt                                                                                                                  |
+| 9   | SIMD schoolbook multiply base                 | OPEN — 1.5–2× constant-factor                                                                                                                         |
+| 10  | `debug_assert(..., "{}".format(...))`         | OPEN — sweep BigUInt + BigDecimal hot paths (Lesson #7)                                                                                               |
+|     | eager allocation                              |                                                                                                                                                       |
+| 11  | Hot-path-first switch reorder in BigDecimal   | OPEN — same-scale & same-sign branch first (Lesson #12)                                                                                               |
+|     | `add`/`sub`                                   |                                                                                                                                                       |
+| 12  | `@no_inline` raise helpers in                 | OPEN — sweep `from_string`, `from_uint32`, etc. (Lesson #10)                                                                                          |
+|     | BigDecimal/BigUInt                            |                                                                                                                                                       |
+| 13  | `from_string` digit batching                  | OPEN — borrowed from decimal128 H#17 follow-up                                                                                                        |
+|     | (UInt64 chunks of 9 or 19)                    |                                                                                                                                                       |
+| 14  | `to_string` `InlineArray` right-aligned       | OPEN — borrowed from decimal128 §2.4                                                                                                                  |
+|     | chunked emit                                  |                                                                                                                                                       |
+| 15  | Single-pass rounding in BigDecimal            | OPEN — borrowed from decimal128 H#16                                                                                                                  |
+|     | `multiply` / `divide`                         |                                                                                                                                                       |
+| 16  | Short-divisor fast path in `divide`           | OPEN — `BigUInt.floor_divide_by_uint32` exists;                                                                                                       |
+|     | (single-word loop)                            | lift to BigDecimal                                                                                                                                    |
+| 17  | Add/sub `multiply_by_power_of_ten` allocates  | OPEN — root cause of 4.7× py on small-precision add                                                                                                   |
+|     | oversized                                     |                                                                                                                                                       |
+| 18  | Small-coefficient mul fast path               | OPEN — borrowed from decimal128 H#4 dispatch-overhead lesson                                                                                          |
+|     | (bypass Karatsuba dispatch)                   |                                                                                                                                                       |
+| 19  | `precision` arg on `add`/`sub`/`multiply`     | DONE (PR #233) — see T-API3                                                                                                                           |
+| 20  | Private functions with `_`; Replace raises    | OPEN — improves runtime performance by avoiding                                                                                                       |
+|     | with debug asserts                            | unnecessary checks                                                                                                                                    |
+| 21  | More inplace variants for `BigUInt`           | OPEN — further reduces allocations and improves performance                                                                                           |
+|     | and `BigDecimal`                              |                                                                                                                                                       |
+| 22  | Zero-copy scale alignment via word-offset     | DISPROVEN — see T-API2                                                                                                                                |
+|     | add/sub                                       |                                                                                                                                                       |
+| 23  | Drop multiply pre-scaling; adjust scale       | OPEN — see T-API2.M                                                                                                                                   |
+|     | on result                                     |                                                                                                                                                       |
+| 24  | `round_to_precision` in-place audit           | DONE (T-R2) — code-quality cleanup; divide bench unchanged (saved allocs lost in noise vs total divide cost; will compound on rounding-dominated ops) |
 
 ## 4. Lessons Learnt (the reusable bits)
 
@@ -299,11 +321,12 @@ P0 — Structural API change (foundation for most P1 wins)
   strategy that originally motivated the API is tracked separately
   as T-API3.
 
-- **T-API2 — Zero-copy scale alignment for add/sub/mul.**
+- **T-API2 - DISPROVEN.** Zero-copy scale alignment for add/sub/mul.  
   Disproven as the performance gain is limited.
 
-- **T-API3 — `add`/`sub`/`multiply` with `precision > 0`: correct
-  pre-truncation.** Disproven as it is trivial.
+- **T-API3 — DISPROVEN.** `add`/`sub`/`multiply` with `precision > 0`:
+  correct pre-truncation  
+  Disproven as it is trivial.
 
 P1 — Add/Sub small-precision target (currently 4.7× / 3.6× py → target ≤2×)
 
@@ -420,40 +443,51 @@ P7 — `round` (2× py → target ≤1.0×)
 - **T-R1: `debug_assert .format` sweep specific to rounding modes.**
   The round dispatcher likely has one assert per mode branch.
 
-- **T-R2: `round_to_precision_inplace` variant.** Today
-  `round_to_precision(result, precision, …)` already mutates its
-  argument in place at the BigDecimal level (`result` is `mut`), but
-  audit whether the inner BigUInt path
-  (`remove_trailing_digits_with_rounding`) allocates a fresh
-  coefficient buffer and copies back. If so, add a true-in-place
-  variant that operates on `coefficient.words` directly. Every
-  `precision > 0` call to `add` / `subtract` / `multiply` (and after
-  T-API3, the multiply pre-truncation path too) ends in a
-  `round_to_precision` call, so the saving compounds across all
-  precision-arg ops. **Estimated:** 5–15% on the precision-arg fast
-  paths; small-coefficient cases benefit most.
+- **T-R2: `round_to_precision_inplace` variant.** DONE (20260516).
+  The free function `round_to_precision` and the
+  `BigDecimal.round_to_precision` method were renamed to
+  `..._inplace` to make their mutating semantics explicit. The
+  underlying `BigUInt.remove_trailing_digits_with_rounding_inplace`
+  already existed and is genuinely allocation-free; the public
+  `round()` was rewritten as `copy + inplace`. Six callsites in
+  `arithmetics.mojo` / `exponential.mojo` were converted from
+  out-of-place to in-place (saving one `BigUInt` allocation + buffer
+  copy each). The out-of-place
+  `BigUInt.remove_trailing_digits_with_rounding` was de-duplicated
+  into a thin `copy + inplace` wrapper (~110 lines removed).
+  **Measured impact on divide bench (p=100/1000/10000):** ~0%
+  (162.5→163.75, 741.9→747.3, 6717→6731 ns/iter — within noise).
+  The per-call alloc saving is real but is dominated by the cost of
+  the divide itself. The cleanup is kept for code quality and
+  because the saving will compound on future rounding-dominated
+  fast paths (e.g. small-coefficient `add`/`subtract`/`multiply`
+  with `precision > 0`).
 
 ### 5.3 Long-term tasks not on the active roadmap
 
-| #   | Task                                                                                                                                                                 | Effort |
-| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
-| 5   | NTT multiplication (≥1024 words). Closes the gap with libmpdec                                                                                                       | XL     |
-| 9   | SIMD-optimised schoolbook mul kernel                                                                                                                                 | M      |
-| 3e  | Binary splitting for ln Taylor series                                                                                                                                | L      |
-| 3g  | AGM-based ln for p ≥ 1000                                                                                                                                            | XL     |
-| 7b  | Reciprocal-Newton for nth root                                                                                                                                       | M      |
-| 7c  | Rational $x^{a/b}$ decomposition                                                                                                                                     | S      |
-| 11  | Make `BigUInt.remove_trailing_digits_with_rounding` private and replace its runtime `raise` with a debug assert (saves one `raises` propagation across all callers). | S      |
+| #   | Task                                                            | Effort |
+| --- | --------------------------------------------------------------- | ------ |
+| 5   | NTT multiplication (≥1024 words). Closes the gap with libmpdec  | XL     |
+| 9   | SIMD-optimised schoolbook mul kernel                            | M      |
+| 3e  | Binary splitting for ln Taylor series                           | L      |
+| 3g  | AGM-based ln for p ≥ 1000                                       | XL     |
+| 7b  | Reciprocal-Newton for nth root                                  | M      |
+| 7c  | Rational $x^{a/b}$ decomposition                                | S      |
+| 11  | Make `BigUInt.remove_trailing_digits_with_rounding` private and |        |
+|     | replace its runtime `raise` with a debug assert                 |        |
+|     | (saves one `raises` propagation across all callers).            | S      |
 
 ## 6. Result-Equivalence vs Python
 
 The 2026-04-30 sweep flags zero `match py` failures across all numeric
 ops. The only acknowledged differences:
 
-| Op   | Source                      | Notes                                                                                     |
-| ---- | --------------------------- | ----------------------------------------------------------------------------------------- |
-| root | Python `da ** (1/n)` oracle | Python rounds `1/n` to working precision before exponentiation; 1–3 ulp differences are   |
-|      |                             | expected and **not bugs**. Negative-base nth roots additionally raise `InvalidOperation`. |
+| Op   | Source                      | Notes                                            |
+| ---- | --------------------------- | ------------------------------------------------ |
+| root | Python `da ** (1/n)` oracle | Python rounds `1/n` to working precision         |
+|      |                             | before exponentiation; 1–3 ulp differences are   |
+|      |                             | expected and **not bugs**. Negative-base         |
+|      |                             | nth roots additionally raise `InvalidOperation`. |
 
 decimo follows IEEE 754-2008 §3.3 preferred-exponent rules for the
 trailing-zero shape of multiply/divide results, matching Python
@@ -504,29 +538,33 @@ binary splitting). All implementable in base-10^9.
 Open items in priority order (target: dm/py ≤ 1.5× across the board,
 some ops < 1.0×):
 
-| #      | Issue                                              | Effort | Priority | Target gain                                    |
-| ------ | -------------------------------------------------- | ------ | -------- | ---------------------------------------------- |
-| T-API1 | `precision` arg on `add`/`sub`/`multiply`          | S      | **DONE** | exact-then-round; foundation for T-API2/T-API3 |
-| T-R2   | `round_to_precision_inplace` audit                 | S      | P7       | 5–15% on precision-arg ops                     |
-| T-A1   | `debug_assert .format` sweep across BigDecimal     | S      | **P1**   | 10–30% all ops                                 |
-| T-A2   | `multiply_by_power_of_ten` audit + inplace variant | M      | **P1**   | 30–50% long-dec add/sub                        |
-| T-A3   | Hot-path-first switch in `add`/`sub`               | S      | **P1**   | 1–3 ns / call                                  |
-| T-A4   | `@no_inline` raise helpers in BigDecimal/BigUInt   | S      | **P1**   | unblocks always-inline                         |
-| T-A5   | `is_zero`/`is_integer` branch audit                | S      | P2       | small                                          |
-| T-M1   | Small-coefficient mul fast path                    | M      | **P1**   | 50–70% small-mul                               |
-| T-M2   | Single-pass rounding in `multiply`                 | S      | P2       | ~5 ns / call                                   |
-| T-D1   | Short-divisor fast path in `divide`                | M      | **P1**   | 3–10× short-divisor                            |
-| T-D2   | Trailing-zero strip allocation in divide           | S      | P2       | 5–15%                                          |
-| T-D3   | Reciprocal-Newton divide (legacy Task 2)           | XL     | P3       | 2× large balanced                              |
-| T-S1   | Small-coef short-circuit in `sqrt` p=100           | S      | P2       | ~50% at p=100                                  |
-| T-L1   | atanh reformulation for ln (T3f)                   | M      | **P1**   | 3× ln near-1                                   |
-| T-L2   | Process-wide ln(10) cache recipe                   | S      | P3       | doc                                            |
-| T-L3   | AGM ln for p ≥ 1000 (T3g)                          | XL     | P4       | 10–50× p≥1000                                  |
-| T-IO1  | `from_string` digit batching                       | M      | P2       | 30–50%                                         |
-| T-IO2  | `to_string` right-aligned InlineArray              | M      | P2       | 20–40%                                         |
-| T-R1   | `round` `.format` sweep                            | S      | P2       | small                                          |
-| T-7b   | Reciprocal-Newton nth root                         | M      | P3       | 1.5–2×                                         |
-| T-7c   | Rational $x^{a/b}$ decomposition                   | S      | P2       | 5–10× frac roots                               |
-| T-5    | NTT multiplication                                 | XL     | P4       | 2–10×                                          |
-| T-9    | SIMD schoolbook mul base                           | M      | P3       | 1.5–2×                                         |
-| T-3e   | Binary splitting for ln Taylor                     | L      | P4       | 2–4× p≥500                                     |
+| #      | Issue                                     | Effort | Priority | Target gain                                    |
+| ------ | ----------------------------------------- | ------ | -------- | ---------------------------------------------- |
+| T-API1 | `precision` arg on `add`/`sub`/`multiply` | S      | **DONE** | exact-then-round; foundation for T-API2/T-API3 |
+| T-R2   | `round_to_precision_inplace` audit        | S      | **DONE** | code-quality; ~0% on divide bench (noise)      |
+| T-A1   | `debug_assert .format` sweep across       | S      | **P1**   | 10–30% all ops                                 |
+|        | BigDecimal                                |        |          |                                                |
+| T-A2   | `multiply_by_power_of_ten` audit          | M      | **P1**   | 30–50% long-dec add/sub                        |
+|        | + inplace variant                         |        |          |                                                |
+| T-A3   | Hot-path-first switch in `add`/`sub`      | S      | **P1**   | 1–3 ns / call                                  |
+| T-A4   | `@no_inline` raise helpers in             | S      | **P1**   | unblocks always-inline                         |
+|        | BigDecimal/BigUInt                        |        |          |                                                |
+| T-A5   | `is_zero`/`is_integer` branch audit       | S      | P2       | small                                          |
+| T-M1   | Small-coefficient mul fast path           | M      | **P1**   | 50–70% small-mul                               |
+| T-M2   | Single-pass rounding in `multiply`        | S      | P2       | ~5 ns / call                                   |
+| T-D1   | Short-divisor fast path in `divide`       | M      | **P1**   | 3–10× short-divisor                            |
+| T-D2   | Trailing-zero strip allocation in divide  | S      | P2       | 5–15%                                          |
+| T-D3   | Reciprocal-Newton divide (legacy Task 2)  | XL     | P3       | 2× large balanced                              |
+| T-S1   | Small-coef short-circuit in `sqrt` p=100  | S      | P2       | ~50% at p=100                                  |
+| T-L1   | atanh reformulation for ln (T3f)          | M      | **P1**   | 3× ln near-1                                   |
+| T-L2   | Process-wide ln(10) cache recipe          | S      | P3       | doc                                            |
+| T-L3   | AGM ln for p ≥ 1000 (T3g)                 | XL     | P4       | 10–50× p≥1000                                  |
+| T-IO1  | `from_string` digit batching              | M      | P2       | 30–50%                                         |
+| T-IO2  | `to_string` right-aligned InlineArray     | M      | P2       | 20–40%                                         |
+| T-R1   | `round` `.format` sweep                   | S      | P2       | small                                          |
+| T-7b   | Reciprocal-Newton nth root                | M      | P3       | 1.5–2×                                         |
+| T-7c   | Rational $x^{a/b}$ decomposition          | S      | P2       | 5–10× frac roots                               |
+| T-5    | NTT multiplication                        | XL     | P4       | 2–10×                                          |
+| T-9    | SIMD schoolbook mul base                  | M      | P3       | 1.5–2×                                         |
+| T-3e   | Binary splitting for ln Taylor            | L      | P4       | 2–4× p≥500                                     |
+

--- a/examples/examples_on_bigfloat.mojo
+++ b/examples/examples_on_bigfloat.mojo
@@ -1,0 +1,21 @@
+from decimo import BigFloat
+
+
+def main() raises:
+    var a = BigFloat("123456789.123456789", precision=28)
+    var b = BigFloat("1234.56789", precision=28)
+
+    # === Basic Arithmetic === #
+    print(a + b)  # 123458023.691346789
+    print(a - b)  # 123455554.555566789
+    print(a * b)  # 152415787654.32099750190521
+    print(a / (b + BigFloat("1")))  # 99919.0656560820708357913866
+
+    # === Exponential Functions === #
+    print(a.sqrt())  # 11111.11106611111096943055498
+    print(a.exp())  # 1.861275588964958703584237786e+53616602
+    print(a.ln())  # 18.63140176716801803269393335
+
+    # === Trigonometric Functions === #
+    print(a.sin())  # 0.99985093087193092464780008
+    print(b.cos())  # -0.996957760386777200584184157

--- a/examples/run_bigfloat.sh
+++ b/examples/run_bigfloat.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# examples/run_bigfloat.sh — Quick build & run for a single BigFloat-using Mojo file.
+#
+# Usage (via pixi):
+#   pixi run bf <file.mojo>
+# Or directly:
+#   bash examples/run_bigfloat.sh <file.mojo>
+#
+# What it does:
+#   1. Ensures the GMP/MPFR C wrapper (libdecimo_gmp_wrapper) is built.
+#   2. Ensures tests/decimo.mojopkg is available (built on demand).
+#   3. Builds <file.mojo> with `-I tests`, debug info, and ASSERT=all,
+#      linking against the C wrapper. Output binary goes to temp/<name>.
+#   4. Executes the binary with DYLD_LIBRARY_PATH / LD_LIBRARY_PATH set
+#      so it can locate the wrapper at runtime.
+
+set -eo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: pixi run bf <file.mojo>" >&2
+    exit 2
+fi
+
+SRC="$1"
+if [[ ! -f "$SRC" ]]; then
+    echo "ERROR: file not found: $SRC" >&2
+    exit 1
+fi
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+cd "$REPO_ROOT"
+
+WRAPPER_DIR="src/decimo/gmp"
+if [[ "$(uname)" == "Darwin" ]]; then
+    WRAPPER_LIB="$WRAPPER_DIR/libdecimo_gmp_wrapper.dylib"
+else
+    WRAPPER_LIB="$WRAPPER_DIR/libdecimo_gmp_wrapper.so"
+fi
+
+# 1. Build the C wrapper if missing.
+if [[ ! -f "$WRAPPER_LIB" ]]; then
+    echo "==> Building GMP/MPFR C wrapper..."
+    bash "$WRAPPER_DIR/build_gmp_wrapper.sh"
+fi
+
+# 2. Ensure decimo.mojopkg exists for `-I tests`.
+if [[ ! -f tests/decimo.mojopkg ]]; then
+    echo "==> Building tests/decimo.mojopkg..."
+    pixi run mojo package src/decimo -o tests/decimo.mojopkg
+fi
+
+# 3. Build the user's .mojo file into temp/<basename>.
+mkdir -p temp
+BIN_NAME=$(basename "$SRC" .mojo)
+BIN_PATH="temp/$BIN_NAME"
+
+echo "==> Building $SRC -> $BIN_PATH"
+pixi run mojo build -I tests -D ASSERT=all --debug-level=full \
+    -Xlinker -L./"$WRAPPER_DIR" -Xlinker -ldecimo_gmp_wrapper \
+    -o "$BIN_PATH" "$SRC"
+
+# 4. Run it with the wrapper on the dynamic loader path.
+echo "==> Running $BIN_PATH"
+DYLD_LIBRARY_PATH="$REPO_ROOT/$WRAPPER_DIR:${DYLD_LIBRARY_PATH:-}" \
+LD_LIBRARY_PATH="$REPO_ROOT/$WRAPPER_DIR:${LD_LIBRARY_PATH:-}" \
+    "$BIN_PATH"

--- a/pixi.toml
+++ b/pixi.toml
@@ -62,6 +62,10 @@ testfloat = "pixi run buildgmp && bash tests/test.sh bigfloat"
 t = "clear && pixi run test"
 tf = "clear && pixi run testfloat"
 
+# quick build & run for a single BigFloat-using .mojo file
+# Usage: pixi run bf path/to/file.mojo
+bf = { cmd = "bash examples/run_bigfloat.sh", description = "Build & run a single BigFloat .mojo file (output binary in temp/)" }
+
 # bench
 bench = "pixi run package && bash benches/run_bench.sh"
 

--- a/src/cli/calculator/evaluator.mojo
+++ b/src/cli/calculator/evaluator.mojo
@@ -355,7 +355,7 @@ def final_round(
     if value.is_zero():
         return value.copy()
     var result = value.copy()
-    result.round_to_precision(precision, rounding_mode, False, False)
+    result.round_to_precision_inplace(precision, rounding_mode, False, False)
     return result^
 
 

--- a/src/decimo/bigdecimal/arithmetics.mojo
+++ b/src/decimo/bigdecimal/arithmetics.mojo
@@ -841,6 +841,7 @@ def true_divide_inexact(
             digits_to_remove,
             RoundingMode.down(),
             remove_extra_digit_due_to_rounding=False,
+            ndigits_before_removal=result_digits,
         )
         # Adjust the scale accordingly
         result_scale -= digits_to_remove
@@ -898,6 +899,7 @@ def _true_divide_inexact_truncated(
             digits_to_remove,
             RoundingMode.down(),
             remove_extra_digit_due_to_rounding=False,
+            ndigits_before_removal=result_digits,
         )
         result_scale -= digits_to_remove
 
@@ -971,6 +973,7 @@ def true_divide_inexact_by_uint32(
             digits_to_remove,
             RoundingMode.down(),
             remove_extra_digit_due_to_rounding=False,
+            ndigits_before_removal=result_digits,
         )
         result_scale -= digits_to_remove
 

--- a/src/decimo/bigdecimal/arithmetics.mojo
+++ b/src/decimo/bigdecimal/arithmetics.mojo
@@ -20,7 +20,7 @@ Implements functions for mathematical operations on BigDecimal objects.
 
 from std import math
 
-import decimo.biguint.arithmetics
+import decimo.biguint.arithmetics as biguint_arithmetics
 from decimo.bigdecimal.rounding import round_to_precision
 from decimo.errors import ZeroDivisionError
 from decimo.rounding_mode import RoundingMode
@@ -318,14 +318,12 @@ def add_inplace(mut x1: BigDecimal, x2: BigDecimal, precision: Int = 0) raises:
         if x1.sign == x2.sign:
             # Same sign: add magnitudes (use inplace add on x1's coefficient)
             if scale_factor2 == 0:
-                decimo.biguint.arithmetics.add_inplace(
-                    x1.coefficient, x2.coefficient
-                )
+                biguint_arithmetics.add_inplace(x1.coefficient, x2.coefficient)
             else:
                 var coef2 = x2.coefficient.multiply_by_power_of_ten(
                     scale_factor2
                 )
-                decimo.biguint.arithmetics.add_inplace(x1.coefficient, coef2)
+                biguint_arithmetics.add_inplace(x1.coefficient, coef2)
             x1.scale = max_scale
         else:
             # Different signs: subtract magnitudes
@@ -337,14 +335,10 @@ def add_inplace(mut x1: BigDecimal, x2: BigDecimal, precision: Int = 0) raises:
             )
 
             if x1.coefficient > coef2:
-                decimo.biguint.arithmetics.subtract_inplace(
-                    x1.coefficient, coef2
-                )
+                biguint_arithmetics.subtract_inplace(x1.coefficient, coef2)
                 x1.scale = max_scale
             elif coef2 > x1.coefficient:
-                decimo.biguint.arithmetics.subtract_inplace(
-                    coef2, x1.coefficient
-                )
+                biguint_arithmetics.subtract_inplace(coef2, x1.coefficient)
                 x1.coefficient = coef2^
                 x1.scale = max_scale
                 x1.sign = x2.sign
@@ -495,11 +489,11 @@ def true_divide_fast(
 
     var coef_x: BigUInt
     if extra_words > 0:
-        coef_x = decimo.biguint.arithmetics.multiply_by_power_of_billion(
+        coef_x = biguint_arithmetics.multiply_by_power_of_billion(
             x.coefficient, extra_words
         )
     elif extra_words < 0:
-        coef_x = decimo.biguint.arithmetics.floor_divide_by_power_of_billion(
+        coef_x = biguint_arithmetics.floor_divide_by_power_of_billion(
             x.coefficient, -extra_words
         )
     else:
@@ -527,12 +521,12 @@ def _true_divide_fast_truncated(
     )
     var y_only_remove = total_y_remove - common_remove
 
-    var y_coef_tr = decimo.biguint.arithmetics.floor_divide_by_power_of_billion(
+    var y_coef_tr = biguint_arithmetics.floor_divide_by_power_of_billion(
         y.coefficient, total_y_remove
     )
     var x_coef_tr: BigUInt
     if common_remove > 0:
-        x_coef_tr = decimo.biguint.arithmetics.floor_divide_by_power_of_billion(
+        x_coef_tr = biguint_arithmetics.floor_divide_by_power_of_billion(
             x.coefficient, common_remove
         )
     else:
@@ -546,11 +540,11 @@ def _true_divide_fast_truncated(
 
     var coef_x: BigUInt
     if extra_words > 0:
-        coef_x = decimo.biguint.arithmetics.multiply_by_power_of_billion(
+        coef_x = biguint_arithmetics.multiply_by_power_of_billion(
             x_coef_tr, extra_words
         )
     elif extra_words < 0:
-        coef_x = decimo.biguint.arithmetics.floor_divide_by_power_of_billion(
+        coef_x = biguint_arithmetics.floor_divide_by_power_of_billion(
             x_coef_tr, -extra_words
         )
     else:
@@ -626,13 +620,13 @@ def true_divide_general(
 
     var coef_x: BigUInt
     if extra_words > 0:
-        coef_x = decimo.biguint.arithmetics.multiply_by_power_of_billion(
+        coef_x = biguint_arithmetics.multiply_by_power_of_billion(
             x.coefficient, extra_words
         )
     elif extra_words < 0:
         # Dividend already has more than enough words for the desired precision.
         # Truncate low-order words to avoid computing unnecessary quotient digits.
-        coef_x = decimo.biguint.arithmetics.floor_divide_by_power_of_billion(
+        coef_x = biguint_arithmetics.floor_divide_by_power_of_billion(
             x.coefficient, -extra_words
         )
     else:
@@ -652,7 +646,7 @@ def true_divide_general(
             extra_digits, coef.number_of_trailing_zeros()
         )
         # TODO: Make a in-place version of this
-        coef = decimo.biguint.arithmetics.floor_divide_by_power_of_ten(
+        coef = biguint_arithmetics.floor_divide_by_power_of_ten(
             coef, num_digits_to_remove
         )
         extra_digits -= num_digits_to_remove
@@ -685,12 +679,12 @@ def _true_divide_general_truncated(
     )
     var y_only_remove = total_y_remove - common_remove
 
-    var y_coef_tr = decimo.biguint.arithmetics.floor_divide_by_power_of_billion(
+    var y_coef_tr = biguint_arithmetics.floor_divide_by_power_of_billion(
         y.coefficient, total_y_remove
     )
     var x_coef_tr: BigUInt
     if common_remove > 0:
-        x_coef_tr = decimo.biguint.arithmetics.floor_divide_by_power_of_billion(
+        x_coef_tr = biguint_arithmetics.floor_divide_by_power_of_billion(
             x.coefficient, common_remove
         )
     else:
@@ -704,11 +698,11 @@ def _true_divide_general_truncated(
 
     var coef_x: BigUInt
     if extra_words > 0:
-        coef_x = decimo.biguint.arithmetics.multiply_by_power_of_billion(
+        coef_x = biguint_arithmetics.multiply_by_power_of_billion(
             x_coef_tr, extra_words
         )
     elif extra_words < 0:
-        coef_x = decimo.biguint.arithmetics.floor_divide_by_power_of_billion(
+        coef_x = biguint_arithmetics.floor_divide_by_power_of_billion(
             x_coef_tr, -extra_words
         )
     else:
@@ -753,7 +747,7 @@ def _true_divide_general_truncated(
 
         if allowed_tz > 0:
             var stripped_coef = (
-                decimo.biguint.arithmetics.floor_divide_by_power_of_ten(
+                biguint_arithmetics.floor_divide_by_power_of_ten(
                     result.coefficient, allowed_tz
                 )
             )
@@ -871,17 +865,13 @@ def _true_divide_inexact_truncated(
     )
     var y_only_remove = total_y_remove - common_remove
 
-    var x2_coef_tr = (
-        decimo.biguint.arithmetics.floor_divide_by_power_of_billion(
-            x2.coefficient, total_y_remove
-        )
+    var x2_coef_tr = biguint_arithmetics.floor_divide_by_power_of_billion(
+        x2.coefficient, total_y_remove
     )
     var x1_coef_tr: BigUInt
     if common_remove > 0:
-        x1_coef_tr = (
-            decimo.biguint.arithmetics.floor_divide_by_power_of_billion(
-                x1.coefficient, common_remove
-            )
+        x1_coef_tr = biguint_arithmetics.floor_divide_by_power_of_billion(
+            x1.coefficient, common_remove
         )
     else:
         x1_coef_tr = x1.coefficient.copy()
@@ -971,9 +961,7 @@ def true_divide_inexact_by_uint32(
         scaled_x1.multiply_by_power_of_ten_inplace(buffer_digits)
 
     # O(n) division by single word — the key speedup
-    var quotient = decimo.biguint.arithmetics.floor_divide_by_uint32(
-        scaled_x1, y
-    )
+    var quotient = biguint_arithmetics.floor_divide_by_uint32(scaled_x1, y)
     var result_scale = buffer_digits + x1.scale
 
     var result_digits = quotient.number_of_digits()

--- a/src/decimo/bigdecimal/arithmetics.mojo
+++ b/src/decimo/bigdecimal/arithmetics.mojo
@@ -21,7 +21,7 @@ Implements functions for mathematical operations on BigDecimal objects.
 from std import math
 
 import decimo.biguint.arithmetics as biguint_arithmetics
-from decimo.bigdecimal.rounding import round_to_precision
+from decimo.bigdecimal.rounding import round_to_precision_inplace
 from decimo.errors import ZeroDivisionError
 from decimo.rounding_mode import RoundingMode
 
@@ -61,7 +61,7 @@ def add(
     """
     if precision > 0:
         var result = add(x1, x2, precision=0)
-        round_to_precision(
+        round_to_precision_inplace(
             result,
             precision,
             RoundingMode.ROUND_HALF_EVEN,
@@ -138,7 +138,7 @@ def subtract(
     """
     if precision > 0:
         var result = subtract(x1, x2, precision=0)
-        round_to_precision(
+        round_to_precision_inplace(
             result,
             precision,
             RoundingMode.ROUND_HALF_EVEN,
@@ -217,7 +217,7 @@ def multiply(
     """
     if precision > 0:
         var result = multiply(x1, x2, precision=0)
-        round_to_precision(
+        round_to_precision_inplace(
             result,
             precision,
             RoundingMode.ROUND_HALF_EVEN,
@@ -268,7 +268,7 @@ def multiply_inplace(
     x1.sign = x1.sign != x2.sign
 
     if precision > 0:
-        round_to_precision(
+        round_to_precision_inplace(
             x1,
             precision,
             RoundingMode.ROUND_HALF_EVEN,
@@ -348,7 +348,7 @@ def add_inplace(mut x1: BigDecimal, x2: BigDecimal, precision: Int = 0) raises:
                 x1.sign = False
 
     if precision > 0:
-        round_to_precision(
+        round_to_precision_inplace(
             x1,
             precision,
             RoundingMode.ROUND_HALF_EVEN,
@@ -657,7 +657,7 @@ def true_divide_general(
         scale=scale,
         sign=x.sign != y.sign,
     )
-    result.round_to_precision(
+    result.round_to_precision_inplace(
         precision,
         RoundingMode.half_even(),
         remove_extra_digit_due_to_rounding=True,
@@ -722,7 +722,7 @@ def _true_divide_general_truncated(
         scale=scale,
         sign=x.sign != y.sign,
     )
-    result.round_to_precision(
+    result.round_to_precision_inplace(
         precision,
         RoundingMode.half_even(),
         remove_extra_digit_due_to_rounding=True,
@@ -837,7 +837,7 @@ def true_divide_inexact(
     var result_digits = quotient.number_of_digits()
     if result_digits > number_of_significant_digits:
         var digits_to_remove = result_digits - number_of_significant_digits
-        quotient = quotient.remove_trailing_digits_with_rounding(
+        quotient.remove_trailing_digits_with_rounding_inplace(
             digits_to_remove,
             RoundingMode.down(),
             remove_extra_digit_due_to_rounding=False,
@@ -894,7 +894,7 @@ def _true_divide_inexact_truncated(
     var result_digits = quotient.number_of_digits()
     if result_digits > number_of_significant_digits:
         var digits_to_remove = result_digits - number_of_significant_digits
-        quotient = quotient.remove_trailing_digits_with_rounding(
+        quotient.remove_trailing_digits_with_rounding_inplace(
             digits_to_remove,
             RoundingMode.down(),
             remove_extra_digit_due_to_rounding=False,
@@ -967,7 +967,7 @@ def true_divide_inexact_by_uint32(
     var result_digits = quotient.number_of_digits()
     if result_digits > number_of_significant_digits:
         var digits_to_remove = result_digits - number_of_significant_digits
-        quotient = quotient.remove_trailing_digits_with_rounding(
+        quotient.remove_trailing_digits_with_rounding_inplace(
             digits_to_remove,
             RoundingMode.down(),
             remove_extra_digit_due_to_rounding=False,

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -30,7 +30,6 @@ from std import testing
 from decimo.errors import ConversionError, ValueError
 from decimo.rounding_mode import RoundingMode
 from decimo.bigdecimal.exponential import MathCache
-from decimo.bigdecimal.rounding import round_to_precision_inplace
 from decimo.bigint10.bigint10 import BigInt10
 import decimo.str as decimo_str
 import decimo.bigdecimal.arithmetics as bigdecimal_arithmetics

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -32,14 +32,14 @@ from decimo.rounding_mode import RoundingMode
 from decimo.bigdecimal.exponential import MathCache
 from decimo.bigdecimal.rounding import round_to_precision
 from decimo.bigint10.bigint10 import BigInt10
-import decimo.str
-import decimo.bigdecimal.arithmetics
-import decimo.bigdecimal.comparison
-import decimo.bigdecimal.constants
-import decimo.bigdecimal.exponential
-import decimo.bigdecimal.rounding
-import decimo.bigdecimal.trigonometric
-import decimo.biguint.arithmetics
+import decimo.str as decimo_str
+import decimo.bigdecimal.arithmetics as bigdecimal_arithmetics
+import decimo.bigdecimal.comparison as bigdecimal_comparison
+import decimo.bigdecimal.constants as bigdecimal_constants
+import decimo.bigdecimal.exponential as bigdecimal_exponential
+import decimo.bigdecimal.rounding as bigdecimal_rounding
+import decimo.bigdecimal.trigonometric as bigdecimal_trigonometric
+import decimo.biguint.arithmetics as biguint_arithmetics
 
 # Type aliases for the arbitrary-precision decimal type.
 # The names BigDecimal, Decimal, and BDec can be used interchangeably.
@@ -456,7 +456,7 @@ struct BigDecimal(
         Returns:
             The BigDecimal representation of the string.
         """
-        _tuple = decimo.str.parse_numeric_string(value)
+        _tuple = decimo_str.parse_numeric_string(value)
         var ref coef: List[UInt8] = _tuple[0]
         var scale: Int = _tuple[1]
         var sign: Bool = _tuple[2]
@@ -1009,9 +1009,7 @@ struct BigDecimal(
         Returns:
             The sum of the two values, rounded to `PRECISION` digits.
         """
-        return decimo.bigdecimal.arithmetics.add(
-            self, other, precision=PRECISION
-        )
+        return bigdecimal_arithmetics.add(self, other, precision=PRECISION)
 
     @always_inline
     def __sub__(self, other: Self) raises -> Self:
@@ -1027,9 +1025,7 @@ struct BigDecimal(
             The difference of the two values, rounded to `PRECISION`
             digits.
         """
-        return decimo.bigdecimal.arithmetics.subtract(
-            self, other, precision=PRECISION
-        )
+        return bigdecimal_arithmetics.subtract(self, other, precision=PRECISION)
 
     @always_inline
     def __mul__(self, other: Self) raises -> Self:
@@ -1045,9 +1041,7 @@ struct BigDecimal(
             The product of the two values, rounded to `PRECISION`
             digits.
         """
-        return decimo.bigdecimal.arithmetics.multiply(
-            self, other, precision=PRECISION
-        )
+        return bigdecimal_arithmetics.multiply(self, other, precision=PRECISION)
 
     @always_inline
     def __truediv__(self, other: Self) raises -> Self:
@@ -1059,7 +1053,7 @@ struct BigDecimal(
         Returns:
             The quotient of the two values.
         """
-        return decimo.bigdecimal.arithmetics.true_divide(
+        return bigdecimal_arithmetics.true_divide(
             self, other, precision=PRECISION
         )
 
@@ -1074,7 +1068,7 @@ struct BigDecimal(
         Returns:
             The integer quotient, truncated toward zero.
         """
-        return decimo.bigdecimal.arithmetics.truncate_divide(self, other)
+        return bigdecimal_arithmetics.truncate_divide(self, other)
 
     @always_inline
     def __mod__(self, other: Self) raises -> Self:
@@ -1087,7 +1081,7 @@ struct BigDecimal(
         Returns:
             The remainder after truncated division.
         """
-        return decimo.bigdecimal.arithmetics.truncate_modulo(
+        return bigdecimal_arithmetics.truncate_modulo(
             self, other, precision=PRECISION
         )
 
@@ -1101,9 +1095,7 @@ struct BigDecimal(
         Returns:
             This value raised to the given exponent.
         """
-        return decimo.bigdecimal.exponential.power(
-            self, exponent, precision=PRECISION
-        )
+        return bigdecimal_exponential.power(self, exponent, precision=PRECISION)
 
     @always_inline
     def __divmod__(self, other: Self) raises -> Tuple[Self, Self]:
@@ -1123,12 +1115,10 @@ struct BigDecimal(
         Returns:
             A tuple of `(quotient, remainder)` from truncated division.
         """
-        var quotient = decimo.bigdecimal.arithmetics.truncate_divide(
-            self, other
-        )
-        var remainder = decimo.bigdecimal.arithmetics.subtract(
+        var quotient = bigdecimal_arithmetics.truncate_divide(self, other)
+        var remainder = bigdecimal_arithmetics.subtract(
             self,
-            decimo.bigdecimal.arithmetics.multiply(quotient, other),
+            bigdecimal_arithmetics.multiply(quotient, other),
         )
         return (quotient^, remainder^)
 
@@ -1142,12 +1132,10 @@ struct BigDecimal(
         Returns:
             A tuple of `(quotient, remainder)` from truncated division.
         """
-        var quotient = decimo.bigdecimal.arithmetics.truncate_divide(
-            other, self
-        )
-        var remainder = decimo.bigdecimal.arithmetics.subtract(
+        var quotient = bigdecimal_arithmetics.truncate_divide(other, self)
+        var remainder = bigdecimal_arithmetics.subtract(
             other,
-            decimo.bigdecimal.arithmetics.multiply(quotient, self),
+            bigdecimal_arithmetics.multiply(quotient, self),
         )
         return (quotient^, remainder^)
 
@@ -1168,9 +1156,7 @@ struct BigDecimal(
         Returns:
             The sum of the two values.
         """
-        return decimo.bigdecimal.arithmetics.add(
-            self, other, precision=PRECISION
-        )
+        return bigdecimal_arithmetics.add(self, other, precision=PRECISION)
 
     @always_inline
     def __rsub__(self, other: Self) raises -> Self:
@@ -1183,9 +1169,7 @@ struct BigDecimal(
         Returns:
             The difference `other - self`.
         """
-        return decimo.bigdecimal.arithmetics.subtract(
-            other, self, precision=PRECISION
-        )
+        return bigdecimal_arithmetics.subtract(other, self, precision=PRECISION)
 
     @always_inline
     def __rmul__(self, other: Self) raises -> Self:
@@ -1198,9 +1182,7 @@ struct BigDecimal(
         Returns:
             The product of the two values.
         """
-        return decimo.bigdecimal.arithmetics.multiply(
-            self, other, precision=PRECISION
-        )
+        return bigdecimal_arithmetics.multiply(self, other, precision=PRECISION)
 
     @always_inline
     def __rfloordiv__(self, other: Self) raises -> Self:
@@ -1212,7 +1194,7 @@ struct BigDecimal(
         Returns:
             The integer quotient `other // self`, truncated toward zero.
         """
-        return decimo.bigdecimal.arithmetics.truncate_divide(other, self)
+        return bigdecimal_arithmetics.truncate_divide(other, self)
 
     @always_inline
     def __rmod__(self, other: Self) raises -> Self:
@@ -1224,7 +1206,7 @@ struct BigDecimal(
         Returns:
             The remainder `other % self`.
         """
-        return decimo.bigdecimal.arithmetics.truncate_modulo(
+        return bigdecimal_arithmetics.truncate_modulo(
             other, self, precision=PRECISION
         )
 
@@ -1238,9 +1220,7 @@ struct BigDecimal(
         Returns:
             The base raised to the power of self.
         """
-        return decimo.bigdecimal.exponential.power(
-            base, self, precision=PRECISION
-        )
+        return bigdecimal_exponential.power(base, self, precision=PRECISION)
 
     @always_inline
     def __rtruediv__(self, other: Self) raises -> Self:
@@ -1252,7 +1232,7 @@ struct BigDecimal(
         Returns:
             The quotient `other / self`.
         """
-        return decimo.bigdecimal.arithmetics.true_divide(
+        return bigdecimal_arithmetics.true_divide(
             other, self, precision=PRECISION
         )
 
@@ -1273,9 +1253,7 @@ struct BigDecimal(
         Args:
             other: The right-hand side operand.
         """
-        decimo.bigdecimal.arithmetics.add_inplace(
-            self, other, precision=PRECISION
-        )
+        bigdecimal_arithmetics.add_inplace(self, other, precision=PRECISION)
 
     @always_inline
     def __isub__(mut self, other: Self) raises:
@@ -1287,7 +1265,7 @@ struct BigDecimal(
         Args:
             other: The right-hand side operand.
         """
-        decimo.bigdecimal.arithmetics.subtract_inplace(
+        bigdecimal_arithmetics.subtract_inplace(
             self, other, precision=PRECISION
         )
 
@@ -1301,7 +1279,7 @@ struct BigDecimal(
         Args:
             other: The right-hand side operand.
         """
-        decimo.bigdecimal.arithmetics.multiply_inplace(
+        bigdecimal_arithmetics.multiply_inplace(
             self, other, precision=PRECISION
         )
 
@@ -1312,7 +1290,7 @@ struct BigDecimal(
         Args:
             other: The right-hand side operand.
         """
-        self = decimo.bigdecimal.arithmetics.true_divide(
+        self = bigdecimal_arithmetics.true_divide(
             self, other, precision=PRECISION
         )
 
@@ -1323,7 +1301,7 @@ struct BigDecimal(
         Args:
             other: The right-hand side operand.
         """
-        self = decimo.bigdecimal.arithmetics.truncate_divide(self, other)
+        self = bigdecimal_arithmetics.truncate_divide(self, other)
 
     @always_inline
     def __imod__(mut self, other: Self) raises:
@@ -1332,7 +1310,7 @@ struct BigDecimal(
         Args:
             other: The right-hand side operand.
         """
-        self = decimo.bigdecimal.arithmetics.truncate_modulo(
+        self = bigdecimal_arithmetics.truncate_modulo(
             self, other, precision=PRECISION
         )
 
@@ -1351,7 +1329,7 @@ struct BigDecimal(
         Returns:
             True if self is greater than other, False otherwise.
         """
-        return decimo.bigdecimal.comparison.compare(self, other) > 0
+        return bigdecimal_comparison.compare(self, other) > 0
 
     @always_inline
     def __ge__(self, other: Self) -> Bool:
@@ -1363,7 +1341,7 @@ struct BigDecimal(
         Returns:
             True if self is greater than or equal to other, False otherwise.
         """
-        return decimo.bigdecimal.comparison.compare(self, other) >= 0
+        return bigdecimal_comparison.compare(self, other) >= 0
 
     @always_inline
     def __lt__(self, other: Self) -> Bool:
@@ -1375,7 +1353,7 @@ struct BigDecimal(
         Returns:
             True if self is less than other, False otherwise.
         """
-        return decimo.bigdecimal.comparison.compare(self, other) < 0
+        return bigdecimal_comparison.compare(self, other) < 0
 
     @always_inline
     def __le__(self, other: Self) -> Bool:
@@ -1387,7 +1365,7 @@ struct BigDecimal(
         Returns:
             True if self is less than or equal to other, False otherwise.
         """
-        return decimo.bigdecimal.comparison.compare(self, other) <= 0
+        return bigdecimal_comparison.compare(self, other) <= 0
 
     @always_inline
     def __eq__(self, other: Self) -> Bool:
@@ -1399,7 +1377,7 @@ struct BigDecimal(
         Returns:
             True if the two values are equal, False otherwise.
         """
-        return decimo.bigdecimal.comparison.compare(self, other) == 0
+        return bigdecimal_comparison.compare(self, other) == 0
 
     @always_inline
     def __ne__(self, other: Self) -> Bool:
@@ -1411,7 +1389,7 @@ struct BigDecimal(
         Returns:
             True if the two values are not equal, False otherwise.
         """
-        return decimo.bigdecimal.comparison.compare(self, other) != 0
+        return bigdecimal_comparison.compare(self, other) != 0
 
     # ===------------------------------------------------------------------=== #
     # Other dunders that implements traits
@@ -1430,7 +1408,7 @@ struct BigDecimal(
             A new `BigDecimal` rounded to the specified decimal places.
         """
         try:
-            return decimo.bigdecimal.rounding.round(
+            return bigdecimal_rounding.round(
                 self,
                 ndigits=ndigits,
                 rounding_mode=RoundingMode.half_even(),
@@ -1447,7 +1425,7 @@ struct BigDecimal(
             A new `BigDecimal` rounded to 0 decimal places.
         """
         try:
-            return decimo.bigdecimal.rounding.round(
+            return bigdecimal_rounding.round(
                 self, ndigits=0, rounding_mode=RoundingMode.half_even()
             )
         except e:
@@ -1469,7 +1447,7 @@ struct BigDecimal(
         if self.scale <= 0:
             return self.copy()
         # Truncate toward zero first
-        var truncated = decimo.bigdecimal.rounding.round(
+        var truncated = bigdecimal_rounding.round(
             self, ndigits=0, rounding_mode=RoundingMode.down()
         )
         # If positive and there was a fractional part, add 1
@@ -1489,7 +1467,7 @@ struct BigDecimal(
         if self.scale <= 0:
             return self.copy()
         # Truncate toward zero first
-        var truncated = decimo.bigdecimal.rounding.round(
+        var truncated = bigdecimal_rounding.round(
             self, ndigits=0, rounding_mode=RoundingMode.down()
         )
         # If negative and there was a fractional part, subtract 1
@@ -1508,7 +1486,7 @@ struct BigDecimal(
         """
         if self.scale <= 0:
             return self.copy()
-        return decimo.bigdecimal.rounding.round(
+        return bigdecimal_rounding.round(
             self, ndigits=0, rounding_mode=RoundingMode.down()
         )
 
@@ -1533,9 +1511,7 @@ struct BigDecimal(
         Returns:
             The sum of the two values.
         """
-        return decimo.bigdecimal.arithmetics.add(
-            self, other, precision=precision
-        )
+        return bigdecimal_arithmetics.add(self, other, precision=precision)
 
     @always_inline
     def subtract(self, other: Self, precision: Int = 0) raises -> Self:
@@ -1554,9 +1530,7 @@ struct BigDecimal(
         Returns:
             The difference of the two values.
         """
-        return decimo.bigdecimal.arithmetics.subtract(
-            self, other, precision=precision
-        )
+        return bigdecimal_arithmetics.subtract(self, other, precision=precision)
 
     @always_inline
     def multiply(self, other: Self, precision: Int = 0) raises -> Self:
@@ -1574,9 +1548,7 @@ struct BigDecimal(
         Returns:
             The product of the two values.
         """
-        return decimo.bigdecimal.arithmetics.multiply(
-            self, other, precision=precision
-        )
+        return bigdecimal_arithmetics.multiply(self, other, precision=precision)
 
     @always_inline
     def true_divide(
@@ -1591,7 +1563,7 @@ struct BigDecimal(
         Returns:
             The quotient of the two values.
         """
-        return decimo.bigdecimal.arithmetics.true_divide(
+        return bigdecimal_arithmetics.true_divide(
             self, other, precision=precision
         )
 
@@ -1608,7 +1580,7 @@ struct BigDecimal(
                 Note: this differs from the `+=` operator which always
                 rounds to `PRECISION` (matching Python `decimal.Decimal`).
         """
-        decimo.bigdecimal.arithmetics.add_inplace(self, other, precision)
+        bigdecimal_arithmetics.add_inplace(self, other, precision)
 
     @always_inline
     def subtract_inplace(mut self, other: Self, precision: Int = 0) raises:
@@ -1624,7 +1596,7 @@ struct BigDecimal(
                 Note: this differs from the `-=` operator which always
                 rounds to `PRECISION` (matching Python `decimal.Decimal`).
         """
-        decimo.bigdecimal.arithmetics.subtract_inplace(self, other, precision)
+        bigdecimal_arithmetics.subtract_inplace(self, other, precision)
 
     @always_inline
     def multiply_inplace(mut self, other: Self, precision: Int = 0) raises:
@@ -1639,7 +1611,7 @@ struct BigDecimal(
                 Note: this differs from the `*=` operator which always
                 rounds to `PRECISION` (matching Python `decimal.Decimal`).
         """
-        decimo.bigdecimal.arithmetics.multiply_inplace(self, other, precision)
+        bigdecimal_arithmetics.multiply_inplace(self, other, precision)
 
     # ===------------------------------------------------------------------=== #
     # Mathematical methods that do not implement a trait (not a dunder)
@@ -1658,7 +1630,7 @@ struct BigDecimal(
         Returns:
             1 if self > other, 0 if equal, -1 if self < other.
         """
-        return decimo.bigdecimal.comparison.compare(self, other)
+        return bigdecimal_comparison.compare(self, other)
 
     @always_inline
     def compare_absolute(self, other: Self) raises -> Int8:
@@ -1671,7 +1643,7 @@ struct BigDecimal(
         Returns:
             1 if |self| > |other|, 0 if equal, -1 if |self| < |other|.
         """
-        return decimo.bigdecimal.comparison.compare_absolute(self, other)
+        return bigdecimal_comparison.compare_absolute(self, other)
 
     # === Extrema === #
 
@@ -1685,7 +1657,7 @@ struct BigDecimal(
         Returns:
             The larger of the two values.
         """
-        return decimo.bigdecimal.comparison.max(self, other)
+        return bigdecimal_comparison.max(self, other)
 
     @always_inline
     def min(self, other: Self) raises -> Self:
@@ -1697,7 +1669,7 @@ struct BigDecimal(
         Returns:
             The smaller of the two values.
         """
-        return decimo.bigdecimal.comparison.min(self, other)
+        return bigdecimal_comparison.min(self, other)
 
     # === Constants === #
 
@@ -1712,7 +1684,7 @@ struct BigDecimal(
         Returns:
             The value of π to the specified precision.
         """
-        return decimo.bigdecimal.constants.pi(precision=precision)
+        return bigdecimal_constants.pi(precision=precision)
 
     @always_inline
     @staticmethod
@@ -1725,7 +1697,7 @@ struct BigDecimal(
         Returns:
             The value of e to the specified precision.
         """
-        return decimo.bigdecimal.exponential.exp(
+        return bigdecimal_exponential.exp(
             x=Self(BigUInt.one()), precision=precision
         )
 
@@ -1741,7 +1713,7 @@ struct BigDecimal(
         Returns:
             The value of e raised to the power of self.
         """
-        return decimo.bigdecimal.exponential.exp(self, precision)
+        return bigdecimal_exponential.exp(self, precision)
 
     @always_inline
     def ln(self, precision: Int = PRECISION) raises -> Self:
@@ -1753,7 +1725,7 @@ struct BigDecimal(
         Returns:
             The natural logarithm (base e) of this value.
         """
-        return decimo.bigdecimal.exponential.ln(self, precision)
+        return bigdecimal_exponential.ln(self, precision)
 
     @always_inline
     def ln(
@@ -1770,7 +1742,7 @@ struct BigDecimal(
         Returns:
             The natural logarithm (base e) of this value.
         """
-        return decimo.bigdecimal.exponential.ln(self, precision, cache)
+        return bigdecimal_exponential.ln(self, precision, cache)
 
     @always_inline
     def log(self, base: Self, precision: Int = PRECISION) raises -> Self:
@@ -1783,7 +1755,7 @@ struct BigDecimal(
         Returns:
             The logarithm of this value in the given base.
         """
-        return decimo.bigdecimal.exponential.log(self, base, precision)
+        return bigdecimal_exponential.log(self, base, precision)
 
     @always_inline
     def log10(self, precision: Int = PRECISION) raises -> Self:
@@ -1795,7 +1767,7 @@ struct BigDecimal(
         Returns:
             The base-10 logarithm of this value.
         """
-        return decimo.bigdecimal.exponential.log10(self, precision)
+        return bigdecimal_exponential.log10(self, precision)
 
     @always_inline
     def root(self, root: Self, precision: Int = PRECISION) raises -> Self:
@@ -1808,7 +1780,7 @@ struct BigDecimal(
         Returns:
             The nth root of this value.
         """
-        return decimo.bigdecimal.exponential.root(self, root, precision)
+        return bigdecimal_exponential.root(self, root, precision)
 
     @always_inline
     def sqrt(self, precision: Int = PRECISION) raises -> Self:
@@ -1820,7 +1792,7 @@ struct BigDecimal(
         Returns:
             The square root of this value.
         """
-        return decimo.bigdecimal.exponential.sqrt(self, precision)
+        return bigdecimal_exponential.sqrt(self, precision)
 
     @always_inline
     def cbrt(self, precision: Int = PRECISION) raises -> Self:
@@ -1832,7 +1804,7 @@ struct BigDecimal(
         Returns:
             The cube root of this value.
         """
-        return decimo.bigdecimal.exponential.cbrt(self, precision)
+        return bigdecimal_exponential.cbrt(self, precision)
 
     @always_inline
     def power(self, exponent: Self, precision: Int = PRECISION) raises -> Self:
@@ -1846,7 +1818,7 @@ struct BigDecimal(
         Returns:
             This value raised to the given exponent.
         """
-        return decimo.bigdecimal.exponential.power(self, exponent, precision)
+        return bigdecimal_exponential.power(self, exponent, precision)
 
     # === Trigonometric operations === #
     @always_inline
@@ -1859,7 +1831,7 @@ struct BigDecimal(
         Returns:
             The sine of this value.
         """
-        return decimo.bigdecimal.trigonometric.sin(self, precision)
+        return bigdecimal_trigonometric.sin(self, precision)
 
     @always_inline
     def cos(self, precision: Int = PRECISION) raises -> Self:
@@ -1871,7 +1843,7 @@ struct BigDecimal(
         Returns:
             The cosine of this value.
         """
-        return decimo.bigdecimal.trigonometric.cos(self, precision)
+        return bigdecimal_trigonometric.cos(self, precision)
 
     @always_inline
     def tan(self, precision: Int = PRECISION) raises -> Self:
@@ -1883,7 +1855,7 @@ struct BigDecimal(
         Returns:
             The tangent of this value.
         """
-        return decimo.bigdecimal.trigonometric.tan(self, precision)
+        return bigdecimal_trigonometric.tan(self, precision)
 
     @always_inline
     def cot(self, precision: Int = PRECISION) raises -> Self:
@@ -1895,7 +1867,7 @@ struct BigDecimal(
         Returns:
             The cotangent of this value.
         """
-        return decimo.bigdecimal.trigonometric.cot(self, precision)
+        return bigdecimal_trigonometric.cot(self, precision)
 
     @always_inline
     def csc(self, precision: Int = PRECISION) raises -> Self:
@@ -1907,7 +1879,7 @@ struct BigDecimal(
         Returns:
             The cosecant of this value.
         """
-        return decimo.bigdecimal.trigonometric.csc(self, precision)
+        return bigdecimal_trigonometric.csc(self, precision)
 
     @always_inline
     def sec(self, precision: Int = PRECISION) raises -> Self:
@@ -1919,7 +1891,7 @@ struct BigDecimal(
         Returns:
             The secant of this value.
         """
-        return decimo.bigdecimal.trigonometric.sec(self, precision)
+        return bigdecimal_trigonometric.sec(self, precision)
 
     @always_inline
     def arctan(self, precision: Int = PRECISION) raises -> Self:
@@ -1931,7 +1903,7 @@ struct BigDecimal(
         Returns:
             The arctangent of this value in radians.
         """
-        return decimo.bigdecimal.trigonometric.arctan(self, precision)
+        return bigdecimal_trigonometric.arctan(self, precision)
 
     # === Arithmetic operations === #
 
@@ -1949,7 +1921,7 @@ struct BigDecimal(
         Returns:
             The quotient of the division with the specified significant digits.
         """
-        return decimo.bigdecimal.arithmetics.true_divide_inexact(
+        return bigdecimal_arithmetics.true_divide_inexact(
             self, other, number_of_significant_digits
         )
 
@@ -1967,7 +1939,7 @@ struct BigDecimal(
         Returns:
             The quotient of dividing this value by the given `UInt32`.
         """
-        return decimo.bigdecimal.arithmetics.true_divide_inexact_by_uint32(
+        return bigdecimal_arithmetics.true_divide_inexact_by_uint32(
             self, y, number_of_significant_digits
         )
 
@@ -1982,7 +1954,7 @@ struct BigDecimal(
         Returns:
             The integer quotient, truncated toward zero.
         """
-        return decimo.bigdecimal.arithmetics.truncate_divide(self, other)
+        return bigdecimal_arithmetics.truncate_divide(self, other)
 
     # === Rounding operations === #
 
@@ -2015,7 +1987,7 @@ struct BigDecimal(
         Returns:
             A new `BigDecimal` rounded to the specified decimal places.
         """
-        return decimo.bigdecimal.rounding.round(self, ndigits, rounding_mode)
+        return bigdecimal_rounding.round(self, ndigits, rounding_mode)
 
     @always_inline
     def round_to_precision(
@@ -2041,7 +2013,7 @@ struct BigDecimal(
             remove_extra_digit_due_to_rounding: Whether to remove an extra leading digit caused by rounding up.
             fill_zeros_to_precision: Whether to pad with trailing zeros to reach the target precision.
         """
-        decimo.bigdecimal.rounding.round_to_precision(
+        bigdecimal_rounding.round_to_precision(
             self,
             precision,
             rounding_mode,
@@ -2097,7 +2069,7 @@ struct BigDecimal(
             See `decimo.bigdecimal.rounding.quantize()` for detailed examples
             and technical information.
         """
-        return decimo.bigdecimal.rounding.quantize(self, exp, rounding_mode)
+        return bigdecimal_rounding.quantize(self, exp, rounding_mode)
 
     def fma(self, a: Self, b: Self) raises -> Self:
         """Fused multiply-add: returns `self * a + b` with no intermediate
@@ -2338,7 +2310,7 @@ struct BigDecimal(
             return self.copy()
 
         return Self(
-            decimo.biguint.arithmetics.multiply_by_power_of_ten(
+            biguint_arithmetics.multiply_by_power_of_ten(
                 self.coefficient, precision_diff
             ),
             self.scale + precision_diff,
@@ -2377,7 +2349,7 @@ struct BigDecimal(
         if precision_diff <= 0:
             return
 
-        decimo.biguint.arithmetics.multiply_by_power_of_ten_inplace(
+        biguint_arithmetics.multiply_by_power_of_ten_inplace(
             self.coefficient, precision_diff
         )
         self.scale += precision_diff
@@ -2444,7 +2416,7 @@ struct BigDecimal(
             var label = "word " + String(i) + ":"
             result += label + String(" ") * (col - label.byte_length())
             result += (
-                decimo.str.rjust(
+                decimo_str.rjust(
                     String(self.coefficient.words[i]), 9, fillchar="0"
                 )
                 + "\n"

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -30,7 +30,7 @@ from std import testing
 from decimo.errors import ConversionError, ValueError
 from decimo.rounding_mode import RoundingMode
 from decimo.bigdecimal.exponential import MathCache
-from decimo.bigdecimal.rounding import round_to_precision
+from decimo.bigdecimal.rounding import round_to_precision_inplace
 from decimo.bigint10.bigint10 import BigInt10
 import decimo.str as decimo_str
 import decimo.bigdecimal.arithmetics as bigdecimal_arithmetics
@@ -1990,7 +1990,7 @@ struct BigDecimal(
         return bigdecimal_rounding.round(self, ndigits, rounding_mode)
 
     @always_inline
-    def round_to_precision(
+    def round_to_precision_inplace(
         mut self,
         precision: Int,
         rounding_mode: RoundingMode,
@@ -2005,7 +2005,7 @@ struct BigDecimal(
         not the number of decimal places. If you want to round to a
         specific number of decimal places, use `round()` instead.
 
-        See `rounding.round_to_precision()` for more information.
+        See `rounding.round_to_precision_inplace()` for more information.
 
         Args:
             precision: The number of significant digits to round to.
@@ -2013,7 +2013,7 @@ struct BigDecimal(
             remove_extra_digit_due_to_rounding: Whether to remove an extra leading digit caused by rounding up.
             fill_zeros_to_precision: Whether to pad with trailing zeros to reach the target precision.
         """
-        bigdecimal_rounding.round_to_precision(
+        bigdecimal_rounding.round_to_precision_inplace(
             self,
             precision,
             rounding_mode,

--- a/src/decimo/bigdecimal/constants.mojo
+++ b/src/decimo/bigdecimal/constants.mojo
@@ -21,7 +21,7 @@ from decimo.bigdecimal.bigdecimal import BigDecimal
 from decimo.errors import ValueError
 from decimo.bigint10.bigint10 import BigInt10
 from decimo.rounding_mode import RoundingMode
-import decimo.bigdecimal.trigonometric
+import decimo.bigdecimal.trigonometric as bigdecimal_trigonometric
 
 comptime PI_1024 = BigDecimal(
     coefficient=BigUInt(
@@ -368,14 +368,14 @@ def pi_machin(precision: Int) raises -> BigDecimal:
     # Calculate 4 * arctan(1/5)
     var one_fifth = bdec_1.true_divide(bdec_5, working_precision)
     var term1 = bdec_4.multiply(
-        decimo.bigdecimal.trigonometric.arctan_taylor_series(
+        bigdecimal_trigonometric.arctan_taylor_series(
             one_fifth, working_precision
         )
     )
 
     # Calculate arctan(1/239)
     var one_239 = bdec_1.true_divide(bdec_239, working_precision)
-    var term2 = decimo.bigdecimal.trigonometric.arctan_taylor_series(
+    var term2 = bigdecimal_trigonometric.arctan_taylor_series(
         one_239, working_precision
     )
 

--- a/src/decimo/bigdecimal/constants.mojo
+++ b/src/decimo/bigdecimal/constants.mojo
@@ -177,7 +177,7 @@ def pi(precision: Int) raises -> BigDecimal:
     # we can check if we have a cached value for the requested precision.
     # if precision <= 1024:
     #     var result = PI_1024
-    #     result.round_to_precision(
+    #     result.round_to_precision_inplace(
     #         precision,
     #         RoundingMode.ROUND_HALF_EVEN,
     #         remove_extra_digit_due_to_rounding=True,
@@ -253,7 +253,7 @@ def pi_chudnovsky_binary_split(precision: Int) raises -> BigDecimal:
         bdec_10005.sqrt(working_precision)
     ).multiply(sum_series)
 
-    result.round_to_precision(
+    result.round_to_precision_inplace(
         precision,
         RoundingMode.half_even(),
         remove_extra_digit_due_to_rounding=True,
@@ -383,7 +383,7 @@ def pi_machin(precision: Int) raises -> BigDecimal:
     var pi_over_4 = term1.subtract(term2)
     var result = bdec_4.multiply(pi_over_4)
 
-    result.round_to_precision(
+    result.round_to_precision_inplace(
         precision,
         RoundingMode.half_even(),
         remove_extra_digit_due_to_rounding=True,

--- a/src/decimo/bigdecimal/exponential.mojo
+++ b/src/decimo/bigdecimal/exponential.mojo
@@ -1699,12 +1699,14 @@ def sqrt_decimal_approach(x: BigDecimal, precision: Int) raises -> BigDecimal:
         iteration_count += 1
 
     # Round to the desired precision (in-place, no intermediate copy)
-    var ndigits_to_remove = guess.coefficient.number_of_digits() - precision
+    var guess_ndigits = guess.coefficient.number_of_digits()
+    var ndigits_to_remove = guess_ndigits - precision
     if ndigits_to_remove > 0:
         guess.coefficient.remove_trailing_digits_with_rounding_inplace(
             ndigits_to_remove,
             rounding_mode=RoundingMode.half_up(),
             remove_extra_digit_due_to_rounding=True,
+            ndigits_before_removal=guess_ndigits,
         )
         guess.scale -= ndigits_to_remove
 

--- a/src/decimo/bigdecimal/exponential.mojo
+++ b/src/decimo/bigdecimal/exponential.mojo
@@ -18,10 +18,10 @@
 
 from std import math
 
-import decimo.bigdecimal.arithmetics
-import decimo.biguint.arithmetics
-import decimo.biguint.exponential
-import decimo.decimal128.utility
+import decimo.bigdecimal.arithmetics as bigdecimal_arithmetics
+import decimo.biguint.arithmetics as biguint_arithmetics
+import decimo.biguint.exponential as biguint_exponential
+import decimo.decimal128.utility as decimal128_utility
 from decimo.bigdecimal.bigdecimal import BigDecimal
 from decimo.errors import ValueError, OverflowError, ZeroDivisionError
 from decimo.rounding_mode import RoundingMode
@@ -340,9 +340,7 @@ def integer_power(
         if exp_value.words[0] % 2 == 1:
             # If current bit is set, multiply result by current power
             # Use inplace multiply
-            decimo.bigdecimal.arithmetics.multiply_inplace(
-                result, current_power
-            )
+            bigdecimal_arithmetics.multiply_inplace(result, current_power)
             # Round to avoid coefficient explosion
             result.round_to_precision(
                 working_precision,
@@ -362,7 +360,7 @@ def integer_power(
             fill_zeros_to_precision=False,
         )
 
-        decimo.biguint.arithmetics.floor_divide_by_2_inplace(exp_value)
+        biguint_arithmetics.floor_divide_by_2_inplace(exp_value)
 
     # For negative exponents, compute reciprocal
     if is_negative_exponent:
@@ -1110,7 +1108,7 @@ def fast_isqrt(c: BigUInt, working_digits: Int) raises -> BigUInt:
             fill_zeros_to_precision=False,
         )
 
-        decimo.bigdecimal.arithmetics.multiply_inplace(r_sq, c_norm)
+        bigdecimal_arithmetics.multiply_inplace(r_sq, c_norm)
         r_sq.round_to_precision(
             precision=ip,
             rounding_mode=RoundingMode.half_up(),
@@ -1120,7 +1118,7 @@ def fast_isqrt(c: BigUInt, working_digits: Int) raises -> BigUInt:
 
         var correction = three.subtract(r_sq)
 
-        decimo.bigdecimal.arithmetics.multiply_inplace(r, correction)
+        bigdecimal_arithmetics.multiply_inplace(r, correction)
         r.round_to_precision(
             precision=ip,
             rounding_mode=RoundingMode.half_up(),
@@ -1151,12 +1149,12 @@ def fast_isqrt(c: BigUInt, working_digits: Int) raises -> BigUInt:
         # Integer or with trailing zeros
         n = result_bd.coefficient.copy()
         if result_bd.scale < 0:
-            n = decimo.biguint.arithmetics.multiply_by_power_of_ten(
+            n = biguint_arithmetics.multiply_by_power_of_ten(
                 n, -result_bd.scale
             )
     else:
         # Has decimal places — truncate to integer
-        n = decimo.biguint.arithmetics.floor_divide_by_power_of_ten(
+        n = biguint_arithmetics.floor_divide_by_power_of_ten(
             result_bd.coefficient, result_bd.scale
         )
 
@@ -1170,7 +1168,7 @@ def fast_isqrt(c: BigUInt, working_digits: Int) raises -> BigUInt:
         # Newton step: n = (n + c/n) / 2
         var q = c.floor_divide(n)
         n += q
-        decimo.biguint.arithmetics.floor_divide_by_2_inplace(n)
+        biguint_arithmetics.floor_divide_by_2_inplace(n)
         if n == prev_n:
             break
         if prev_n == n + BigUInt.one():
@@ -1249,7 +1247,7 @@ def sqrt_exact(x: BigDecimal, precision: Int) raises -> BigDecimal:
 
     if x_exp & 1:
         # Odd exponent: c = c * 10
-        c = decimo.biguint.arithmetics.multiply_by_power_of_ten(c, 1)
+        c = biguint_arithmetics.multiply_by_power_of_ten(c, 1)
         l = (num_digits >> 1) + 1
     else:
         # Even exponent
@@ -1263,10 +1261,10 @@ def sqrt_exact(x: BigDecimal, precision: Int) raises -> BigDecimal:
 
     if shift >= 0:
         # Pad c with 2*shift zeros: c = c * 100^shift
-        c = decimo.biguint.arithmetics.multiply_by_power_of_ten(c, 2 * shift)
+        c = biguint_arithmetics.multiply_by_power_of_ten(c, 2 * shift)
     else:
         # Truncate c: c, remainder = divmod(c, 100^(-shift))
-        var divisor = decimo.biguint.arithmetics.multiply_by_power_of_ten(
+        var divisor = biguint_arithmetics.multiply_by_power_of_ten(
             BigUInt.one(), -2 * shift
         )
         var qr = c.__divmod__(divisor)
@@ -1280,7 +1278,7 @@ def sqrt_exact(x: BigDecimal, precision: Int) raises -> BigDecimal:
     # For small c (≤ 180 digits), BigUInt.sqrt() is fast enough directly.
     var n: BigUInt
     if len(c.words) <= 20:
-        n = decimo.biguint.exponential.sqrt(c)
+        n = biguint_exponential.sqrt(c)
     else:
         n = fast_isqrt(c, prec + 10)
 
@@ -1291,11 +1289,9 @@ def sqrt_exact(x: BigDecimal, precision: Int) raises -> BigDecimal:
         # Undo the rescaling to get the natural number of significant digits.
         # This naturally strips artificial trailing zeros.
         if shift >= 0:
-            n = decimo.biguint.arithmetics.floor_divide_by_power_of_ten(
-                n, shift
-            )
+            n = biguint_arithmetics.floor_divide_by_power_of_ten(n, shift)
         else:
-            n = decimo.biguint.arithmetics.multiply_by_power_of_ten(n, -shift)
+            n = biguint_arithmetics.multiply_by_power_of_ten(n, -shift)
         e += shift
     else:
         # For inexact results, if n ends in 0 or 5, perturb by +1.
@@ -1303,7 +1299,7 @@ def sqrt_exact(x: BigDecimal, precision: Int) raises -> BigDecimal:
         # Check: n % 5 == 0
         # Since our BigUInt base is 10^9, n % 5 == (last_word % 5)
         if n.words[0] % 5 == 0:
-            decimo.biguint.arithmetics.add_by_uint32_inplace(n, 1)
+            biguint_arithmetics.add_by_uint32_inplace(n, 1)
 
     # Construct result: coefficient=n, scale=-e (since exponent=e means *10^e)
     var result = BigDecimal(n^, -e, False)
@@ -1432,7 +1428,7 @@ def sqrt_reciprocal(x: BigDecimal, precision: Int) raises -> BigDecimal:
         )
 
         # x_norm * r^2 (inplace to avoid allocation: r_sq becomes x_norm * r^2)
-        decimo.bigdecimal.arithmetics.multiply_inplace(r_sq, x_norm)
+        bigdecimal_arithmetics.multiply_inplace(r_sq, x_norm)
         r_sq.round_to_precision(
             precision=ip,
             rounding_mode=RoundingMode.half_up(),
@@ -1444,7 +1440,7 @@ def sqrt_reciprocal(x: BigDecimal, precision: Int) raises -> BigDecimal:
         var correction = three.subtract(r_sq)
 
         # r * (3 - x_norm * r^2) (inplace)
-        decimo.bigdecimal.arithmetics.multiply_inplace(r, correction)
+        bigdecimal_arithmetics.multiply_inplace(r, correction)
         r.round_to_precision(
             precision=ip,
             rounding_mode=RoundingMode.half_up(),
@@ -1473,10 +1469,8 @@ def sqrt_reciprocal(x: BigDecimal, precision: Int) raises -> BigDecimal:
     # Only strip if the stripped result is a verified perfect square.
     var n_trailing = result.coefficient.number_of_trailing_zeros()
     if n_trailing > 0:
-        var stripped_coef = (
-            decimo.biguint.arithmetics.floor_divide_by_power_of_ten(
-                result.coefficient, n_trailing
-            )
+        var stripped_coef = biguint_arithmetics.floor_divide_by_power_of_ten(
+            result.coefficient, n_trailing
         )
         var stripped_scale = result.scale - n_trailing
         var candidate = BigDecimal(stripped_coef^, stripped_scale, False)
@@ -1489,7 +1483,7 @@ def sqrt_reciprocal(x: BigDecimal, precision: Int) raises -> BigDecimal:
             # But sqrt(1e10) should return "1E+5" (scale=-5) since input has scale=-10.
             if candidate.scale < 0 and x.scale >= 0:
                 candidate.coefficient = (
-                    decimo.biguint.arithmetics.multiply_by_power_of_ten(
+                    biguint_arithmetics.multiply_by_power_of_ten(
                         candidate.coefficient, -candidate.scale
                     )
                 )
@@ -1552,22 +1546,18 @@ def sqrt_newton(x: BigDecimal, precision: Int) raises -> BigDecimal:
     var half_n_digits_to_extend = n_digits_to_extend // 2
     var extended_coefficient: BigUInt
     if n_digits_to_extend > 0:
-        extended_coefficient = (
-            decimo.biguint.arithmetics.multiply_by_power_of_ten(
-                x.coefficient, n_digits_to_extend
-            )
+        extended_coefficient = biguint_arithmetics.multiply_by_power_of_ten(
+            x.coefficient, n_digits_to_extend
         )
     elif n_digits_to_extend == 0:
         extended_coefficient = x.coefficient.copy()
     else:  # n_digits_to_extend < 0
-        extended_coefficient = (
-            decimo.biguint.arithmetics.floor_divide_by_power_of_ten(
-                x.coefficient, -n_digits_to_extend
-            )
+        extended_coefficient = biguint_arithmetics.floor_divide_by_power_of_ten(
+            x.coefficient, -n_digits_to_extend
         )
 
     # STEP 2: Calculate the square root of the extended coefficient
-    var sqrt_coefficient = decimo.biguint.exponential.sqrt(extended_coefficient)
+    var sqrt_coefficient = biguint_exponential.sqrt(extended_coefficient)
 
     # If the last p digits of the coefficient are zeros, this means that
     # we have a perfect square, so we can scale down the coefficient
@@ -1575,10 +1565,8 @@ def sqrt_newton(x: BigDecimal, precision: Int) raises -> BigDecimal:
     if (
         sqrt_coefficient.number_of_trailing_zeros() >= half_n_digits_to_extend
     ) and (half_n_digits_to_extend > 0):
-        sqrt_coefficient = (
-            decimo.biguint.arithmetics.floor_divide_by_power_of_ten(
-                sqrt_coefficient, half_n_digits_to_extend
-            )
+        sqrt_coefficient = biguint_arithmetics.floor_divide_by_power_of_ten(
+            sqrt_coefficient, half_n_digits_to_extend
         )
         new_scale -= half_n_digits_to_extend
 
@@ -1685,7 +1673,7 @@ def sqrt_decimal_approach(x: BigDecimal, precision: Int) raises -> BigDecimal:
         )
     if odd_ndigits_frac_part:
         value = value * UInt128(10)
-    var sqrt_value = decimo.decimal128.utility.sqrt(value)
+    var sqrt_value = decimal128_utility.sqrt(value)
     var sqrt_value_biguint = BigUInt.from_unsigned_integral_scalar(sqrt_value)
     guess = BigDecimal(
         sqrt_value_biguint,
@@ -1863,9 +1851,7 @@ def exp(x: BigDecimal, precision: Int) raises -> BigDecimal:
         # This is exact — no rounding needed.
         var reduced_coeff = x.coefficient.copy()
         for _ in range(m):
-            decimo.biguint.arithmetics.multiply_by_uint32_inplace(
-                reduced_coeff, 5
-            )
+            biguint_arithmetics.multiply_by_uint32_inplace(reduced_coeff, 5)
         var reduced_x = BigDecimal(reduced_coeff^, x.scale + m, False)
 
         # Compute exp(x/2^M) via Taylor series (converges in ~√(3.3·p) terms)
@@ -1941,7 +1927,7 @@ def exp_taylor_series(
         # Use O(n) single-word division instead of full BigDecimal div
         var add_on = x.true_divide_inexact_by_uint32(n, minimum_precision)
         # Use inplace multiply to avoid BigDecimal allocation
-        decimo.bigdecimal.arithmetics.multiply_inplace(term, add_on)
+        bigdecimal_arithmetics.multiply_inplace(term, add_on)
         term.round_to_precision(
             precision=minimum_precision,
             rounding_mode=RoundingMode.half_up(),
@@ -2278,7 +2264,7 @@ def ln_series_expansion(
         result.add_inplace(term)  # first term is z
 
         for _ in range(2, max_terms):
-            decimo.bigdecimal.arithmetics.multiply_inplace(term, z)
+            bigdecimal_arithmetics.multiply_inplace(term, z)
             # Truncate to prevent unbounded coefficient growth.
             # The coefficient grows by z_digits each iteration; without
             # this, after k iterations it has ~k×z_digits digits, making
@@ -2334,7 +2320,7 @@ def ln_series_expansion(
     # Series: 2*atanh(u) = 2u + 2u³/3 + 2u⁵/5 + ...
     # First term: t₀ = 2u
     # Recurrence: t_k = t_{k-1} * u² * (2k-1) / (2k+1)
-    decimo.bigdecimal.arithmetics.multiply_inplace(u, two)
+    bigdecimal_arithmetics.multiply_inplace(u, two)
     var term = u^  # term = 2u (first term, k=0)
     var result = term.copy()
 
@@ -2348,11 +2334,11 @@ def ln_series_expansion(
         # Step 1: Undo previous denominator: multiply by (2k-1).
         # Note: when k=1, old_denom=1, so this is a no-op by design;
         # the first term (k=0) has denominator 1, which needs no undoing.
-        decimo.biguint.arithmetics.multiply_by_uint32_inplace(
+        biguint_arithmetics.multiply_by_uint32_inplace(
             term.coefficient, old_denom
         )
         # Step 2: Multiply by u²
-        decimo.bigdecimal.arithmetics.multiply_inplace(term, u_squared)
+        bigdecimal_arithmetics.multiply_inplace(term, u_squared)
         # Step 3: Divide by (2k+1) — also truncates to working_precision
         term = term.true_divide_inexact_by_uint32(new_denom, working_precision)
 
@@ -2447,12 +2433,10 @@ def compute_ln2(working_precision: Int) raises -> BigDecimal:
         var new_k = k + 2
         # Use O(n) single-word division instead of full BigDecimal div
         # Use cached x_squared with inplace multiply, and uint32 multiply for k
-        decimo.bigdecimal.arithmetics.multiply_inplace(term, x_squared)
+        bigdecimal_arithmetics.multiply_inplace(term, x_squared)
         term = term.true_divide_inexact_by_uint32(new_k, working_precision)
         # Multiply by k using coefficient-level UInt32 multiply (avoids BigDecimal alloc)
-        decimo.biguint.arithmetics.multiply_by_uint32_inplace(
-            term.coefficient, k
-        )
+        biguint_arithmetics.multiply_by_uint32_inplace(term.coefficient, k)
         k = new_k
         if term.adjusted() < -working_precision:
             break

--- a/src/decimo/bigdecimal/exponential.mojo
+++ b/src/decimo/bigdecimal/exponential.mojo
@@ -125,7 +125,7 @@ struct MathCache:
         """
         if self._ln2_precision >= precision:
             var result = self._ln2.copy()
-            result.round_to_precision(
+            result.round_to_precision_inplace(
                 precision=precision,
                 rounding_mode=RoundingMode.down(),
                 remove_extra_digit_due_to_rounding=False,
@@ -151,7 +151,7 @@ struct MathCache:
         """
         if self._ln1d25_precision >= precision:
             var result = self._ln1d25.copy()
-            result.round_to_precision(
+            result.round_to_precision_inplace(
                 precision=precision,
                 rounding_mode=RoundingMode.down(),
                 remove_extra_digit_due_to_rounding=False,
@@ -180,7 +180,7 @@ struct MathCache:
         """
         if self._ln10_precision >= precision:
             var result = self._ln10.copy()
-            result.round_to_precision(
+            result.round_to_precision_inplace(
                 precision=precision,
                 rounding_mode=RoundingMode.down(),
                 remove_extra_digit_due_to_rounding=False,
@@ -194,7 +194,7 @@ struct MathCache:
         var ln2 = self.get_ln2(extra)
         var ln1d25 = self.get_ln1d25(extra)
         self._ln10 = ln2.multiply(BigDecimal(3)).add(ln1d25)
-        self._ln10.round_to_precision(
+        self._ln10.round_to_precision_inplace(
             precision=precision,
             rounding_mode=RoundingMode.down(),
             remove_extra_digit_due_to_rounding=False,
@@ -262,7 +262,7 @@ def power(
     if exponent == BigDecimal(BigUInt.one(), 0, False):
         # return base  # x^1 = x
         var result = base.copy()
-        result.round_to_precision(
+        result.round_to_precision_inplace(
             precision,
             rounding_mode=RoundingMode.half_even(),
             remove_extra_digit_due_to_rounding=True,
@@ -295,7 +295,7 @@ def power(
     if base.sign and exponent.is_integer() and exponent.is_odd():
         exp_result.sign = True
 
-    exp_result.round_to_precision(
+    exp_result.round_to_precision_inplace(
         precision,
         rounding_mode=RoundingMode.half_even(),
         remove_extra_digit_due_to_rounding=True,
@@ -342,7 +342,7 @@ def integer_power(
             # Use inplace multiply
             bigdecimal_arithmetics.multiply_inplace(result, current_power)
             # Round to avoid coefficient explosion
-            result.round_to_precision(
+            result.round_to_precision_inplace(
                 working_precision,
                 rounding_mode=RoundingMode.down(),
                 remove_extra_digit_due_to_rounding=False,
@@ -353,7 +353,7 @@ def integer_power(
         # because we need to copy first — just use regular multiply
         current_power = current_power.multiply(current_power)
         # Round to avoid coefficient explosion
-        current_power.round_to_precision(
+        current_power.round_to_precision_inplace(
             working_precision,
             rounding_mode=RoundingMode.down(),
             remove_extra_digit_due_to_rounding=False,
@@ -368,7 +368,7 @@ def integer_power(
             result, working_precision
         )
 
-    result.round_to_precision(
+    result.round_to_precision_inplace(
         precision,
         rounding_mode=RoundingMode.half_even(),
         remove_extra_digit_due_to_rounding=False,
@@ -526,7 +526,7 @@ def root(x: BigDecimal, n: BigDecimal, precision: Int) raises -> BigDecimal:
     if x.sign:
         result.sign = True
 
-    result.round_to_precision(
+    result.round_to_precision_inplace(
         precision=precision,
         rounding_mode=RoundingMode.half_even(),
         remove_extra_digit_due_to_rounding=True,
@@ -584,7 +584,7 @@ def integer_root(
     # Special case: n = 1 (1st root is just the number itself)
     if n.is_one():
         var result = x.copy()
-        result.round_to_precision(
+        result.round_to_precision_inplace(
             precision,
             rounding_mode=RoundingMode.half_even(),
             remove_extra_digit_due_to_rounding=True,
@@ -711,7 +711,7 @@ def integer_root(
         # integer_power to produce huge coefficients that trigger BigUInt
         # division edge cases.
         if r.coefficient.number_of_digits() > iter_precision + BUFFER_DIGITS:
-            r.round_to_precision(
+            r.round_to_precision_inplace(
                 precision=iter_precision + BUFFER_DIGITS,
                 rounding_mode=RoundingMode.half_even(),
                 remove_extra_digit_due_to_rounding=True,
@@ -743,14 +743,14 @@ def integer_root(
             if iter_precision >= working_precision:
                 # Final precision reached: compare at target precision
                 var r_rounded = r.copy()
-                r_rounded.round_to_precision(
+                r_rounded.round_to_precision_inplace(
                     precision=precision,
                     rounding_mode=RoundingMode.half_even(),
                     remove_extra_digit_due_to_rounding=True,
                     fill_zeros_to_precision=False,
                 )
                 var r_new_rounded = r_new.copy()
-                r_new_rounded.round_to_precision(
+                r_new_rounded.round_to_precision_inplace(
                     precision=precision,
                     rounding_mode=RoundingMode.half_even(),
                     remove_extra_digit_due_to_rounding=True,
@@ -763,14 +763,14 @@ def integer_root(
                 # Before final precision: detect early convergence (exact results
                 # like cbrt(0.001)=0.1 converge in few iterations at any precision).
                 var r_rounded = r.copy()
-                r_rounded.round_to_precision(
+                r_rounded.round_to_precision_inplace(
                     precision=iter_precision,
                     rounding_mode=RoundingMode.half_even(),
                     remove_extra_digit_due_to_rounding=True,
                     fill_zeros_to_precision=False,
                 )
                 var r_new_rounded = r_new.copy()
-                r_new_rounded.round_to_precision(
+                r_new_rounded.round_to_precision_inplace(
                     precision=iter_precision,
                     rounding_mode=RoundingMode.half_even(),
                     remove_extra_digit_due_to_rounding=True,
@@ -782,7 +782,7 @@ def integer_root(
         r = r_new^
 
     r.sign = result_sign
-    r.round_to_precision(
+    r.round_to_precision_inplace(
         precision=precision,
         rounding_mode=RoundingMode.half_even(),
         remove_extra_digit_due_to_rounding=True,
@@ -817,7 +817,7 @@ def _integer_root_via_exp_ln(
     var result = exp(ln_divided, working_precision)
     result.sign = result_sign
 
-    result.round_to_precision(
+    result.round_to_precision_inplace(
         precision=precision,
         rounding_mode=RoundingMode.half_even(),
         remove_extra_digit_due_to_rounding=True,
@@ -1101,7 +1101,7 @@ def fast_isqrt(c: BigUInt, working_digits: Int) raises -> BigUInt:
         var ip = prec_schedule[i] + 10
 
         var r_sq = r.multiply(r)
-        r_sq.round_to_precision(
+        r_sq.round_to_precision_inplace(
             precision=ip,
             rounding_mode=RoundingMode.half_up(),
             remove_extra_digit_due_to_rounding=True,
@@ -1109,7 +1109,7 @@ def fast_isqrt(c: BigUInt, working_digits: Int) raises -> BigUInt:
         )
 
         bigdecimal_arithmetics.multiply_inplace(r_sq, c_norm)
-        r_sq.round_to_precision(
+        r_sq.round_to_precision_inplace(
             precision=ip,
             rounding_mode=RoundingMode.half_up(),
             remove_extra_digit_due_to_rounding=True,
@@ -1119,7 +1119,7 @@ def fast_isqrt(c: BigUInt, working_digits: Int) raises -> BigUInt:
         var correction = three.subtract(r_sq)
 
         bigdecimal_arithmetics.multiply_inplace(r, correction)
-        r.round_to_precision(
+        r.round_to_precision_inplace(
             precision=ip,
             rounding_mode=RoundingMode.half_up(),
             remove_extra_digit_due_to_rounding=True,
@@ -1133,7 +1133,7 @@ def fast_isqrt(c: BigUInt, working_digits: Int) raises -> BigUInt:
     result_bd.scale -= norm_shift // 2
 
     # Round to enough digits to get an accurate integer
-    result_bd.round_to_precision(
+    result_bd.round_to_precision_inplace(
         precision=working_digits,
         rounding_mode=RoundingMode.half_up(),
         remove_extra_digit_due_to_rounding=True,
@@ -1309,7 +1309,7 @@ def sqrt_exact(x: BigDecimal, precision: Int) raises -> BigDecimal:
     # `precision` digits this is a no-op, but when the natural digit count
     # exceeds `precision` (e.g. sqrt(10000) at precision=1) it correctly
     # truncates — matching CPython's `_fix(context)` behavior.
-    result.round_to_precision(
+    result.round_to_precision_inplace(
         precision=precision,
         rounding_mode=RoundingMode.half_even(),
         remove_extra_digit_due_to_rounding=True,
@@ -1420,7 +1420,7 @@ def sqrt_reciprocal(x: BigDecimal, precision: Int) raises -> BigDecimal:
 
         # r^2 (self-squaring, cannot use multiply_inplace)
         var r_sq = r.multiply(r)
-        r_sq.round_to_precision(
+        r_sq.round_to_precision_inplace(
             precision=ip,
             rounding_mode=RoundingMode.half_up(),
             remove_extra_digit_due_to_rounding=True,
@@ -1429,7 +1429,7 @@ def sqrt_reciprocal(x: BigDecimal, precision: Int) raises -> BigDecimal:
 
         # x_norm * r^2 (inplace to avoid allocation: r_sq becomes x_norm * r^2)
         bigdecimal_arithmetics.multiply_inplace(r_sq, x_norm)
-        r_sq.round_to_precision(
+        r_sq.round_to_precision_inplace(
             precision=ip,
             rounding_mode=RoundingMode.half_up(),
             remove_extra_digit_due_to_rounding=True,
@@ -1441,7 +1441,7 @@ def sqrt_reciprocal(x: BigDecimal, precision: Int) raises -> BigDecimal:
 
         # r * (3 - x_norm * r^2) (inplace)
         bigdecimal_arithmetics.multiply_inplace(r, correction)
-        r.round_to_precision(
+        r.round_to_precision_inplace(
             precision=ip,
             rounding_mode=RoundingMode.half_up(),
             remove_extra_digit_due_to_rounding=True,
@@ -1458,7 +1458,7 @@ def sqrt_reciprocal(x: BigDecimal, precision: Int) raises -> BigDecimal:
     result.scale -= shift // 2
 
     # --- Round to desired precision ---
-    result.round_to_precision(
+    result.round_to_precision_inplace(
         precision=precision,
         rounding_mode=RoundingMode.half_up(),
         remove_extra_digit_due_to_rounding=True,
@@ -1575,7 +1575,7 @@ def sqrt_newton(x: BigDecimal, precision: Int) raises -> BigDecimal:
         new_scale,
         False,
     )
-    result.round_to_precision(
+    result.round_to_precision_inplace(
         precision=precision,
         rounding_mode=RoundingMode.half_up(),
         remove_extra_digit_due_to_rounding=True,
@@ -1698,16 +1698,14 @@ def sqrt_decimal_approach(x: BigDecimal, precision: Int) raises -> BigDecimal:
         guess = sum_val.true_divide_inexact_by_uint32(2, working_precision)
         iteration_count += 1
 
-    # Round to the desired precision
+    # Round to the desired precision (in-place, no intermediate copy)
     var ndigits_to_remove = guess.coefficient.number_of_digits() - precision
     if ndigits_to_remove > 0:
-        var coefficient = guess.coefficient.copy()
-        coefficient = coefficient.remove_trailing_digits_with_rounding(
+        guess.coefficient.remove_trailing_digits_with_rounding_inplace(
             ndigits_to_remove,
             rounding_mode=RoundingMode.half_up(),
             remove_extra_digit_due_to_rounding=True,
         )
-        guess.coefficient = coefficient^
         guess.scale -= ndigits_to_remove
 
     # Remove trailing zeros for exact results
@@ -1733,7 +1731,7 @@ def sqrt_decimal_approach(x: BigDecimal, precision: Int) raises -> BigDecimal:
             var expected_ndigits_of_result = (
                 x.coefficient.number_of_digits() + 1
             ) // 2
-            guess.round_to_precision(
+            guess.round_to_precision_inplace(
                 precision=expected_ndigits_of_result,
                 rounding_mode=RoundingMode.down(),
                 remove_extra_digit_due_to_rounding=False,
@@ -1860,14 +1858,14 @@ def exp(x: BigDecimal, precision: Int) raises -> BigDecimal:
         # Square result M times: exp(x) = exp(x/2^M)^(2^M)
         for _ in range(m):
             result = result.multiply(result)
-            result.round_to_precision(
+            result.round_to_precision_inplace(
                 precision=working_precision,
                 rounding_mode=RoundingMode.half_up(),
                 remove_extra_digit_due_to_rounding=False,
                 fill_zeros_to_precision=False,
             )
 
-        result.round_to_precision(
+        result.round_to_precision_inplace(
             precision=precision,
             rounding_mode=RoundingMode.half_even(),
             remove_extra_digit_due_to_rounding=False,
@@ -1880,7 +1878,7 @@ def exp(x: BigDecimal, precision: Int) raises -> BigDecimal:
     var working_precision_basic = precision + 9
     var result = exp_taylor_series(x, working_precision_basic)
 
-    result.round_to_precision(
+    result.round_to_precision_inplace(
         precision=precision,
         rounding_mode=RoundingMode.half_even(),
         remove_extra_digit_due_to_rounding=True,
@@ -1928,7 +1926,7 @@ def exp_taylor_series(
         var add_on = x.true_divide_inexact_by_uint32(n, minimum_precision)
         # Use inplace multiply to avoid BigDecimal allocation
         bigdecimal_arithmetics.multiply_inplace(term, add_on)
-        term.round_to_precision(
+        term.round_to_precision_inplace(
             precision=minimum_precision,
             rounding_mode=RoundingMode.half_up(),
             remove_extra_digit_due_to_rounding=False,
@@ -1945,7 +1943,7 @@ def exp_taylor_series(
         if term.adjusted() < -minimum_precision:
             break
 
-    result.round_to_precision(
+    result.round_to_precision_inplace(
         precision=minimum_precision,
         rounding_mode=RoundingMode.half_up(),
         remove_extra_digit_due_to_rounding=False,
@@ -2075,7 +2073,7 @@ def ln(
         )
 
     # Round to final precision
-    result.round_to_precision(
+    result.round_to_precision_inplace(
         precision=precision,
         rounding_mode=RoundingMode.half_even(),
         remove_extra_digit_due_to_rounding=True,
@@ -2273,7 +2271,7 @@ def ln_series_expansion(
                 term.coefficient.number_of_digits()
                 > working_precision + z_digits
             ):
-                term.round_to_precision(
+                term.round_to_precision_inplace(
                     working_precision,
                     RoundingMode.down(),
                     remove_extra_digit_due_to_rounding=False,
@@ -2294,7 +2292,7 @@ def ln_series_expansion(
             if next_term.adjusted() < -working_precision:
                 break
 
-        result.round_to_precision(
+        result.round_to_precision_inplace(
             precision=working_precision,
             rounding_mode=RoundingMode.down(),
             remove_extra_digit_due_to_rounding=False,
@@ -2310,7 +2308,7 @@ def ln_series_expansion(
 
     # Compute u² (cached for the recurrence)
     var u_squared = u.multiply(u)
-    u_squared.round_to_precision(
+    u_squared.round_to_precision_inplace(
         working_precision,
         RoundingMode.down(),
         remove_extra_digit_due_to_rounding=False,
@@ -2347,7 +2345,7 @@ def ln_series_expansion(
         if term.adjusted() < -working_precision:
             break
 
-    result.round_to_precision(
+    result.round_to_precision_inplace(
         precision=working_precision,
         rounding_mode=RoundingMode.down(),
         remove_extra_digit_due_to_rounding=False,
@@ -2398,7 +2396,7 @@ def compute_ln2(working_precision: Int) raises -> BigDecimal:
             90,
             False,
         )
-        result.round_to_precision(
+        result.round_to_precision_inplace(
             precision=working_precision,
             rounding_mode=RoundingMode.down(),
             remove_extra_digit_due_to_rounding=False,
@@ -2441,7 +2439,7 @@ def compute_ln2(working_precision: Int) raises -> BigDecimal:
         if term.adjusted() < -working_precision:
             break
 
-    result.round_to_precision(
+    result.round_to_precision_inplace(
         precision=working_precision,
         rounding_mode=RoundingMode.down(),
         remove_extra_digit_due_to_rounding=False,

--- a/src/decimo/bigdecimal/rounding.mojo
+++ b/src/decimo/bigdecimal/rounding.mojo
@@ -67,7 +67,8 @@ def round(
         return number.extend_precision(precision_diff=-ndigits_to_remove)
     else:  # ndigits_to_remove > 0
         # Remove trailing digits from the number
-        if ndigits_to_remove > number.coefficient.number_of_digits():
+        var ndigits_coefficient = number.coefficient.number_of_digits()
+        if ndigits_to_remove > ndigits_coefficient:
             # All significant digits are removed. For ROUND_DOWN this is
             # always 0. For ROUND_UP (away from zero), any non-zero value
             # rounds to 1 at the target scale. For ROUND_HALF_UP /
@@ -98,10 +99,11 @@ def round(
         # `round_to_precision_inplace` from drifting in behaviour.
         var result = number.copy()
         result.coefficient.remove_trailing_digits_with_rounding_inplace(
-            ndigits=ndigits_to_remove,
+            ndigits_to_remove=ndigits_to_remove,
             rounding_mode=rounding_mode,
             remove_extra_digit_due_to_rounding=False,
             sign=number.sign,
+            ndigits_before_removal=ndigits_coefficient,
         )
         result.scale = ndigits
         return result^
@@ -147,10 +149,11 @@ def round_to_precision_inplace(
             return
 
     number.coefficient.remove_trailing_digits_with_rounding_inplace(
-        ndigits=ndigits_to_remove,
+        ndigits_to_remove=ndigits_to_remove,
         rounding_mode=rounding_mode,
         remove_extra_digit_due_to_rounding=False,
         sign=number.sign,
+        ndigits_before_removal=ndigits_coefficient,
     )
     number.scale -= ndigits_to_remove
 
@@ -158,9 +161,10 @@ def round_to_precision_inplace(
         number.coefficient.number_of_digits() > precision
     ):
         number.coefficient.remove_trailing_digits_with_rounding_inplace(
-            ndigits=1,
+            ndigits_to_remove=1,
             rounding_mode=RoundingMode.down(),
             remove_extra_digit_due_to_rounding=False,
+            ndigits_before_removal=precision + 1,
         )
         number.scale -= 1
 

--- a/src/decimo/bigdecimal/rounding.mojo
+++ b/src/decimo/bigdecimal/rounding.mojo
@@ -93,22 +93,21 @@ def round(
                 scale=ndigits,
                 sign=number.sign,
             )
-        var coefficient = (
-            number.coefficient.remove_trailing_digits_with_rounding(
-                ndigits=ndigits_to_remove,
-                rounding_mode=rounding_mode,
-                remove_extra_digit_due_to_rounding=False,
-                sign=number.sign,
-            )
-        )
-        return BigDecimal(
-            coefficient=coefficient,
-            scale=ndigits,
+        # Copy once, then mutate in place via the single shared rounding
+        # path. Keeps `round()` (out-of-place public API) and
+        # `round_to_precision_inplace` from drifting in behaviour.
+        var result = number.copy()
+        result.coefficient.remove_trailing_digits_with_rounding_inplace(
+            ndigits=ndigits_to_remove,
+            rounding_mode=rounding_mode,
+            remove_extra_digit_due_to_rounding=False,
             sign=number.sign,
         )
+        result.scale = ndigits
+        return result^
 
 
-def round_to_precision(
+def round_to_precision_inplace(
     mut number: BigDecimal,
     precision: Int,
     rounding_mode: RoundingMode,

--- a/src/decimo/bigdecimal/trigonometric.mojo
+++ b/src/decimo/bigdecimal/trigonometric.mojo
@@ -23,8 +23,8 @@ from std import time
 from decimo.bigdecimal.bigdecimal import BigDecimal
 from decimo.errors import ValueError
 from decimo.rounding_mode import RoundingMode
-import decimo.bigdecimal.constants
-import decimo.bigdecimal.exponential
+import decimo.bigdecimal.constants as bigdecimal_constants
+import decimo.bigdecimal.exponential as bigdecimal_exponential
 
 
 # ===----------------------------------------------------------------------=== #
@@ -63,7 +63,7 @@ def sin(x: BigDecimal, precision: Int) raises -> BigDecimal:
     var bdec_2 = BigDecimal.from_raw_components(UInt32(2), scale=0, sign=False)
     var bdec_4 = BigDecimal.from_raw_components(UInt32(4), scale=0, sign=False)
     var bdec_6 = BigDecimal.from_raw_components(UInt32(6), scale=0, sign=False)
-    var bdec_pi = decimo.bigdecimal.constants.pi(precision=working_precision)
+    var bdec_pi = bigdecimal_constants.pi(precision=working_precision)
     var bdec_2pi = bdec_2.multiply(bdec_pi)
     var bdec_pi_div_2 = bdec_pi.true_divide(bdec_2, precision=working_precision)
     var bdec_1d6 = BigDecimal.from_raw_components(
@@ -232,7 +232,7 @@ def cos(x: BigDecimal, precision: Int) raises -> BigDecimal:
         return BigDecimal(BigUInt.one())
 
     # cos(x) = sin(π/2 - x)
-    var pi = decimo.bigdecimal.constants.pi(precision=working_precision)
+    var pi = bigdecimal_constants.pi(precision=working_precision)
     var pi_div_2 = pi.true_divide(2, precision=working_precision)
     var result = sin(pi_div_2.subtract(x), precision=precision)
     return result^
@@ -371,7 +371,7 @@ def tan_cot(x: BigDecimal, precision: Int, is_tan: Bool) raises -> BigDecimal:
                 message="cot(nπ) is undefined", function="tan_cot()"
             )
 
-    var pi = decimo.bigdecimal.constants.pi(precision=working_precision_pi)
+    var pi = bigdecimal_constants.pi(precision=working_precision_pi)
     var bdec_2 = BigDecimal.from_raw_components(UInt32(2), scale=0, sign=False)
     var two_pi = bdec_2.multiply(pi)
     var pi_div_2 = pi.true_divide(bdec_2, precision=working_precision_pi)
@@ -515,7 +515,7 @@ def arctan(x: BigDecimal, precision: Int) raises -> BigDecimal:
         # print(bdec_1 + x * x)
         # Use sqrt_reciprocal for speed — exact perfect square detection is
         # unnecessary since this is an intermediate computation.
-        var sqrt_term = decimo.bigdecimal.exponential.sqrt_reciprocal(
+        var sqrt_term = bigdecimal_exponential.sqrt_reciprocal(
             bdec_1.add(x.multiply(x)), working_precision
         )
         var x_divided = x.true_divide(
@@ -531,7 +531,7 @@ def arctan(x: BigDecimal, precision: Int) raises -> BigDecimal:
         # For x < -2: arctan(x) = -π/2 - arctan(1/x)
         # This is to ensure convergence of the Taylor series.
         # print("Using identity for arctan with |x| > 2")
-        var half_pi = decimo.bigdecimal.constants.pi(
+        var half_pi = bigdecimal_constants.pi(
             precision=working_precision
         ).true_divide(bdec_2, precision=working_precision)
         var reciprocal_x = bdec_1.true_divide(x, precision=working_precision)

--- a/src/decimo/bigdecimal/trigonometric.mojo
+++ b/src/decimo/bigdecimal/trigonometric.mojo
@@ -140,7 +140,7 @@ def sin(x: BigDecimal, precision: Int) raises -> BigDecimal:
     if is_negative:
         result = -result
 
-    result.round_to_precision(
+    result.round_to_precision_inplace(
         precision,
         RoundingMode.half_even(),
         remove_extra_digit_due_to_rounding=True,
@@ -201,7 +201,7 @@ def sin_taylor_series(
         sign *= -1
 
         # Ensure that the result will not explode in size
-        result.round_to_precision(
+        result.round_to_precision_inplace(
             working_precision,
             rounding_mode=RoundingMode.down(),
             remove_extra_digit_due_to_rounding=False,
@@ -291,7 +291,7 @@ def cos_taylor_series(
         sign *= -1
 
         # # Prevent size explosion
-        result.round_to_precision(
+        result.round_to_precision_inplace(
             working_precision,
             rounding_mode=RoundingMode.down(),
             remove_extra_digit_due_to_rounding=False,
@@ -408,7 +408,7 @@ def tan_cot(x: BigDecimal, precision: Int, is_tan: Bool) raises -> BigDecimal:
             sin_x, precision=working_precision
         )
 
-    result.round_to_precision(
+    result.round_to_precision_inplace(
         precision,
         RoundingMode.half_even(),
         remove_extra_digit_due_to_rounding=True,
@@ -544,7 +544,7 @@ def arctan(x: BigDecimal, precision: Int) raises -> BigDecimal:
         else:
             result = half_pi.subtract(arctan_reciprocal)
 
-    result.round_to_precision(
+    result.round_to_precision_inplace(
         precision,
         RoundingMode.half_even(),
         remove_extra_digit_due_to_rounding=True,
@@ -605,7 +605,7 @@ def arctan_taylor_series(
             result.subtract_inplace(term_divided)
         sign *= -1
         # Ensure that the result will not explode in size
-        result.round_to_precision(
+        result.round_to_precision_inplace(
             working_precision,
             rounding_mode=RoundingMode.down(),
             remove_extra_digit_due_to_rounding=False,

--- a/src/decimo/bigint/bigint.mojo
+++ b/src/decimo/bigint/bigint.mojo
@@ -30,12 +30,12 @@ in little-endian order, and a separate sign bit.
 from std.memory import UnsafePointer, memcpy
 from std.sys import size_of
 
-import decimo.bigint.arithmetics
-import decimo.bigint.bitwise
-import decimo.bigint.comparison
-import decimo.bigint.exponential
-import decimo.bigint.number_theory
-import decimo.str
+import decimo.bigint.arithmetics as bigint_arithmetics
+import decimo.bigint.bitwise as bigint_bitwise
+import decimo.bigint.comparison as bigint_comparison
+import decimo.bigint.exponential as bigint_exponential
+import decimo.bigint.number_theory as bigint_number_theory
+import decimo.str as decimo_str
 from decimo.bigint10.bigint10 import BigInt10
 from decimo.biguint.biguint import BigUInt
 from decimo.errors import (
@@ -460,7 +460,7 @@ struct BigInt(
         """
         # Use the shared string parser for format handling
         try:
-            _tuple = decimo.str.parse_numeric_string(value)
+            _tuple = decimo_str.parse_numeric_string(value)
         except e:
             raise ConversionError(
                 function="BigInt.from_string(value: String)",
@@ -959,7 +959,7 @@ struct BigInt(
         Returns:
             The sum of the two values.
         """
-        return decimo.bigint.arithmetics.add(self, other)
+        return bigint_arithmetics.add(self, other)
 
     @always_inline
     def __sub__(self, other: Self) -> Self:
@@ -971,7 +971,7 @@ struct BigInt(
         Returns:
             The difference of the two values.
         """
-        return decimo.bigint.arithmetics.subtract(self, other)
+        return bigint_arithmetics.subtract(self, other)
 
     @always_inline
     def __mul__(self, other: Self) -> Self:
@@ -983,7 +983,7 @@ struct BigInt(
         Returns:
             The product of the two values.
         """
-        return decimo.bigint.arithmetics.multiply(self, other)
+        return bigint_arithmetics.multiply(self, other)
 
     @always_inline
     def __floordiv__(self, other: Self) raises -> Self:
@@ -999,7 +999,7 @@ struct BigInt(
             ZeroDivisionError: If the divisor is zero.
         """
         try:
-            return decimo.bigint.arithmetics.floor_divide(self, other)
+            return bigint_arithmetics.floor_divide(self, other)
         except e:
             raise ZeroDivisionError(
                 message="See the above exception.",
@@ -1021,7 +1021,7 @@ struct BigInt(
             ZeroDivisionError: If the divisor is zero.
         """
         try:
-            return decimo.bigint.arithmetics.floor_modulo(self, other)
+            return bigint_arithmetics.floor_modulo(self, other)
         except e:
             raise ZeroDivisionError(
                 message="See the above exception.",
@@ -1043,7 +1043,7 @@ struct BigInt(
             ZeroDivisionError: If the divisor is zero.
         """
         try:
-            return decimo.bigint.arithmetics.floor_divmod(self, other)
+            return bigint_arithmetics.floor_divmod(self, other)
         except e:
             raise ZeroDivisionError(
                 message="See the above exception.",
@@ -1092,7 +1092,7 @@ struct BigInt(
         Returns:
             The left-shifted value.
         """
-        return decimo.bigint.arithmetics.left_shift(self, shift)
+        return bigint_arithmetics.left_shift(self, shift)
 
     @always_inline
     def __rshift__(self, shift: Int) -> Self:
@@ -1104,7 +1104,7 @@ struct BigInt(
         Returns:
             The right-shifted value.
         """
-        return decimo.bigint.arithmetics.right_shift(self, shift)
+        return bigint_arithmetics.right_shift(self, shift)
 
     # ===------------------------------------------------------------------=== #
     # Basic binary right-side arithmetic operation dunders
@@ -1120,7 +1120,7 @@ struct BigInt(
         Returns:
             The sum of the two values.
         """
-        return decimo.bigint.arithmetics.add(self, other)
+        return bigint_arithmetics.add(self, other)
 
     @always_inline
     def __rsub__(self, other: Self) -> Self:
@@ -1132,7 +1132,7 @@ struct BigInt(
         Returns:
             The difference of the two values.
         """
-        return decimo.bigint.arithmetics.subtract(other, self)
+        return bigint_arithmetics.subtract(other, self)
 
     @always_inline
     def __rmul__(self, other: Self) -> Self:
@@ -1144,7 +1144,7 @@ struct BigInt(
         Returns:
             The product of the two values.
         """
-        return decimo.bigint.arithmetics.multiply(self, other)
+        return bigint_arithmetics.multiply(self, other)
 
     @always_inline
     def __rfloordiv__(self, other: Self) raises -> Self:
@@ -1159,7 +1159,7 @@ struct BigInt(
         Raises:
             ZeroDivisionError: If the divisor is zero.
         """
-        return decimo.bigint.arithmetics.floor_divide(other, self)
+        return bigint_arithmetics.floor_divide(other, self)
 
     @always_inline
     def __rmod__(self, other: Self) raises -> Self:
@@ -1174,7 +1174,7 @@ struct BigInt(
         Raises:
             ZeroDivisionError: If the divisor is zero.
         """
-        return decimo.bigint.arithmetics.floor_modulo(other, self)
+        return bigint_arithmetics.floor_modulo(other, self)
 
     @always_inline
     def __rdivmod__(self, other: Self) raises -> Tuple[Self, Self]:
@@ -1189,7 +1189,7 @@ struct BigInt(
         Raises:
             ZeroDivisionError: If the divisor is zero.
         """
-        return decimo.bigint.arithmetics.floor_divmod(other, self)
+        return bigint_arithmetics.floor_divmod(other, self)
 
     @always_inline
     def __rpow__(self, base: Self) raises -> Self:
@@ -1218,7 +1218,7 @@ struct BigInt(
         Args:
             other: The right-hand side operand.
         """
-        decimo.bigint.arithmetics.add_inplace(self, other)
+        bigint_arithmetics.add_inplace(self, other)
 
     @always_inline
     def __iadd__(mut self, other: Int):
@@ -1227,7 +1227,7 @@ struct BigInt(
         Args:
             other: The right-hand side operand.
         """
-        decimo.bigint.arithmetics.add_int_inplace(self, other)
+        bigint_arithmetics.add_int_inplace(self, other)
 
     @always_inline
     def __isub__(mut self, other: Self):
@@ -1236,7 +1236,7 @@ struct BigInt(
         Args:
             other: The right-hand side operand.
         """
-        decimo.bigint.arithmetics.subtract_inplace(self, other)
+        bigint_arithmetics.subtract_inplace(self, other)
 
     @always_inline
     def __imul__(mut self, other: Self):
@@ -1245,7 +1245,7 @@ struct BigInt(
         Args:
             other: The right-hand side operand.
         """
-        decimo.bigint.arithmetics.multiply_inplace(self, other)
+        bigint_arithmetics.multiply_inplace(self, other)
 
     @always_inline
     def __ifloordiv__(mut self, other: Self) raises:
@@ -1257,7 +1257,7 @@ struct BigInt(
         Raises:
             ZeroDivisionError: If the divisor is zero.
         """
-        decimo.bigint.arithmetics.floor_divide_inplace(self, other)
+        bigint_arithmetics.floor_divide_inplace(self, other)
 
     @always_inline
     def __imod__(mut self, other: Self) raises:
@@ -1269,7 +1269,7 @@ struct BigInt(
         Raises:
             ZeroDivisionError: If the divisor is zero.
         """
-        decimo.bigint.arithmetics.floor_modulo_inplace(self, other)
+        bigint_arithmetics.floor_modulo_inplace(self, other)
 
     @always_inline
     def __ilshift__(mut self, shift: Int):
@@ -1278,7 +1278,7 @@ struct BigInt(
         Args:
             shift: The number of bits to shift left.
         """
-        decimo.bigint.arithmetics.left_shift_inplace(self, shift)
+        bigint_arithmetics.left_shift_inplace(self, shift)
 
     @always_inline
     def __irshift__(mut self, shift: Int):
@@ -1287,7 +1287,7 @@ struct BigInt(
         Args:
             shift: The number of bits to shift right.
         """
-        decimo.bigint.arithmetics.right_shift_inplace(self, shift)
+        bigint_arithmetics.right_shift_inplace(self, shift)
 
     # ===------------------------------------------------------------------=== #
     # Basic binary comparison operation dunders
@@ -1304,7 +1304,7 @@ struct BigInt(
         Returns:
             `True` if self is greater than other, `False` otherwise.
         """
-        return decimo.bigint.comparison.greater(self, other)
+        return bigint_comparison.greater(self, other)
 
     @always_inline
     def __gt__(self, other: Int) -> Bool:
@@ -1316,7 +1316,7 @@ struct BigInt(
         Returns:
             `True` if self is greater than other, `False` otherwise.
         """
-        return decimo.bigint.comparison.greater(self, Self.from_int(other))
+        return bigint_comparison.greater(self, Self.from_int(other))
 
     @always_inline
     def __ge__(self, other: Self) -> Bool:
@@ -1328,7 +1328,7 @@ struct BigInt(
         Returns:
             `True` if self is greater than or equal to other, `False` otherwise.
         """
-        return decimo.bigint.comparison.greater_equal(self, other)
+        return bigint_comparison.greater_equal(self, other)
 
     @always_inline
     def __ge__(self, other: Int) -> Bool:
@@ -1340,9 +1340,7 @@ struct BigInt(
         Returns:
             `True` if self is greater than or equal to other, `False` otherwise.
         """
-        return decimo.bigint.comparison.greater_equal(
-            self, Self.from_int(other)
-        )
+        return bigint_comparison.greater_equal(self, Self.from_int(other))
 
     @always_inline
     def __lt__(self, other: Self) -> Bool:
@@ -1354,7 +1352,7 @@ struct BigInt(
         Returns:
             `True` if self is less than other, `False` otherwise.
         """
-        return decimo.bigint.comparison.less(self, other)
+        return bigint_comparison.less(self, other)
 
     @always_inline
     def __lt__(self, other: Int) -> Bool:
@@ -1366,7 +1364,7 @@ struct BigInt(
         Returns:
             `True` if self is less than other, `False` otherwise.
         """
-        return decimo.bigint.comparison.less(self, Self.from_int(other))
+        return bigint_comparison.less(self, Self.from_int(other))
 
     @always_inline
     def __le__(self, other: Self) -> Bool:
@@ -1378,7 +1376,7 @@ struct BigInt(
         Returns:
             `True` if self is less than or equal to other, `False` otherwise.
         """
-        return decimo.bigint.comparison.less_equal(self, other)
+        return bigint_comparison.less_equal(self, other)
 
     @always_inline
     def __le__(self, other: Int) -> Bool:
@@ -1390,7 +1388,7 @@ struct BigInt(
         Returns:
             `True` if self is less than or equal to other, `False` otherwise.
         """
-        return decimo.bigint.comparison.less_equal(self, Self.from_int(other))
+        return bigint_comparison.less_equal(self, Self.from_int(other))
 
     @always_inline
     def __eq__(self, other: Self) -> Bool:
@@ -1402,7 +1400,7 @@ struct BigInt(
         Returns:
             `True` if the two values are equal, `False` otherwise.
         """
-        return decimo.bigint.comparison.equal(self, other)
+        return bigint_comparison.equal(self, other)
 
     @always_inline
     def __eq__(self, other: Int) -> Bool:
@@ -1414,7 +1412,7 @@ struct BigInt(
         Returns:
             `True` if the two values are equal, `False` otherwise.
         """
-        return decimo.bigint.comparison.equal(self, Self.from_int(other))
+        return bigint_comparison.equal(self, Self.from_int(other))
 
     @always_inline
     def __ne__(self, other: Self) -> Bool:
@@ -1426,7 +1424,7 @@ struct BigInt(
         Returns:
             `True` if the two values are not equal, `False` otherwise.
         """
-        return decimo.bigint.comparison.not_equal(self, other)
+        return bigint_comparison.not_equal(self, other)
 
     @always_inline
     def __ne__(self, other: Int) -> Bool:
@@ -1438,7 +1436,7 @@ struct BigInt(
         Returns:
             `True` if the two values are not equal, `False` otherwise.
         """
-        return decimo.bigint.comparison.not_equal(self, Self.from_int(other))
+        return bigint_comparison.not_equal(self, Self.from_int(other))
 
     # ===------------------------------------------------------------------=== #
     # Mathematical methods that do not implement a trait (not a dunder)
@@ -1455,7 +1453,7 @@ struct BigInt(
         Returns:
             The quotient, truncated toward zero.
         """
-        return decimo.bigint.arithmetics.truncate_divide(self, other)
+        return bigint_arithmetics.truncate_divide(self, other)
 
     @always_inline
     def floor_modulo(self, other: Self) raises -> Self:
@@ -1468,7 +1466,7 @@ struct BigInt(
         Returns:
             The floor remainder with the same sign as the divisor.
         """
-        return decimo.bigint.arithmetics.floor_modulo(self, other)
+        return bigint_arithmetics.floor_modulo(self, other)
 
     @always_inline
     def truncate_modulo(self, other: Self) raises -> Self:
@@ -1481,7 +1479,7 @@ struct BigInt(
         Returns:
             The truncated remainder with the same sign as the dividend.
         """
-        return decimo.bigint.arithmetics.truncate_modulo(self, other)
+        return bigint_arithmetics.truncate_modulo(self, other)
 
     def power(self, exponent: Int) raises -> Self:
         """Raises the BigInt to the power of an integer exponent.
@@ -1496,7 +1494,7 @@ struct BigInt(
             ValueError: If the exponent is negative.
             ValueError: If the exponent is too large (>= 1_000_000_000).
         """
-        return decimo.bigint.arithmetics.power(self, exponent)
+        return bigint_arithmetics.power(self, exponent)
 
     def power(self, exponent: Self) raises -> Self:
         """Raises the BigInt to the power of another BigInt.
@@ -1538,7 +1536,7 @@ struct BigInt(
         Raises:
             Error: If the value is negative.
         """
-        return decimo.bigint.exponential.sqrt(self)
+        return bigint_exponential.sqrt(self)
 
     def isqrt(self) raises -> Self:
         """Returns the integer square root of this BigInt.
@@ -1550,7 +1548,7 @@ struct BigInt(
         Raises:
             Error: If the value is negative.
         """
-        return decimo.bigint.exponential.sqrt(self)
+        return bigint_exponential.sqrt(self)
 
     @always_inline
     def compare_magnitudes(self, other: Self) -> Int8:
@@ -1563,7 +1561,7 @@ struct BigInt(
         Returns:
             1 if |self| > |other|, 0 if equal, -1 if |self| < |other|.
         """
-        return decimo.bigint.comparison.compare_magnitudes(self, other)
+        return bigint_comparison.compare_magnitudes(self, other)
 
     @always_inline
     def compare(self, other: Self) -> Int8:
@@ -1576,7 +1574,7 @@ struct BigInt(
         Returns:
             1 if self > other, 0 if equal, -1 if self < other.
         """
-        return decimo.bigint.comparison.compare(self, other)
+        return bigint_comparison.compare(self, other)
 
     # ===------------------------------------------------------------------=== #
     # Bitwise operations
@@ -1592,7 +1590,7 @@ struct BigInt(
         Returns:
             The bitwise AND of the two values.
         """
-        return decimo.bigint.bitwise.bitwise_and(self, other)
+        return bigint_bitwise.bitwise_and(self, other)
 
     @always_inline
     def __and__(self, other: Int) -> Self:
@@ -1604,7 +1602,7 @@ struct BigInt(
         Returns:
             The bitwise AND of the two values.
         """
-        return decimo.bigint.bitwise.bitwise_and(self, Self(other))
+        return bigint_bitwise.bitwise_and(self, Self(other))
 
     @always_inline
     def __or__(self, other: Self) -> Self:
@@ -1616,7 +1614,7 @@ struct BigInt(
         Returns:
             The bitwise OR of the two values.
         """
-        return decimo.bigint.bitwise.bitwise_or(self, other)
+        return bigint_bitwise.bitwise_or(self, other)
 
     @always_inline
     def __or__(self, other: Int) -> Self:
@@ -1628,7 +1626,7 @@ struct BigInt(
         Returns:
             The bitwise OR of the two values.
         """
-        return decimo.bigint.bitwise.bitwise_or(self, Self(other))
+        return bigint_bitwise.bitwise_or(self, Self(other))
 
     @always_inline
     def __xor__(self, other: Self) -> Self:
@@ -1640,7 +1638,7 @@ struct BigInt(
         Returns:
             The bitwise XOR of the two values.
         """
-        return decimo.bigint.bitwise.bitwise_xor(self, other)
+        return bigint_bitwise.bitwise_xor(self, other)
 
     @always_inline
     def __xor__(self, other: Int) -> Self:
@@ -1652,7 +1650,7 @@ struct BigInt(
         Returns:
             The bitwise XOR of the two values.
         """
-        return decimo.bigint.bitwise.bitwise_xor(self, Self(other))
+        return bigint_bitwise.bitwise_xor(self, Self(other))
 
     @always_inline
     def __invert__(self) -> Self:
@@ -1661,7 +1659,7 @@ struct BigInt(
         Returns:
             The bitwise complement, equal to -(self + 1).
         """
-        return decimo.bigint.bitwise.bitwise_not(self)
+        return bigint_bitwise.bitwise_not(self)
 
     @always_inline
     def __iand__(mut self, other: Self):
@@ -1670,7 +1668,7 @@ struct BigInt(
         Args:
             other: The right-hand side operand.
         """
-        decimo.bigint.bitwise.bitwise_and_inplace(self, other)
+        bigint_bitwise.bitwise_and_inplace(self, other)
 
     @always_inline
     def __ior__(mut self, other: Self):
@@ -1679,7 +1677,7 @@ struct BigInt(
         Args:
             other: The right-hand side operand.
         """
-        decimo.bigint.bitwise.bitwise_or_inplace(self, other)
+        bigint_bitwise.bitwise_or_inplace(self, other)
 
     @always_inline
     def __ixor__(mut self, other: Self):
@@ -1688,7 +1686,7 @@ struct BigInt(
         Args:
             other: The right-hand side operand.
         """
-        decimo.bigint.bitwise.bitwise_xor_inplace(self, other)
+        bigint_bitwise.bitwise_xor_inplace(self, other)
 
     # ===------------------------------------------------------------------=== #
     # Number-theoretic methods
@@ -1704,7 +1702,7 @@ struct BigInt(
         Returns:
             The greatest common divisor of the two values.
         """
-        return decimo.bigint.number_theory.gcd(self, other)
+        return bigint_number_theory.gcd(self, other)
 
     @always_inline
     def extended_gcd(self, other: Self) raises -> Tuple[Self, Self, Self]:
@@ -1721,7 +1719,7 @@ struct BigInt(
         Args:
             other: The second value for the extended GCD computation.
         """
-        return decimo.bigint.number_theory.extended_gcd(self, other)
+        return bigint_number_theory.extended_gcd(self, other)
 
     @always_inline
     def lcm(self, other: Self) raises -> Self:
@@ -1733,7 +1731,7 @@ struct BigInt(
         Returns:
             The least common multiple of the two values.
         """
-        return decimo.bigint.number_theory.lcm(self, other)
+        return bigint_number_theory.lcm(self, other)
 
     @always_inline
     def mod_pow(self, exponent: Self, modulus: Self) raises -> Self:
@@ -1747,7 +1745,7 @@ struct BigInt(
         Returns:
             The result of (self ** exponent) % modulus.
         """
-        return decimo.bigint.number_theory.mod_pow(self, exponent, modulus)
+        return bigint_number_theory.mod_pow(self, exponent, modulus)
 
     @always_inline
     def mod_pow(self, exponent: Int, modulus: Self) raises -> Self:
@@ -1761,7 +1759,7 @@ struct BigInt(
         Returns:
             The result of (self ** exponent) % modulus.
         """
-        return decimo.bigint.number_theory.mod_pow(
+        return bigint_number_theory.mod_pow(
             self, Self.from_int(exponent), modulus
         )
 
@@ -1776,7 +1774,7 @@ struct BigInt(
         Returns:
             The modular multiplicative inverse.
         """
-        return decimo.bigint.number_theory.mod_inverse(self, modulus)
+        return bigint_number_theory.mod_inverse(self, modulus)
 
     # ===------------------------------------------------------------------=== #
     # Instance query methods
@@ -1990,7 +1988,7 @@ struct BigInt(
         for i in range(len(self.words)):
             var label = "word " + String(i) + ":"
             result += label + String(" ") * (col - label.byte_length())
-            result += "0x" + decimo.str.rjust(
+            result += "0x" + decimo_str.rjust(
                 String(hex(self.words[i])[byte=2:]), 8, fillchar="0"
             )
             result += "  (" + String(self.words[i]) + ")\n"
@@ -2334,7 +2332,7 @@ def _dc_from_str_recursive(
     # Use _add_magnitudes_inplace directly to avoid BigInt.__iadd__ overhead
     # (which creates a new BigInt via arithmetics.add).
     var result = high * power_table[level]
-    decimo.bigint.arithmetics._add_magnitudes_inplace(result.words, low.words)
+    bigint_arithmetics._add_magnitudes_inplace(result.words, low.words)
     return result^
 
 
@@ -2560,7 +2558,7 @@ def _dc_to_str_recursive(
         return _magnitude_to_decimal_simple(n.words, eff)
 
     # Divide n by powers[level] = 10^(2^level)
-    var qr = decimo.bigint.arithmetics.floor_divmod(n, power_table[level])
+    var qr = bigint_arithmetics.floor_divmod(n, power_table[level])
     var q = qr[0].copy()
     var r = qr[1].copy()
 

--- a/src/decimo/bigint/exponential.mojo
+++ b/src/decimo/bigint/exponential.mojo
@@ -23,8 +23,8 @@ base-2^32 representation for efficient bit-level operations.
 
 from std import math
 
+import decimo.bigint.arithmetics as bigint_arithmetics
 from decimo.bigint.bigint import BigInt
-import decimo.bigint.arithmetics
 from decimo.errors import ValueError
 
 
@@ -391,10 +391,8 @@ def _sqrt_precision_doubling_fast(x: BigInt) raises -> BigInt:
         # All iterations completed natively
         # Final check: a -= 1 if a*a > x
         var a_words = _uint64_to_words(a_val)
-        var a_sq = decimo.bigint.arithmetics._multiply_magnitudes(
-            a_words, a_words
-        )
-        if decimo.bigint.arithmetics._compare_word_lists(a_sq, x.words) > 0:
+        var a_sq = bigint_arithmetics._multiply_magnitudes(a_words, a_words)
+        if bigint_arithmetics._compare_word_lists(a_sq, x.words) > 0:
             a_val -= 1
         return BigInt.from_integral_scalar(a_val)
 
@@ -429,10 +427,8 @@ def _sqrt_precision_doubling_fast(x: BigInt) raises -> BigInt:
     if phase15_end == -1:
         # All iterations completed natively (UInt64 + UInt128)
         var a_words = _uint128_to_words(a128)
-        var a_sq = decimo.bigint.arithmetics._multiply_magnitudes(
-            a_words, a_words
-        )
-        if decimo.bigint.arithmetics._compare_word_lists(a_sq, x.words) > 0:
+        var a_sq = bigint_arithmetics._multiply_magnitudes(a_words, a_words)
+        if bigint_arithmetics._compare_word_lists(a_sq, x.words) > 0:
             if a128 > 0:
                 a128 -= 1
             a_words = _uint128_to_words(a128)
@@ -452,19 +448,17 @@ def _sqrt_precision_doubling_fast(x: BigInt) raises -> BigInt:
         var n_shifted = _right_shift_magnitude_bits(x.words, shift_n)
 
         # Divide n_shifted by current a (before shifting)
-        var div_result = decimo.bigint.arithmetics._divmod_magnitudes(
+        var div_result = bigint_arithmetics._divmod_magnitudes(
             n_shifted, a_words
         )
 
         # Shift a left, then add quotient in-place (saves 2 allocations)
         a_words = _left_shift_magnitude_bits(a_words, shift_a)
-        decimo.bigint.arithmetics._add_magnitudes_inplace(
-            a_words, div_result[0]
-        )
+        bigint_arithmetics._add_magnitudes_inplace(a_words, div_result[0])
 
     # Final check: a -= 1 if a*a > x
-    var a_sq = decimo.bigint.arithmetics._multiply_magnitudes(a_words, a_words)
-    if decimo.bigint.arithmetics._compare_word_lists(a_sq, x.words) > 0:
+    var a_sq = bigint_arithmetics._multiply_magnitudes(a_words, a_words)
+    if bigint_arithmetics._compare_word_lists(a_sq, x.words) > 0:
         # Decrement a_words by 1 in-place
         var borrow: UInt64 = 1
         for i in range(len(a_words)):

--- a/src/decimo/bigint10/arithmetics.mojo
+++ b/src/decimo/bigint10/arithmetics.mojo
@@ -22,7 +22,7 @@ from decimo.bigint10.bigint10 import BigInt10
 from decimo.biguint.biguint import BigUInt
 from decimo.errors import ZeroDivisionError
 from decimo.rounding_mode import RoundingMode
-import decimo.biguint.arithmetics
+import decimo.biguint.arithmetics as biguint_arithmetics
 
 
 def add(x1: BigInt10, x2: BigInt10) -> BigInt10:
@@ -74,7 +74,7 @@ def add_inplace(mut x1: BigInt10, x2: BigInt10) -> None:
 
     # Same sign: add magnitudes in place
     else:
-        decimo.biguint.arithmetics.add_inplace(x1.magnitude, x2.magnitude)
+        biguint_arithmetics.add_inplace(x1.magnitude, x2.magnitude)
 
     return
 
@@ -119,17 +119,13 @@ def subtract(x1: BigInt10, x2: BigInt10) -> BigInt10:
     if comparison_result > 0:  # |x1| > |x2|
         # Subtract smaller from larger
         magnitude = x1.magnitude.copy()
-        decimo.biguint.arithmetics.subtract_no_check_inplace(
-            magnitude, x2.magnitude
-        )
+        biguint_arithmetics.subtract_no_check_inplace(magnitude, x2.magnitude)
         sign = x1.sign
 
     else:  # |x1| < |x2|
         # Subtract larger from smaller and negate the result
         magnitude = x2.magnitude.copy()
-        decimo.biguint.arithmetics.subtract_no_check_inplace(
-            magnitude, x1.magnitude
-        )
+        biguint_arithmetics.subtract_no_check_inplace(magnitude, x1.magnitude)
         sign = not x1.sign
 
     return BigInt10(magnitude^, sign=sign)
@@ -221,7 +217,7 @@ def floor_divide(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
     if x1.sign == x2.sign:
         # Use floor division of the magnitudes
         try:
-            magnitude = decimo.biguint.arithmetics.floor_divide(
+            magnitude = biguint_arithmetics.floor_divide(
                 x1.magnitude, x2.magnitude
             )
         except e:
@@ -235,7 +231,7 @@ def floor_divide(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
     else:
         # Use ceil division of the magnitudes
         try:
-            magnitude = decimo.biguint.arithmetics.ceil_divide(
+            magnitude = biguint_arithmetics.ceil_divide(
                 x1.magnitude, x2.magnitude
             )
         except e:
@@ -264,9 +260,7 @@ def truncate_divide(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
     """
     var magnitude: BigUInt
     try:
-        magnitude = decimo.biguint.arithmetics.floor_divide(
-            x1.magnitude, x2.magnitude
-        )
+        magnitude = biguint_arithmetics.floor_divide(x1.magnitude, x2.magnitude)
     except e:
         raise ZeroDivisionError(
             message="See the above exception.",
@@ -297,7 +291,7 @@ def floor_modulo(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
     if x1.sign == x2.sign:
         # Use floor (truncate) division between magnitudes
         try:
-            magnitude = decimo.biguint.arithmetics.floor_modulo(
+            magnitude = biguint_arithmetics.floor_modulo(
                 x1.magnitude, x2.magnitude
             )
         except e:
@@ -311,7 +305,7 @@ def floor_modulo(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
     else:
         # Use ceil division of the magnitudes
         try:
-            magnitude = decimo.biguint.arithmetics.ceil_modulo(
+            magnitude = biguint_arithmetics.ceil_modulo(
                 x1.magnitude, x2.magnitude
             )
         except e:
@@ -340,9 +334,7 @@ def truncate_modulo(x1: BigInt10, x2: BigInt10) raises -> BigInt10:
     """
     var magnitude: BigUInt
     try:
-        magnitude = decimo.biguint.arithmetics.floor_modulo(
-            x1.magnitude, x2.magnitude
-        )
+        magnitude = biguint_arithmetics.floor_modulo(x1.magnitude, x2.magnitude)
     except e:
         raise ZeroDivisionError(
             message="See the above exception.",

--- a/src/decimo/bigint10/bigint10.mojo
+++ b/src/decimo/bigint10/bigint10.mojo
@@ -26,9 +26,9 @@ mathematical methods that do not implement a trait.
 from std.memory import UnsafePointer
 from std.python import PythonObject
 
-import decimo.bigint10.arithmetics
-import decimo.bigint10.comparison
-import decimo.biguint.arithmetics
+import decimo.bigint10.arithmetics as bigint10_arithmetics
+import decimo.bigint10.comparison as bigint10_comparison
+import decimo.biguint.arithmetics as biguint_arithmetics
 from decimo.bigdecimal.bigdecimal import BigDecimal
 from decimo.biguint.biguint import BigUInt
 from decimo.errors import (
@@ -37,7 +37,7 @@ from decimo.errors import (
     ConversionError,
     ZeroDivisionError,
 )
-import decimo.str
+import decimo.str as decimo_str
 
 
 struct BigInt10(
@@ -351,7 +351,7 @@ struct BigInt10(
     @staticmethod
     def from_string(value: String) raises -> Self:
         """Initializes a BigInt10 from a string representation.
-        The string is normalized with `decimo.str.parse_numeric_string()`.
+        The string is normalized with `decimo_str.parse_numeric_string()`.
 
         Args:
             value: The string representation of the BigInt10.
@@ -363,7 +363,7 @@ struct BigInt10(
             ConversionError: If the string cannot be parsed.
         """
         try:
-            _tuple = decimo.str.parse_numeric_string(value)
+            _tuple = decimo_str.parse_numeric_string(value)
         except e:
             raise ConversionError(
                 function="BigInt10.from_string(value: String)",
@@ -583,7 +583,7 @@ struct BigInt10(
         Returns:
             The absolute value.
         """
-        return decimo.bigint10.arithmetics.absolute(self)
+        return bigint10_arithmetics.absolute(self)
 
     @always_inline
     def __neg__(self) -> Self:
@@ -593,7 +593,7 @@ struct BigInt10(
         Returns:
             The negated value.
         """
-        return decimo.bigint10.arithmetics.negative(self)
+        return bigint10_arithmetics.negative(self)
 
     # ===------------------------------------------------------------------=== #
     # Basic binary arithmetic operation dunders
@@ -611,7 +611,7 @@ struct BigInt10(
         Returns:
             The sum of the two values.
         """
-        return decimo.bigint10.arithmetics.add(self, other)
+        return bigint10_arithmetics.add(self, other)
 
     @always_inline
     def __sub__(self, other: Self) -> Self:
@@ -623,7 +623,7 @@ struct BigInt10(
         Returns:
             The difference of the two values.
         """
-        return decimo.bigint10.arithmetics.subtract(self, other)
+        return bigint10_arithmetics.subtract(self, other)
 
     @always_inline
     def __mul__(self, other: Self) -> Self:
@@ -635,7 +635,7 @@ struct BigInt10(
         Returns:
             The product of the two values.
         """
-        return decimo.bigint10.arithmetics.multiply(self, other)
+        return bigint10_arithmetics.multiply(self, other)
 
     @always_inline
     def __floordiv__(self, other: Self) raises -> Self:
@@ -651,7 +651,7 @@ struct BigInt10(
             ZeroDivisionError: If the divisor is zero.
         """
         try:
-            return decimo.bigint10.arithmetics.floor_divide(self, other)
+            return bigint10_arithmetics.floor_divide(self, other)
         except e:
             raise ZeroDivisionError(
                 message="See the above exception.",
@@ -673,7 +673,7 @@ struct BigInt10(
             ZeroDivisionError: If the divisor is zero.
         """
         try:
-            return decimo.bigint10.arithmetics.floor_modulo(self, other)
+            return bigint10_arithmetics.floor_modulo(self, other)
         except e:
             raise ZeroDivisionError(
                 message="See the above exception.",
@@ -712,7 +712,7 @@ struct BigInt10(
         Returns:
             The sum of the two values.
         """
-        return decimo.bigint10.arithmetics.add(self, other)
+        return bigint10_arithmetics.add(self, other)
 
     @always_inline
     def __rsub__(self, other: Self) -> Self:
@@ -724,7 +724,7 @@ struct BigInt10(
         Returns:
             The difference of the two values.
         """
-        return decimo.bigint10.arithmetics.subtract(other, self)
+        return bigint10_arithmetics.subtract(other, self)
 
     @always_inline
     def __rmul__(self, other: Self) -> Self:
@@ -736,7 +736,7 @@ struct BigInt10(
         Returns:
             The product of the two values.
         """
-        return decimo.bigint10.arithmetics.multiply(self, other)
+        return bigint10_arithmetics.multiply(self, other)
 
     @always_inline
     def __rfloordiv__(self, other: Self) raises -> Self:
@@ -748,7 +748,7 @@ struct BigInt10(
         Returns:
             The floor division quotient.
         """
-        return decimo.bigint10.arithmetics.floor_divide(other, self)
+        return bigint10_arithmetics.floor_divide(other, self)
 
     @always_inline
     def __rmod__(self, other: Self) raises -> Self:
@@ -760,7 +760,7 @@ struct BigInt10(
         Returns:
             The remainder of the floor division.
         """
-        return decimo.bigint10.arithmetics.floor_modulo(other, self)
+        return bigint10_arithmetics.floor_modulo(other, self)
 
     @always_inline
     def __rpow__(self, base: Self) raises -> Self:
@@ -788,7 +788,7 @@ struct BigInt10(
         Args:
             other: The right-hand side operand.
         """
-        decimo.bigint10.arithmetics.add_inplace(self, other)
+        bigint10_arithmetics.add_inplace(self, other)
 
     @always_inline
     def __iadd__(mut self, other: Int):
@@ -799,11 +799,11 @@ struct BigInt10(
         """
         # Optimize the case `i += 1`
         if (self >= 0) and (other >= 0) and (other <= 999_999_999):
-            decimo.biguint.arithmetics.add_by_uint32_inplace(
+            biguint_arithmetics.add_by_uint32_inplace(
                 self.magnitude, UInt32(other)
             )
         else:
-            decimo.bigint10.arithmetics.add_inplace(self, Self(other))
+            bigint10_arithmetics.add_inplace(self, Self(other))
 
     @always_inline
     def __isub__(mut self, other: Self):
@@ -812,7 +812,7 @@ struct BigInt10(
         Args:
             other: The right-hand side operand.
         """
-        self = decimo.bigint10.arithmetics.subtract(self, other)
+        self = bigint10_arithmetics.subtract(self, other)
 
     @always_inline
     def __imul__(mut self, other: Self):
@@ -821,7 +821,7 @@ struct BigInt10(
         Args:
             other: The right-hand side operand.
         """
-        self = decimo.bigint10.arithmetics.multiply(self, other)
+        self = bigint10_arithmetics.multiply(self, other)
 
     @always_inline
     def __ifloordiv__(mut self, other: Self) raises:
@@ -830,7 +830,7 @@ struct BigInt10(
         Args:
             other: The right-hand side operand.
         """
-        self = decimo.bigint10.arithmetics.floor_divide(self, other)
+        self = bigint10_arithmetics.floor_divide(self, other)
 
     @always_inline
     def __imod__(mut self, other: Self) raises:
@@ -839,7 +839,7 @@ struct BigInt10(
         Args:
             other: The right-hand side operand.
         """
-        self = decimo.bigint10.arithmetics.floor_modulo(self, other)
+        self = bigint10_arithmetics.floor_modulo(self, other)
 
     # ===------------------------------------------------------------------=== #
     # Basic binary comparison operation dunders
@@ -856,7 +856,7 @@ struct BigInt10(
         Returns:
             `True` if `self > other`, `False` otherwise.
         """
-        return decimo.bigint10.comparison.greater(self, other)
+        return bigint10_comparison.greater(self, other)
 
     @always_inline
     def __gt__(self, other: Int) -> Bool:
@@ -868,7 +868,7 @@ struct BigInt10(
         Returns:
             `True` if `self > other`, `False` otherwise.
         """
-        return decimo.bigint10.comparison.greater(self, Self.from_int(other))
+        return bigint10_comparison.greater(self, Self.from_int(other))
 
     @always_inline
     def __ge__(self, other: Self) -> Bool:
@@ -880,7 +880,7 @@ struct BigInt10(
         Returns:
             `True` if `self >= other`, `False` otherwise.
         """
-        return decimo.bigint10.comparison.greater_equal(self, other)
+        return bigint10_comparison.greater_equal(self, other)
 
     @always_inline
     def __ge__(self, other: Int) -> Bool:
@@ -892,9 +892,7 @@ struct BigInt10(
         Returns:
             `True` if `self >= other`, `False` otherwise.
         """
-        return decimo.bigint10.comparison.greater_equal(
-            self, Self.from_int(other)
-        )
+        return bigint10_comparison.greater_equal(self, Self.from_int(other))
 
     @always_inline
     def __lt__(self, other: Self) -> Bool:
@@ -906,7 +904,7 @@ struct BigInt10(
         Returns:
             `True` if `self < other`, `False` otherwise.
         """
-        return decimo.bigint10.comparison.less(self, other)
+        return bigint10_comparison.less(self, other)
 
     @always_inline
     def __lt__(self, other: Int) -> Bool:
@@ -918,7 +916,7 @@ struct BigInt10(
         Returns:
             `True` if `self < other`, `False` otherwise.
         """
-        return decimo.bigint10.comparison.less(self, Self.from_int(other))
+        return bigint10_comparison.less(self, Self.from_int(other))
 
     @always_inline
     def __le__(self, other: Self) -> Bool:
@@ -930,7 +928,7 @@ struct BigInt10(
         Returns:
             `True` if `self <= other`, `False` otherwise.
         """
-        return decimo.bigint10.comparison.less_equal(self, other)
+        return bigint10_comparison.less_equal(self, other)
 
     @always_inline
     def __le__(self, other: Int) -> Bool:
@@ -942,7 +940,7 @@ struct BigInt10(
         Returns:
             `True` if `self <= other`, `False` otherwise.
         """
-        return decimo.bigint10.comparison.less_equal(self, Self.from_int(other))
+        return bigint10_comparison.less_equal(self, Self.from_int(other))
 
     @always_inline
     def __eq__(self, other: Self) -> Bool:
@@ -954,7 +952,7 @@ struct BigInt10(
         Returns:
             `True` if `self == other`, `False` otherwise.
         """
-        return decimo.bigint10.comparison.equal(self, other)
+        return bigint10_comparison.equal(self, other)
 
     @always_inline
     def __eq__(self, other: Int) -> Bool:
@@ -966,7 +964,7 @@ struct BigInt10(
         Returns:
             `True` if `self == other`, `False` otherwise.
         """
-        return decimo.bigint10.comparison.equal(self, Self.from_int(other))
+        return bigint10_comparison.equal(self, Self.from_int(other))
 
     @always_inline
     def __ne__(self, other: Self) -> Bool:
@@ -978,7 +976,7 @@ struct BigInt10(
         Returns:
             `True` if `self != other`, `False` otherwise.
         """
-        return decimo.bigint10.comparison.not_equal(self, other)
+        return bigint10_comparison.not_equal(self, other)
 
     @always_inline
     def __ne__(self, other: Int) -> Bool:
@@ -990,7 +988,7 @@ struct BigInt10(
         Returns:
             `True` if `self != other`, `False` otherwise.
         """
-        return decimo.bigint10.comparison.not_equal(self, Self.from_int(other))
+        return bigint10_comparison.not_equal(self, Self.from_int(other))
 
     # ===------------------------------------------------------------------=== #
     # Other dunders
@@ -1022,7 +1020,7 @@ struct BigInt10(
         Returns:
             The floor division quotient.
         """
-        return decimo.bigint10.arithmetics.floor_divide(self, other)
+        return bigint10_arithmetics.floor_divide(self, other)
 
     @always_inline
     def truncate_divide(self, other: Self) raises -> Self:
@@ -1035,7 +1033,7 @@ struct BigInt10(
         Returns:
             The truncated division quotient.
         """
-        return decimo.bigint10.arithmetics.truncate_divide(self, other)
+        return bigint10_arithmetics.truncate_divide(self, other)
 
     @always_inline
     def floor_modulo(self, other: Self) raises -> Self:
@@ -1048,7 +1046,7 @@ struct BigInt10(
         Returns:
             The floor division remainder.
         """
-        return decimo.bigint10.arithmetics.floor_modulo(self, other)
+        return bigint10_arithmetics.floor_modulo(self, other)
 
     @always_inline
     def truncate_modulo(self, other: Self) raises -> Self:
@@ -1061,7 +1059,7 @@ struct BigInt10(
         Returns:
             The truncated division remainder.
         """
-        return decimo.bigint10.arithmetics.truncate_modulo(self, other)
+        return bigint10_arithmetics.truncate_modulo(self, other)
 
     def power(self, exponent: Int) raises -> Self:
         """Raises the BigInt10 to the power of an integer exponent.
@@ -1115,7 +1113,7 @@ struct BigInt10(
         Returns:
             1 if `self` magnitude is greater, -1 if less, 0 if equal.
         """
-        return decimo.bigint10.comparison.compare_magnitudes(self, other)
+        return bigint10_comparison.compare_magnitudes(self, other)
 
     @always_inline
     def compare(self, other: Self) -> Int8:
@@ -1128,7 +1126,7 @@ struct BigInt10(
         Returns:
             1 if `self` is greater, -1 if less, 0 if equal.
         """
-        return decimo.bigint10.comparison.compare(self, other)
+        return bigint10_comparison.compare(self, other)
 
     # ===------------------------------------------------------------------=== #
     # Other methods
@@ -1209,7 +1207,7 @@ struct BigInt10(
             var label = "word " + String(i) + ":"
             result += label + String(" ") * (col - label.byte_length())
             result += (
-                decimo.str.rjust(
+                decimo_str.rjust(
                     String(self.magnitude.words[i]), 9, fillchar="0"
                 )
                 + "\n"

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -23,7 +23,7 @@ from std import math
 from std.memory import memcpy, memset_zero
 
 from decimo.biguint.biguint import BigUInt
-import decimo.biguint.comparison
+import decimo.biguint.comparison as biguint_comparison
 from decimo.errors import (
     OverflowError,
     ValueError,
@@ -1313,7 +1313,7 @@ def multiply_slices_toom3(
     var pxm1_neg: Bool
     if has_x1:
         var x1_val = BigUInt.from_slice(x, (sx1_start, sx1_end))
-        var cmp = decimo.biguint.comparison.compare(x0_plus_x2, x1_val)
+        var cmp = biguint_comparison.compare(x0_plus_x2, x1_val)
         if cmp >= 0:
             pxm1 = x0_plus_x2.copy()
             subtract_no_check_inplace(pxm1, x1_val)
@@ -1331,7 +1331,7 @@ def multiply_slices_toom3(
     var qym1_neg: Bool
     if has_y1:
         var y1_val = BigUInt.from_slice(y, (sy1_start, sy1_end))
-        var cmp = decimo.biguint.comparison.compare(y0_plus_y2, y1_val)
+        var cmp = biguint_comparison.compare(y0_plus_y2, y1_val)
         if cmp >= 0:
             qym1 = y0_plus_y2.copy()
             subtract_no_check_inplace(qym1, y1_val)

--- a/src/decimo/biguint/biguint.mojo
+++ b/src/decimo/biguint/biguint.mojo
@@ -2210,7 +2210,38 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         `remove_trailing_digits_with_rounding_inplace`: copies `self`
         once and delegates to the in-place variant. Keeps a single
         source of truth for the rounding logic.
+
+        Argument validation is performed here (before the copy) so the
+        raised error's `function` tag points at this out-of-place API
+        rather than at the inner `_inplace` helper. The in-place path
+        re-validates with its own tag for callers that invoke it
+        directly.
         """
+        # Pre-flight validation so errors are tagged with the
+        # user-facing function name. Cheap (three comparisons +
+        # one `number_of_digits()` only on the bounds path).
+        if ndigits_to_remove < 0:
+            raise ValueError(
+                function="BigUInt.remove_trailing_digits_with_rounding()",
+                message=(
+                    "The number of digits to remove is negative: "
+                    + String(ndigits_to_remove)
+                ),
+            )
+        if ndigits_to_remove == 0:
+            return self.copy()
+        var ndigits_self = self.number_of_digits()
+        if ndigits_to_remove > ndigits_self:
+            raise ValueError(
+                function="BigUInt.remove_trailing_digits_with_rounding()",
+                message=(
+                    "The number of digits to remove is larger than the "
+                    "number of digits in the BigUInt: "
+                    + String(ndigits_to_remove)
+                    + " > "
+                    + String(ndigits_self)
+                ),
+            )
         var result = self.copy()
         result.remove_trailing_digits_with_rounding_inplace(
             ndigits_to_remove=ndigits_to_remove,
@@ -2219,6 +2250,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
                 remove_extra_digit_due_to_rounding
             ),
             sign=sign,
+            ndigits_before_removal=ndigits_self,
         )
         return result^
 

--- a/src/decimo/biguint/biguint.mojo
+++ b/src/decimo/biguint/biguint.mojo
@@ -2205,91 +2205,21 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Rounding can result in an extra digit. Exmaple: remove last 1 digit of
         999 with rounding up results in 100. If
         `remove_extra_digit_due_to_rounding` is True, the result will be 10.
+
+        Thin wrapper around
+        `remove_trailing_digits_with_rounding_inplace`: copies `self`
+        once and delegates to the in-place variant. Keeps a single
+        source of truth for the rounding logic.
         """
-        if ndigits < 0:
-            raise ValueError(
-                function="BigUInt.remove_trailing_digits_with_rounding()",
-                message=(
-                    "The number of digits to remove is negative: "
-                    + String(ndigits)
-                ),
-            )
-        if ndigits == 0:
-            return self.copy()
-        if ndigits > self.number_of_digits():
-            raise ValueError(
-                function="BigUInt.remove_trailing_digits_with_rounding()",
-                message=(
-                    "The number of digits to remove is larger than the "
-                    "number of digits in the BigUInt: "
-                    + String(ndigits)
-                    + " > "
-                    + String(self.number_of_digits())
-                ),
-            )
-
-        # floor_divide_by_power_of_ten is the same as removing the last n digits
-        var result = biguint_arithmetics.floor_divide_by_power_of_ten(
-            self, ndigits
+        var result = self.copy()
+        result.remove_trailing_digits_with_rounding_inplace(
+            ndigits=ndigits,
+            rounding_mode=rounding_mode,
+            remove_extra_digit_due_to_rounding=(
+                remove_extra_digit_due_to_rounding
+            ),
+            sign=sign,
         )
-        var round_up: Bool = False
-
-        # Translate CEILING/FLOOR to UP/DOWN based on sign.
-        # CEILING (toward +inf): positive -> UP, negative -> DOWN
-        # FLOOR (toward -inf): positive -> DOWN, negative -> UP
-        var effective_mode = rounding_mode
-        if rounding_mode == RoundingMode.ceiling():
-            effective_mode = (
-                RoundingMode.up() if not sign else RoundingMode.down()
-            )
-        elif rounding_mode == RoundingMode.floor():
-            effective_mode = (
-                RoundingMode.down() if not sign else RoundingMode.up()
-            )
-
-        if effective_mode == RoundingMode.down():
-            pass
-        elif effective_mode == RoundingMode.up():
-            if self.number_of_trailing_zeros() < ndigits:
-                round_up = True
-        elif effective_mode == RoundingMode.half_up():
-            if self.ith_digit(ndigits - 1) >= 5:
-                round_up = True
-        elif effective_mode == RoundingMode.half_down():
-            var cut_off_digit = self.ith_digit(ndigits - 1)
-            if cut_off_digit > 5:
-                round_up = True
-            elif cut_off_digit == 5:
-                # Round up only if there are non-zero digits beyond the 5
-                if self.number_of_trailing_zeros() < ndigits - 1:
-                    round_up = True
-        elif effective_mode == RoundingMode.half_even():
-            var cut_off_digit = self.ith_digit(ndigits - 1)
-            if cut_off_digit > 5:
-                round_up = True
-            elif cut_off_digit < 5:
-                pass
-            else:  # cut_off_digit == 5
-                if self.number_of_trailing_zeros() < ndigits - 1:
-                    round_up = True
-                else:
-                    round_up = self.ith_digit(ndigits) % 2 == 1
-        # TODO: Remove this fallback once Mojo has proper enum support,
-        # which will make exhaustive matching a compile-time guarantee.
-        else:
-            raise ValueError(
-                function="BigUInt.remove_trailing_digits_with_rounding()",
-                message=("Unknown rounding mode: " + String(rounding_mode)),
-            )
-
-        if round_up:
-            biguint_arithmetics.add_by_uint32_inplace(result, UInt32(1))
-            # Check whether rounding results in extra digit
-            if result.is_power_of_10():
-                if remove_extra_digit_due_to_rounding:
-                    result = biguint_arithmetics.floor_divide_by_power_of_ten(
-                        result, 1
-                    )
         return result^
 
     @always_inline
@@ -2308,7 +2238,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         fresh coefficient buffer. Saves one alloc and one full-buffer
         copy per call, which compounds across every `precision > 0`
         invocation of `add` / `subtract` / `multiply` (each ends in a
-        `round_to_precision` call).
+        `round_to_precision_inplace` call).
 
         Args:
             ndigits: The number of digits to remove.

--- a/src/decimo/biguint/biguint.mojo
+++ b/src/decimo/biguint/biguint.mojo
@@ -2172,7 +2172,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
     @always_inline
     def remove_trailing_digits_with_rounding(
         self,
-        ndigits: Int,
+        ndigits_to_remove: Int,
         rounding_mode: RoundingMode,
         remove_extra_digit_due_to_rounding: Bool,
         sign: Bool = False,
@@ -2180,7 +2180,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         """Removes trailing digits from the BigUInt with rounding.
 
         Args:
-            ndigits: The number of digits to remove.
+            ndigits_to_remove: The number of digits to remove.
             rounding_mode: The rounding mode to use.
                 RoundingMode.ROUND_DOWN: Round toward zero.
                 RoundingMode.ROUND_UP: Round away from zero.
@@ -2213,7 +2213,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         """
         var result = self.copy()
         result.remove_trailing_digits_with_rounding_inplace(
-            ndigits=ndigits,
+            ndigits_to_remove=ndigits_to_remove,
             rounding_mode=rounding_mode,
             remove_extra_digit_due_to_rounding=(
                 remove_extra_digit_due_to_rounding
@@ -2225,14 +2225,15 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
     @always_inline
     def remove_trailing_digits_with_rounding_inplace(
         mut self,
-        ndigits: Int,
+        ndigits_to_remove: Int,
         rounding_mode: RoundingMode,
         remove_extra_digit_due_to_rounding: Bool,
         sign: Bool = False,
+        ndigits_before_removal: Int = -1,
     ) raises:
         """In-place sibling of `remove_trailing_digits_with_rounding`.
 
-        Drops the lowest `ndigits` decimal digits of `self`, applying the
+        Drops the lowest `ndigits_to_remove` decimal digits of `self`, applying the
         same rounding rules, but reuses the existing `words` storage via
         `floor_divide_by_power_of_ten_inplace` instead of allocating a
         fresh coefficient buffer. Saves one alloc and one full-buffer
@@ -2241,7 +2242,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         `round_to_precision_inplace` call).
 
         Args:
-            ndigits: The number of digits to remove.
+            ndigits_to_remove: The number of digits to remove.
             rounding_mode: The rounding mode to use. See
                 `remove_trailing_digits_with_rounding` for the full list.
             remove_extra_digit_due_to_rounding: If True, also drop one
@@ -2249,25 +2250,34 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
                 leading digit (e.g. 999 → 1000 → 100).
             sign: The sign of the original number (True = negative).
                 Only consulted for CEILING / FLOOR modes.
+            ndigits_before_removal: Optional pre-computed value of
+                `self.number_of_digits()`. If `>= 0`, used directly
+                instead of recomputing (saves one `number_of_digits()`
+                pass when the caller already has it, e.g.
+                `round_to_precision_inplace`). Must be correct — no
+                validation is performed beyond the bounds check.
 
         Raises:
-            ValueError: If `ndigits` is negative or exceeds the digit
+            ValueError: If `ndigits_to_remove` is negative or exceeds the digit
                 count of `self`.
         """
-        if ndigits < 0:
+        if ndigits_to_remove < 0:
             raise ValueError(
                 function=(
                     "BigUInt.remove_trailing_digits_with_rounding_inplace()"
                 ),
                 message=(
                     "The number of digits to remove is negative: "
-                    + String(ndigits)
+                    + String(ndigits_to_remove)
                 ),
             )
-        if ndigits == 0:
+        if ndigits_to_remove == 0:
             return
-        var ndigits_self = self.number_of_digits()
-        if ndigits > ndigits_self:
+        var ndigits_self = (
+            ndigits_before_removal if ndigits_before_removal
+            >= 0 else self.number_of_digits()
+        )
+        if ndigits_to_remove > ndigits_self:
             raise ValueError(
                 function=(
                     "BigUInt.remove_trailing_digits_with_rounding_inplace()"
@@ -2275,7 +2285,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
                 message=(
                     "The number of digits to remove is larger than the "
                     "number of digits in the BigUInt: "
-                    + String(ndigits)
+                    + String(ndigits_to_remove)
                     + " > "
                     + String(ndigits_self)
                 ),
@@ -2297,29 +2307,29 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         if effective_mode == RoundingMode.down():
             pass
         elif effective_mode == RoundingMode.up():
-            if self.number_of_trailing_zeros() < ndigits:
+            if self.number_of_trailing_zeros() < ndigits_to_remove:
                 round_up = True
         elif effective_mode == RoundingMode.half_up():
-            if self.ith_digit(ndigits - 1) >= 5:
+            if self.ith_digit(ndigits_to_remove - 1) >= 5:
                 round_up = True
         elif effective_mode == RoundingMode.half_down():
-            var cut_off_digit = self.ith_digit(ndigits - 1)
+            var cut_off_digit = self.ith_digit(ndigits_to_remove - 1)
             if cut_off_digit > 5:
                 round_up = True
             elif cut_off_digit == 5:
-                if self.number_of_trailing_zeros() < ndigits - 1:
+                if self.number_of_trailing_zeros() < ndigits_to_remove - 1:
                     round_up = True
         elif effective_mode == RoundingMode.half_even():
-            var cut_off_digit = self.ith_digit(ndigits - 1)
+            var cut_off_digit = self.ith_digit(ndigits_to_remove - 1)
             if cut_off_digit > 5:
                 round_up = True
             elif cut_off_digit < 5:
                 pass
             else:  # cut_off_digit == 5
-                if self.number_of_trailing_zeros() < ndigits - 1:
+                if self.number_of_trailing_zeros() < ndigits_to_remove - 1:
                     round_up = True
                 else:
-                    round_up = self.ith_digit(ndigits) % 2 == 1
+                    round_up = self.ith_digit(ndigits_to_remove) % 2 == 1
         # TODO: Remove this fallback once Mojo has proper enum support.
         else:
             raise ValueError(
@@ -2330,7 +2340,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             )
 
         # Drop the digits in place, then apply the carry from rounding.
-        biguint_arithmetics.floor_divide_by_power_of_ten_inplace(self, ndigits)
+        biguint_arithmetics.floor_divide_by_power_of_ten_inplace(
+            self, ndigits_to_remove
+        )
         if round_up:
             biguint_arithmetics.add_by_uint32_inplace(self, UInt32(1))
             if self.is_power_of_10():

--- a/src/decimo/biguint/biguint.mojo
+++ b/src/decimo/biguint/biguint.mojo
@@ -26,9 +26,9 @@ mathematical methods that do not implement a trait.
 from std.memory import UnsafePointer, memcpy, memcmp
 
 from decimo.bigint10.bigint10 import BigInt10
-import decimo.biguint.arithmetics
-import decimo.biguint.comparison
-import decimo.biguint.exponential
+import decimo.biguint.arithmetics as biguint_arithmetics
+import decimo.biguint.comparison as biguint_comparison
+import decimo.biguint.exponential as biguint_exponential
 from decimo.errors import (
     ConversionError,
     ValueError,
@@ -36,7 +36,7 @@ from decimo.errors import (
     OverflowError,
     ZeroDivisionError,
 )
-import decimo.str
+import decimo.str as decimo_str
 
 # Type aliases
 comptime BUInt = BigUInt
@@ -127,7 +127,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Returns:
             A `BigUInt` representing 10 raised to the power of `exponent`.
         """
-        return decimo.biguint.arithmetics.power_of_10(exponent)
+        return biguint_arithmetics.power_of_10(exponent)
 
     # ===------------------------------------------------------------------=== #
     # Constructors and life time dunder methods
@@ -654,7 +654,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Returns:
             The BigUInt representation of the string.
         """
-        _tuple = decimo.str.parse_numeric_string(value)
+        _tuple = decimo_str.parse_numeric_string(value)
         var ref coef: List[UInt8] = _tuple[0]
         var scale: Int = _tuple[1]
         var sign: Bool = _tuple[2]
@@ -1018,7 +1018,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             if i == len(self.words) - 1:
                 result += String(self.words[i])
             else:
-                result += decimo.str.rjust(
+                result += decimo_str.rjust(
                     String(self.words[i]), width=9, fillchar="0"
                 )
 
@@ -1078,7 +1078,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Returns:
             The absolute value.
         """
-        return decimo.biguint.arithmetics.absolute(self)
+        return biguint_arithmetics.absolute(self)
 
     @always_inline
     def __neg__(self) raises -> Self:
@@ -1091,7 +1091,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Raises:
             OverflowError: If the number is non-zero (negative of unsigned is undefined).
         """
-        return decimo.biguint.arithmetics.negative(self)
+        return biguint_arithmetics.negative(self)
 
     @always_inline
     def __rshift__(self, shift_amount: Int) -> Self:
@@ -1105,7 +1105,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         """
         var result = self.copy()
         for _ in range(shift_amount):
-            decimo.biguint.arithmetics.floor_divide_by_2_inplace(result)
+            biguint_arithmetics.floor_divide_by_2_inplace(result)
         return result^
 
     # ===------------------------------------------------------------------=== #
@@ -1124,7 +1124,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Returns:
             The sum.
         """
-        return decimo.biguint.arithmetics.add(self, other)
+        return biguint_arithmetics.add(self, other)
 
     @always_inline
     def __sub__(self, other: Self) raises -> Self:
@@ -1140,7 +1140,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             OverflowError: If the result would be negative.
         """
         try:
-            return decimo.biguint.arithmetics.subtract(self, other)
+            return biguint_arithmetics.subtract(self, other)
         except e:
             raise e^
 
@@ -1154,7 +1154,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Returns:
             The product.
         """
-        return decimo.biguint.arithmetics.multiply(self, other)
+        return biguint_arithmetics.multiply(self, other)
 
     @always_inline
     def __floordiv__(self, other: Self) raises -> Self:
@@ -1170,7 +1170,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             ZeroDivisionError: If the divisor is zero.
         """
         try:
-            return decimo.biguint.arithmetics.floor_divide(self, other)
+            return biguint_arithmetics.floor_divide(self, other)
         except e:
             raise ZeroDivisionError(
                 message="See the above exception.",
@@ -1192,7 +1192,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             ZeroDivisionError: If the divisor is zero.
         """
         try:
-            return decimo.biguint.arithmetics.ceil_divide(self, other)
+            return biguint_arithmetics.ceil_divide(self, other)
         except e:
             raise ZeroDivisionError(
                 message="See the above exception.",
@@ -1214,7 +1214,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             ZeroDivisionError: If the divisor is zero.
         """
         try:
-            return decimo.biguint.arithmetics.floor_modulo(self, other)
+            return biguint_arithmetics.floor_modulo(self, other)
         except e:
             raise ZeroDivisionError(
                 message="See the above exception.",
@@ -1236,7 +1236,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             ZeroDivisionError: If the divisor is zero.
         """
         try:
-            return decimo.biguint.arithmetics.floor_divide_modulo(self, other)
+            return biguint_arithmetics.floor_divide_modulo(self, other)
         except e:
             raise e^
 
@@ -1300,7 +1300,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Returns:
             The sum.
         """
-        return decimo.biguint.arithmetics.add(self, other)
+        return biguint_arithmetics.add(self, other)
 
     @always_inline
     def __rsub__(self, other: Self) raises -> Self:
@@ -1315,7 +1315,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Raises:
             OverflowError: If the result would be negative.
         """
-        return decimo.biguint.arithmetics.subtract(other, self)
+        return biguint_arithmetics.subtract(other, self)
 
     @always_inline
     def __rmul__(self, other: Self) raises -> Self:
@@ -1327,7 +1327,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Returns:
             The product.
         """
-        return decimo.biguint.arithmetics.multiply(self, other)
+        return biguint_arithmetics.multiply(self, other)
 
     @always_inline
     def __rfloordiv__(self, other: Self) raises -> Self:
@@ -1342,7 +1342,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Raises:
             ZeroDivisionError: If the divisor is zero.
         """
-        return decimo.biguint.arithmetics.floor_divide(other, self)
+        return biguint_arithmetics.floor_divide(other, self)
 
     @always_inline
     def __rmod__(self, other: Self) raises -> Self:
@@ -1357,7 +1357,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Raises:
             ZeroDivisionError: If the divisor is zero.
         """
-        return decimo.biguint.arithmetics.floor_modulo(other, self)
+        return biguint_arithmetics.floor_modulo(other, self)
 
     @always_inline
     def __rdivmod__(self, other: Self) raises -> Tuple[Self, Self]:
@@ -1372,7 +1372,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Raises:
             ZeroDivisionError: If the divisor is zero.
         """
-        return decimo.biguint.arithmetics.floor_divide_modulo(other, self)
+        return biguint_arithmetics.floor_divide_modulo(other, self)
 
     @always_inline
     def __rpow__(self, base: Self) raises -> Self:
@@ -1404,7 +1404,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Args:
             other: The operand to add.
         """
-        decimo.biguint.arithmetics.add_inplace(self, other)
+        biguint_arithmetics.add_inplace(self, other)
 
     @always_inline
     def __isub__(mut self, other: Self) raises:
@@ -1417,7 +1417,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Raises:
             OverflowError: If the result would be negative.
         """
-        decimo.biguint.arithmetics.subtract_inplace(self, other)
+        biguint_arithmetics.subtract_inplace(self, other)
 
     @always_inline
     def __imul__(mut self, other: Self) raises:
@@ -1426,7 +1426,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Args:
             other: The operand to multiply by.
         """
-        self = decimo.biguint.arithmetics.multiply(self, other)
+        self = biguint_arithmetics.multiply(self, other)
 
     @always_inline
     def __ifloordiv__(mut self, other: Self) raises:
@@ -1438,7 +1438,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Raises:
             ZeroDivisionError: If the divisor is zero.
         """
-        self = decimo.biguint.arithmetics.floor_divide(self, other)
+        self = biguint_arithmetics.floor_divide(self, other)
 
     @always_inline
     def __imod__(mut self, other: Self) raises:
@@ -1450,7 +1450,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Raises:
             ZeroDivisionError: If the divisor is zero.
         """
-        self = decimo.biguint.arithmetics.floor_modulo(self, other)
+        self = biguint_arithmetics.floor_modulo(self, other)
 
     # ===------------------------------------------------------------------=== #
     # Basic binary comparison operation dunders
@@ -1467,7 +1467,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Returns:
             `True` if `self` is greater than `other`, `False` otherwise.
         """
-        return decimo.biguint.comparison.greater(self, other)
+        return biguint_comparison.greater(self, other)
 
     @always_inline
     def __ge__(self, other: Self) -> Bool:
@@ -1479,7 +1479,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Returns:
             `True` if `self` is greater than or equal to `other`, `False` otherwise.
         """
-        return decimo.biguint.comparison.greater_equal(self, other)
+        return biguint_comparison.greater_equal(self, other)
 
     @always_inline
     def __lt__(self, other: Self) -> Bool:
@@ -1491,7 +1491,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Returns:
             `True` if `self` is less than `other`, `False` otherwise.
         """
-        return decimo.biguint.comparison.less(self, other)
+        return biguint_comparison.less(self, other)
 
     @always_inline
     def __le__(self, other: Self) -> Bool:
@@ -1503,7 +1503,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Returns:
             `True` if `self` is less than or equal to `other`, `False` otherwise.
         """
-        return decimo.biguint.comparison.less_equal(self, other)
+        return biguint_comparison.less_equal(self, other)
 
     @always_inline
     def __eq__(self, other: Self) -> Bool:
@@ -1515,7 +1515,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Returns:
             `True` if `self` equals `other`, `False` otherwise.
         """
-        return decimo.biguint.comparison.equal(self, other)
+        return biguint_comparison.equal(self, other)
 
     @always_inline
     def __ne__(self, other: Self) -> Bool:
@@ -1527,7 +1527,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Returns:
             `True` if `self` does not equal `other`, `False` otherwise.
         """
-        return decimo.biguint.comparison.not_equal(self, other)
+        return biguint_comparison.not_equal(self, other)
 
     # ===------------------------------------------------------------------=== #
     # Other dunders
@@ -1568,7 +1568,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Args:
             other: The operand to add.
         """
-        decimo.biguint.arithmetics.add_inplace(self, other)
+        biguint_arithmetics.add_inplace(self, other)
 
     @always_inline
     def floor_divide(self, other: Self) raises -> Self:
@@ -1582,7 +1582,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Returns:
             The quotient.
         """
-        return decimo.biguint.arithmetics.floor_divide(self, other)
+        return biguint_arithmetics.floor_divide(self, other)
 
     @always_inline
     def truncate_divide(self, other: Self) raises -> Self:
@@ -1596,7 +1596,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Returns:
             The quotient.
         """
-        return decimo.biguint.arithmetics.truncate_divide(self, other)
+        return biguint_arithmetics.truncate_divide(self, other)
 
     @always_inline
     def ceil_divide(self, other: Self) raises -> Self:
@@ -1609,7 +1609,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Returns:
             The quotient rounded up.
         """
-        return decimo.biguint.arithmetics.ceil_divide(self, other)
+        return biguint_arithmetics.ceil_divide(self, other)
 
     @always_inline
     def floor_modulo(self, other: Self) raises -> Self:
@@ -1622,7 +1622,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Returns:
             The remainder.
         """
-        return decimo.biguint.arithmetics.floor_modulo(self, other)
+        return biguint_arithmetics.floor_modulo(self, other)
 
     @always_inline
     def truncate_modulo(self, other: Self) raises -> Self:
@@ -1635,7 +1635,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Returns:
             The remainder.
         """
-        return decimo.biguint.arithmetics.truncate_modulo(self, other)
+        return biguint_arithmetics.truncate_modulo(self, other)
 
     @always_inline
     def ceil_modulo(self, other: Self) raises -> Self:
@@ -1648,7 +1648,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Returns:
             The remainder.
         """
-        return decimo.biguint.arithmetics.ceil_modulo(self, other)
+        return biguint_arithmetics.ceil_modulo(self, other)
 
     @always_inline
     def divmod(self, other: Self) raises -> Tuple[Self, Self]:
@@ -1661,7 +1661,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Returns:
             A tuple of (quotient, remainder).
         """
-        return decimo.biguint.arithmetics.floor_divide_modulo(self, other)
+        return biguint_arithmetics.floor_divide_modulo(self, other)
 
     @always_inline
     def floor_divide_by_2_inplace(mut self) raises:
@@ -1669,7 +1669,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         See `decimo.biguint.arithmetics.floor_divide_by_2_inplace()`
         for more information.
         """
-        decimo.biguint.arithmetics.floor_divide_by_2_inplace(self)
+        biguint_arithmetics.floor_divide_by_2_inplace(self)
 
     @always_inline
     def multiply_by_power_of_ten(self, n: Int) -> Self:
@@ -1682,7 +1682,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Returns:
             The product of this number and 10^n.
         """
-        return decimo.biguint.arithmetics.multiply_by_power_of_ten(self, n)
+        return biguint_arithmetics.multiply_by_power_of_ten(self, n)
 
     @always_inline
     def multiply_by_power_of_ten_inplace(mut self, n: Int):
@@ -1694,7 +1694,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Args:
             n: The power of 10 to multiply by.
         """
-        decimo.biguint.arithmetics.multiply_by_power_of_ten_inplace(self, n)
+        biguint_arithmetics.multiply_by_power_of_ten_inplace(self, n)
 
     @always_inline
     def floor_divide_by_power_of_ten(self, n: Int) -> Self:
@@ -1708,7 +1708,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Returns:
             The quotient after removing the last `n` digits.
         """
-        return decimo.biguint.arithmetics.floor_divide_by_power_of_ten(self, n)
+        return biguint_arithmetics.floor_divide_by_power_of_ten(self, n)
 
     @always_inline
     def multiply_by_power_of_billion_inplace(mut self, n: Int):
@@ -1718,7 +1718,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Args:
             n: The power of 10^9 to multiply by. Should be non-negative.
         """
-        decimo.biguint.arithmetics.multiply_by_power_of_billion_inplace(self, n)
+        biguint_arithmetics.multiply_by_power_of_billion_inplace(self, n)
 
     def power(self, exponent: Int) raises -> Self:
         """Returns the result of raising this number to the power of `exponent`.
@@ -1804,7 +1804,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         The square root is the largest integer y such that y * y <= x.
         """
-        return decimo.biguint.exponential.sqrt(self)
+        return biguint_exponential.sqrt(self)
 
     def isqrt(self) -> Self:
         """Returns the square root of this number.
@@ -1817,7 +1817,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         The square root is the largest integer y such that y * y <= x.
         """
-        return decimo.biguint.exponential.sqrt(self)
+        return biguint_exponential.sqrt(self)
 
     @always_inline
     def compare(self, other: Self) -> Int8:
@@ -1830,7 +1830,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         Returns:
             A positive value if `self > other`, 0 if equal, or a negative value if `self < other`.
         """
-        return decimo.biguint.comparison.compare(self, other)
+        return biguint_comparison.compare(self, other)
 
     # ===------------------------------------------------------------------=== #
     # Other methods
@@ -1871,7 +1871,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             var label = "word " + String(i) + ":"
             result += label + String(" ") * (col - label.byte_length())
             result += (
-                decimo.str.rjust(String(self.words[i]), 9, fillchar="0") + "\n"
+                decimo_str.rjust(String(self.words[i]), 9, fillchar="0") + "\n"
             )
 
         result += sep_line
@@ -2229,7 +2229,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             )
 
         # floor_divide_by_power_of_ten is the same as removing the last n digits
-        var result = decimo.biguint.arithmetics.floor_divide_by_power_of_ten(
+        var result = biguint_arithmetics.floor_divide_by_power_of_ten(
             self, ndigits
         )
         var round_up: Bool = False
@@ -2283,14 +2283,12 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             )
 
         if round_up:
-            decimo.biguint.arithmetics.add_by_uint32_inplace(result, UInt32(1))
+            biguint_arithmetics.add_by_uint32_inplace(result, UInt32(1))
             # Check whether rounding results in extra digit
             if result.is_power_of_10():
                 if remove_extra_digit_due_to_rounding:
-                    result = (
-                        decimo.biguint.arithmetics.floor_divide_by_power_of_ten(
-                            result, 1
-                        )
+                    result = biguint_arithmetics.floor_divide_by_power_of_ten(
+                        result, 1
                     )
         return result^
 
@@ -2402,13 +2400,11 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
             )
 
         # Drop the digits in place, then apply the carry from rounding.
-        decimo.biguint.arithmetics.floor_divide_by_power_of_ten_inplace(
-            self, ndigits
-        )
+        biguint_arithmetics.floor_divide_by_power_of_ten_inplace(self, ndigits)
         if round_up:
-            decimo.biguint.arithmetics.add_by_uint32_inplace(self, UInt32(1))
+            biguint_arithmetics.add_by_uint32_inplace(self, UInt32(1))
             if self.is_power_of_10():
                 if remove_extra_digit_due_to_rounding:
-                    decimo.biguint.arithmetics.floor_divide_by_power_of_ten_inplace(
+                    biguint_arithmetics.floor_divide_by_power_of_ten_inplace(
                         self, 1
                     )

--- a/src/decimo/biguint/exponential.mojo
+++ b/src/decimo/biguint/exponential.mojo
@@ -20,7 +20,7 @@ from std import math
 from std.memory import memset_zero
 
 from decimo.biguint.biguint import BigUInt
-import decimo.biguint.arithmetics
+import decimo.biguint.arithmetics as biguint_arithmetics
 
 # ===----------------------------------------------------------------------=== #
 # Square Root
@@ -98,7 +98,7 @@ def sqrt(x: BigUInt) -> BigUInt:
                 quotient = BigUInt.one()
 
             guess += quotient
-            decimo.biguint.arithmetics.floor_divide_by_2_inplace(guess)
+            biguint_arithmetics.floor_divide_by_2_inplace(guess)
 
             if guess == prev_guess:
                 break

--- a/src/decimo/decimal128/arithmetics.mojo
+++ b/src/decimo/decimal128/arithmetics.mojo
@@ -40,7 +40,7 @@ from decimo.errors import (
     OverflowError,
     ZeroDivisionError,
 )
-import decimo.decimal128.utility
+import decimo.decimal128.utility as decimal128_utility
 
 
 @always_inline
@@ -104,7 +104,7 @@ def add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
         # >= 29 digits: drop trailing digits to fit. If we'd need to drop more
         # digits than `x1_scale` provides, the result truly overflows.
-        var fitted = decimo.decimal128.utility.fit_to_max_coefficient(summation)
+        var fitted = decimal128_utility.fit_to_max_coefficient(summation)
         if UInt32(fitted[1]) > UInt32(x1_scale):
             raise OverflowError(
                 message="Decimal128 overflow in addition.",
@@ -128,7 +128,7 @@ def add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         var scale = min(
             max(x1_scale, x2_scale),
             Decimal128.MAX_NUM_DIGITS
-            - decimo.decimal128.utility.number_of_digits(x2.to_uint128()),
+            - decimal128_utility.number_of_digits(x2.to_uint128()),
         )
         ## If x2_coef > 7922816251426433759354395033
         if (
@@ -137,7 +137,7 @@ def add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             and (scale > x2_scale)
         ):
             scale -= 1
-        sum_coef *= decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
+        sum_coef *= decimal128_utility.power_of_10_unsafe[DType.uint128](
             Int(scale - x2_scale)
         )
         return Decimal128.from_uint128(
@@ -151,7 +151,7 @@ def add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         var scale = min(
             max(x1_scale, x2_scale),
             Decimal128.MAX_NUM_DIGITS
-            - decimo.decimal128.utility.number_of_digits(x1.to_uint128()),
+            - decimal128_utility.number_of_digits(x1.to_uint128()),
         )
         ## If x1_coef > 7922816251426433759354395033
         if (
@@ -160,7 +160,7 @@ def add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             and (scale > x1_scale)
         ):
             scale -= 1
-        sum_coef *= decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
+        sum_coef *= decimal128_utility.power_of_10_unsafe[DType.uint128](
             Int(scale - x1_scale)
         )
         return Decimal128.from_uint128(
@@ -176,7 +176,7 @@ def add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         var x1_coef_scaled: UInt256 = UInt256(x1_coef)
         var x2_coef_scaled: UInt256 = UInt256(
             x2_coef
-        ) * decimo.decimal128.utility.power_of_10_unsafe[DType.uint256](
+        ) * decimal128_utility.power_of_10_unsafe[DType.uint256](
             Int(x1_scale - x2_scale)
         )
 
@@ -199,7 +199,7 @@ def add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         # Scale up x1_coef to match x2_scale
         var x1_coef_scaled: UInt256 = UInt256(
             x1_coef
-        ) * decimo.decimal128.utility.power_of_10_unsafe[DType.uint256](
+        ) * decimal128_utility.power_of_10_unsafe[DType.uint256](
             Int(x2_scale - x1_scale)
         )
         var x2_coef_scaled: UInt256 = UInt256(x2_coef)
@@ -226,7 +226,7 @@ def add(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             is_negative,
         )
 
-    var fitted = decimo.decimal128.utility.fit_to_max_coefficient(summation)
+    var fitted = decimal128_utility.fit_to_max_coefficient(summation)
     var working_scale = UInt32(max(x1_scale, x2_scale))
     if UInt32(fitted[1]) > working_scale:
         raise OverflowError(
@@ -302,7 +302,7 @@ def subtract(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
                 False if summation == 0 else is_negative,
             )
 
-        var fitted = decimo.decimal128.utility.fit_to_max_coefficient(summation)
+        var fitted = decimal128_utility.fit_to_max_coefficient(summation)
         if UInt32(fitted[1]) > UInt32(x1_scale):
             raise OverflowError(
                 message="Decimal128 overflow in subtraction.",
@@ -328,7 +328,7 @@ def subtract(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         var scale = min(
             max(x1_scale, x2_scale),
             Decimal128.MAX_NUM_DIGITS
-            - decimo.decimal128.utility.number_of_digits(x2.to_uint128()),
+            - decimal128_utility.number_of_digits(x2.to_uint128()),
         )
         ## If x2_coef > 7922816251426433759354395033
         if (
@@ -337,7 +337,7 @@ def subtract(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             and (scale > x2_scale)
         ):
             scale -= 1
-        sum_coef *= decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
+        sum_coef *= decimal128_utility.power_of_10_unsafe[DType.uint128](
             Int(scale - x2_scale)
         )
         # Sign of result is sign of -x2.
@@ -352,7 +352,7 @@ def subtract(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         var scale = min(
             max(x1_scale, x2_scale),
             Decimal128.MAX_NUM_DIGITS
-            - decimo.decimal128.utility.number_of_digits(x1.to_uint128()),
+            - decimal128_utility.number_of_digits(x1.to_uint128()),
         )
         ## If x1_coef > 7922816251426433759354395033
         if (
@@ -361,7 +361,7 @@ def subtract(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             and (scale > x1_scale)
         ):
             scale -= 1
-        sum_coef *= decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
+        sum_coef *= decimal128_utility.power_of_10_unsafe[DType.uint128](
             Int(scale - x1_scale)
         )
         return Decimal128.from_uint128(
@@ -380,7 +380,7 @@ def subtract(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         var x1_coef_scaled: UInt256 = UInt256(x1_coef)
         var x2_coef_scaled: UInt256 = UInt256(
             x2_coef
-        ) * decimo.decimal128.utility.power_of_10_unsafe[DType.uint256](
+        ) * decimal128_utility.power_of_10_unsafe[DType.uint256](
             Int(x1_scale - x2_scale)
         )
 
@@ -403,7 +403,7 @@ def subtract(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
     else:  # x1_scale < x2_scale
         var x1_coef_scaled: UInt256 = UInt256(
             x1_coef
-        ) * decimo.decimal128.utility.power_of_10_unsafe[DType.uint256](
+        ) * decimal128_utility.power_of_10_unsafe[DType.uint256](
             Int(x2_scale - x1_scale)
         )
         var x2_coef_scaled: UInt256 = UInt256(x2_coef)
@@ -430,7 +430,7 @@ def subtract(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             is_negative,
         )
 
-    var fitted = decimo.decimal128.utility.fit_to_max_coefficient(diff)
+    var fitted = decimal128_utility.fit_to_max_coefficient(diff)
     var working_scale = UInt32(max(x1_scale, x2_scale))
     if UInt32(fitted[1]) > working_scale:
         raise OverflowError(
@@ -552,7 +552,7 @@ def multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         else:
             var prod = x2_coef
             # Rounding may be needed.
-            var truncated_prod = decimo.decimal128.utility.round_coefficient(
+            var truncated_prod = decimal128_utility.round_coefficient(
                 prod,
                 ndigits_to_remove=combined_scale - Decimal128.MAX_SCALE,
             )
@@ -573,7 +573,7 @@ def multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         else:
             var prod = x1_coef
             # Rounding may be needed.
-            var truncated_prod = decimo.decimal128.utility.round_coefficient(
+            var truncated_prod = decimal128_utility.round_coefficient(
                 prod,
                 ndigits_to_remove=combined_scale - Decimal128.MAX_SCALE,
             )
@@ -585,8 +585,8 @@ def multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
     # Determine the number of bits in the coefficients
     # Used to determine the appropriate multiplication method
     # The coefficient of result would be the sum of the two numbers of bits
-    var x1_num_bits = decimo.decimal128.utility.number_of_bits(x1_coef)
-    var x2_num_bits = decimo.decimal128.utility.number_of_bits(x2_coef)
+    var x1_num_bits = decimal128_utility.number_of_bits(x1_coef)
+    var x2_num_bits = decimal128_utility.number_of_bits(x2_coef)
     var combined_num_bits = x1_num_bits + x2_num_bits
 
     # SPECIAL CASE: Both operands are true integers
@@ -655,7 +655,7 @@ def multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         # subsequent `min(MAX_SCALE, combined_scale)` always yielded
         # MAX_SCALE and the second-pass rounding branch was dead code.
         else:
-            prod = decimo.decimal128.utility.round_coefficient(
+            prod = decimal128_utility.round_coefficient(
                 prod,
                 ndigits_to_remove=combined_scale - Decimal128.MAX_SCALE,
             )
@@ -688,7 +688,7 @@ def multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         # MAX_SCALE) constraints are satisfied in one `round_coefficient`
         # call. Saves the extra `number_of_digits` + wide divide that the
         # old `fit_to_max_coefficient` + re-round pattern incurred.
-        var ndigits = decimo.decimal128.utility.number_of_digits(prod)
+        var ndigits = decimal128_utility.number_of_digits(prod)
         var drop_for_scale = Int(combined_scale) - Decimal128.MAX_SCALE
         var drop_for_fit: Int
         if prod > Decimal128.MAX_AS_UINT128:
@@ -706,7 +706,7 @@ def multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
                 function="multiply()",
             )
 
-        var rounded = decimo.decimal128.utility.round_coefficient[
+        var rounded = decimal128_utility.round_coefficient[
             skip_digit_check=True
         ](prod, ndigits_to_remove=drop)
         # Rounding-up may carry into a new most-significant digit, pushing
@@ -718,7 +718,7 @@ def multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
                     message="Decimal128 overflow in multiplication.",
                     function="multiply()",
                 )
-            rounded = decimo.decimal128.utility.round_coefficient[
+            rounded = decimal128_utility.round_coefficient[
                 skip_digit_check=True
             ](prod, ndigits_to_remove=drop)
 
@@ -741,7 +741,7 @@ def multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
     # constraints are satisfied in one `round_coefficient` call. Saves
     # the extra UInt256 division that the old `fit_to_max_coefficient`
     # + re-round pattern incurred.
-    var ndigits = decimo.decimal128.utility.number_of_digits(prod)
+    var ndigits = decimal128_utility.number_of_digits(prod)
     var drop_for_scale = Int(combined_scale) - Decimal128.MAX_SCALE
     var drop_for_fit: Int
     if prod > UInt256(Decimal128.MAX_AS_UINT128):
@@ -756,9 +756,9 @@ def multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             function="multiply()",
         )
 
-    var rounded = decimo.decimal128.utility.round_coefficient[
-        skip_digit_check=True
-    ](prod, ndigits_to_remove=drop)
+    var rounded = decimal128_utility.round_coefficient[skip_digit_check=True](
+        prod, ndigits_to_remove=drop
+    )
     # Rounding-up may carry into a new most-significant digit, pushing
     # the result past MAX_AS_UINT128. Re-round the ORIGINAL `prod` (not
     # the already-rounded value) with one more digit dropped to avoid
@@ -770,9 +770,9 @@ def multiply(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
                 message="Decimal128 overflow in multiplication.",
                 function="multiply()",
             )
-        rounded = decimo.decimal128.utility.round_coefficient[
-            skip_digit_check=True
-        ](prod, ndigits_to_remove=drop)
+        rounded = decimal128_utility.round_coefficient[skip_digit_check=True](
+            prod, ndigits_to_remove=drop
+        )
 
     var final_scale = Int(combined_scale) - drop
 
@@ -858,22 +858,19 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         else:
             # If the result can be stored in UInt128
             if (
-                decimo.decimal128.utility.number_of_digits(x1_coef) - diff_scale
+                decimal128_utility.number_of_digits(x1_coef) - diff_scale
                 < Decimal128.MAX_NUM_DIGITS
             ):
-                var quot = (
-                    x1_coef
-                    * decimo.decimal128.utility.power_of_10_unsafe[
-                        DType.uint128
-                    ](Int(-diff_scale))
-                )
+                var quot = x1_coef * decimal128_utility.power_of_10_unsafe[
+                    DType.uint128
+                ](Int(-diff_scale))
                 return Decimal128.from_uint128(quot, 0, is_negative)
 
             # If the result should be stored in UInt256
             else:
                 var quot = UInt256(
                     x1_coef
-                ) * decimo.decimal128.utility.power_of_10_unsafe[DType.uint256](
+                ) * decimal128_utility.power_of_10_unsafe[DType.uint256](
                     Int(-diff_scale)
                 )
                 if quot > Decimal128.MAX_AS_UINT256:
@@ -906,11 +903,9 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         # For example, 1234 / 0.1234 = 10000
         # Since -diff_scale is less than 28, the result would not overflow
         else:
-            var quot = UInt128(
-                1
-            ) * decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
-                Int(-diff_scale)
-            )
+            var quot = UInt128(1) * decimal128_utility.power_of_10_unsafe[
+                DType.uint128
+            ](Int(-diff_scale))
             return Decimal128.from_uint128(quot, 0, is_negative)
 
     # SPECIAL CASE: Modulus of coefficients is zero (exact division)
@@ -939,10 +934,10 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
             # If the result can be stored in UInt128
             if (
-                decimo.decimal128.utility.number_of_digits(quot) - diff_scale
+                decimal128_utility.number_of_digits(quot) - diff_scale
                 < Decimal128.MAX_NUM_DIGITS
             ):
-                var quot = quot * decimo.decimal128.utility.power_of_10_unsafe[
+                var quot = quot * decimal128_utility.power_of_10_unsafe[
                     DType.uint128
                 ](Int(-diff_scale))
                 return Decimal128.from_uint128(quot, 0, is_negative)
@@ -951,7 +946,7 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             else:
                 var quot = UInt256(
                     quot
-                ) * decimo.decimal128.utility.power_of_10_unsafe[DType.uint256](
+                ) * decimal128_utility.power_of_10_unsafe[DType.uint256](
                     Int(-diff_scale)
                 )
                 if quot > Decimal128.MAX_AS_UINT256:
@@ -1005,8 +1000,8 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
     # Yuhao's notes: remainder should be positive beacuse the previous cases have been handled
     # 朱宇浩注: 餘數應該爲正,因爲之前的特例已經處理過了
 
-    var x1_ndigits = decimo.decimal128.utility.number_of_digits(x1_coef)
-    var x2_ndigits = decimo.decimal128.utility.number_of_digits(x2_coef)
+    var x1_ndigits = decimal128_utility.number_of_digits(x1_coef)
+    var x2_ndigits = decimal128_utility.number_of_digits(x2_coef)
     var diff_digits = x1_ndigits - x2_ndigits
     # Here is an estimation of the maximum possible number of digits of the quotient's integral part
     # If it is higher than 28, we need to use UInt256 to store the quotient
@@ -1024,12 +1019,9 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
     # The adjusted dividend coefficient will not exceed 2^96 - 1
     if diff_digits < 0:
-        var adjusted_x1_coef = (
-            x1_coef
-            * decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
-                Int(-diff_digits)
-            )
-        )
+        var adjusted_x1_coef = x1_coef * decimal128_utility.power_of_10_unsafe[
+            DType.uint128
+        ](Int(-diff_digits))
         quot = adjusted_x1_coef // x2_coef
         rem = adjusted_x1_coef % x2_coef
         adjusted_scale = -diff_digits
@@ -1052,9 +1044,7 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
         # The final step counter stands for the number of decimal points.
         var step_counter = 0
-        var ndigits_initial_quot = decimo.decimal128.utility.number_of_digits(
-            quot
-        )
+        var ndigits_initial_quot = decimal128_utility.number_of_digits(quot)
         # Two-phase long division.
         #
         # Phase 1: a short probe loop (up to PROBE_STEPS digits) catches
@@ -1092,7 +1082,7 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             # `step_counter >= PROBE_STEPS = 2`, so in practice
             # `bulk_steps <= 29 - 2 = 27`, well within
             # `power_of_10_unsafe`'s `0 <= n <= 29` range for `uint128`.
-            var scale_factor = decimo.decimal128.utility.power_of_10_unsafe[
+            var scale_factor = decimal128_utility.power_of_10_unsafe[
                 DType.uint128
             ](bulk_steps)
             # `rem * 10^bulk_steps` always fits in UInt256: rem < x2_coef
@@ -1104,7 +1094,7 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             var rem_after_u128: UInt128
             if x2_coef <= UInt128(0xFFFF_FFFF_FFFF_FFFF):
                 # Fast path: 4-step schoolbook over u64 limbs.
-                var pair = decimo.decimal128.utility.udiv_u256_by_u64(
+                var pair = decimal128_utility.udiv_u256_by_u64(
                     rem_scaled, UInt64(x2_coef)
                 )
                 # `quot_added < 10^bulk_steps <= 10^27 < 2^90`, fits UInt128.
@@ -1205,9 +1195,9 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
         # If the scale is negative, we need to scale up the quotient
         if scale_of_quot < 0:
-            quot = quot * decimo.decimal128.utility.power_of_10_unsafe[
-                DType.uint128
-            ](Int(-scale_of_quot))
+            quot = quot * decimal128_utility.power_of_10_unsafe[DType.uint128](
+                Int(-scale_of_quot)
+            )
             scale_of_quot = 0
 
         # print(
@@ -1221,7 +1211,7 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         # If quot is within MAX, return the result
         if quot <= Decimal128.MAX_AS_UINT128:
             if scale_of_quot > Decimal128.MAX_SCALE:
-                quot = decimo.decimal128.utility.round_coefficient(
+                quot = decimal128_utility.round_coefficient(
                     quot,
                     ndigits_to_remove=scale_of_quot - Decimal128.MAX_SCALE,
                 )
@@ -1233,12 +1223,12 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
         # Otherwise, we need to truncate the first 29 or 28 digits
         else:
-            var fitted = decimo.decimal128.utility.fit_to_max_coefficient(quot)
+            var fitted = decimal128_utility.fit_to_max_coefficient(quot)
             var truncated_quot = fitted[0]
             var scale_of_truncated_quot = scale_of_quot - fitted[1]
 
             if scale_of_truncated_quot > Decimal128.MAX_SCALE:
-                truncated_quot = decimo.decimal128.utility.round_coefficient(
+                truncated_quot = decimal128_utility.round_coefficient(
                     truncated_quot,
                     ndigits_to_remove=scale_of_truncated_quot
                     - Decimal128.MAX_SCALE,
@@ -1266,9 +1256,7 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         var digit = UInt256(0)
         # The final step counter stands for the number of decimal points
         var step_counter = 0
-        var ndigits_initial_quot = decimo.decimal128.utility.number_of_digits(
-            quot256
-        )
+        var ndigits_initial_quot = decimal128_utility.number_of_digits(quot256)
         while (
             (rem256 != 0)
             and (
@@ -1305,7 +1293,7 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
         # If the scale is negative, we need to scale up the quotient
         if scale_of_quot < 0:
-            quot256 = quot256 * decimo.decimal128.utility.power_of_10_unsafe[
+            quot256 = quot256 * decimal128_utility.power_of_10_unsafe[
                 DType.uint256
             ](Int(-scale_of_quot))
             scale_of_quot = 0
@@ -1313,7 +1301,7 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
         # If quot is within MAX, return the result
         if quot256 <= Decimal128.MAX_AS_UINT256:
             if scale_of_quot > Decimal128.MAX_SCALE:
-                quot256 = decimo.decimal128.utility.round_coefficient(
+                quot256 = decimal128_utility.round_coefficient(
                     quot256,
                     ndigits_to_remove=scale_of_quot - Decimal128.MAX_SCALE,
                 )
@@ -1329,9 +1317,7 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
 
         # Otherwise, we need to truncate the first 29 or 28 digits
         else:
-            var fitted = decimo.decimal128.utility.fit_to_max_coefficient(
-                quot256
-            )
+            var fitted = decimal128_utility.fit_to_max_coefficient(quot256)
             var truncated_quot = fitted[0]
             var digits_removed = fitted[1]
 
@@ -1345,7 +1331,7 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
             var scale_of_truncated_quot = scale_of_quot - digits_removed
 
             if scale_of_truncated_quot > Decimal128.MAX_SCALE:
-                truncated_quot = decimo.decimal128.utility.round_coefficient(
+                truncated_quot = decimal128_utility.round_coefficient(
                     truncated_quot,
                     ndigits_to_remove=scale_of_truncated_quot
                     - Decimal128.MAX_SCALE,
@@ -1463,14 +1449,11 @@ def fma(x1: Decimal128, x2: Decimal128, x3: Decimal128) raises -> Decimal128:
     var common_scale: Int
     if p_scale > b_scale:
         var diff = p_scale - b_scale
-        var b_ndigits = decimo.decimal128.utility.number_of_digits(b_coef_256)
+        var b_ndigits = decimal128_utility.number_of_digits(b_coef_256)
         if b_ndigits + diff <= WORK_DIGITS_CAP:
-            b_coef_256 = (
-                b_coef_256
-                * decimo.decimal128.utility.power_of_10_unsafe[DType.uint256](
-                    diff
-                )
-            )
+            b_coef_256 = b_coef_256 * decimal128_utility.power_of_10_unsafe[
+                DType.uint256
+            ](diff)
             common_scale = p_scale
         else:
             # Fallback: scaling b would overflow UInt256. Drop to the
@@ -1478,14 +1461,11 @@ def fma(x1: Decimal128, x2: Decimal128, x3: Decimal128) raises -> Decimal128:
             return multiply(x1, x2) + x3
     elif b_scale > p_scale:
         var diff = b_scale - p_scale
-        var p_ndigits = decimo.decimal128.utility.number_of_digits(p_coef_256)
+        var p_ndigits = decimal128_utility.number_of_digits(p_coef_256)
         if p_ndigits + diff <= WORK_DIGITS_CAP:
-            p_coef_256 = (
-                p_coef_256
-                * decimo.decimal128.utility.power_of_10_unsafe[DType.uint256](
-                    diff
-                )
-            )
+            p_coef_256 = p_coef_256 * decimal128_utility.power_of_10_unsafe[
+                DType.uint256
+            ](diff)
             common_scale = b_scale
         else:
             return multiply(x1, x2) + x3
@@ -1523,7 +1503,7 @@ def fma(x1: Decimal128, x2: Decimal128, x3: Decimal128) raises -> Decimal128:
     # digits to drop so that both `sum_coef <= MAX_AS_UINT128` and
     # `final_scale <= MAX_SCALE` are satisfied in one round_coefficient
     # call.
-    var ndigits = decimo.decimal128.utility.number_of_digits(sum_coef)
+    var ndigits = decimal128_utility.number_of_digits(sum_coef)
     var drop_for_scale = common_scale - Decimal128.MAX_SCALE
     var drop_for_fit: Int
     if sum_coef > UInt256(Decimal128.MAX_AS_UINT128):
@@ -1542,9 +1522,9 @@ def fma(x1: Decimal128, x2: Decimal128, x3: Decimal128) raises -> Decimal128:
     if drop == 0:
         rounded = sum_coef
     else:
-        rounded = decimo.decimal128.utility.round_coefficient[
-            skip_digit_check=True
-        ](sum_coef, ndigits_to_remove=drop)
+        rounded = decimal128_utility.round_coefficient[skip_digit_check=True](
+            sum_coef, ndigits_to_remove=drop
+        )
         # Banker's-rounding carry may push the value past MAX_AS_UINT128.
         # Re-round the ORIGINAL sum_coef (not the already-rounded value)
         # with one more digit dropped to avoid double-rounding artifacts.
@@ -1555,7 +1535,7 @@ def fma(x1: Decimal128, x2: Decimal128, x3: Decimal128) raises -> Decimal128:
                     message="Decimal128 overflow in fma().",
                     function="fma()",
                 )
-            rounded = decimo.decimal128.utility.round_coefficient[
+            rounded = decimal128_utility.round_coefficient[
                 skip_digit_check=True
             ](sum_coef, ndigits_to_remove=drop)
 

--- a/src/decimo/decimal128/comparison.mojo
+++ b/src/decimo/decimal128/comparison.mojo
@@ -45,7 +45,7 @@ Implements functions for comparison operations on Decimal128 objects.
 from std import testing
 
 from decimo.decimal128.decimal128 import Decimal128
-import decimo.decimal128.utility
+import decimo.decimal128.utility as decimal128_utility
 from decimo.errors import ValueError
 
 
@@ -125,20 +125,15 @@ def compare_absolute(x: Decimal128, y: Decimal128) -> Int8:
     if x_scale > y_scale:
         var scale_diff = x_scale - y_scale
         if scale_diff <= 9:
-            var y_scaled = (
-                y_coef
-                * decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
-                    scale_diff
-                )
-            )
+            var y_scaled = y_coef * decimal128_utility.power_of_10_unsafe[
+                DType.uint128
+            ](scale_diff)
             if x_coef == y_scaled:
                 return 0
             return Int8(1) if x_coef > y_scaled else Int8(-1)
         var y_scaled_w = UInt256(
             y_coef
-        ) * decimo.decimal128.utility.power_of_10_unsafe[DType.uint256](
-            scale_diff
-        )
+        ) * decimal128_utility.power_of_10_unsafe[DType.uint256](scale_diff)
         var x_wide = UInt256(x_coef)
         if x_wide == y_scaled_w:
             return 0
@@ -147,15 +142,15 @@ def compare_absolute(x: Decimal128, y: Decimal128) -> Int8:
     # x_scale < y_scale: scale up x.
     var scale_diff = y_scale - x_scale
     if scale_diff <= 9:
-        var x_scaled = x_coef * decimo.decimal128.utility.power_of_10_unsafe[
+        var x_scaled = x_coef * decimal128_utility.power_of_10_unsafe[
             DType.uint128
         ](scale_diff)
         if x_scaled == y_coef:
             return 0
         return Int8(1) if x_scaled > y_coef else Int8(-1)
-    var x_scaled_w = UInt256(
-        x_coef
-    ) * decimo.decimal128.utility.power_of_10_unsafe[DType.uint256](scale_diff)
+    var x_scaled_w = UInt256(x_coef) * decimal128_utility.power_of_10_unsafe[
+        DType.uint256
+    ](scale_diff)
     var y_wide = UInt256(y_coef)
     if x_scaled_w == y_wide:
         return 0

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -26,18 +26,18 @@ mathematical methods that do not implement a trait.
 from std.memory import UnsafePointer
 from std.hashlib.hasher import Hasher
 
-import decimo.decimal128.arithmetics
-import decimo.decimal128.comparison
-import decimo.decimal128.constants
-import decimo.decimal128.exponential
-import decimo.decimal128.rounding
+import decimo.decimal128.arithmetics as decimal128_arithmetics
+import decimo.decimal128.comparison as decimal128_comparison
+import decimo.decimal128.constants as decimal128_constants
+import decimo.decimal128.exponential as decimal128_exponential
+import decimo.decimal128.rounding as decimal128_rounding
 from decimo.rounding_mode import RoundingMode
 from decimo.errors import (
     ValueError,
     OverflowError,
     ConversionError,
 )
-import decimo.decimal128.utility
+import decimo.decimal128.utility as decimal128_utility
 from decimo.bigdecimal.bigdecimal import BigDecimal
 
 comptime Dec128 = Decimal128
@@ -184,7 +184,7 @@ struct Decimal128(
         Returns:
             The value of pi (π).
         """
-        return decimo.decimal128.constants.PI()
+        return decimal128_constants.PI()
 
     @always_inline
     @staticmethod
@@ -194,7 +194,7 @@ struct Decimal128(
         Returns:
             The value of Euler's number (e).
         """
-        return decimo.decimal128.constants.E()
+        return decimal128_constants.E()
 
     # ===------------------------------------------------------------------=== #
     # Constructors and life time dunder methods
@@ -850,7 +850,7 @@ struct Decimal128(
                             ).format(raw_exponent),
                             function="Decimal128.from_string()",
                         )
-                    coef = coef * decimo.decimal128.utility.power_of_10_unsafe[
+                    coef = coef * decimal128_utility.power_of_10_unsafe[
                         DType.uint128
                     ](exponent_delta)
                     scale = 0
@@ -862,7 +862,7 @@ struct Decimal128(
         # because it is used in many cases
         if coef <= Decimal128.MAX_AS_UINT128:
             if scale > UInt32(Decimal128.MAX_SCALE):
-                coef = decimo.decimal128.utility.round_coefficient(
+                coef = decimal128_utility.round_coefficient(
                     coef,
                     ndigits_to_remove=Int(scale - UInt32(Decimal128.MAX_SCALE)),
                 )
@@ -871,7 +871,7 @@ struct Decimal128(
             return Decimal128.from_uint128(coef, scale, mantissa_sign)
 
         else:
-            var fitted = decimo.decimal128.utility.fit_to_max_coefficient(coef)
+            var fitted = decimal128_utility.fit_to_max_coefficient(coef)
             var truncated_coef = fitted[0]
             var truncated_digits = UInt32(fitted[1])
             # Guard against integral-digit overflow: if more digits were removed
@@ -888,7 +888,7 @@ struct Decimal128(
             var scale_of_truncated_coef = scale - truncated_digits
 
             if scale_of_truncated_coef > UInt32(Decimal128.MAX_SCALE):
-                truncated_coef = decimo.decimal128.utility.round_coefficient(
+                truncated_coef = decimal128_utility.round_coefficient(
                     truncated_coef,
                     ndigits_to_remove=Int(
                         scale_of_truncated_coef - UInt32(Decimal128.MAX_SCALE)
@@ -1012,12 +1012,9 @@ struct Decimal128(
             # print("DEBUG: scale = ", scale)
             # print("DEBUG: remainder = ", remainder)
 
-        coefficient = (
-            coefficient
-            // decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
-                Int(num_trailing_zeros)
-            )
-        )
+        coefficient = coefficient // decimal128_utility.power_of_10_unsafe[
+            DType.uint128
+        ](Int(num_trailing_zeros))
         scale -= num_trailing_zeros
 
         var low = UInt32(coefficient & 0xFFFFFFFF)
@@ -1297,12 +1294,9 @@ struct Decimal128(
 
         # Otherwise, get the integer part by dividing by 10^scale
         else:
-            res = (
-                self.coefficient()
-                // decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
-                    self.scale()
-                )
-            )
+            res = self.coefficient() // decimal128_utility.power_of_10_unsafe[
+                DType.uint128
+            ](self.scale())
 
         return res
 
@@ -1537,7 +1531,7 @@ struct Decimal128(
         Returns:
             The absolute value.
         """
-        return decimo.decimal128.arithmetics.absolute(self)
+        return decimal128_arithmetics.absolute(self)
 
     @always_inline
     def __neg__(self) -> Self:
@@ -1547,7 +1541,7 @@ struct Decimal128(
         Returns:
             The negated value.
         """
-        return decimo.decimal128.arithmetics.negative(self)
+        return decimal128_arithmetics.negative(self)
 
     @always_inline
     def __bool__(self) -> Bool:
@@ -1587,7 +1581,7 @@ struct Decimal128(
         Returns:
             The sum.
         """
-        return decimo.decimal128.arithmetics.add(self, other)
+        return decimal128_arithmetics.add(self, other)
 
     @always_inline
     def __sub__(self, other: Self) raises -> Self:
@@ -1599,7 +1593,7 @@ struct Decimal128(
         Returns:
             The difference.
         """
-        return decimo.decimal128.arithmetics.subtract(self, other)
+        return decimal128_arithmetics.subtract(self, other)
 
     @always_inline
     def __mul__(self, other: Self) raises -> Self:
@@ -1611,7 +1605,7 @@ struct Decimal128(
         Returns:
             The product.
         """
-        return decimo.decimal128.arithmetics.multiply(self, other)
+        return decimal128_arithmetics.multiply(self, other)
 
     @always_inline
     def __truediv__(self, other: Self) raises -> Self:
@@ -1623,7 +1617,7 @@ struct Decimal128(
         Returns:
             The quotient.
         """
-        return decimo.decimal128.arithmetics.divide(self, other)
+        return decimal128_arithmetics.divide(self, other)
 
     @always_inline
     def __floordiv__(self, other: Self) raises -> Self:
@@ -1635,7 +1629,7 @@ struct Decimal128(
         Returns:
             The truncated quotient.
         """
-        return decimo.decimal128.arithmetics.truncate_divide(self, other)
+        return decimal128_arithmetics.truncate_divide(self, other)
 
     @always_inline
     def __mod__(self, other: Self) raises -> Self:
@@ -1647,7 +1641,7 @@ struct Decimal128(
         Returns:
             The remainder.
         """
-        return decimo.decimal128.arithmetics.modulo(self, other)
+        return decimal128_arithmetics.modulo(self, other)
 
     @always_inline
     def __divmod__(self, other: Self) raises -> Tuple[Self, Self]:
@@ -1671,7 +1665,7 @@ struct Decimal128(
             ZeroDivisionError: If `other` is zero.
             OverflowError: If the result overflows.
         """
-        var q = decimo.decimal128.arithmetics.truncate_divide(self, other)
+        var q = decimal128_arithmetics.truncate_divide(self, other)
         return (q, self - q * other)
 
     @always_inline
@@ -1684,7 +1678,7 @@ struct Decimal128(
         Returns:
             The value raised to the given power.
         """
-        return decimo.decimal128.exponential.power(self, exponent)
+        return decimal128_exponential.power(self, exponent)
 
     @always_inline
     def __pow__(self, exponent: Int) raises -> Self:
@@ -1696,7 +1690,7 @@ struct Decimal128(
         Returns:
             The value raised to the given power.
         """
-        return decimo.decimal128.exponential.power(self, exponent)
+        return decimal128_exponential.power(self, exponent)
 
     # ===------------------------------------------------------------------=== #
     # Basic binary arithmetic operation dunders with reflected operands
@@ -1715,7 +1709,7 @@ struct Decimal128(
         Returns:
             The sum.
         """
-        return decimo.decimal128.arithmetics.add(other, self)
+        return decimal128_arithmetics.add(other, self)
 
     @always_inline
     def __rsub__(self, other: Self) raises -> Self:
@@ -1727,7 +1721,7 @@ struct Decimal128(
         Returns:
             The difference.
         """
-        return decimo.decimal128.arithmetics.subtract(other, self)
+        return decimal128_arithmetics.subtract(other, self)
 
     @always_inline
     def __rmul__(self, other: Self) raises -> Self:
@@ -1739,7 +1733,7 @@ struct Decimal128(
         Returns:
             The product.
         """
-        return decimo.decimal128.arithmetics.multiply(other, self)
+        return decimal128_arithmetics.multiply(other, self)
 
     @always_inline
     def __rtruediv__(self, other: Self) raises -> Self:
@@ -1751,7 +1745,7 @@ struct Decimal128(
         Returns:
             The quotient.
         """
-        return decimo.decimal128.arithmetics.divide(other, self)
+        return decimal128_arithmetics.divide(other, self)
 
     @always_inline
     def __rfloordiv__(self, other: Self) raises -> Self:
@@ -1763,7 +1757,7 @@ struct Decimal128(
         Returns:
             The truncated quotient.
         """
-        return decimo.decimal128.arithmetics.truncate_divide(other, self)
+        return decimal128_arithmetics.truncate_divide(other, self)
 
     @always_inline
     def __rmod__(self, other: Self) raises -> Self:
@@ -1775,7 +1769,7 @@ struct Decimal128(
         Returns:
             The remainder.
         """
-        return decimo.decimal128.arithmetics.modulo(other, self)
+        return decimal128_arithmetics.modulo(other, self)
 
     # ===------------------------------------------------------------------=== #
     # Basic binary augmented arithmetic assignments dunders
@@ -1791,7 +1785,7 @@ struct Decimal128(
         Args:
             other: The right-hand side operand.
         """
-        self = decimo.decimal128.arithmetics.add(self, other)
+        self = decimal128_arithmetics.add(self, other)
 
     @always_inline
     def __isub__(mut self, other: Self) raises:
@@ -1800,7 +1794,7 @@ struct Decimal128(
         Args:
             other: The right-hand side operand.
         """
-        self = decimo.decimal128.arithmetics.subtract(self, other)
+        self = decimal128_arithmetics.subtract(self, other)
 
     @always_inline
     def __imul__(mut self, other: Self) raises:
@@ -1809,7 +1803,7 @@ struct Decimal128(
         Args:
             other: The right-hand side operand.
         """
-        self = decimo.decimal128.arithmetics.multiply(self, other)
+        self = decimal128_arithmetics.multiply(self, other)
 
     @always_inline
     def __itruediv__(mut self, other: Self) raises:
@@ -1818,7 +1812,7 @@ struct Decimal128(
         Args:
             other: The right-hand side operand.
         """
-        self = decimo.decimal128.arithmetics.divide(self, other)
+        self = decimal128_arithmetics.divide(self, other)
 
     @always_inline
     def __ifloordiv__(mut self, other: Self) raises:
@@ -1827,7 +1821,7 @@ struct Decimal128(
         Args:
             other: The right-hand side operand.
         """
-        self = decimo.decimal128.arithmetics.truncate_divide(self, other)
+        self = decimal128_arithmetics.truncate_divide(self, other)
 
     @always_inline
     def __imod__(mut self, other: Self) raises:
@@ -1836,7 +1830,7 @@ struct Decimal128(
         Args:
             other: The right-hand side operand.
         """
-        self = decimo.decimal128.arithmetics.modulo(self, other)
+        self = decimal128_arithmetics.modulo(self, other)
 
     # ===------------------------------------------------------------------=== #
     # Basic binary comparison operation dunders
@@ -1854,7 +1848,7 @@ struct Decimal128(
         Returns:
             `True` if this value is greater than `other`, `False` otherwise.
         """
-        return decimo.decimal128.comparison.greater(self, other)
+        return decimal128_comparison.greater(self, other)
 
     @always_inline
     def __lt__(self, other: Decimal128) -> Bool:
@@ -1867,7 +1861,7 @@ struct Decimal128(
         Returns:
             `True` if this value is less than `other`, `False` otherwise.
         """
-        return decimo.decimal128.comparison.less(self, other)
+        return decimal128_comparison.less(self, other)
 
     @always_inline
     def __ge__(self, other: Decimal128) -> Bool:
@@ -1880,7 +1874,7 @@ struct Decimal128(
         Returns:
             `True` if this value is greater than or equal to `other`, `False` otherwise.
         """
-        return decimo.decimal128.comparison.greater_equal(self, other)
+        return decimal128_comparison.greater_equal(self, other)
 
     @always_inline
     def __le__(self, other: Decimal128) -> Bool:
@@ -1893,7 +1887,7 @@ struct Decimal128(
         Returns:
             `True` if this value is less than or equal to `other`, `False` otherwise.
         """
-        return decimo.decimal128.comparison.less_equal(self, other)
+        return decimal128_comparison.less_equal(self, other)
 
     @always_inline
     def __eq__(self, other: Decimal128) -> Bool:
@@ -1906,7 +1900,7 @@ struct Decimal128(
         Returns:
             `True` if the values are equal, `False` otherwise.
         """
-        return decimo.decimal128.comparison.equal(self, other)
+        return decimal128_comparison.equal(self, other)
 
     @always_inline
     def __ne__(self, other: Decimal128) -> Bool:
@@ -1919,7 +1913,7 @@ struct Decimal128(
         Returns:
             `True` if the values are not equal, `False` otherwise.
         """
-        return decimo.decimal128.comparison.not_equal(self, other)
+        return decimal128_comparison.not_equal(self, other)
 
     # ===------------------------------------------------------------------=== #
     # min / max / clamp
@@ -1936,7 +1930,7 @@ struct Decimal128(
         Returns:
             `self` if `self >= other`, otherwise `other`.
         """
-        return decimo.decimal128.comparison.max(self, other)
+        return decimal128_comparison.max(self, other)
 
     @always_inline
     def min(self, other: Decimal128) -> Decimal128:
@@ -1949,7 +1943,7 @@ struct Decimal128(
         Returns:
             `self` if `self <= other`, otherwise `other`.
         """
-        return decimo.decimal128.comparison.min(self, other)
+        return decimal128_comparison.min(self, other)
 
     @always_inline
     def clamp(self, lower: Decimal128, upper: Decimal128) raises -> Decimal128:
@@ -1966,7 +1960,7 @@ struct Decimal128(
         Raises:
             ValueError: If `lower > upper`.
         """
-        return decimo.decimal128.comparison.clamp(self, lower, upper)
+        return decimal128_comparison.clamp(self, lower, upper)
 
     # ===------------------------------------------------------------------=== #
     # Other dunders that implements traits
@@ -1989,7 +1983,7 @@ struct Decimal128(
             The rounded `Decimal128` value.
         """
         try:
-            return decimo.decimal128.rounding.round(
+            return decimal128_rounding.round(
                 self,
                 ndigits=ndigits,
                 rounding_mode=RoundingMode.half_even(),
@@ -2005,7 +1999,7 @@ struct Decimal128(
             The `Decimal128` rounded to 0 decimal places.
         """
         try:
-            return decimo.decimal128.rounding.round(
+            return decimal128_rounding.round(
                 self, ndigits=0, rounding_mode=RoundingMode.half_even()
             )
         except e:
@@ -2066,7 +2060,7 @@ struct Decimal128(
         Returns:
             The rounded `Decimal128` value.
         """
-        return decimo.decimal128.rounding.round(
+        return decimal128_rounding.round(
             self, ndigits=ndigits, rounding_mode=rounding_mode
         )
 
@@ -2086,7 +2080,7 @@ struct Decimal128(
         Returns:
             The quantized `Decimal128` value.
         """
-        return decimo.decimal128.rounding.quantize(self, exp, rounding_mode)
+        return decimal128_rounding.quantize(self, exp, rounding_mode)
 
     @always_inline
     def fma(self, other: Self, third: Self) raises -> Self:
@@ -2126,7 +2120,7 @@ struct Decimal128(
         Raises:
             OverflowError: If the result overflows Decimal128 capacity.
         """
-        return decimo.decimal128.arithmetics.fma(self, other, third)
+        return decimal128_arithmetics.fma(self, other, third)
 
     @always_inline
     def exp(self) raises -> Self:
@@ -2136,7 +2130,7 @@ struct Decimal128(
         Returns:
             The value of e raised to this power.
         """
-        return decimo.decimal128.exponential.exp(self)
+        return decimal128_exponential.exp(self)
 
     @always_inline
     def ln(self) raises -> Self:
@@ -2146,7 +2140,7 @@ struct Decimal128(
         Returns:
             The natural logarithm of this value.
         """
-        return decimo.decimal128.exponential.ln(self)
+        return decimal128_exponential.ln(self)
 
     @always_inline
     def log10(self) raises -> Decimal128:
@@ -2155,7 +2149,7 @@ struct Decimal128(
         Returns:
             The base-10 logarithm of this value.
         """
-        return decimo.decimal128.exponential.log10(self)
+        return decimal128_exponential.log10(self)
 
     @always_inline
     def log(self, base: Decimal128) raises -> Decimal128:
@@ -2167,7 +2161,7 @@ struct Decimal128(
         Returns:
             The logarithm of this value in the given base.
         """
-        return decimo.decimal128.exponential.log(self, base)
+        return decimal128_exponential.log(self, base)
 
     @always_inline
     def power(self, exponent: Int) raises -> Decimal128:
@@ -2179,7 +2173,7 @@ struct Decimal128(
         Returns:
             The value raised to the given power.
         """
-        return decimo.decimal128.exponential.power(self, Self(exponent))
+        return decimal128_exponential.power(self, Self(exponent))
 
     @always_inline
     def power(self, exponent: Decimal128) raises -> Decimal128:
@@ -2191,7 +2185,7 @@ struct Decimal128(
         Returns:
             The value raised to the given power.
         """
-        return decimo.decimal128.exponential.power(self, exponent)
+        return decimal128_exponential.power(self, exponent)
 
     @always_inline
     def root(self, n: Int) raises -> Self:
@@ -2205,7 +2199,7 @@ struct Decimal128(
         Returns:
             The n-th root of this value.
         """
-        return decimo.decimal128.exponential.root(self, n)
+        return decimal128_exponential.root(self, n)
 
     @always_inline
     def sqrt(self) raises -> Self:
@@ -2216,7 +2210,7 @@ struct Decimal128(
         Returns:
             The square root of this value.
         """
-        return decimo.decimal128.exponential.sqrt(self)
+        return decimal128_exponential.sqrt(self)
 
     @always_inline
     def cbrt(self) raises -> Self:
@@ -2230,7 +2224,7 @@ struct Decimal128(
         Raises:
             Any error raised by `cbrt()`.
         """
-        return decimo.decimal128.exponential.cbrt(self)
+        return decimal128_exponential.cbrt(self)
 
     # ===------------------------------------------------------------------=== #
     # Integer-part / fractional-part / sign helpers
@@ -2260,7 +2254,7 @@ struct Decimal128(
         ```
         End of example.
         """
-        return decimo.decimal128.rounding.round(
+        return decimal128_rounding.round(
             self, ndigits=0, rounding_mode=RoundingMode.ROUND_DOWN
         )
 
@@ -2286,7 +2280,7 @@ struct Decimal128(
         ```
         End of example.
         """
-        return decimo.decimal128.rounding.round(
+        return decimal128_rounding.round(
             self, ndigits=0, rounding_mode=RoundingMode.ROUND_FLOOR
         )
 
@@ -2313,7 +2307,7 @@ struct Decimal128(
         ```
         End of example.
         """
-        return decimo.decimal128.rounding.round(
+        return decimal128_rounding.round(
             self, ndigits=0, rounding_mode=RoundingMode.ROUND_CEILING
         )
 
@@ -2478,9 +2472,7 @@ struct Decimal128(
         # `0..29` contract. Each iteration consumes one `__udivmodti4`
         # (LLVM CSE-folds `// + %`).
         comptime CHUNK = 9
-        var pow9 = decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
-            CHUNK
-        )
+        var pow9 = decimal128_utility.power_of_10_unsafe[DType.uint128](CHUNK)
         while scale >= CHUNK and coef % pow9 == 0:
             coef = coef // pow9
             scale -= CHUNK
@@ -2597,7 +2589,7 @@ struct Decimal128(
         ```
         End of example.
         """
-        return decimo.decimal128.comparison.compare_total(self, other)
+        return decimal128_comparison.compare_total(self, other)
 
     @always_inline
     def is_signed(self) -> Bool:
@@ -2648,7 +2640,7 @@ struct Decimal128(
         # Fast implementation using bitcast
         # Use bitcast to directly convert the three 32-bit parts to a UInt128
         # UInt128 must little-endian on memory
-        return decimo.decimal128.utility.bitcast[DType.uint128](self)
+        return decimal128_utility.bitcast[DType.uint128](self)
 
         # Alternative implementation using arithmetic
         # Combine the three 32-bit parts into a single Int128
@@ -2721,7 +2713,7 @@ struct Decimal128(
         # If yes, then raise an error
         var max_coefficient = ~UInt128(
             0
-        ) / decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
+        ) / decimal128_utility.power_of_10_unsafe[DType.uint128](
             Int(precision_diff)
         )
         if coefficient > max_coefficient:
@@ -2839,7 +2831,7 @@ struct Decimal128(
         # blob's `0..29` range.
         return (
             self.coefficient()
-            % decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](scale)
+            % decimal128_utility.power_of_10_unsafe[DType.uint128](scale)
         ) == 0
 
     @always_inline
@@ -2874,9 +2866,9 @@ struct Decimal128(
         var coef = self.coefficient()
         var scale = self.scale()
         if scale > 0:
-            coef = coef // decimo.decimal128.utility.power_of_10_unsafe[
-                DType.uint128
-            ](scale)
+            coef = coef // decimal128_utility.power_of_10_unsafe[DType.uint128](
+                scale
+            )
         return Bool(coef & 1)
 
     @always_inline
@@ -2897,9 +2889,7 @@ struct Decimal128(
         if scale == 0 and coef == 1:
             return True
 
-        if coef == decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
-            scale
-        ):
+        if coef == decimal128_utility.power_of_10_unsafe[DType.uint128](scale):
             return True
 
         return False
@@ -2951,7 +2941,7 @@ struct Decimal128(
         if coef == 0:
             return 0  # Zero has zero significant digit
         else:
-            return decimo.decimal128.utility.number_of_digits(coef)
+            return decimal128_utility.number_of_digits(coef)
 
     def number_of_trailing_zeros(self) -> Int:
         """Returns the number of trailing zero digits in the coefficient.

--- a/src/decimo/decimal128/exponential.mojo
+++ b/src/decimo/decimal128/exponential.mojo
@@ -21,9 +21,9 @@ from std import testing
 from std import time
 
 from decimo.errors import ValueError, OverflowError, ZeroDivisionError
-import decimo.decimal128.constants
-import decimo.decimal128.special
-import decimo.decimal128.utility
+import decimo.decimal128.constants as decimal128_constants
+import decimo.decimal128.special as decimal128_special
+import decimo.decimal128.utility as decimal128_utility
 
 # ===----------------------------------------------------------------------=== #
 # Power and root functions
@@ -69,7 +69,7 @@ def power(base: Decimal128, exponent: Decimal128) raises -> Decimal128:
 
     # CASE: If the exponent is simple fractions
     # 0.5
-    if exponent == decimo.decimal128.constants.M0D5():
+    if exponent == decimal128_constants.M0D5():
         try:
             return sqrt(base)
         except e:
@@ -308,11 +308,9 @@ def root(x: Decimal128, n: Int) raises -> Decimal128:
 
     # No need to do this if the last digit of the coefficient of guess is not zero
     if guess_coef % 10 == 0:
-        var num_digits_x_ceof = decimo.decimal128.utility.number_of_digits(
-            x_coef
-        )
+        var num_digits_x_ceof = decimal128_utility.number_of_digits(x_coef)
         var num_digits_x_root_coef = (num_digits_x_ceof // n) + 1
-        var num_digits_guess_coef = decimo.decimal128.utility.number_of_digits(
+        var num_digits_guess_coef = decimal128_utility.number_of_digits(
             guess_coef
         )
         var num_digits_to_decrease = (
@@ -345,8 +343,7 @@ def root(x: Decimal128, n: Int) raises -> Decimal128:
             # below.
             if n <= 38 and (
                 guess_coef_powered
-                == x_coef
-                * decimo.decimal128.utility.power_of_10[DType.uint128](n)
+                == x_coef * decimal128_utility.power_of_10[DType.uint128](n)
             ):
                 return Decimal128.from_uint128(
                     guess_coef // 10,
@@ -481,11 +478,9 @@ def sqrt(x: Decimal128) raises -> Decimal128:
 
     # No need to do this if the last digit of the coefficient of guess is not zero
     if guess_coef % 10 == 0:
-        var num_digits_x_ceof = decimo.decimal128.utility.number_of_digits(
-            x_coef
-        )
+        var num_digits_x_ceof = decimal128_utility.number_of_digits(x_coef)
         var num_digits_x_sqrt_coef = (num_digits_x_ceof >> 1) + 1
-        var num_digits_guess_coef = decimo.decimal128.utility.number_of_digits(
+        var num_digits_guess_coef = decimal128_utility.number_of_digits(
             guess_coef
         )
         var num_digits_to_decrease = (
@@ -585,7 +580,7 @@ def exp(x: Decimal128) raises -> Decimal128:
     var x_int = Int(x)
 
     if x.is_one():
-        return decimo.decimal128.constants.E()
+        return decimal128_constants.E()
 
     elif x_int < 1:
         # Sub-unit chunking by the first two decimal digits.
@@ -611,23 +606,23 @@ def exp(x: Decimal128) raises -> Decimal128:
             var d1_over_10 = Decimal128.from_int(value=d1, scale=UInt32(1))
             var residual = x - d1_over_10
             if d1 == 1:
-                exp_chunk = decimo.decimal128.constants.E0D1()
+                exp_chunk = decimal128_constants.E0D1()
             elif d1 == 2:
-                exp_chunk = decimo.decimal128.constants.E0D2()
+                exp_chunk = decimal128_constants.E0D2()
             elif d1 == 3:
-                exp_chunk = decimo.decimal128.constants.E0D3()
+                exp_chunk = decimal128_constants.E0D3()
             elif d1 == 4:
-                exp_chunk = decimo.decimal128.constants.E0D4()
+                exp_chunk = decimal128_constants.E0D4()
             elif d1 == 5:
-                exp_chunk = decimo.decimal128.constants.E0D5()
+                exp_chunk = decimal128_constants.E0D5()
             elif d1 == 6:
-                exp_chunk = decimo.decimal128.constants.E0D6()
+                exp_chunk = decimal128_constants.E0D6()
             elif d1 == 7:
-                exp_chunk = decimo.decimal128.constants.E0D7()
+                exp_chunk = decimal128_constants.E0D7()
             elif d1 == 8:
-                exp_chunk = decimo.decimal128.constants.E0D8()
+                exp_chunk = decimal128_constants.E0D8()
             else:  # d1 == 9
-                exp_chunk = decimo.decimal128.constants.E0D9()
+                exp_chunk = decimal128_constants.E0D9()
             remainder = residual
         else:
             # d1 == 0 ⇒ x < 0.1, drop into tier 2.
@@ -639,93 +634,93 @@ def exp(x: Decimal128) raises -> Decimal128:
             var d2_over_100 = Decimal128.from_int(value=d2, scale=UInt32(2))
             var residual = x - d2_over_100
             if d2 == 1:
-                exp_chunk = decimo.decimal128.constants.E0D01()
+                exp_chunk = decimal128_constants.E0D01()
             elif d2 == 2:
-                exp_chunk = decimo.decimal128.constants.E0D02()
+                exp_chunk = decimal128_constants.E0D02()
             elif d2 == 3:
-                exp_chunk = decimo.decimal128.constants.E0D03()
+                exp_chunk = decimal128_constants.E0D03()
             elif d2 == 4:
-                exp_chunk = decimo.decimal128.constants.E0D04()
+                exp_chunk = decimal128_constants.E0D04()
             elif d2 == 5:
-                exp_chunk = decimo.decimal128.constants.E0D05()
+                exp_chunk = decimal128_constants.E0D05()
             elif d2 == 6:
-                exp_chunk = decimo.decimal128.constants.E0D06()
+                exp_chunk = decimal128_constants.E0D06()
             elif d2 == 7:
-                exp_chunk = decimo.decimal128.constants.E0D07()
+                exp_chunk = decimal128_constants.E0D07()
             elif d2 == 8:
-                exp_chunk = decimo.decimal128.constants.E0D08()
+                exp_chunk = decimal128_constants.E0D08()
             else:  # d2 == 9
-                exp_chunk = decimo.decimal128.constants.E0D09()
+                exp_chunk = decimal128_constants.E0D09()
             remainder = residual
 
     elif x_int == 1:  # 1 <= x < 2, chunk = 1
-        exp_chunk = decimo.decimal128.constants.E()
+        exp_chunk = decimal128_constants.E()
         remainder = x - x_int
 
     elif x_int == 2:  # 2 <= x < 3, chunk = 2
-        exp_chunk = decimo.decimal128.constants.E2()
+        exp_chunk = decimal128_constants.E2()
         remainder = x - x_int
 
     elif x_int == 3:  # 3 <= x < 4, chunk = 3
-        exp_chunk = decimo.decimal128.constants.E3()
+        exp_chunk = decimal128_constants.E3()
         remainder = x - x_int
 
     elif x_int == 4:  # 4 <= x < 5, chunk = 4
-        exp_chunk = decimo.decimal128.constants.E4()
+        exp_chunk = decimal128_constants.E4()
         remainder = x - x_int
 
     elif x_int == 5:  # 5 <= x < 6, chunk = 5
-        exp_chunk = decimo.decimal128.constants.E5()
+        exp_chunk = decimal128_constants.E5()
         remainder = x - x_int
 
     elif x_int == 6:  # 6 <= x < 7, chunk = 6
-        exp_chunk = decimo.decimal128.constants.E6()
+        exp_chunk = decimal128_constants.E6()
         remainder = x - x_int
 
     elif x_int == 7:  # 7 <= x < 8, chunk = 7
-        exp_chunk = decimo.decimal128.constants.E7()
+        exp_chunk = decimal128_constants.E7()
         remainder = x - x_int
 
     elif x_int == 8:  # 8 <= x < 9, chunk = 8
-        exp_chunk = decimo.decimal128.constants.E8()
+        exp_chunk = decimal128_constants.E8()
         remainder = x - x_int
 
     elif x_int == 9:  # 9 <= x < 10, chunk = 9
-        exp_chunk = decimo.decimal128.constants.E9()
+        exp_chunk = decimal128_constants.E9()
         remainder = x - x_int
 
     elif x_int == 10:  # 10 <= x < 11, chunk = 10
-        exp_chunk = decimo.decimal128.constants.E10()
+        exp_chunk = decimal128_constants.E10()
         remainder = x - x_int
 
     elif x_int == 11:  # 11 <= x < 12, chunk = 11
-        exp_chunk = decimo.decimal128.constants.E11()
+        exp_chunk = decimal128_constants.E11()
         remainder = x - x_int
 
     elif x_int == 12:  # 12 <= x < 13, chunk = 12
-        exp_chunk = decimo.decimal128.constants.E12()
+        exp_chunk = decimal128_constants.E12()
         remainder = x - x_int
 
     elif x_int == 13:  # 13 <= x < 14, chunk = 13
-        exp_chunk = decimo.decimal128.constants.E13()
+        exp_chunk = decimal128_constants.E13()
         remainder = x - x_int
 
     elif x_int == 14:  # 14 <= x < 15, chunk = 14
-        exp_chunk = decimo.decimal128.constants.E14()
+        exp_chunk = decimal128_constants.E14()
         remainder = x - x_int
 
     elif x_int == 15:  # 15 <= x < 16, chunk = 15
-        exp_chunk = decimo.decimal128.constants.E15()
+        exp_chunk = decimal128_constants.E15()
         remainder = x - x_int
 
     elif x_int < 32:  # 16 <= x < 32, chunk = 16
         num_chunks = x_int >> 4
-        exp_chunk = decimo.decimal128.constants.E16()
+        exp_chunk = decimal128_constants.E16()
         remainder = x - (num_chunks << 4)
 
     else:  # chunk = 32
         num_chunks = x_int >> 5
-        exp_chunk = decimo.decimal128.constants.E32()
+        exp_chunk = decimal128_constants.E32()
         remainder = x - (num_chunks << 5)
 
     # Calculate e^(chunk * num_chunks) = (e^chunk)^num_chunks
@@ -785,7 +780,7 @@ def exp_series(x: Decimal128) raises -> Decimal128:
 
     for i in range(1, max_terms + 1):
         x_power = x_power * x
-        term = x_power * decimo.decimal128.special.factorial_reciprocal(i)
+        term = x_power * decimal128_special.factorial_reciprocal(i)
         # Check for convergence
         if term.is_zero():
             break
@@ -832,7 +827,7 @@ def ln(x: Decimal128) raises -> Decimal128:
         return Decimal128.ZERO()
 
     # Special cases for common values
-    if x == decimo.decimal128.constants.E():
+    if x == decimal128_constants.E():
         return Decimal128.ONE()
 
     # For values close to 1, use series expansion directly
@@ -853,12 +848,10 @@ def ln(x: Decimal128) raises -> Decimal128:
     # For magnitudes outside [0.1, 10), read q directly from the scale instead
     # of looping divides: pick new_scale = num_digits(coef) - 1 so the
     # reconstructed m = coef * 10^(-new_scale) lies in [1, 10).
-    if x >= decimo.decimal128.constants.M10() or x < Decimal128(
-        1, 0, 0, 1 << 16
-    ):
+    if x >= decimal128_constants.M10() or x < Decimal128(1, 0, 0, 1 << 16):
         var x_coef = x.coefficient()
         var x_scale = Int(x.scale())
-        var num_digits = decimo.decimal128.utility.number_of_digits(x_coef)
+        var num_digits = decimal128_utility.number_of_digits(x_coef)
         var new_scale = num_digits - 1  # in [0, 28]
         q = new_scale - x_scale
         m = Decimal128.from_uint128(x_coef, scale=UInt32(new_scale), sign=False)
@@ -869,13 +862,13 @@ def ln(x: Decimal128) raises -> Decimal128:
     # STEP 2:
     # normalize m to [0.5, 2) using powers of 2.
     # After step 1, m is in [0.1, 10); at most 4 halvings or 1 doubling.
-    if m >= decimo.decimal128.constants.M2():
-        while m >= decimo.decimal128.constants.M2():
-            m = m / decimo.decimal128.constants.M2()
+    if m >= decimal128_constants.M2():
+        while m >= decimal128_constants.M2():
+            m = m / decimal128_constants.M2()
             p += 1
     elif m < Decimal128(5, 0, 0, 1 << 16):
         while m < Decimal128(5, 0, 0, 1 << 16):
-            m = m * decimo.decimal128.constants.M2()
+            m = m * decimal128_constants.M2()
             p -= 1
 
     # Now 0.5 <= m < 2
@@ -888,41 +881,41 @@ def ln(x: Decimal128) raises -> Decimal128:
             ln_m = (
                 ln_series(
                     (m - Decimal128(9, 0, 0, 1 << 16))
-                    * decimo.decimal128.constants.INV0D9()
+                    * decimal128_constants.INV0D9()
                 )
-                + decimo.decimal128.constants.LN0D9()
+                + decimal128_constants.LN0D9()
             )
         elif m >= Decimal128(8, 0, 0, 1 << 16):
             ln_m = (
                 ln_series(
                     (m - Decimal128(8, 0, 0, 1 << 16))
-                    * decimo.decimal128.constants.INV0D8()
+                    * decimal128_constants.INV0D8()
                 )
-                + decimo.decimal128.constants.LN0D8()
+                + decimal128_constants.LN0D8()
             )
         elif m >= Decimal128(7, 0, 0, 1 << 16):
             ln_m = (
                 ln_series(
                     (m - Decimal128(7, 0, 0, 1 << 16))
-                    * decimo.decimal128.constants.INV0D7()
+                    * decimal128_constants.INV0D7()
                 )
-                + decimo.decimal128.constants.LN0D7()
+                + decimal128_constants.LN0D7()
             )
         elif m >= Decimal128(6, 0, 0, 1 << 16):
             ln_m = (
                 ln_series(
                     (m - Decimal128(6, 0, 0, 1 << 16))
-                    * decimo.decimal128.constants.INV0D6()
+                    * decimal128_constants.INV0D6()
                 )
-                + decimo.decimal128.constants.LN0D6()
+                + decimal128_constants.LN0D6()
             )
         else:  # 0.5 <= m < 0.6
             ln_m = (
                 ln_series(
                     (m - Decimal128(5, 0, 0, 1 << 16))
-                    * decimo.decimal128.constants.INV0D5()
+                    * decimal128_constants.INV0D5()
                 )
-                + decimo.decimal128.constants.LN0D5()
+                + decimal128_constants.LN0D5()
             )
 
     else:
@@ -933,73 +926,73 @@ def ln(x: Decimal128) raises -> Decimal128:
             ln_m = (
                 ln_series(
                     (m - Decimal128(11, 0, 0, 1 << 16))
-                    * decimo.decimal128.constants.INV1D1()
+                    * decimal128_constants.INV1D1()
                 )
-                + decimo.decimal128.constants.LN1D1()
+                + decimal128_constants.LN1D1()
             )
         elif m < Decimal128(13, 0, 0, 1 << 16):  # 1.2 <= m < 1.3
             ln_m = (
                 ln_series(
                     (m - Decimal128(12, 0, 0, 1 << 16))
-                    * decimo.decimal128.constants.INV1D2()
+                    * decimal128_constants.INV1D2()
                 )
-                + decimo.decimal128.constants.LN1D2()
+                + decimal128_constants.LN1D2()
             )
         elif m < Decimal128(14, 0, 0, 1 << 16):  # 1.3 <= m < 1.4
             ln_m = (
                 ln_series(
                     (m - Decimal128(13, 0, 0, 1 << 16))
-                    * decimo.decimal128.constants.INV1D3()
+                    * decimal128_constants.INV1D3()
                 )
-                + decimo.decimal128.constants.LN1D3()
+                + decimal128_constants.LN1D3()
             )
         elif m < Decimal128(15, 0, 0, 1 << 16):  # 1.4 <= m < 1.5
             ln_m = (
                 ln_series(
                     (m - Decimal128(14, 0, 0, 1 << 16))
-                    * decimo.decimal128.constants.INV1D4()
+                    * decimal128_constants.INV1D4()
                 )
-                + decimo.decimal128.constants.LN1D4()
+                + decimal128_constants.LN1D4()
             )
         elif m < Decimal128(16, 0, 0, 1 << 16):  # 1.5 <= m < 1.6
             ln_m = (
                 ln_series(
                     (m - Decimal128(15, 0, 0, 1 << 16))
-                    * decimo.decimal128.constants.INV1D5()
+                    * decimal128_constants.INV1D5()
                 )
-                + decimo.decimal128.constants.LN1D5()
+                + decimal128_constants.LN1D5()
             )
         elif m < Decimal128(17, 0, 0, 1 << 16):  # 1.6 <= m < 1.7
             ln_m = (
                 ln_series(
                     (m - Decimal128(16, 0, 0, 1 << 16))
-                    * decimo.decimal128.constants.INV1D6()
+                    * decimal128_constants.INV1D6()
                 )
-                + decimo.decimal128.constants.LN1D6()
+                + decimal128_constants.LN1D6()
             )
         elif m < Decimal128(18, 0, 0, 1 << 16):  # 1.7 <= m < 1.8
             ln_m = (
                 ln_series(
                     (m - Decimal128(17, 0, 0, 1 << 16))
-                    * decimo.decimal128.constants.INV1D7()
+                    * decimal128_constants.INV1D7()
                 )
-                + decimo.decimal128.constants.LN1D7()
+                + decimal128_constants.LN1D7()
             )
         elif m < Decimal128(19, 0, 0, 1 << 16):  # 1.8 <= m < 1.9
             ln_m = (
                 ln_series(
                     (m - Decimal128(18, 0, 0, 1 << 16))
-                    * decimo.decimal128.constants.INV1D8()
+                    * decimal128_constants.INV1D8()
                 )
-                + decimo.decimal128.constants.LN1D8()
+                + decimal128_constants.LN1D8()
             )
         else:  # 1.9 <= m < 2
             ln_m = (
                 ln_series(
                     (m - Decimal128(19, 0, 0, 1 << 16))
-                    * decimo.decimal128.constants.INV1D9()
+                    * decimal128_constants.INV1D9()
                 )
-                + decimo.decimal128.constants.LN1D9()
+                + decimal128_constants.LN1D9()
             )
 
     # Combine result: ln(x) = ln(m) + p*ln(2) + q*ln(10)
@@ -1007,11 +1000,11 @@ def ln(x: Decimal128) raises -> Decimal128:
 
     # Add power of 2 contribution
     if p != 0:
-        result = result + Decimal128(p) * decimo.decimal128.constants.LN2()
+        result = result + Decimal128(p) * decimal128_constants.LN2()
 
     # Add power of 10 contribution
     if q != 0:
-        result = result + Decimal128(q) * decimo.decimal128.constants.LN10()
+        result = result + Decimal128(q) * decimal128_constants.LN10()
 
     return result
 
@@ -1067,7 +1060,7 @@ def ln_series(z: Decimal128) raises -> Decimal128:
         neg = not neg  # Alternate sign
 
         if i <= 20:
-            term = term * z * decimo.decimal128.constants.N_DIVIDE_NEXT(i)
+            term = term * z * decimal128_constants.N_DIVIDE_NEXT(i)
         else:
             term = term * z * Decimal128(i) / Decimal128(i + 1)
 
@@ -1181,7 +1174,7 @@ def log10(x: Decimal128) raises -> Decimal128:
         else:
             return Decimal128(UInt32(x_scale), 0, 0, 0x8000_0000)
 
-    var ten_to_power_of_scale = decimo.decimal128.utility.power_of_10_unsafe[
+    var ten_to_power_of_scale = decimal128_utility.power_of_10_unsafe[
         DType.uint128
     ](x_scale)
 
@@ -1194,12 +1187,12 @@ def log10(x: Decimal128) raises -> Decimal128:
     # Use `number_of_digits()` instead of a per-digit divide-by-10 loop.
     if x_coef % ten_to_power_of_scale == 0:
         var integral_part = x_coef // ten_to_power_of_scale
-        var n_digits = decimo.decimal128.utility.number_of_digits(integral_part)
-        var pow10_check = decimo.decimal128.utility.power_of_10_unsafe[
-            DType.uint128
-        ](n_digits - 1)
+        var n_digits = decimal128_utility.number_of_digits(integral_part)
+        var pow10_check = decimal128_utility.power_of_10_unsafe[DType.uint128](
+            n_digits - 1
+        )
         if integral_part == pow10_check:
             return Decimal128(UInt32(n_digits - 1), 0, 0, 0)
 
     # Use the identity: log10(x) = ln(x) / ln(10)
-    return ln(x) / decimo.decimal128.constants.LN10()
+    return ln(x) / decimal128_constants.LN10()

--- a/src/decimo/decimal128/rounding.mojo
+++ b/src/decimo/decimal128/rounding.mojo
@@ -34,7 +34,7 @@ from std import testing
 from decimo.decimal128.decimal128 import Decimal128
 from decimo.rounding_mode import RoundingMode
 from decimo.errors import OverflowError
-import decimo.decimal128.utility
+import decimo.decimal128.utility as decimal128_utility
 
 # ===------------------------------------------------------------------------===#
 # Rounding
@@ -84,7 +84,7 @@ def round(
         return number
 
     var x_coef = number.coefficient()
-    var ndigits_of_x = decimo.decimal128.utility.number_of_digits(x_coef)
+    var ndigits_of_x = decimal128_utility.number_of_digits(x_coef)
 
     # CASE: If ndigits is larger than the current scale
     # Scale up the coefficient of the number to the desired scale
@@ -112,12 +112,9 @@ def round(
 
         # If the digits of result <= 29, calculate the result by scaling up
         else:
-            var res_coef = (
-                x_coef
-                * decimo.decimal128.utility.power_of_10_unsafe[DType.uint128](
-                    Int(scale_diff)
-                )
-            )
+            var res_coef = x_coef * decimal128_utility.power_of_10_unsafe[
+                DType.uint128
+            ](Int(scale_diff))
 
             # If the digits of result == 29, but the result >= 2^96, raise an error
             if (ndigits_of_x + scale_diff == Decimal128.MAX_NUM_DIGITS) and (
@@ -166,7 +163,7 @@ def round(
             return Decimal128.ZERO()
 
         # Round coefficient by removing trailing digits
-        var res_coef = decimo.decimal128.utility.round_coefficient(
+        var res_coef = decimal128_utility.round_coefficient(
             x_coef,
             ndigits_to_remove=ndigits_to_remove,
             rounding_mode=rounding_mode,
@@ -180,9 +177,9 @@ def round(
 
         # if `ndigits` is negative and `ndigits_to_keep` >= 0, scale up the result
         elif ndigits_to_keep >= 0:
-            res_coef *= decimo.decimal128.utility.power_of_10_unsafe[
-                DType.uint128
-            ](Int(-ndigits))
+            res_coef *= decimal128_utility.power_of_10_unsafe[DType.uint128](
+                Int(-ndigits)
+            )
             return Decimal128.from_uint128(
                 res_coef, scale=UInt32(0), sign=number.is_negative()
             )

--- a/tests/bigdecimal/test_bigdecimal_arithmetics.mojo
+++ b/tests/bigdecimal/test_bigdecimal_arithmetics.mojo
@@ -12,7 +12,7 @@ from std import testing
 
 from decimo import BDec
 from decimo.bigdecimal.arithmetics import add, subtract, multiply
-from decimo.bigdecimal.rounding import round_to_precision
+from decimo.bigdecimal.rounding import round_to_precision_inplace
 from decimo.rounding_mode import RoundingMode
 from decimo.tests import TestCase, parse_file, load_test_cases
 
@@ -153,7 +153,7 @@ def test_bigdecimal_arithmetics_with_precision() raises:
     """Tests `add`/`subtract`/`multiply` with `precision > 0`.
 
     Each precision-arg call must equal `op(x1, x2, precision=0)`
-    followed by an explicit `round_to_precision(..., HALF_EVEN)` on
+    followed by an explicit `round_to_precision_inplace(..., HALF_EVEN)` on
     every input below.
 
     Coverage:
@@ -242,7 +242,7 @@ def test_bigdecimal_arithmetics_with_precision() raises:
 
         # add: precision-arg fast path must equal exact-then-round.
         var add_ref = add(ma, mb, precision=0)
-        round_to_precision(
+        round_to_precision_inplace(
             add_ref,
             PRECISION,
             RoundingMode.ROUND_HALF_EVEN,
@@ -262,7 +262,7 @@ def test_bigdecimal_arithmetics_with_precision() raises:
             count_wrong += 1
 
         var sub_ref = subtract(ma, mb, precision=0)
-        round_to_precision(
+        round_to_precision_inplace(
             sub_ref,
             PRECISION,
             RoundingMode.ROUND_HALF_EVEN,
@@ -282,7 +282,7 @@ def test_bigdecimal_arithmetics_with_precision() raises:
             count_wrong += 1
 
         var mul_ref = multiply(ma, mb, precision=0)
-        round_to_precision(
+        round_to_precision_inplace(
             mul_ref,
             PRECISION,
             RoundingMode.ROUND_HALF_EVEN,

--- a/tests/decimal128/test_decimal128_comparison.mojo
+++ b/tests/decimal128/test_decimal128_comparison.mojo
@@ -1,12 +1,11 @@
 """
 Test Decimal128 comparison operations including:
-
-1. equality / inequality (function-based and operator-based)
-2. greater / greater_equal / less / less_equal
-3. zero comparison edge cases
-4. edge cases (transitivity, precision)
-5. exact comparison with trailing zeros
-6. min / max / clamp
+1. equality / inequality (function-based and operator-based).
+2. greater / greater_equal / less / less_equal.
+3. zero comparison edge cases.
+4. edge cases (transitivity, precision).
+5. exact comparison with trailing zeros.
+6. min / max / clamp.
 """
 
 from std import testing

--- a/tests/decimal128/test_decimal128_exponential.mojo
+++ b/tests/decimal128/test_decimal128_exponential.mojo
@@ -97,7 +97,7 @@ def test_exp_extreme() raises:
     )
     testing.assert_true(exp(Decimal128("20")) > Decimal128("100000000"))
     var result = exp(Decimal128("1.23456789012345678901234567"))
-    testing.assert_true(len(String(result)) > 15)
+    testing.assert_true(String(result).byte_length() > 15)
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/toml/test_decimo_toml.mojo
+++ b/tests/toml/test_decimo_toml.mojo
@@ -269,7 +269,7 @@ def test_multiline_strings() raises:
     var tbl = doc.get_table("test")
     var ml = tbl["ml"].as_string()
     # The multiline string should contain the newlines
-    assert_true(len(ml) > 0, "multiline string not empty")
+    assert_true(ml.byte_length() > 0, "multiline string not empty")
     print("  PASS  test_multiline_strings")
 
 


### PR DESCRIPTION
This PR primarily refactors module imports to use local aliases (improving readability and reducing fully-qualified references) and updates BigDecimal rounding to use a consistently in-place, allocation-minimizing rounding path. It also adjusts tests/benches and adds a convenience Pixi task + script for quickly building/running a BigFloat example file.

**Changes:**
- Replace many `decimo.<module>` fully-qualified references with `import ... as <alias>` across Decimal128/BigInt/BigUInt/BigDecimal code.
- Rename BigDecimal “round-to-precision” APIs to `*_inplace` and route rounding through in-place BigUInt digit removal.
- Add `pixi run bf` helper plus an example/script for quickly building and running a BigFloat-using Mojo file.