### PR TITLE
[core][doc] Add raises to docstrings and fix related issues

### DIFF
--- a/benches/decimal128/mojo/bigdec_ref.mojo
+++ b/benches/decimal128/mojo/bigdec_ref.mojo
@@ -48,10 +48,10 @@ def _csv_quote(s: String) -> String:
 
 
 def _pad(s: String, width: Int) -> String:
-    if len(s) >= width:
+    if s.byte_length() >= width:
         return s
     var out = s
-    var pad = width - len(s)
+    var pad = width - s.byte_length()
     for _ in range(pad):
         out += " "
     return out

--- a/src/cli/calculator/engine.mojo
+++ b/src/cli/calculator/engine.mojo
@@ -58,6 +58,9 @@ def evaluate_and_print(
         show_expr_on_error: If True, show the expression with a caret
             indicator on error. If False, show only the error message.
         variables: A name→value mapping of user-defined variables.
+
+    Raises:
+        Error: Propagated from tokenization, parsing, or evaluation.
     """
     try:
         var tokens = tokenize(expr, variables)
@@ -189,6 +192,9 @@ def evaluate_and_return(
 
     Returns:
         The evaluated Decimal result.
+
+    Raises:
+        Error: Propagated from tokenization, parsing, or evaluation.
     """
     try:
         var tokens = tokenize(expr, variables)

--- a/src/decimo/bigdecimal/arithmetics.mojo
+++ b/src/decimo/bigdecimal/arithmetics.mojo
@@ -58,6 +58,9 @@ def add(
     - When `precision == 0`, the result is exact and its scale is the
       maximum of the two operands' scales.
     - The result's sign is determined by the signs of the operands.
+
+    Raises:
+        Error: If an arithmetic error occurs during computation.
     """
     if precision > 0:
         var result = add(x1, x2, precision=0)
@@ -135,6 +138,9 @@ def subtract(
     - When `precision == 0`, the result is exact and its scale is the
       maximum of the two operands' scales.
     - The result's sign is determined by the signs of the operands.
+
+    Raises:
+        Error: If an arithmetic error occurs during computation.
     """
     if precision > 0:
         var result = subtract(x1, x2, precision=0)
@@ -214,6 +220,9 @@ def multiply(
     - When `precision == 0`, the result is exact and its scale is the
       sum of the two operands' scales (except for zero).
     - The result's sign follows the standard sign rules for multiplication.
+
+    Raises:
+        Error: If an arithmetic error occurs during computation.
     """
     if precision > 0:
         var result = multiply(x1, x2, precision=0)
@@ -256,6 +265,9 @@ def multiply_inplace(
             result. When `0` (default) the in-place product is exact.
             When `>0` the exact product is computed and then rounded
             in place to `precision` significant digits via HALF_EVEN.
+
+    Raises:
+        Error: If an arithmetic error occurs during computation.
     """
     if x1.coefficient.is_zero() or x2.coefficient.is_zero():
         x1.coefficient = BigUInt.zero()
@@ -290,6 +302,9 @@ def add_inplace(mut x1: BigDecimal, x2: BigDecimal, precision: Int = 0) raises:
             result. When `0` (default) the in-place sum is exact.
             When `>0` the exact sum is computed and then rounded in
             place to `precision` significant digits via HALF_EVEN.
+
+    Raises:
+        Error: If an arithmetic error occurs during computation.
     """
     var max_scale = max(x1.scale, x2.scale)
     var scale_factor1 = (max_scale - x1.scale) if x1.scale < max_scale else 0
@@ -372,6 +387,9 @@ def subtract_inplace(
             exact. When `>0` the exact difference is computed and
             then rounded in place to `precision` significant digits
             via HALF_EVEN.
+
+    Raises:
+        Error: If an arithmetic error occurs during computation.
     """
     # Create a negated view of x2 and use add_inplace
     var neg_x2 = BigDecimal(
@@ -449,6 +467,9 @@ def true_divide_fast(
     This function conduct a quick division that:
     (1) does not round the result to the specified precision.
     (2) does not check the exact division nor remove extra trailing zeros.
+
+    Raises:
+        Error: If an arithmetic error occurs during computation.
     """
 
     # Yuhao Zhu:
@@ -578,6 +599,9 @@ def true_divide_general(
     This function conduct a division that:
     (1) rounds the result to the specified precision,
     (2) checks the exact division and remove extra trailing zeros.
+
+    Raises:
+        Error: If an arithmetic error occurs during computation.
     """
 
     # Yuhao Zhu:
@@ -928,6 +952,9 @@ def true_divide_inexact_by_uint32(
 
     Returns:
         The quotient x1 / y with the specified precision.
+
+    Raises:
+        Error: If an arithmetic error occurs during computation.
     """
     debug_assert[assert_mode="none"](
         y != 0,

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -208,6 +208,9 @@ struct BigDecimal(
 
         Args:
             value: The string to parse (e.g. "123.456" or "1.23E+5").
+
+        Raises:
+            ValueError: If the string does not represent a valid number.
         """
         # The string is normalized with `decimo.str.parse_numeric_string()`.
         self = Self.from_string(value)
@@ -264,6 +267,9 @@ struct BigDecimal(
 
         Args:
             py: A Python `decimal.Decimal` object.
+
+        Raises:
+            ConversionError: If the conversion from Python Decimal fails.
         """
         self = Self.from_python_decimal(py)
 
@@ -454,6 +460,9 @@ struct BigDecimal(
 
         Returns:
             The BigDecimal representation of the string.
+
+        Raises:
+            ValueError: If the string does not represent a valid number.
         """
         _tuple = decimo_str.parse_numeric_string(value)
         var ref coef: List[UInt8] = _tuple[0]
@@ -632,6 +641,9 @@ struct BigDecimal(
 
         Returns:
             The integer representation, truncating any fractional part.
+
+        Raises:
+            ValueError: If the value cannot be represented as an `Int`.
         """
         return Int(self.to_string())
 
@@ -640,6 +652,9 @@ struct BigDecimal(
 
         Returns:
             The `Float64` representation of this value.
+
+        Raises:
+            ValueError: If the value cannot be parsed as a `Float64`.
         """
         return Float64(self.to_string())
 
@@ -1007,6 +1022,9 @@ struct BigDecimal(
 
         Returns:
             The sum of the two values, rounded to `PRECISION` digits.
+
+        Raises:
+            Error: If the underlying addition or rounding fails.
         """
         return bigdecimal_arithmetics.add(self, other, precision=PRECISION)
 
@@ -1023,6 +1041,9 @@ struct BigDecimal(
         Returns:
             The difference of the two values, rounded to `PRECISION`
             digits.
+
+        Raises:
+            Error: If the underlying subtraction or rounding fails.
         """
         return bigdecimal_arithmetics.subtract(self, other, precision=PRECISION)
 
@@ -1039,6 +1060,9 @@ struct BigDecimal(
         Returns:
             The product of the two values, rounded to `PRECISION`
             digits.
+
+        Raises:
+            Error: If the underlying multiplication or rounding fails.
         """
         return bigdecimal_arithmetics.multiply(self, other, precision=PRECISION)
 
@@ -1051,6 +1075,9 @@ struct BigDecimal(
 
         Returns:
             The quotient of the two values.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return bigdecimal_arithmetics.true_divide(
             self, other, precision=PRECISION
@@ -1066,6 +1093,9 @@ struct BigDecimal(
 
         Returns:
             The integer quotient, truncated toward zero.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return bigdecimal_arithmetics.truncate_divide(self, other)
 
@@ -1079,6 +1109,9 @@ struct BigDecimal(
 
         Returns:
             The remainder after truncated division.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return bigdecimal_arithmetics.truncate_modulo(
             self, other, precision=PRECISION
@@ -1093,6 +1126,12 @@ struct BigDecimal(
 
         Returns:
             This value raised to the given exponent.
+
+        Raises:
+            ValueError: If the operation is mathematically undefined
+                (e.g. negative base with non-integer exponent, or `0**0`
+                in contexts that disallow it).
+            OverflowError: If the result is too large to represent.
         """
         return bigdecimal_exponential.power(self, exponent, precision=PRECISION)
 
@@ -1113,6 +1152,9 @@ struct BigDecimal(
 
         Returns:
             A tuple of `(quotient, remainder)` from truncated division.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         var quotient = bigdecimal_arithmetics.truncate_divide(self, other)
         var remainder = bigdecimal_arithmetics.subtract(
@@ -1130,6 +1172,9 @@ struct BigDecimal(
 
         Returns:
             A tuple of `(quotient, remainder)` from truncated division.
+
+        Raises:
+            ZeroDivisionError: If `self` (the divisor) is zero.
         """
         var quotient = bigdecimal_arithmetics.truncate_divide(other, self)
         var remainder = bigdecimal_arithmetics.subtract(
@@ -1154,6 +1199,9 @@ struct BigDecimal(
 
         Returns:
             The sum of the two values.
+
+        Raises:
+            Error: If the underlying addition or rounding fails.
         """
         return bigdecimal_arithmetics.add(self, other, precision=PRECISION)
 
@@ -1167,6 +1215,9 @@ struct BigDecimal(
 
         Returns:
             The difference `other - self`.
+
+        Raises:
+            Error: If the underlying subtraction or rounding fails.
         """
         return bigdecimal_arithmetics.subtract(other, self, precision=PRECISION)
 
@@ -1180,6 +1231,9 @@ struct BigDecimal(
 
         Returns:
             The product of the two values.
+
+        Raises:
+            Error: If the underlying multiplication or rounding fails.
         """
         return bigdecimal_arithmetics.multiply(self, other, precision=PRECISION)
 
@@ -1192,6 +1246,9 @@ struct BigDecimal(
 
         Returns:
             The integer quotient `other // self`, truncated toward zero.
+
+        Raises:
+            ZeroDivisionError: If `self` (the divisor) is zero.
         """
         return bigdecimal_arithmetics.truncate_divide(other, self)
 
@@ -1204,6 +1261,9 @@ struct BigDecimal(
 
         Returns:
             The remainder `other % self`.
+
+        Raises:
+            ZeroDivisionError: If `self` (the divisor) is zero.
         """
         return bigdecimal_arithmetics.truncate_modulo(
             other, self, precision=PRECISION
@@ -1218,6 +1278,10 @@ struct BigDecimal(
 
         Returns:
             The base raised to the power of self.
+
+        Raises:
+            ValueError: If the operation is mathematically undefined.
+            OverflowError: If the result is too large to represent.
         """
         return bigdecimal_exponential.power(base, self, precision=PRECISION)
 
@@ -1230,6 +1294,9 @@ struct BigDecimal(
 
         Returns:
             The quotient `other / self`.
+
+        Raises:
+            ZeroDivisionError: If `self` (the divisor) is zero.
         """
         return bigdecimal_arithmetics.true_divide(
             other, self, precision=PRECISION
@@ -1251,6 +1318,9 @@ struct BigDecimal(
 
         Args:
             other: The right-hand side operand.
+
+        Raises:
+            Error: If the underlying addition or rounding fails.
         """
         bigdecimal_arithmetics.add_inplace(self, other, precision=PRECISION)
 
@@ -1263,6 +1333,9 @@ struct BigDecimal(
 
         Args:
             other: The right-hand side operand.
+
+        Raises:
+            Error: If the underlying subtraction or rounding fails.
         """
         bigdecimal_arithmetics.subtract_inplace(
             self, other, precision=PRECISION
@@ -1277,6 +1350,9 @@ struct BigDecimal(
 
         Args:
             other: The right-hand side operand.
+
+        Raises:
+            Error: If the underlying multiplication or rounding fails.
         """
         bigdecimal_arithmetics.multiply_inplace(
             self, other, precision=PRECISION
@@ -1288,6 +1364,9 @@ struct BigDecimal(
 
         Args:
             other: The right-hand side operand.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         self = bigdecimal_arithmetics.true_divide(
             self, other, precision=PRECISION
@@ -1299,6 +1378,9 @@ struct BigDecimal(
 
         Args:
             other: The right-hand side operand.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         self = bigdecimal_arithmetics.truncate_divide(self, other)
 
@@ -1308,6 +1390,9 @@ struct BigDecimal(
 
         Args:
             other: The right-hand side operand.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         self = bigdecimal_arithmetics.truncate_modulo(
             self, other, precision=PRECISION
@@ -1442,6 +1527,9 @@ struct BigDecimal(
 
         Returns:
             The ceiling of this value.
+
+        Raises:
+            Error: If the underlying rounding or addition fails.
         """
         if self.scale <= 0:
             return self.copy()
@@ -1462,6 +1550,9 @@ struct BigDecimal(
 
         Returns:
             The floor of this value.
+
+        Raises:
+            Error: If the underlying rounding or subtraction fails.
         """
         if self.scale <= 0:
             return self.copy()
@@ -1482,6 +1573,9 @@ struct BigDecimal(
 
         Returns:
             The truncated integer part of this value.
+
+        Raises:
+            Error: If the underlying rounding operation fails.
         """
         if self.scale <= 0:
             return self.copy()
@@ -1509,6 +1603,9 @@ struct BigDecimal(
 
         Returns:
             The sum of the two values.
+
+        Raises:
+            Error: If the underlying addition or rounding fails.
         """
         return bigdecimal_arithmetics.add(self, other, precision=precision)
 
@@ -1528,6 +1625,9 @@ struct BigDecimal(
 
         Returns:
             The difference of the two values.
+
+        Raises:
+            Error: If the underlying subtraction or rounding fails.
         """
         return bigdecimal_arithmetics.subtract(self, other, precision=precision)
 
@@ -1546,6 +1646,9 @@ struct BigDecimal(
 
         Returns:
             The product of the two values.
+
+        Raises:
+            Error: If the underlying multiplication or rounding fails.
         """
         return bigdecimal_arithmetics.multiply(self, other, precision=precision)
 
@@ -1561,6 +1664,9 @@ struct BigDecimal(
 
         Returns:
             The quotient of the two values.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return bigdecimal_arithmetics.true_divide(
             self, other, precision=precision
@@ -1578,6 +1684,9 @@ struct BigDecimal(
                 rounded HALF_EVEN to `precision` significant digits.
                 Note: this differs from the `+=` operator which always
                 rounds to `PRECISION` (matching Python `decimal.Decimal`).
+
+        Raises:
+            Error: If the underlying addition or rounding fails.
         """
         bigdecimal_arithmetics.add_inplace(self, other, precision)
 
@@ -1594,6 +1703,9 @@ struct BigDecimal(
                 significant digits.
                 Note: this differs from the `-=` operator which always
                 rounds to `PRECISION` (matching Python `decimal.Decimal`).
+
+        Raises:
+            Error: If the underlying subtraction or rounding fails.
         """
         bigdecimal_arithmetics.subtract_inplace(self, other, precision)
 
@@ -1609,6 +1721,9 @@ struct BigDecimal(
                 then rounded HALF_EVEN to `precision` significant digits.
                 Note: this differs from the `*=` operator which always
                 rounds to `PRECISION` (matching Python `decimal.Decimal`).
+
+        Raises:
+            Error: If the underlying multiplication or rounding fails.
         """
         bigdecimal_arithmetics.multiply_inplace(self, other, precision)
 
@@ -1628,6 +1743,9 @@ struct BigDecimal(
 
         Returns:
             1 if self > other, 0 if equal, -1 if self < other.
+
+        Raises:
+            Error: If the underlying comparison fails.
         """
         return bigdecimal_comparison.compare(self, other)
 
@@ -1641,6 +1759,9 @@ struct BigDecimal(
 
         Returns:
             1 if |self| > |other|, 0 if equal, -1 if |self| < |other|.
+
+        Raises:
+            Error: If the underlying comparison fails.
         """
         return bigdecimal_comparison.compare_absolute(self, other)
 
@@ -1655,6 +1776,9 @@ struct BigDecimal(
 
         Returns:
             The larger of the two values.
+
+        Raises:
+            Error: If the underlying comparison fails.
         """
         return bigdecimal_comparison.max(self, other)
 
@@ -1667,6 +1791,9 @@ struct BigDecimal(
 
         Returns:
             The smaller of the two values.
+
+        Raises:
+            Error: If the underlying comparison fails.
         """
         return bigdecimal_comparison.min(self, other)
 
@@ -1682,6 +1809,9 @@ struct BigDecimal(
 
         Returns:
             The value of π to the specified precision.
+
+        Raises:
+            Error: If the underlying computation fails.
         """
         return bigdecimal_constants.pi(precision=precision)
 
@@ -1695,6 +1825,9 @@ struct BigDecimal(
 
         Returns:
             The value of e to the specified precision.
+
+        Raises:
+            Error: If the underlying computation fails.
         """
         return bigdecimal_exponential.exp(
             x=Self(BigUInt.one()), precision=precision
@@ -1711,6 +1844,9 @@ struct BigDecimal(
 
         Returns:
             The value of e raised to the power of self.
+
+        Raises:
+            OverflowError: If the result is too large to represent.
         """
         return bigdecimal_exponential.exp(self, precision)
 
@@ -1723,6 +1859,9 @@ struct BigDecimal(
 
         Returns:
             The natural logarithm (base e) of this value.
+
+        Raises:
+            ValueError: If the value is zero or negative.
         """
         return bigdecimal_exponential.ln(self, precision)
 
@@ -1740,6 +1879,9 @@ struct BigDecimal(
 
         Returns:
             The natural logarithm (base e) of this value.
+
+        Raises:
+            ValueError: If the value is zero or negative.
         """
         return bigdecimal_exponential.ln(self, precision, cache)
 
@@ -1753,6 +1895,10 @@ struct BigDecimal(
 
         Returns:
             The logarithm of this value in the given base.
+
+        Raises:
+            ValueError: If the value or base is zero, negative, or if the
+                base equals one.
         """
         return bigdecimal_exponential.log(self, base, precision)
 
@@ -1765,6 +1911,9 @@ struct BigDecimal(
 
         Returns:
             The base-10 logarithm of this value.
+
+        Raises:
+            ValueError: If the value is zero or negative.
         """
         return bigdecimal_exponential.log10(self, precision)
 
@@ -1778,6 +1927,10 @@ struct BigDecimal(
 
         Returns:
             The nth root of this value.
+
+        Raises:
+            ValueError: If the value is negative for an even root, or if
+                the root degree is invalid.
         """
         return bigdecimal_exponential.root(self, root, precision)
 
@@ -1790,6 +1943,9 @@ struct BigDecimal(
 
         Returns:
             The square root of this value.
+
+        Raises:
+            ValueError: If the value is negative.
         """
         return bigdecimal_exponential.sqrt(self, precision)
 
@@ -1802,6 +1958,9 @@ struct BigDecimal(
 
         Returns:
             The cube root of this value.
+
+        Raises:
+            Error: If the underlying computation fails.
         """
         return bigdecimal_exponential.cbrt(self, precision)
 
@@ -1816,6 +1975,10 @@ struct BigDecimal(
 
         Returns:
             This value raised to the given exponent.
+
+        Raises:
+            ValueError: If the operation is mathematically undefined.
+            OverflowError: If the result is too large to represent.
         """
         return bigdecimal_exponential.power(self, exponent, precision)
 
@@ -1829,6 +1992,9 @@ struct BigDecimal(
 
         Returns:
             The sine of this value.
+
+        Raises:
+            Error: If the underlying computation fails.
         """
         return bigdecimal_trigonometric.sin(self, precision)
 
@@ -1841,6 +2007,9 @@ struct BigDecimal(
 
         Returns:
             The cosine of this value.
+
+        Raises:
+            Error: If the underlying computation fails.
         """
         return bigdecimal_trigonometric.cos(self, precision)
 
@@ -1853,6 +2022,9 @@ struct BigDecimal(
 
         Returns:
             The tangent of this value.
+
+        Raises:
+            ValueError: If the tangent is undefined (cosine is zero).
         """
         return bigdecimal_trigonometric.tan(self, precision)
 
@@ -1865,6 +2037,9 @@ struct BigDecimal(
 
         Returns:
             The cotangent of this value.
+
+        Raises:
+            ValueError: If the cotangent is undefined (sine is zero).
         """
         return bigdecimal_trigonometric.cot(self, precision)
 
@@ -1877,6 +2052,9 @@ struct BigDecimal(
 
         Returns:
             The cosecant of this value.
+
+        Raises:
+            ValueError: If the cosecant is undefined (sine is zero).
         """
         return bigdecimal_trigonometric.csc(self, precision)
 
@@ -1889,6 +2067,9 @@ struct BigDecimal(
 
         Returns:
             The secant of this value.
+
+        Raises:
+            ValueError: If the secant is undefined (cosine is zero).
         """
         return bigdecimal_trigonometric.sec(self, precision)
 
@@ -1901,6 +2082,9 @@ struct BigDecimal(
 
         Returns:
             The arctangent of this value in radians.
+
+        Raises:
+            Error: If the underlying computation fails.
         """
         return bigdecimal_trigonometric.arctan(self, precision)
 
@@ -1919,6 +2103,9 @@ struct BigDecimal(
 
         Returns:
             The quotient of the division with the specified significant digits.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return bigdecimal_arithmetics.true_divide_inexact(
             self, other, number_of_significant_digits
@@ -1937,6 +2124,9 @@ struct BigDecimal(
 
         Returns:
             The quotient of dividing this value by the given `UInt32`.
+
+        Raises:
+            ZeroDivisionError: If `y` is zero.
         """
         return bigdecimal_arithmetics.true_divide_inexact_by_uint32(
             self, y, number_of_significant_digits
@@ -1952,6 +2142,9 @@ struct BigDecimal(
 
         Returns:
             The integer quotient, truncated toward zero.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return bigdecimal_arithmetics.truncate_divide(self, other)
 
@@ -1985,6 +2178,9 @@ struct BigDecimal(
 
         Returns:
             A new `BigDecimal` rounded to the specified decimal places.
+
+        Raises:
+            Error: If the underlying rounding operation fails.
         """
         return bigdecimal_rounding.round(self, ndigits, rounding_mode)
 
@@ -2011,6 +2207,9 @@ struct BigDecimal(
             rounding_mode: The rounding strategy to use.
             remove_extra_digit_due_to_rounding: Whether to remove an extra leading digit caused by rounding up.
             fill_zeros_to_precision: Whether to pad with trailing zeros to reach the target precision.
+
+        Raises:
+            Error: If the underlying rounding operation fails.
         """
         bigdecimal_rounding.round_to_precision_inplace(
             self,
@@ -2041,6 +2240,9 @@ struct BigDecimal(
         Returns:
             A new BigDecimal with the same value (subject to rounding) and
             the same scale as `exp`.
+
+        Raises:
+            Error: If the underlying rounding operation fails.
 
         Examples:
 
@@ -2088,6 +2290,9 @@ struct BigDecimal(
 
         Returns:
             The exact result of `self * a + b`.
+
+        Raises:
+            Error: If the underlying multiplication or addition fails.
 
         Examples:
 
@@ -2487,6 +2692,9 @@ struct BigDecimal(
 
         Returns:
             True if the integer part is odd, False otherwise.
+
+        Raises:
+            IndexError: If accessing the digit at the truncation position fails.
         """
         if self.scale < 0:
             return False
@@ -2502,6 +2710,9 @@ struct BigDecimal(
 
         Returns:
             True if the value equals 1, False otherwise.
+
+        Raises:
+            IndexError: If accessing the digit at the truncation position fails.
         """
         if self.sign:
             return False
@@ -2541,6 +2752,9 @@ struct BigDecimal(
 
         Returns:
             A new `BigDecimal` with trailing zeros removed.
+
+        Raises:
+            Error: If the underlying division operation fails.
         """
         if self.coefficient.is_zero():
             return Self(BigUInt(raw_words=[0]), 0, False)

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -2024,7 +2024,8 @@ struct BigDecimal(
             The tangent of this value.
 
         Raises:
-            ValueError: If the tangent is undefined (cosine is zero).
+            ZeroDivisionError: At the singularities x = π/2 + nπ where
+                cos(x) is zero and tan(x) is undefined.
         """
         return bigdecimal_trigonometric.tan(self, precision)
 
@@ -2039,7 +2040,9 @@ struct BigDecimal(
             The cotangent of this value.
 
         Raises:
-            ValueError: If the cotangent is undefined (sine is zero).
+            ValueError: If this value is zero (cot(0) is treated as undefined).
+            ZeroDivisionError: At other singularities x = nπ (n != 0) where
+                sin(x) is zero.
         """
         return bigdecimal_trigonometric.cot(self, precision)
 
@@ -2054,7 +2057,9 @@ struct BigDecimal(
             The cosecant of this value.
 
         Raises:
-            ValueError: If the cosecant is undefined (sine is zero).
+            ValueError: If this value is zero (csc(0) is undefined).
+            ZeroDivisionError: At other singularities x = nπ (n != 0) where
+                sin(x) is zero.
         """
         return bigdecimal_trigonometric.csc(self, precision)
 
@@ -2069,7 +2074,8 @@ struct BigDecimal(
             The secant of this value.
 
         Raises:
-            ValueError: If the secant is undefined (cosine is zero).
+            ZeroDivisionError: At the singularities x = π/2 + nπ where
+                cos(x) is zero and sec(x) is undefined.
         """
         return bigdecimal_trigonometric.sec(self, precision)
 

--- a/src/decimo/bigdecimal/constants.mojo
+++ b/src/decimo/bigdecimal/constants.mojo
@@ -230,6 +230,9 @@ def pi_chudnovsky_binary_split(precision: Int) raises -> BigDecimal:
 
     Returns:
         The value of π to the specified precision.
+
+    Raises:
+        Error: If an arithmetic error occurs during computation.
     """
 
     var working_precision = precision + 9  # 1 words
@@ -274,6 +277,9 @@ def chudnovsky_split(
 
     Returns:
         A `_RationalBigInt10` representing the partial sum of the Chudnovsky series.
+
+    Raises:
+        Error: If an arithmetic error occurs during computation.
     """
 
     var bint_1 = BigInt10(1)
@@ -326,6 +332,9 @@ def compute_m_k_rational(k: Int) raises -> _RationalBigInt10:
 
     Returns:
         A `_RationalBigInt10` with numerator (6k)!/(3k)! and denominator (k!)³.
+
+    Raises:
+        Error: If an arithmetic error occurs during computation.
     """
 
     var bint_1 = BigInt10(1)
@@ -356,6 +365,9 @@ def pi_machin(precision: Int) raises -> BigDecimal:
 
     Returns:
         The value of π to the specified precision.
+
+    Raises:
+        Error: If an arithmetic error occurs during computation.
     """
 
     var working_precision = precision + 9

--- a/src/decimo/bigdecimal/exponential.mojo
+++ b/src/decimo/bigdecimal/exponential.mojo
@@ -122,6 +122,9 @@ struct MathCache:
 
         Returns:
             The value of ln(2) with at least the specified precision.
+
+        Raises:
+            Error: Propagated from underlying arithmetic and conversion operations.
         """
         if self._ln2_precision >= precision:
             var result = self._ln2.copy()
@@ -148,6 +151,9 @@ struct MathCache:
 
         Returns:
             The value of ln(1.25) with at least the specified precision.
+
+        Raises:
+            Error: Propagated from underlying arithmetic and conversion operations.
         """
         if self._ln1d25_precision >= precision:
             var result = self._ln1d25.copy()
@@ -177,6 +183,9 @@ struct MathCache:
 
         Returns:
             The value of ln(10) with at least the specified precision.
+
+        Raises:
+            Error: Propagated from underlying arithmetic and conversion operations.
         """
         if self._ln10_precision >= precision:
             var result = self._ln10.copy()
@@ -316,6 +325,10 @@ def integer_power(
 
     Returns:
         The result of base^exponent.
+
+    Raises:
+        ZeroDivisionError: If the base is zero and the exponent is negative.
+        Error: Propagated from arithmetic operations.
     """
     var working_precision = precision + 9  # Add buffer digits
     var abs_exp = abs(exponent)
@@ -838,6 +851,9 @@ def is_integer_reciprocal_and_return(
     Returns:
         True if 1/n is an odd integer, False otherwise.
         The integer reciprocal of n.
+
+    Raises:
+        ZeroDivisionError: If n is zero.
     """
     var m = BigDecimal(BigUInt.one(), 0, False).true_divide(
         n, precision=n.coefficient.number_of_digits() + 9
@@ -854,6 +870,9 @@ def is_odd_reciprocal(n: BigDecimal) raises -> Bool:
 
     Returns:
         True if 1/n is an odd integer, False otherwise.
+
+    Raises:
+        ZeroDivisionError: If n is zero.
 
     Notes:
 
@@ -1046,6 +1065,9 @@ def fast_isqrt(c: BigUInt, working_digits: Int) raises -> BigUInt:
 
     Returns:
         The integer square root floor(sqrt(c)).
+
+    Raises:
+        Error: Propagated from arithmetic operations.
     """
     # Convert c to BigDecimal for the reciprocal sqrt approximation
     var c_bd = BigDecimal(c.copy(), 0, False)
@@ -1753,6 +1775,9 @@ def cbrt(x: BigDecimal, precision: Int) raises -> BigDecimal:
 
     Returns:
         The cube root of x with the specified precision.
+
+    Raises:
+        Error: Propagated from integer_root.
     """
 
     result = integer_root(
@@ -1902,6 +1927,9 @@ def exp_taylor_series(
     Returns:
         The natural exponential of x (e^x) to the specified precision with some
         extra digits to ensure accuracy.
+
+    Raises:
+        Error: Propagated from arithmetic operations.
     """
     # Theoretical number of terms needed based on precision
     # For |x| ≤ 1, error after n terms is approximately |x|^(n+1)/(n+1)!
@@ -2227,6 +2255,9 @@ def ln_series_expansion(
     Returns:
         The ln(1+z) computed to the specified working precision.
 
+    Raises:
+        Error: Propagated from arithmetic operations.
+
     Notes:
         The last few digits of result are not accurate as there is no buffer
         for precision. You need to use a larger precision to get the last few
@@ -2365,6 +2396,9 @@ def compute_ln2(working_precision: Int) raises -> BigDecimal:
     Returns:
         The ln(2) computed to the specified precision.
 
+    Raises:
+        Error: Propagated from underlying arithmetic operations.
+
     Notes:
 
     The last few digits of result are not accurate as there is no buffer for
@@ -2458,6 +2492,9 @@ def compute_ln1d25(precision: Int) raises -> BigDecimal:
 
     Returns:
         The ln(1.25) computed to the specified precision.
+
+    Raises:
+        Error: Propagated from ln_series_expansion.
     """
     var z = BigDecimal(BigUInt(raw_words=[25]), 2, False)
     var result = ln_series_expansion(z^, precision)

--- a/src/decimo/bigdecimal/rounding.mojo
+++ b/src/decimo/bigdecimal/rounding.mojo
@@ -57,6 +57,9 @@ def round(
 
     Returns:
         A new `BigDecimal` rounded to the specified number of decimal places.
+
+    Raises:
+        Error: If an arithmetic error occurs during computation.
     """
 
     var ndigits_to_remove = number.scale - ndigits
@@ -133,6 +136,9 @@ def round_to_precision_inplace(
         remove_extra_digit_due_to_rounding: If True, remove a trailing digit if
             the rounding mode result in an extra leading digit.
         fill_zeros_to_precision: If True, fill trailing zeros to the precision.
+
+    Raises:
+        Error: If an arithmetic error occurs during computation.
     """
 
     var ndigits_coefficient = number.coefficient.number_of_digits()
@@ -238,6 +244,9 @@ def quantize(
     _ = round(y, -2)                     # -> "1E+2" (ndigits=-2)
     ```
     End of examples.
+
+    Raises:
+        Error: If an arithmetic error occurs during computation.
     """
 
     # Determine the target scale from the exp parameter

--- a/src/decimo/bigdecimal/trigonometric.mojo
+++ b/src/decimo/bigdecimal/trigonometric.mojo
@@ -14,9 +14,12 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-# ===----------------------------------------------------------------------=== #
-# Trigonometric functions for BigDecimal
-# ===----------------------------------------------------------------------=== #
+"""Trigonometric functions for BigDecimal.
+
+Provides high-precision implementations of trigonometric and inverse
+trigonometric functions (sin, cos, tan, asin, acos, atan, atan2, etc.)
+operating on the arbitrary-precision BigDecimal type.
+"""
 
 from std import time
 
@@ -41,6 +44,9 @@ def sin(x: BigDecimal, precision: Int) raises -> BigDecimal:
 
     Returns:
         The sine of x with the specified precision.
+
+    Raises:
+        Error: Propagated from underlying arithmetic operations.
 
     Notes:
     This function adopts range reduction for optimal convergence.
@@ -163,6 +169,9 @@ def sin_taylor_series(
         The sine of the input number with the specified precision plus
         some extra digits to ensure accuracy.
 
+    Raises:
+        Error: Propagated from underlying arithmetic operations.
+
     Notes:
 
     Using Taylor series.
@@ -221,6 +230,9 @@ def cos(x: BigDecimal, precision: Int) raises -> BigDecimal:
     Returns:
         The cosine of x with the specified precision.
 
+    Raises:
+        Error: Propagated from underlying arithmetic operations.
+
     Notes:
     This function adopts range reduction for optimal convergence.
     """
@@ -250,6 +262,9 @@ def cos_taylor_series(
     Returns:
         The cosine of the input number with the specified precision plus
         some extra digits to ensure accuracy.
+
+    Raises:
+        Error: Propagated from underlying arithmetic operations.
 
     Notes:
 
@@ -311,6 +326,10 @@ def tan(x: BigDecimal, precision: Int) raises -> BigDecimal:
     Returns:
         The tangent of x with the specified precision.
 
+    Raises:
+        Error: Propagated from underlying arithmetic operations (e.g.,
+            division by zero at singularities x = π/2 + nπ).
+
     Notes:
 
     This function calculates tan(x) = sin(x) / cos(x).
@@ -327,6 +346,10 @@ def cot(x: BigDecimal, precision: Int) raises -> BigDecimal:
 
     Returns:
         The cotangent of x with the specified precision.
+
+    Raises:
+        Error: Propagated from underlying arithmetic operations (e.g.,
+            division by zero at singularities x = nπ).
 
     Notes:
 
@@ -456,6 +479,10 @@ def sec(x: BigDecimal, precision: Int) raises -> BigDecimal:
     Returns:
         The secant of x with the specified precision.
 
+    Raises:
+        Error: Propagated from underlying arithmetic operations (e.g.,
+            division by zero when cos(x) = 0 at x = π/2 + nπ).
+
     Notes:
 
     This function calculates sec(x) = 1 / cos(x).
@@ -491,6 +518,9 @@ def arctan(x: BigDecimal, precision: Int) raises -> BigDecimal:
 
     Returns:
         The arctangent of x in radians, in the range (-π/2, π/2).
+
+    Raises:
+        Error: Propagated from underlying arithmetic operations.
     """
 
     comptime BUFFER_DIGITS = 9  # word-length, easy to append and trim
@@ -565,6 +595,9 @@ def arctan_taylor_series(
     Returns:
         The arctangent of the input number with the specified precision plus
         some extra digits to ensure accuracy.
+
+    Raises:
+        Error: Propagated from underlying arithmetic operations.
 
     Notes:
 

--- a/src/decimo/bigdecimal/trigonometric.mojo
+++ b/src/decimo/bigdecimal/trigonometric.mojo
@@ -348,8 +348,10 @@ def cot(x: BigDecimal, precision: Int) raises -> BigDecimal:
         The cotangent of x with the specified precision.
 
     Raises:
-        Error: Propagated from underlying arithmetic operations (e.g.,
-            division by zero at singularities x = nπ).
+        ValueError: If x is zero (cot(0) is treated as undefined in
+            `tan_cot()`).
+        ZeroDivisionError: At other singularities x = nπ (n != 0) where
+            sin(x) is zero, propagated from the underlying division.
 
     Notes:
 

--- a/src/decimo/bigfloat/bigfloat.mojo
+++ b/src/decimo/bigfloat/bigfloat.mojo
@@ -184,6 +184,9 @@ struct BigFloat(Comparable, Movable, Writable):
         Args:
             value: The integer to convert.
             precision: The number of significant decimal digits.
+
+        Raises:
+            ConversionError: If the integer cannot be represented as a BigFloat.
         """
         self = Self(String(value), precision)
 
@@ -195,6 +198,9 @@ struct BigFloat(Comparable, Movable, Writable):
         Args:
             decimal: The `BigDecimal` to convert.
             precision: The number of significant decimal digits.
+
+        Raises:
+            ConversionError: If the BigDecimal string cannot be parsed as a BigFloat.
         """
         self = Self(decimal.to_string(), precision)
 
@@ -597,6 +603,9 @@ struct BigFloat(Comparable, Movable, Writable):
 
         Returns:
             The result of `self` raised to `exponent`.
+
+        Raises:
+            Error: Propagated from `power()`.
         """
         return self.power(exponent)
 

--- a/src/decimo/bigint/bigint.mojo
+++ b/src/decimo/bigint/bigint.mojo
@@ -603,6 +603,9 @@ struct BigInt(
 
         Returns:
             The value as a Float64.
+
+        Raises:
+            Error: Propagated from Float64 conversion.
         """
         return Float64(self.to_string())
 
@@ -1452,6 +1455,9 @@ struct BigInt(
 
         Returns:
             The quotient, truncated toward zero.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return bigint_arithmetics.truncate_divide(self, other)
 
@@ -1465,6 +1471,9 @@ struct BigInt(
 
         Returns:
             The floor remainder with the same sign as the divisor.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return bigint_arithmetics.floor_modulo(self, other)
 
@@ -1478,6 +1487,9 @@ struct BigInt(
 
         Returns:
             The truncated remainder with the same sign as the dividend.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return bigint_arithmetics.truncate_modulo(self, other)
 
@@ -1718,6 +1730,9 @@ struct BigInt(
 
         Args:
             other: The second value for the extended GCD computation.
+
+        Raises:
+            Error: Propagated from underlying arithmetic operations.
         """
         return bigint_number_theory.extended_gcd(self, other)
 
@@ -1730,6 +1745,9 @@ struct BigInt(
 
         Returns:
             The least common multiple of the two values.
+
+        Raises:
+            Error: Propagated from underlying arithmetic operations.
         """
         return bigint_number_theory.lcm(self, other)
 
@@ -1744,6 +1762,9 @@ struct BigInt(
 
         Returns:
             The result of (self ** exponent) % modulus.
+
+        Raises:
+            ValueError: If the exponent is negative or the modulus is not positive.
         """
         return bigint_number_theory.mod_pow(self, exponent, modulus)
 
@@ -1758,6 +1779,9 @@ struct BigInt(
 
         Returns:
             The result of (self ** exponent) % modulus.
+
+        Raises:
+            ValueError: If the exponent is negative or the modulus is not positive.
         """
         return bigint_number_theory.mod_pow(
             self, Self.from_int(exponent), modulus
@@ -1773,6 +1797,9 @@ struct BigInt(
 
         Returns:
             The modular multiplicative inverse.
+
+        Raises:
+            ValueError: If the modulus is not positive or the modular inverse does not exist.
         """
         return bigint_number_theory.mod_inverse(self, modulus)
 

--- a/src/decimo/bigint/number_theory.mojo
+++ b/src/decimo/bigint/number_theory.mojo
@@ -155,6 +155,9 @@ def extended_gcd(a: BigInt, b: BigInt) raises -> Tuple[BigInt, BigInt, BigInt]:
     Returns:
         A 3-tuple (g, x, y) where g is the non-negative GCD and x, y are
         Bézout coefficients satisfying a * x + b * y = g.
+
+    Raises:
+        Error: Propagated from underlying BigInt arithmetic.
     """
     var a_neg = a.is_negative()
     var b_neg = b.is_negative()
@@ -213,6 +216,9 @@ def lcm(a: BigInt, b: BigInt) raises -> BigInt:
 
     Returns:
         The least common multiple, always >= 0.
+
+    Raises:
+        Error: Propagated from underlying BigInt arithmetic.
     """
     if a.is_zero() or b.is_zero():
         return BigInt(0)

--- a/src/decimo/bigint10/bigint10.mojo
+++ b/src/decimo/bigint10/bigint10.mojo
@@ -747,6 +747,9 @@ struct BigInt10(
 
         Returns:
             The floor division quotient.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return bigint10_arithmetics.floor_divide(other, self)
 
@@ -759,6 +762,9 @@ struct BigInt10(
 
         Returns:
             The remainder of the floor division.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return bigint10_arithmetics.floor_modulo(other, self)
 
@@ -771,6 +777,10 @@ struct BigInt10(
 
         Returns:
             The result of raising to the given power.
+
+        Raises:
+            OverflowError: If the exponent is too large.
+            ValueError: If the exponent is negative or too large.
         """
         return base.power(self)
 
@@ -829,6 +839,9 @@ struct BigInt10(
 
         Args:
             other: The right-hand side operand.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         self = bigint10_arithmetics.floor_divide(self, other)
 
@@ -838,6 +851,9 @@ struct BigInt10(
 
         Args:
             other: The right-hand side operand.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         self = bigint10_arithmetics.floor_modulo(self, other)
 
@@ -1019,6 +1035,9 @@ struct BigInt10(
 
         Returns:
             The floor division quotient.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return bigint10_arithmetics.floor_divide(self, other)
 
@@ -1032,6 +1051,9 @@ struct BigInt10(
 
         Returns:
             The truncated division quotient.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return bigint10_arithmetics.truncate_divide(self, other)
 
@@ -1045,6 +1067,9 @@ struct BigInt10(
 
         Returns:
             The floor division remainder.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return bigint10_arithmetics.floor_modulo(self, other)
 
@@ -1058,6 +1083,9 @@ struct BigInt10(
 
         Returns:
             The truncated division remainder.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return bigint10_arithmetics.truncate_modulo(self, other)
 
@@ -1177,6 +1205,9 @@ struct BigInt10(
 
         Returns:
             A formatted string showing the internal representation.
+
+        Raises:
+            Error: Propagated from string formatting / write operations.
         """
         # Collect all labels to find max width
         var max_label_len = "number:".byte_length()
@@ -1217,5 +1248,9 @@ struct BigInt10(
         return result^
 
     def print_internal_representation(self) raises:
-        """Prints the internal representation details of a BigInt10."""
+        """Prints the internal representation details of a BigInt10.
+
+        Raises:
+            Error: Propagated from string formatting / write operations.
+        """
         print(self.internal_representation())

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -2754,6 +2754,9 @@ def floor_divide_burnikel_ziegler(
 
     Returns:
         The quotient of `a` divided by `b`.
+
+    Raises:
+        Error: If an arithmetic error occurs during computation.
     """
 
     var BLOCK_SIZE_OF_WORDS = cut_off
@@ -2899,6 +2902,9 @@ def floor_divide_two_by_one(
 
     You need to ensure that n is even to continue with the algorithm.
     Otherwise, it will use the schoolbook division algorithm.
+
+    Raises:
+        Error: If an arithmetic error occurs during computation.
     """
     debug_assert[assert_mode="none"](
         b.words[len(b.words) - 1] >= 500_000_000,
@@ -2966,6 +2972,9 @@ def floor_divide_three_by_two(
     Notes:
 
     a is a BigUInt with 3n words and b is a BigUInt with 2n words.
+
+    Raises:
+        Error: If an arithmetic error occurs during computation.
     """
 
     var a2a1: BigUInt
@@ -3042,6 +3051,9 @@ def floor_divide_slices_two_by_one(
     bounds_a0 = (bounds_a[0], bounds_a[0] + n // 2)\\
     bounds_b1 = (bounds_b[0] + n // 2, bounds_b[0] + n)\\
     bounds_b0 = (bounds_b[0], bounds_b[0] + n // 2).
+
+    Raises:
+        Error: If an arithmetic error occurs during computation.
     """
 
     debug_assert[assert_mode="none"](
@@ -3135,6 +3147,9 @@ def floor_divide_slices_three_by_two(
     bounds_a0 = (bounds_a[0], bounds_a[0] + n)\\
     bounds_b1 = (bounds_b[0] + n, bounds_b[0] + 2 * n)\\
     bounds_b0 = (bounds_b[0], bounds_b[0] + n).
+
+    Raises:
+        Error: If an arithmetic error occurs during computation.
     """
 
     # SPECIAL CASE:

--- a/src/decimo/biguint/biguint.mojo
+++ b/src/decimo/biguint/biguint.mojo
@@ -126,6 +126,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Returns:
             A `BigUInt` representing 10 raised to the power of `exponent`.
+
+        Raises:
+            ValueError: If the exponent is negative.
         """
         return biguint_arithmetics.power_of_10(exponent)
 
@@ -1299,6 +1302,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Returns:
             The sum.
+
+        Raises:
+            Error: Propagated from underlying operations.
         """
         return biguint_arithmetics.add(self, other)
 
@@ -1326,6 +1332,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Returns:
             The product.
+
+        Raises:
+            Error: Propagated from underlying operations.
         """
         return biguint_arithmetics.multiply(self, other)
 
@@ -1425,6 +1434,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Args:
             other: The operand to multiply by.
+
+        Raises:
+            Error: Propagated from underlying operations.
         """
         self = biguint_arithmetics.multiply(self, other)
 
@@ -1567,6 +1579,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Args:
             other: The operand to add.
+
+        Raises:
+            Error: Propagated from underlying operations.
         """
         biguint_arithmetics.add_inplace(self, other)
 
@@ -1581,6 +1596,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Returns:
             The quotient.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return biguint_arithmetics.floor_divide(self, other)
 
@@ -1595,6 +1613,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Returns:
             The quotient.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return biguint_arithmetics.truncate_divide(self, other)
 
@@ -1608,6 +1629,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Returns:
             The quotient rounded up.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return biguint_arithmetics.ceil_divide(self, other)
 
@@ -1621,6 +1645,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Returns:
             The remainder.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return biguint_arithmetics.floor_modulo(self, other)
 
@@ -1634,6 +1661,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Returns:
             The remainder.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return biguint_arithmetics.truncate_modulo(self, other)
 
@@ -1647,6 +1677,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Returns:
             The remainder.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return biguint_arithmetics.ceil_modulo(self, other)
 
@@ -1660,6 +1693,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
 
         Returns:
             A tuple of (quotient, remainder).
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
         """
         return biguint_arithmetics.floor_divide_modulo(self, other)
 
@@ -1668,6 +1704,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
         """Divides this number by 2 in place.
         See `decimo.biguint.arithmetics.floor_divide_by_2_inplace()`
         for more information.
+
+        Raises:
+            Error: Propagated from underlying operations.
         """
         biguint_arithmetics.floor_divide_by_2_inplace(self)
 

--- a/src/decimo/decimal128/__init__.mojo
+++ b/src/decimo/decimal128/__init__.mojo
@@ -1,0 +1,17 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright 2025-2026 Yuhao Zhu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Sub-package for the 128-bit fixed-precision Decimal128 type."""

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -1580,6 +1580,9 @@ struct Decimal128(
 
         Returns:
             The sum.
+
+        Raises:
+            OverflowError: If the result overflows Decimal128 capacity.
         """
         return decimal128_arithmetics.add(self, other)
 
@@ -1592,6 +1595,9 @@ struct Decimal128(
 
         Returns:
             The difference.
+
+        Raises:
+            OverflowError: If the result overflows Decimal128 capacity.
         """
         return decimal128_arithmetics.subtract(self, other)
 
@@ -1604,6 +1610,9 @@ struct Decimal128(
 
         Returns:
             The product.
+
+        Raises:
+            OverflowError: If the result overflows Decimal128 capacity.
         """
         return decimal128_arithmetics.multiply(self, other)
 
@@ -1616,6 +1625,10 @@ struct Decimal128(
 
         Returns:
             The quotient.
+
+        Raises:
+            OverflowError: If the result overflows Decimal128 capacity.
+            ZeroDivisionError: If the divisor is zero.
         """
         return decimal128_arithmetics.divide(self, other)
 
@@ -1628,6 +1641,10 @@ struct Decimal128(
 
         Returns:
             The truncated quotient.
+
+        Raises:
+            OverflowError: If the result overflows Decimal128 capacity.
+            ZeroDivisionError: If the divisor is zero.
         """
         return decimal128_arithmetics.truncate_divide(self, other)
 
@@ -1640,6 +1657,10 @@ struct Decimal128(
 
         Returns:
             The remainder.
+
+        Raises:
+            OverflowError: If the result overflows Decimal128 capacity.
+            ZeroDivisionError: If the divisor is zero.
         """
         return decimal128_arithmetics.modulo(self, other)
 
@@ -1677,6 +1698,10 @@ struct Decimal128(
 
         Returns:
             The value raised to the given power.
+
+        Raises:
+            ValueError: If the base is negative with a non-integer exponent.
+            OverflowError: If the result overflows Decimal128 capacity.
         """
         return decimal128_exponential.power(self, exponent)
 
@@ -1689,6 +1714,10 @@ struct Decimal128(
 
         Returns:
             The value raised to the given power.
+
+        Raises:
+            ValueError: If the base is zero and the exponent is negative.
+            OverflowError: If the result overflows Decimal128 capacity.
         """
         return decimal128_exponential.power(self, exponent)
 
@@ -1708,6 +1737,9 @@ struct Decimal128(
 
         Returns:
             The sum.
+
+        Raises:
+            OverflowError: If the result overflows Decimal128 capacity.
         """
         return decimal128_arithmetics.add(other, self)
 
@@ -1720,6 +1752,9 @@ struct Decimal128(
 
         Returns:
             The difference.
+
+        Raises:
+            OverflowError: If the result overflows Decimal128 capacity.
         """
         return decimal128_arithmetics.subtract(other, self)
 
@@ -1732,6 +1767,9 @@ struct Decimal128(
 
         Returns:
             The product.
+
+        Raises:
+            OverflowError: If the result overflows Decimal128 capacity.
         """
         return decimal128_arithmetics.multiply(other, self)
 
@@ -1744,6 +1782,10 @@ struct Decimal128(
 
         Returns:
             The quotient.
+
+        Raises:
+            OverflowError: If the result overflows Decimal128 capacity.
+            ZeroDivisionError: If the divisor is zero.
         """
         return decimal128_arithmetics.divide(other, self)
 
@@ -1756,6 +1798,10 @@ struct Decimal128(
 
         Returns:
             The truncated quotient.
+
+        Raises:
+            OverflowError: If the result overflows Decimal128 capacity.
+            ZeroDivisionError: If the divisor is zero.
         """
         return decimal128_arithmetics.truncate_divide(other, self)
 
@@ -1768,6 +1814,10 @@ struct Decimal128(
 
         Returns:
             The remainder.
+
+        Raises:
+            OverflowError: If the result overflows Decimal128 capacity.
+            ZeroDivisionError: If the divisor is zero.
         """
         return decimal128_arithmetics.modulo(other, self)
 
@@ -1784,6 +1834,9 @@ struct Decimal128(
 
         Args:
             other: The right-hand side operand.
+
+        Raises:
+            OverflowError: If the result overflows Decimal128 capacity.
         """
         self = decimal128_arithmetics.add(self, other)
 
@@ -1793,6 +1846,9 @@ struct Decimal128(
 
         Args:
             other: The right-hand side operand.
+
+        Raises:
+            OverflowError: If the result overflows Decimal128 capacity.
         """
         self = decimal128_arithmetics.subtract(self, other)
 
@@ -1802,6 +1858,9 @@ struct Decimal128(
 
         Args:
             other: The right-hand side operand.
+
+        Raises:
+            OverflowError: If the result overflows Decimal128 capacity.
         """
         self = decimal128_arithmetics.multiply(self, other)
 
@@ -1811,6 +1870,10 @@ struct Decimal128(
 
         Args:
             other: The right-hand side operand.
+
+        Raises:
+            OverflowError: If the result overflows Decimal128 capacity.
+            ZeroDivisionError: If the divisor is zero.
         """
         self = decimal128_arithmetics.divide(self, other)
 
@@ -1820,6 +1883,10 @@ struct Decimal128(
 
         Args:
             other: The right-hand side operand.
+
+        Raises:
+            OverflowError: If the result overflows Decimal128 capacity.
+            ZeroDivisionError: If the divisor is zero.
         """
         self = decimal128_arithmetics.truncate_divide(self, other)
 
@@ -1829,6 +1896,10 @@ struct Decimal128(
 
         Args:
             other: The right-hand side operand.
+
+        Raises:
+            OverflowError: If the result overflows Decimal128 capacity.
+            ZeroDivisionError: If the divisor is zero.
         """
         self = decimal128_arithmetics.modulo(self, other)
 
@@ -2059,6 +2130,9 @@ struct Decimal128(
 
         Returns:
             The rounded `Decimal128` value.
+
+        Raises:
+            OverflowError: If the result overflows Decimal128 capacity.
         """
         return decimal128_rounding.round(
             self, ndigits=ndigits, rounding_mode=rounding_mode
@@ -2079,6 +2153,9 @@ struct Decimal128(
 
         Returns:
             The quantized `Decimal128` value.
+
+        Raises:
+            OverflowError: If the result overflows Decimal128 capacity.
         """
         return decimal128_rounding.quantize(self, exp, rounding_mode)
 
@@ -2129,6 +2206,9 @@ struct Decimal128(
 
         Returns:
             The value of e raised to this power.
+
+        Raises:
+            OverflowError: If the exponent is too large.
         """
         return decimal128_exponential.exp(self)
 
@@ -2139,6 +2219,9 @@ struct Decimal128(
 
         Returns:
             The natural logarithm of this value.
+
+        Raises:
+            ValueError: If the value is non-positive.
         """
         return decimal128_exponential.ln(self)
 
@@ -2148,6 +2231,9 @@ struct Decimal128(
 
         Returns:
             The base-10 logarithm of this value.
+
+        Raises:
+            ValueError: If the value is non-positive.
         """
         return decimal128_exponential.log10(self)
 
@@ -2160,6 +2246,9 @@ struct Decimal128(
 
         Returns:
             The logarithm of this value in the given base.
+
+        Raises:
+            ValueError: If the value or base is non-positive, or the base equals 1.
         """
         return decimal128_exponential.log(self, base)
 
@@ -2172,6 +2261,10 @@ struct Decimal128(
 
         Returns:
             The value raised to the given power.
+
+        Raises:
+            ValueError: If the base is zero and the exponent is negative.
+            OverflowError: If the result overflows Decimal128 capacity.
         """
         return decimal128_exponential.power(self, Self(exponent))
 
@@ -2184,6 +2277,10 @@ struct Decimal128(
 
         Returns:
             The value raised to the given power.
+
+        Raises:
+            ValueError: If the base is negative with a non-integer exponent.
+            OverflowError: If the result overflows Decimal128 capacity.
         """
         return decimal128_exponential.power(self, exponent)
 
@@ -2198,6 +2295,9 @@ struct Decimal128(
 
         Returns:
             The n-th root of this value.
+
+        Raises:
+            ValueError: If `n` is non-positive, or `n` is even and the value is negative.
         """
         return decimal128_exponential.root(self, n)
 
@@ -2209,6 +2309,9 @@ struct Decimal128(
 
         Returns:
             The square root of this value.
+
+        Raises:
+            ValueError: If the value is negative.
         """
         return decimal128_exponential.sqrt(self)
 

--- a/src/decimo/decimal128/utility.mojo
+++ b/src/decimo/decimal128/utility.mojo
@@ -13,11 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
-#
-# Implements internal utility functions for the Decimal128 type
-# WARNING: These functions are not meant to be used directly by the user.
-#
-# ===----------------------------------------------------------------------=== #
+
+"""Internal utility functions for the Decimal128 type.
+
+WARNING: These functions are implementation details and are not meant to be
+used directly by end users. They support the public Decimal128 API with
+low-level helpers such as bit manipulation, rounding helpers, and
+representation conversions.
+"""
 
 from std.memory import UnsafePointer
 from std import sys

--- a/src/decimo/rational/arithmetics.mojo
+++ b/src/decimo/rational/arithmetics.mojo
@@ -1,0 +1,21 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright 2026 Yuhao Zhu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Arithmetic operations for the Rational type.
+
+Implements addition, subtraction, multiplication, division, and other
+arithmetic helpers for the arbitrary-precision Rational number type.
+"""

--- a/src/decimo/rational/comparison.mojo
+++ b/src/decimo/rational/comparison.mojo
@@ -1,0 +1,21 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright 2026 Yuhao Zhu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Comparison operations for the Rational type.
+
+Implements equality and ordering comparisons (==, !=, <, <=, >, >=) for
+the arbitrary-precision Rational number type.
+"""

--- a/src/decimo/rational/rational.mojo
+++ b/src/decimo/rational/rational.mojo
@@ -387,6 +387,9 @@ struct Rational(
 
         Returns:
             The sum.
+
+        Raises:
+            Error: Propagated from underlying BigInt arithmetic.
         """
         var num = (
             self.numerator * other.denominator
@@ -403,6 +406,9 @@ struct Rational(
 
         Returns:
             The difference.
+
+        Raises:
+            Error: Propagated from underlying BigInt arithmetic.
         """
         var num = (
             self.numerator * other.denominator
@@ -423,6 +429,9 @@ struct Rational(
 
         Returns:
             The product.
+
+        Raises:
+            Error: Propagated from underlying BigInt arithmetic.
         """
         # (a/b) * (c/d) = (a*c) / (b*d) = (a/gcd_ad * c/gcd_bc) / (b/gcd_bc * d/gcd_ad)
         var gcd_ad = gcd(self.numerator, other.denominator)

--- a/src/decimo/tests.mojo
+++ b/src/decimo/tests.mojo
@@ -234,6 +234,9 @@ def expand_value(s: String) raises -> String:
     Returns:
         The expanded string with all patterns resolved.
 
+    Raises:
+        ValueError: If a `{C,N}` pattern contains an invalid integer count.
+
     Examples:
         "42"            → "42"
         "{9,100}"       → "999...9" (100 nines)
@@ -340,6 +343,9 @@ def load_test_cases[
 
     Returns:
         A list of TestCase objects containing the test cases.
+
+    Raises:
+        Error: Propagated from TOML lookup or value expansion.
     """
     var cases_array = toml.get_array_of_tables(table_name)
     var test_cases = List[TestCase]()
@@ -379,6 +385,10 @@ def load_bench_cases(toml_path: String) raises -> List[BenchCase]:
 
     Returns:
         A list of BenchCase objects.
+
+    Raises:
+        ValueError: If the TOML file cannot be parsed.
+        Error: Propagated from TOML lookup or value expansion.
     """
     var doc = parse_file(toml_path)
     var cases_array = doc.get_array_of_tables("cases")
@@ -409,6 +419,9 @@ def load_bench_iterations(toml_path: String) raises -> Int:
 
     Returns:
         The iterations count, defaulting to 1000.
+
+    Raises:
+        ValueError: If the TOML file cannot be parsed.
     """
     var doc = parse_file(toml_path)
     try:
@@ -428,6 +441,9 @@ def load_bench_precision(toml_path: String) raises -> Int:
 
     Returns:
         The precision, defaulting to 36 (BigDecimal default).
+
+    Raises:
+        ValueError: If the TOML file cannot be parsed.
     """
     var doc = parse_file(toml_path)
     try:
@@ -506,6 +522,10 @@ def load_bench_precision_levels(
 
     Returns:
         A list of PrecisionLevel objects, one per table.
+
+    Raises:
+        ValueError: If the TOML file cannot be parsed.
+        Error: Propagated from TOML lookup or value conversion.
     """
     var doc = parse_file(toml_path)
     var levels_array = doc.get_array_of_tables("precision_levels")
@@ -533,6 +553,9 @@ def open_log_file(prefix: String) raises -> PythonObject:
 
     Returns:
         A Python file object opened for writing.
+
+    Raises:
+        Error: If Python interop fails or the log file cannot be created.
     """
     var python = Python.import_module("builtins")
     var datetime = Python.import_module("datetime")
@@ -556,6 +579,9 @@ def log_print(msg: String, log_file: PythonObject) raises:
     Args:
         msg: The message to print.
         log_file: The Python file object to write to.
+
+    Raises:
+        Error: If the underlying Python write/flush call fails.
     """
     print(msg)
     log_file.write(msg + "\n")
@@ -573,6 +599,9 @@ def print_header(title: String, log_file: PythonObject) raises:
     Args:
         title: The benchmark title.
         log_file: The Python file object.
+
+    Raises:
+        Error: If logging or Python interop fails.
     """
     var datetime = Python.import_module("datetime")
     log_print("=== " + title + " ===", log_file)
@@ -612,6 +641,9 @@ def print_summary(
         label: Label for the Mojo implementation (e.g. "BigUInt").
         iterations: Iterations per case.
         log_file: The Python file object.
+
+    Raises:
+        Error: If logging to the Python file object fails.
     """
     if len(speedup_factors) == 0:
         log_print("\nNo valid benchmark cases were completed", log_file)
@@ -667,6 +699,9 @@ def print_summary_dual(
         label2: Label for the second implementation (e.g. "BigInt").
         iterations: Iterations per case.
         log_file: The Python file object.
+
+    Raises:
+        Error: If logging to the Python file object fails.
     """
     if len(sf1) == 0:
         log_print("\nNo valid benchmark cases were completed", log_file)

--- a/src/decimo/toml/parser.mojo
+++ b/src/decimo/toml/parser.mojo
@@ -377,6 +377,9 @@ struct TOMLDocument(Copyable, Movable):
 
         Returns:
             The value for `key`, or an empty `TOMLValue` if not found.
+
+        Raises:
+            KeyError: Propagated from the underlying dict access.
         """
         if key in self.root:
             return self.root[key]
@@ -390,6 +393,9 @@ struct TOMLDocument(Copyable, Movable):
 
         Returns:
             A copy of the table's key-value pairs, or an empty dictionary.
+
+        Raises:
+            KeyError: Propagated from the underlying dict access.
         """
         if (
             table_name in self.root
@@ -406,6 +412,9 @@ struct TOMLDocument(Copyable, Movable):
 
         Returns:
             A copy of the array elements, or an empty list.
+
+        Raises:
+            KeyError: Propagated from the underlying dict access.
         """
         if key in self.root and self.root[key].type == TOMLValueType.ARRAY:
             return self.root[key].array_values.copy()
@@ -421,6 +430,9 @@ struct TOMLDocument(Copyable, Movable):
 
         Returns:
             A list of table dictionaries, or an empty list.
+
+        Raises:
+            KeyError: Propagated from the underlying dict access.
         """
         var result = List[Dict[String, TOMLValue]]()
 
@@ -1030,6 +1042,9 @@ def parse_string(input: String) raises -> TOMLDocument:
 
     Returns:
         The parsed `TOMLDocument`.
+
+    Raises:
+        ValueError: If the input is not valid TOML.
     """
     var parser = TOMLParser(input)
     return parser.parse()
@@ -1043,6 +1058,10 @@ def parse_file(file_path: String) raises -> TOMLDocument:
 
     Returns:
         The parsed `TOMLDocument`.
+
+    Raises:
+        Error: If the file cannot be opened or read.
+        ValueError: If the file contents are not valid TOML.
     """
 
     with open(file_path, "r") as file:

--- a/src/decimo/toml/parser.mojo
+++ b/src/decimo/toml/parser.mojo
@@ -379,7 +379,8 @@ struct TOMLDocument(Copyable, Movable):
             The value for `key`, or an empty `TOMLValue` if not found.
 
         Raises:
-            KeyError: Propagated from the underlying dict access.
+            Error: Propagated from the underlying dictionary operations.
+                Missing keys are handled gracefully and do not raise.
         """
         if key in self.root:
             return self.root[key]
@@ -395,7 +396,8 @@ struct TOMLDocument(Copyable, Movable):
             A copy of the table's key-value pairs, or an empty dictionary.
 
         Raises:
-            KeyError: Propagated from the underlying dict access.
+            Error: Propagated from the underlying dictionary operations.
+                Missing tables are handled gracefully and do not raise.
         """
         if (
             table_name in self.root
@@ -414,7 +416,8 @@ struct TOMLDocument(Copyable, Movable):
             A copy of the array elements, or an empty list.
 
         Raises:
-            KeyError: Propagated from the underlying dict access.
+            Error: Propagated from the underlying dictionary operations.
+                Missing keys are handled gracefully and do not raise.
         """
         if key in self.root and self.root[key].type == TOMLValueType.ARRAY:
             return self.root[key].array_values.copy()
@@ -432,7 +435,8 @@ struct TOMLDocument(Copyable, Movable):
             A list of table dictionaries, or an empty list.
 
         Raises:
-            KeyError: Propagated from the underlying dict access.
+            Error: Propagated from the underlying dictionary operations.
+                Missing keys are handled gracefully and do not raise.
         """
         var result = List[Dict[String, TOMLValue]]()
 
@@ -1041,10 +1045,14 @@ def parse_string(input: String) raises -> TOMLDocument:
         input: The TOML-formatted string to parse.
 
     Returns:
-        The parsed `TOMLDocument`.
+        The parsed `TOMLDocument`. Note that tokenization or parsing
+        errors that are not explicitly detected may yield a partial
+        document rather than raise.
 
     Raises:
-        ValueError: If the input is not valid TOML.
+        Error: Propagated from the underlying tokenizer or parser when an
+            invalid construct is explicitly detected (e.g. malformed values
+            or unsupported syntax in a recognized position).
     """
     var parser = TOMLParser(input)
     return parser.parse()
@@ -1057,11 +1065,14 @@ def parse_file(file_path: String) raises -> TOMLDocument:
         file_path: The path to the TOML file.
 
     Returns:
-        The parsed `TOMLDocument`.
+        The parsed `TOMLDocument`. Note that tokenization or parsing
+        errors that are not explicitly detected may yield a partial
+        document rather than raise.
 
     Raises:
-        Error: If the file cannot be opened or read.
-        ValueError: If the file contents are not valid TOML.
+        Error: If the file cannot be opened or read, or propagated from
+            the underlying tokenizer/parser when an invalid construct is
+            explicitly detected.
     """
 
     with open(file_path, "r") as file:

--- a/tests/bigdecimal/test_bigdecimal_arithmetics.mojo
+++ b/tests/bigdecimal/test_bigdecimal_arithmetics.mojo
@@ -1,10 +1,9 @@
 """
 Test BigDecimal arithmetic operations including:
-
-1. addition
-2. subtraction
-3. multiplication
-4. division
+1. addition.
+2. subtraction.
+3. multiplication.
+4. division.
 """
 
 from std.python import Python

--- a/tests/bigdecimal/test_bigdecimal_methods.mojo
+++ b/tests/bigdecimal/test_bigdecimal_methods.mojo
@@ -11,7 +11,9 @@ Tests for BigDecimal utility methods:
   - same_quantum()
   - scaleb()
   - fma()
-  - to_string_with_separators().
+  - to_string_with_separators()
+
+More tests can be added here for other non-arithmetic methods as needed.
 """
 
 from std import testing

--- a/tests/bigdecimal/test_bigdecimal_methods.mojo
+++ b/tests/bigdecimal/test_bigdecimal_methods.mojo
@@ -1,6 +1,6 @@
 # Consider incorporating some of the tests to other test files in future
 """
-Tests for BigDecimal utility methods added in v0.8.x:
+Tests for BigDecimal utility methods:
   - is_positive()
   - __rtruediv__()
   - to_scientific_string() / to_eng_string()
@@ -11,7 +11,7 @@ Tests for BigDecimal utility methods added in v0.8.x:
   - same_quantum()
   - scaleb()
   - fma()
-  - to_string_with_separators()
+  - to_string_with_separators().
 """
 
 from std import testing


### PR DESCRIPTION
This PR focuses on documentation correctness and clarity across Decimo’s Mojo codebase, primarily by expanding docstrings with explicit `Raises:` sections and converting some file header comments into proper module docstrings.

**Changes:**
- Add/standardize `Raises:` sections across many public APIs (BigDecimal/BigInt/BigUInt/Decimal128/TOML utilities, CLI engine, test helpers).
- Improve module-level documentation by replacing banner-style comments with descriptive module docstrings and adding missing package/module docstrings.
- Minor benchmark helper adjustment: `_pad()` now uses `String.byte_length()` when computing padding.