### PR TITLE
[biguint] Add deferred-carry multiplication to `BigUInt`

### DIFF
--- a/benches/bigdecimal/cases/divide.toml
+++ b/benches/bigdecimal/cases/divide.toml
@@ -343,3 +343,20 @@ name = "Division 65536 words / 2048 words"
 a = "{123456789,1024}.{123456789,1024}"
 b = "{987654321,512}.{987654321,512}"
 name = "Division 65536 words / 1024 words"
+
+# === LARGE BALANCED DIVIDE TESTS (deferred-carry B-Z range) ===
+# Divisor large enough that Burnikel-Ziegler's internal multiplies cross the
+# deferred-carry threshold, but small enough to avoid the precision-truncation
+# fast path at precision >= 1000 (needed_divisor_words ~ ceil(p/9)+6). At
+# precision 100 these still truncate; the deferred-carry effect shows at
+# p>=1000.
+
+[[cases]]
+a = "{142857,100}"
+b = "{271828,50}"
+name = "Div 600-digit / 300-digit (~67w / ~34w)"
+
+[[cases]]
+a = "{142857,200}"
+b = "{271828,100}"
+name = "Div 1200-digit / 600-digit (~134w / ~67w)"

--- a/benches/bigdecimal/cases/exp.toml
+++ b/benches/bigdecimal/cases/exp.toml
@@ -1,7 +1,6 @@
 [config]
-precision = 50
-# iterations are auto-tuned per case targeting ~50ms total
-iterations = 200
+iterations = 50
+precision = 1000
 
 [[cases]]
 a = "0"

--- a/benches/bigdecimal/cases/ln.toml
+++ b/benches/bigdecimal/cases/ln.toml
@@ -1,6 +1,6 @@
 [config]
-precision = 50
-iterations = 200
+iterations = 10 # ln is much more expensive
+precision = 1000 
 
 [[cases]]
 a = "1"

--- a/benches/bigdecimal/cases/multiply.toml
+++ b/benches/bigdecimal/cases/multiply.toml
@@ -270,3 +270,29 @@ name = "Volume calc (partial - length * width)"
 a = "123.456789"
 b = "1000"
 name = "Scale calc (multiplying by factor)"
+
+# === LARGE-COEFFICIENT TESTS (deferred-carry multiply range) ===
+# These multiply coefficients of >= ~130 digits, so the product crosses the
+# deferred-carry threshold (n_x * n_y >= 200 base-10^9 words). The
+# smaller cases above stay on the scalar schoolbook inner loop. Operand size
+# (not the rounding `precision`) is what drives the multiply cost here.
+
+[[cases]]
+a = "{142857,25}"
+b = "{271828,25}"
+name = "Mul 150-digit x 150-digit (~17w)"
+
+[[cases]]
+a = "{142857,75}"
+b = "{271828,75}"
+name = "Mul 450-digit x 450-digit (~50w)"
+
+[[cases]]
+a = "{142857,150}"
+b = "{271828,150}"
+name = "Mul 900-digit x 900-digit (~100w)"
+
+[[cases]]
+a = "{142857,15}"
+b = "{271828,150}"
+name = "Mul 90-digit x 900-digit (rectangular)"

--- a/benches/bigdecimal/mojo/bench.mojo
+++ b/benches/bigdecimal/mojo/bench.mojo
@@ -64,7 +64,7 @@ def _parse_round_param(b: String) raises -> Tuple[Int, RoundingMode]:
     if idx < 0:
         raise Error("round case missing '|' in b field: " + b)
     var ndigits = atol(String(b[byte=0:idx]))
-    var mode_str = String(b[byte = idx + 1 : len(b)])
+    var mode_str = String(b[byte = idx + 1 : b.byte_length()])
     if mode_str == "ROUND_DOWN":
         return Tuple[Int, RoundingMode](ndigits, RoundingMode.ROUND_DOWN)
     if mode_str == "ROUND_UP":
@@ -120,8 +120,8 @@ def _emit(v: BigDecimal) raises -> String:
         var coef_digits = v.coefficient.number_of_digits()
         var sign_chars = 1 if v.sign else 0
         var expected_total = coef_digits + (-v.scale) + sign_chars
-        if len(s) < expected_total:
-            var pad = expected_total - len(s)
+        if s.byte_length() < expected_total:
+            var pad = expected_total - s.byte_length()
             for _ in range(pad):
                 s += "0"
     return s^
@@ -215,7 +215,7 @@ def _time_kernel(
         return
     if op == "comparison":
         var s = _cmp_3way(a, b)
-        keep(len(s))
+        keep(s.byte_length())
         return
     if op == "from_string":
         var v = BigDecimal(a_str)
@@ -224,7 +224,7 @@ def _time_kernel(
         return
     if op == "to_string":
         var s = a.to_string(force_plain=True)
-        keep(len(s))
+        keep(s.byte_length())
         return
     if op == "sqrt":
         var r = bd_sqrt(a, precision)
@@ -341,10 +341,10 @@ def _bench_case(
 
 
 def _pad(s: String, w: Int) -> String:
-    if len(s) >= w:
+    if s.byte_length() >= w:
         return s
     var out = s
-    for _ in range(w - len(s)):
+    for _ in range(w - s.byte_length()):
         out += " "
     return out
 
@@ -406,7 +406,9 @@ def main() raises:
         var pair = _bench_case(op, bc, iter_hint, precision)
         var result = pair[0]
         var per = pair[1]
-        var rs = result if len(result) <= 34 else String(result[byte=0:34])
+        var rs = result if result.byte_length() <= 34 else String(
+            result[byte=0:34]
+        )
         print(_pad(bc.name, 44), _pad(rs, 36), per)
         log.write(
             ts

--- a/docs/plans/bigdecimal_enhancement.md
+++ b/docs/plans/bigdecimal_enhancement.md
@@ -275,6 +275,28 @@ because the lesson generalises to the variable-length case unchanged.
     when both constraints are independent.** Re-round must use the
     **original** value, not the already-rounded one.
 
+17. **In hot O(n²) loops over `List` buffers, hoist a raw data pointer
+    once (`var p = some_list.unsafe_ptr()`) and index through `p`
+    instead of through `some_list[i]`.** A `List` access reloads the
+    `_data` field from the List struct on every element access (the
+    compiler usually cannot prove `_data` is loop-invariant), whereas a
+    hoisted pointer stays in a register, saving one memory load per
+    iteration. Measured **~8% at 64-word operands** in
+    `multiply_slices_deferred_carry` (20260616), and this is *not* a
+    bounds-check effect — under `-D ASSERT=none` the `List.__getitem__`
+    bounds check (`debug_assert[assert_mode="safe"]`) is already compiled
+    out, and `List.unsafe_get`/`unsafe_set` measured identical to plain
+    `[]` there. Safety preconditions: the buffer must not be resized
+    while the pointer is live (only element-mutated) and indices must be
+    provably in-bounds. The owner does **not** need a manual lifetime
+    extension — `List.unsafe_ptr()` returns an origin-parameterized
+    `UnsafePointer` tied to the List's origin, so Mojo's lifetime
+    tracking keeps the List alive for as long as the pointer is used
+    (verified 20260616). **Worth auditing other hot O(n²)/O(n·m)
+    kernels** — schoolbook multiply (`multiply_slices_schoolbook`), the
+    SIMD add/subtract inner loops, Karatsuba/Toom-3 combine steps, and
+    divide normalization — where the same ~8% could compound.
+
 ## 5. Open Items / Future Improvements
 
 ### 5.1 Worst-case ratios still > 1.5× python (latest sweep 2026-05-01, post-T-API1)

--- a/docs/plans/bigdecimal_enhancement.md
+++ b/docs/plans/bigdecimal_enhancement.md
@@ -804,3 +804,5 @@ some ops < 1.0×):
 | T-9    | SIMD schoolbook mul base                  | M      | **DONE** | deferred-carry (product-scanning);             |
 |        |                                           |        |          | Definitely worth bringing it to `BigInt` too   |
 | T-3e   | Binary splitting for ln Taylor            | L      | P4       | 2–4× p≥500                                     |
+| T-P1   | Use pointer than list indexing            | M      | P4       | Use `UnsafePointer` for loops;                 |
+|        |                                           |        |          | Similar to `multiply_slices_deferred_carry`.   |

--- a/docs/plans/bigdecimal_enhancement.md
+++ b/docs/plans/bigdecimal_enhancement.md
@@ -156,11 +156,11 @@ kernels (parse/render are precision-insensitive ops).
 | 6   | Toom-3 between Karatsuba and NTT              | DONE (T6) — +14–29% for ≥256w                                 |
 | 7a  | `integer_root` via direct Newton              | DONE (T7a) — 0.14×→25× py at p=1000 for cbrt                  |
 |     | (was exp(ln(x)/n))                            |                                                               |
-| 7b  | Reciprocal-Newton for nth root (no divide)    | OPEN — estimated 1.5–2×                                       |
-| 7c  | Rational decomposition $x^{a/b}$              | OPEN — fractional roots still 0.2–0.4× py                     |
-|     | → root then power                             |                                                               |
+| 7b  | Reciprocal-Newton for nth root (no divide)    | DEFERRED (T-7b) — break-even at current mul speed             |
+|     |                                               | (div ~2.7× mul); root already 0.2× py                         |
 | 8   | BigDecimal-level inplace ops in Taylor loops  | DONE (T8) — +15–27% exp/ln, +9% sqrt                          |
-| 9   | SIMD schoolbook multiply base                 | OPEN — 1.5–2× constant-factor                                 |
+| 9   | SIMD schoolbook multiply base                 | DONE (T-9) — deferred-carry (product-scanning);               |
+|     |                                               | 32w 2×, 48w 2.4×, 64w 2.9× faster                             |
 | 10  | `debug_assert(..., "{}".format(...))`         | OPEN — sweep BigUInt + BigDecimal hot paths (Lesson #7)       |
 |     | eager allocation                              |                                                               |
 | 11  | Hot-path-first switch reorder in BigDecimal   | OPEN — same-scale & same-sign branch first (Lesson #12)       |
@@ -419,6 +419,59 @@ P2 — Multiply small-precision (2.3× py → target ≤1.5×)
   once. Multiply median improved 90 → 80 ns (1.7x → 1.5x py @ p100,
   1.8x → 1.7x @ p1000); all 100 multiply cases still match Python.
 
+- **T-9: Deferred-carry (product-scanning) schoolbook multiply (H#9).**
+  **DONE (20260615).** The scalar `multiply_slices_schoolbook` normalized a
+  base-10^9 carry (`% BASE` + `// BASE`) on *every* inner step — `n_x ·
+  n_y` divisions. Added `multiply_slices_deferred_carry`, which
+  accumulates each column sum in a `UInt64` buffer and normalizes only
+  every `SAFE_ROWS = 15` rows (overflow-safe: 15·(10^9)^2 < 2^64),
+  cutting the division count ~8×. (This is the column-accumulation /
+  product-scanning idea historically called "Comba multiplication" —
+  P. G. Comba, IBM Systems Journal 29(4), 1990; the docstring carries
+  the full citation.) `multiply_slices_schoolbook` now dispatches to it when
+  `n_x · n_y >= CUTOFF_DEFERRED_CARRY_PRODUCT` (200 — a *product*, not a
+  word count, so it is reached for operands ≥ ~15 words within the
+  ≤64-word schoolbook range and as the Karatsuba/Toom-3 base; benchmarked
+  crossover ~144).
+  This speeds up every schoolbook base case (direct multiply ≤64 words
+  *and* Karatsuba/Toom-3 recursion bases). Measured (M4 Pro, integrated):
+  32-word 1175 → 595 ns (~2×), 48-word 2874 → 1185 (~2.4×), 64-word
+  5544 → 1918 (~2.9×); small operands (≤~11 words) stay on the scalar
+  path with no regression. Correctness: 196/196 standalone cases (incl.
+  64-word all-nines overflow stress) plus the full biguint / bigint /
+  bigdecimal / bigint10 suites (0 failures) and 100% cross-language
+  multiply match. (Pure SIMD vectorisation of the partial-product loop
+  on top of this is a possible future follow-up; the deferred-carry
+  restructuring alone already captures the targeted 1.5–2×, exceeding it
+  at larger sizes.) **Downstream impact (anything that multiplies large
+  coefficients internally).** The standard cross-language report
+  originally showed no change because its multiply cases used
+  small-coefficient operands (the `precision` knob rounds the *result*,
+  not the operand size). Large-coefficient cases were therefore added to
+  `cases/multiply.toml` (150/450/900-digit operands) and
+  `cases/divide.toml` (balanced ~67w/34w, ~134w/67w) so the existing
+  report exercises the deferred-carry path. With it, the 450-digit
+  multiply is 0.8× py and the 900-digit multiply 0.6× py (both now
+  *faster* than Python, vs ~2.3–2.5× *slower* before). Measured
+  before/after on large operands: multiply 450-digit 2.5×, 900-digit
+  2.3×, 4500-digit 2.1×;
+  divide (Burnikel-Ziegler) 1.3–1.6×; sqrt p5000 1.67×; exp p1000 2.4×;
+  ln p5000 1.9×; cbrt p5000 1.65×. Small operands (≤~90 digits)
+  unchanged.
+  **Cutoff re-tuning follow-up (20260616).** Since deferred-carry only
+  speeds up the schoolbook *base* (which Karatsuba and Toom-3 both
+  recurse into), it does not shift the Karatsuba/Toom-3 boundary, and it
+  moved the schoolbook→Karatsuba crossover only marginally (~64 → ~72
+  words), so `CUTOFF_KARATSUBA = 64` was left as-is. Direct-comparison
+  benchmarks did expose a *pre-existing* mistuning, though: Toom-3 (5
+  evaluation points + interpolation) only beats Karatsuba at ≥ ~256–384
+  words — it was ~9% *slower* than Karatsuba at 160w and equal at 256w —
+  so the old `CUTOFF_TOOM3 = 128` routed the 128–256 band to Toom-3
+  prematurely. Raised `CUTOFF_TOOM3` to **256** (~4× `CUTOFF_KARATSUBA`,
+  the usual ratio): dispatcher before/after shows multiply −7.6% @150w,
+  −4.2% @192w, −2% @224w, neutral at 256w and ≥384w; biguint/bigint
+  suites still pass (0 failures).
+
 P3 — Divide all precisions (5× py → target ≤2×)
 
 - **T-D1: Short-divisor fast path (H#16).** **DONE — already covered by
@@ -454,10 +507,22 @@ P3 — Divide all precisions (5× py → target ≤2×)
   `_true_divide_general_truncated` keeps its copy — it needs the
   unmodified `result` for the multiply-back exactness verification.)
 
-- **T-D3: Reciprocal-Newton divide (legacy Task 2).** For balanced
-  large operands, invert the divisor once and multiply. `2× mul` per
-  Newton step beats the `1× div` of B-Z. (Lesson #3.) Long-term;
-  combine with NTT (Task 5) for full benefit.
+- **T-D3: Reciprocal-Newton divide (legacy Task 2).** **DEFERRED —
+  not beneficial before NTT; measured (20260615).** Reciprocal-Newton
+  trades one divide for several multiplies, so it only wins when
+  multiplication is much cheaper than division. A micro-bench of the
+  current primitives (M4 Pro, non-structured balanced operands) confirms
+  `floor_divide` (Burnikel-Ziegler) costs **~2.1–3.1× a same-size
+  multiply** (64w 2.2×, 128w 2.7×, 256w 3.1×, 512w 2.6×, 1024w 2.5×) —
+  exactly the Karatsuba regime of Lesson #3. Cost model for a
+  reciprocal-Newton divide at this multiply speed: precision-doubled
+  reciprocal ≈ 3× a full multiply, plus `a·r` (1×) plus an exactness
+  correction `a − q·b` (1×) ≈ **~5× multiply**, i.e. ~1.7–2× *slower*
+  than today's B-Z divide, before accounting for the extra floor/
+  remainder-correction complexity. The crossover requires NTT
+  (O(n log n) multiply, T-5) to make multiplies cheap enough; until then
+  this XL rewrite of a core op would be a regression. Correctly gated on
+  T-5; left deferred.
 
 P4 — sqrt at p=100 (2.1× py → target ≤1.0×)
 
@@ -497,9 +562,18 @@ P5 — ln far-from-1 (4.6×–9.2× py → target ≤2×)
   cache state, not addressable by T-L1.
 
 - **T-L2: Process-wide `ln(10)` cache (workaround for missing global
-  vars).** When Mojo gains module-level mutable state, install a
-  process-wide MathCache. Until then, document the recipe for users
-  to construct one cache and pass it across calls.
+  vars).** **DONE for the implementable part; remainder blocked on Mojo
+  (20260615).** The `MathCache` struct already caches `ln(2)`,
+  `ln(1.25)` **and `ln(10)`** with automatic precision-upgrade logic, is
+  accepted by `ln(x, precision, mut cache)`, `log`, and `log10`, and
+  carries a copy-pasteable usage recipe in its own docstring (construct
+  one `MathCache`, pass it across calls). So the user-facing recipe and
+  the cache-passing API both exist today. The only outstanding piece —
+  an *automatic* process-wide cache that callers get for free without
+  threading a `MathCache` through — requires module-level mutable state,
+  which Mojo does not yet provide; it cannot be implemented in library
+  code. Nothing actionable until the language gains global mutable
+  state.
 
 - **T-L3: AGM ln (T3g / H#3g).** Long-term, only worth implementing
   alongside or after NTT (Task 5).
@@ -550,7 +624,22 @@ P6 — `from_string` / `to_string` (1.2–1.3× py → target ≤1.0×)
 P7 — `round` (2× py → target ≤1.0×)
 
 - **T-R1: `debug_assert .format` sweep specific to rounding modes.**
-  The round dispatcher likely has one assert per mode branch.
+  **INVALID — no such asserts; dispatch swap perf-neutral (20260615).**
+  The premise (one `.format` `debug_assert` per mode branch in the round
+  dispatcher) does not match the code: neither `bigdecimal/rounding.mojo`
+  `round` / `round_to_precision_inplace` nor
+  `BigUInt.remove_trailing_digits_with_rounding_inplace` contains any
+  `.format` (the only `.format` raises live in `decimal128/` and
+  `str.mojo`), and the mode dispatch raises only on the cold
+  unknown-mode fallback with plain concatenation. As a speculative
+  micro-opt the dispatch's `== RoundingMode.down()` (`def`-factory)
+  comparisons were swapped for the comptime `RoundingMode.ROUND_*`
+  aliases; an A/B micro-bench (M4 Pro, 3M iters/mode) showed **no
+  measurable difference** (~96–106 ns either way — the optimiser already
+  folds the trivial factories, and the dispatch is dwarfed by the
+  `copy()` + `number_of_digits()` + digit ops). Reverted to keep the
+  diff minimal. `round` is 2.1× py @p100 driven by the per-call copy and
+  digit scans, not the mode dispatch.
 
 - **T-R2: `round_to_precision_inplace` variant.** DONE (20260516).
   The free function `round_to_precision` and the
@@ -675,18 +764,21 @@ some ops < 1.0×):
 | T-M2   | Single-pass rounding in `multiply`        | S      | **DONE** | already single-pass; 90→80 ns                  |
 | T-D1   | Short-divisor fast path in `divide`       | M      | **DONE** | already via BigUInt dispatch                   |
 | T-D2   | Trailing-zero strip allocation in divide  | S      | **DONE** | inplace strip; −16–21% exact-divide            |
-| T-D3   | Reciprocal-Newton divide (legacy Task 2)  | XL     | P3       | 2× large balanced                              |
+| T-D3   | Reciprocal-Newton divide (legacy Task 2)  | XL     | **WAIT** | div only 2.1–3.1× mul →                        |
+|        |                                           |        |          | recip-Newton ~5× mul (slower); gated on NTT    |
 | T-S1   | Small-coef short-circuit in `sqrt` p=100  | S      | **NO**   | already short-circuits                         |
 | T-L1   | atanh reformulation for ln (T3f)          | M      | **DONE** | already a hybrid; near-1 0.9–1.8× py           |
-| T-L2   | Process-wide ln(10) cache recipe          | S      | P3       | doc                                            |
+| T-L2   | Process-wide ln(10) cache recipe          | S      | **DONE** | `MathCache` (ln2/ln1.25/ln10) + recipe exist;  |
+|        |                                           |        |          | auto-cache blocked on Mojo                     |
 | T-L3   | AGM ln for p ≥ 1000 (T3g)                 | XL     | P4       | 10–50× p≥1000                                  |
 | T-IO1  | `from_string` digit batching              | M      | **DONE** | batching already present;                      |
 |        |                                           |        |          | slice removed, 1.4×→1.2×                       |
 | T-IO2  | `to_string` right-aligned InlineArray     | M      | **DONE** | hybrid exact-size direct-write;                |
 |        |                                           |        |          | long 2.5–2.9×→0.8×                             |
-| T-R1   | `round` `.format` sweep                   | S      | P2       | small                                          |
-| T-7b   | Reciprocal-Newton nth root                | M      | P3       | 1.5–2×                                         |
-| T-7c   | Rational $x^{a/b}$ decomposition          | S      | P2       | 5–10× frac roots                               |
+| T-R1   | `round` `.format` sweep                   | S      | **NO**   | no `.format` asserts in round; great           |
+| T-7b   | Reciprocal-Newton nth root                | M      | **WAIT** | break-even at current mul speed                |
+|        |                                           |        |          | (div ~2.7× mul); root already 0.2× py          |
 | T-5    | NTT multiplication                        | XL     | P4       | 2–10×                                          |
-| T-9    | SIMD schoolbook mul base                  | M      | P3       | 1.5–2×                                         |
+| T-9    | SIMD schoolbook mul base                  | M      | **DONE** | deferred-carry (product-scanning);             |
+|        |                                           |        |          | Definitely worth bringing it to `BigInt` too   |
 | T-3e   | Binary splitting for ln Taylor            | L      | P4       | 2–4× p≥500                                     |

--- a/docs/plans/bigdecimal_enhancement.md
+++ b/docs/plans/bigdecimal_enhancement.md
@@ -191,6 +191,8 @@ kernels (parse/render are precision-insensitive ops).
 | 24  | `round_to_precision` in-place audit           | DONE (T-R2) — code-quality cleanup; divide bench unchanged    |
 |     |                                               | (saved allocs lost in noise vs total divide cost;             |
 |     |                                               | will compound on rounding-dominated ops)                      |
+| 25  | Data-pointer over list indexing across        | OPEN — see T-U1 (cross-kernel BigUInt hot-loop sweep)         |
+|     | BigUInt hot kernels                           |                                                               |
 
 ## 4. Lessons Learnt (the reusable bits)
 
@@ -493,6 +495,24 @@ P2 — Multiply small-precision (2.3× py → target ≤1.5×)
   the usual ratio): dispatcher before/after shows multiply −7.6% @150w,
   −4.2% @192w, −2% @224w, neutral at 256w and ≥384w; biguint/bigint
   suites still pass (0 failures).
+
+- **T-U1: Cross-kernel data-pointer (H#25). OPEN.**
+  Extend Lesson #17 beyond `multiply_slices_deferred_carry` by auditing
+  BigUInt hot loops that still perform repeated `List` indexing in
+  O(n²) / O(n·m) kernels. Candidate set from code inspection (20260618):
+  `add_by_biguint_inplace` carry propagation loop,
+  `multiply_by_uint32_inplace`,
+  `multiply_by_power_of_ten_inplace` partial-word multiply loop,
+  `floor_divide_by_uint32` and `floor_divide_by_uint32_inplace`, and
+  Burnikel-Ziegler normalization/correction loops with dense `words[i]`
+  traffic.
+  Execution plan: for each candidate, build a minimal A/B variant
+  (`unsafe_ptr` vs current indexing), run focused micro-benches
+  plus the standard cross-language suite, and keep only changes with
+  stable gains (target ≥3% median) and no small-input regressions.
+  Safety constraints: keep owner Lists alive for pointer lifetime,
+  never resize while pointer is live, and document in-bounds invariants
+  at each pointerized loop.
 
 P3 — Divide all precisions (5× py → target ≤2×)
 
@@ -804,5 +824,5 @@ some ops < 1.0×):
 | T-9    | SIMD schoolbook mul base                  | M      | **DONE** | deferred-carry (product-scanning);             |
 |        |                                           |        |          | Definitely worth bringing it to `BigInt` too   |
 | T-3e   | Binary splitting for ln Taylor            | L      | P4       | 2–4× p≥500                                     |
-| T-P1   | Use pointer than list indexing            | M      | P4       | Use `UnsafePointer` for loops;                 |
+| T-U1   | Use pointers rather than list indexing    | M      | P4       | Use `UnsafePointer` for loops;                 |
 |        |                                           |        |          | Similar to `multiply_slices_deferred_carry`.   |

--- a/docs/plans/bigint2_benchmark_analysis.md
+++ b/docs/plans/bigint2_benchmark_analysis.md
@@ -305,7 +305,7 @@ Implemented Karatsuba O(n^1.585) in `_multiply_magnitudes_karatsuba()` with:
 - **Pointer-based inner loops:** `_data` pointer access in schoolbook avoids bounds checking
 - **Offset-based assembly:** `_add_at_offset_inplace(a, b, offset)` replaces the
   expensive `shift_left_words + add` pattern, eliminating O(n) memory copies
-- **Slice-based sub-operations:** `_multiply_magnitudes_school(a, a_start, a_end, b, b_start, b_end)`
+- **Slice-based sub-operations:** `_multiply_magnitudes_schoolbook(a, a_start, a_end, b, b_start, b_end)`
   avoids creating sub-lists for Karatsuba's recursive calls
 
 **Result:** 10000-digit multiply: 745 µs → 195 µs (**3.8× internal speedup**).

--- a/src/decimo/bigint/arithmetics.mojo
+++ b/src/decimo/bigint/arithmetics.mojo
@@ -205,7 +205,7 @@ def _multiply_magnitudes(a: List[UInt32], b: List[UInt32]) -> List[UInt32]:
     # Dispatch based on size
     var len_max = max(len_a, len_b)
     if len_max <= CUTOFF_KARATSUBA:
-        return _multiply_magnitudes_school(a, 0, len_a, b, 0, len_b)
+        return _multiply_magnitudes_schoolbook(a, 0, len_a, b, 0, len_b)
     else:
         return _multiply_magnitudes_karatsuba(a, 0, len_a, b, 0, len_b)
 
@@ -257,7 +257,7 @@ def _multiply_magnitude_by_word(
     return result^
 
 
-def _multiply_magnitudes_school(
+def _multiply_magnitudes_schoolbook(
     read a: List[UInt32],
     a_start: Int,
     a_end: Int,
@@ -365,7 +365,9 @@ def _multiply_magnitudes_karatsuba(
 
     var len_max = max(len_a, len_b)
     if len_max <= CUTOFF_KARATSUBA:
-        return _multiply_magnitudes_school(a, a_start, a_end, b, b_start, b_end)
+        return _multiply_magnitudes_schoolbook(
+            a, a_start, a_end, b, b_start, b_end
+        )
 
     # Split point: half of the larger operand
     var m = len_max // 2
@@ -1097,7 +1099,9 @@ def _multiply_magnitudes_slices(
         return _multiply_magnitude_by_word(a, a_start, a_end, b[b_start])
     var len_max = max(len_a, len_b)
     if len_max <= CUTOFF_KARATSUBA:
-        return _multiply_magnitudes_school(a, a_start, a_end, b, b_start, b_end)
+        return _multiply_magnitudes_schoolbook(
+            a, a_start, a_end, b, b_start, b_end
+        )
     return _multiply_magnitudes_karatsuba(a, a_start, a_end, b, b_start, b_end)
 
 

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -33,10 +33,27 @@ from decimo.rounding_mode import RoundingMode
 
 comptime CUTOFF_KARATSUBA = 64
 """The cutoff number of words for using Karatsuba multiplication."""
-comptime CUTOFF_TOOM3 = 128
-"""The cutoff number of words for using Toom-3 multiplication."""
+comptime CUTOFF_TOOM3 = 256
+"""The cutoff number of words for using Toom-3 multiplication.
+
+NOTE: Karatsuba is used for `CUTOFF_KARATSUBA < max_words <= CUTOFF_TOOM3`.
+"""
 comptime CUTOFF_BURNIKEL_ZIEGLER = 32
 """The cutoff number of words for using Burnikel-Ziegler division."""
+comptime CUTOFF_DEFERRED_CARRY_PRODUCT = 200
+"""Threshold for switching the schoolbook inner loop to deferred-carry
+accumulation.
+
+NOTE: unlike `CUTOFF_KARATSUBA` / `CUTOFF_TOOM3`, which are
+word counts, this is a product `n_words_x * n_words_y` (the number of
+single-word partial products). It is therefore reached *within* the schoolbook
+range (`max_words <= CUTOFF_KARATSUBA` = 64): two ~15-word operands give a
+product of 225 >= 200, and a 64x64 multiply gives 4096. So the deferred-carry
+path runs for the ~15-64 word band directly and for the Karatsuba / Toom-3
+recursion base cases (whose sub-multiplies are <= 64 words). Below this product
+the per-step-carry loop is faster (the accumulator + final-normalization
+overhead dominates).
+"""
 
 # ===----------------------------------------------------------------------=== #
 # List of functions in this module:
@@ -56,7 +73,7 @@ comptime CUTOFF_BURNIKEL_ZIEGLER = 32
 # subtract_by_uint32_inplace(x: BigUInt, y: UInt32) -> None
 #
 # multiply(x1: BigUInt, x2: BigUInt) -> BigUInt
-# multiply_slices_school(x: BigUInt, y: BigUInt, start_x: Int, end_x: Int, start_y: Int, end_y: Int) -> BigUInt
+# multiply_slices_schoolbook(x: BigUInt, y: BigUInt, start_x: Int, end_x: Int, start_y: Int, end_y: Int) -> BigUInt
 # multiply_slices_karatsuba(x: BigUInt, y: BigUInt, start_x: Int, end_x: Int, start_y: Int, end_y: Int, cutoff_number_of_words: Int) -> BigUInt
 # multiply_slices_toom3(x: BigUInt, y: BigUInt, bounds_x: Tuple[Int, Int], bounds_y: Tuple[Int, Int]) -> BigUInt
 # multiply_by_uint32_inplace(x: BigUInt, y: UInt32) -> None
@@ -66,7 +83,7 @@ comptime CUTOFF_BURNIKEL_ZIEGLER = 32
 # exact_divide_by_3_inplace(mut x: BigUInt)
 #
 # floor_divide(x1: BigUInt, x2: BigUInt) -> BigUInt
-# floor_divide_school(x1: BigUInt, x2: BigUInt) -> BigUInt
+# floor_divide_schoolbook(x1: BigUInt, x2: BigUInt) -> BigUInt
 # floor_divide_estimate_quotient(x1: BigUInt, x2: BigUInt, j: Int, m: Int) -> UInt64
 # floor_divide_by_single_word_inplace(x1: BigUInt, x2: BigUInt) -> None
 # floor_divide_by_double_words_inplace(x1: BigUInt, x2: BigUInt) -> None
@@ -494,10 +511,10 @@ def subtract(x: BigUInt, y: BigUInt) raises -> BigUInt:
     # Below is a school method for subtraction.
     # You go from the least significant word to the most significant word.
     #
-    # return subtract_school(x, y)
+    # return subtract_schoolbook(x, y)
 
 
-def subtract_school(x: BigUInt, y: BigUInt) raises -> BigUInt:
+def subtract_schoolbook(x: BigUInt, y: BigUInt) raises -> BigUInt:
     """Returns the difference of two unsigned integers using the school method.
 
     Args:
@@ -520,7 +537,7 @@ def subtract_school(x: BigUInt, y: BigUInt) raises -> BigUInt:
     # If the subtrahend is zero, return the minuend
     if y.is_zero():
         debug_assert[assert_mode="none"](
-            len(y.words) == 1, "subtract_school(): leading zero words"
+            len(y.words) == 1, "subtract_schoolbook(): leading zero words"
         )
         return x.copy()
 
@@ -531,7 +548,7 @@ def subtract_school(x: BigUInt, y: BigUInt) raises -> BigUInt:
         return BigUInt.zero()  # Return zero
     if comparison_result < 0:
         raise OverflowError(
-            function="subtract_school()",
+            function="subtract_schoolbook()",
             message=(
                 "biguint.arithmetics.subtract(): Result is negative due to"
                 " x < y"
@@ -866,11 +883,11 @@ def multiply(x: BigUInt, y: BigUInt) -> BigUInt:
     # Use school multiplication for small numbers
     var max_words = max(len(x.words), len(y.words))
     if max_words <= CUTOFF_KARATSUBA:
-        # return multiply_slices_school (x, y)
-        return multiply_slices_school(
+        # return multiply_slices_schoolbook (x, y)
+        return multiply_slices_schoolbook(
             x, y, (0, len(x.words)), (0, len(y.words))
         )
-        # multiply_slices_school can also takes in x, y, and indices
+        # multiply_slices_schoolbook can also takes in x, y, and indices
 
     # CASE 2
     # Use Toom-3 multiplication for very large numbers
@@ -916,9 +933,9 @@ def multiply_slices(
     # Use school multiplication for small numbers
     var max_words = max(n_words_x_slice, n_words_y_slice)
     if max_words <= CUTOFF_KARATSUBA:
-        # return multiply_slices_school (x, y)
-        return multiply_slices_school(x, y, bounds_x, bounds_y)
-        # multiply_slices_school can also takes in x, y, and indices
+        # return multiply_slices_schoolbook (x, y)
+        return multiply_slices_schoolbook(x, y, bounds_x, bounds_y)
+        # multiply_slices_schoolbook can also takes in x, y, and indices
 
     # CASE 2
     # Use Toom-3 multiplication for very large numbers
@@ -933,13 +950,13 @@ def multiply_slices(
         )
 
 
-def multiply_slices_school(
+def multiply_slices_schoolbook(
     read x: BigUInt,
     read y: BigUInt,
     bounds_x: Tuple[Int, Int],
     bounds_y: Tuple[Int, Int],
 ) -> BigUInt:
-    """Multiplies two BigUInt slices using the school method.
+    """Multiplies two BigUInt slices using the schoolbook method.
 
     Args:
         x: The first BigUInt operand (multiplicand).
@@ -975,6 +992,16 @@ def multiply_slices_school(
             var result = BigUInt.from_slice(x, (bounds_x[0], bounds_x[1]))
             multiply_by_uint32_inplace(result, y_word)
             return result^
+
+    # Deferred-carry multiply for larger slices: accumulate column
+    # sums in a UInt64 buffer and normalize the base-10^9 carry only
+    # periodically, doing ~8x fewer div/mods than the per-step-carry loop
+    # below. The gate is a PRODUCT (n_x * n_y), not a word count, so it is
+    # reached for both operands >= ~15 words (within the <=64-word schoolbook
+    # range) and for the Karatsuba/Toom-3 recursion base cases. Below the
+    # crossover the buffer + final-normalization overhead loses.
+    if n_words_x_slice * n_words_y_slice >= CUTOFF_DEFERRED_CARRY_PRODUCT:
+        return multiply_slices_deferred_carry(x, y, bounds_x, bounds_y)
 
     # The max number of words in the result is the sum of the words in the operands
     var max_result_len = n_words_x_slice + n_words_y_slice
@@ -1022,6 +1049,105 @@ def multiply_slices_school(
     return result^
 
 
+def multiply_slices_deferred_carry(
+    read x: BigUInt,
+    read y: BigUInt,
+    bounds_x: Tuple[Int, Int],
+    bounds_y: Tuple[Int, Int],
+) -> BigUInt:
+    """Multiplies two BigUInt slices using deferred-carry accumulation.
+
+    Args:
+        x: The first BigUInt operand (multiplicand).
+        y: The second BigUInt operand (multiplier).
+        bounds_x: A tuple containing the start and end indices of the slice in x.
+        bounds_y: A tuple containing the start and end indices of the slice in y.
+
+    Returns:
+        The product of the two BigUInt slices.
+
+    Notes:
+
+    Unlike `multiply_slices_schoolbook`, which performs a base-10^9 carry
+    normalization (`% BASE` and `// BASE`) on every inner-loop step
+    (`n_x * n_y` divisions), this accumulates each partial product into a
+    `UInt64` column buffer and normalizes only every `SAFE_ROWS` rows, plus
+    once at the end. That reduces the division count to roughly
+    `n_x * n_y / SAFE_ROWS`, which dominates the runtime for larger slices.
+
+    This is the deferred-carry / column-accumulation idea behind
+    product-scanning multiplication (also known in the literature as "Comba
+    multiplication"): P. G. Comba, "Exponentiation cribs", IBM Systems
+    Journal 29(4), 1990, pp. 526-538; see also Koc, Acar & Kaliski,
+    "Analyzing and comparing Montgomery multiplication algorithms", IEEE
+    Micro 16(3), 1996, for the operand-scanning vs product-scanning contrast.
+    Here the accumulator is a base-10^9 `UInt64` column buffer rather than a
+    binary one, and carries are deferred in batches of `SAFE_ROWS` rows for
+    overflow safety.
+
+    Overflow safety: each partial product `x_i * y_j` is `< (10^9)^2 = 10^18`,
+    and at most `SAFE_ROWS = 15` rows accumulate into any column between
+    normalizations, so each accumulator stays below `15 * 10^18 < 2^64 - 1`.
+    Caller (`multiply_slices_schoolbook`) only routes here above the benchmarked
+    product crossover, and never with a single-word slice.
+    """
+    var start_x = bounds_x[0]
+    var start_y = bounds_y[0]
+    var n_words_x_slice = bounds_x[1] - start_x
+    var n_words_y_slice = bounds_y[1] - start_y
+
+    comptime SAFE_ROWS = 15
+
+    var total = n_words_x_slice + n_words_y_slice
+    var acc = List[UInt64](unsafe_uninit_length=total)
+    var ap = acc.unsafe_ptr()
+    memset_zero(ptr=ap, count=total)
+
+    var xp = x.words.unsafe_ptr()
+    var yp = y.words.unsafe_ptr()
+
+    var rows_since_norm = 0
+    var top = 0  # highest accumulator index touched + 1
+
+    for i in range(n_words_x_slice):
+        var xi = UInt64(xp[start_x + i])
+        if xi == 0:
+            continue
+        for j in range(n_words_y_slice):
+            ap[i + j] += xi * UInt64(yp[start_y + j])
+        if i + n_words_y_slice > top:
+            top = i + n_words_y_slice
+        rows_since_norm += 1
+        if rows_since_norm == SAFE_ROWS:
+            # Propagate base-10^9 carries across the touched range.
+            var carry: UInt64 = 0
+            for k in range(top):
+                var v = ap[k] + carry
+                ap[k] = v % UInt64(BigUInt.BASE)
+                carry = v // UInt64(BigUInt.BASE)
+            var kk = top
+            while carry > 0:
+                var v = ap[kk] + carry
+                ap[kk] = v % UInt64(BigUInt.BASE)
+                carry = v // UInt64(BigUInt.BASE)
+                kk += 1
+                if kk > top:
+                    top = kk
+            rows_since_norm = 0
+
+    # Final normalization into base-10^9 words.
+    var result = BigUInt(unsafe_uninit_length=total)
+    var rp = result.words.unsafe_ptr()
+    var carry: UInt64 = 0
+    for k in range(total):
+        var v = ap[k] + carry
+        rp[k] = UInt32(v % UInt64(BigUInt.BASE))
+        carry = v // UInt64(BigUInt.BASE)
+
+    result.remove_leading_empty_words()
+    return result^
+
+
 def multiply_slices_karatsuba(
     read x: BigUInt,
     read y: BigUInt,
@@ -1064,16 +1190,16 @@ def multiply_slices_karatsuba(
     # we can use school multiplication because this is only one loop
     # No need to split the long number into two parts
     if n_words_x_slice == 1 or n_words_y_slice == 1:
-        return multiply_slices_school(x, y, bounds_x, bounds_y)
+        return multiply_slices_schoolbook(x, y, bounds_x, bounds_y)
 
     # CASE 2:
     # The allocation cost is too high for small numbers to use Karatsuba
     # Use school multiplication for small numbers
     var n_words_max = max(n_words_x_slice, n_words_y_slice)
     if n_words_max <= cutoff_number_of_words:
-        # return multiply_slices_school (x, y)
-        return multiply_slices_school(x, y, bounds_x, bounds_y)
-        # multiply_slices_school can also takes in x, y, and indices
+        # return multiply_slices_schoolbook (x, y)
+        return multiply_slices_schoolbook(x, y, bounds_x, bounds_y)
+        # multiply_slices_schoolbook can also takes in x, y, and indices
 
     # Otherwise, use Karatsuba
 
@@ -1909,7 +2035,7 @@ def exact_divide_by_3_inplace(mut x: BigUInt):
 # ===----------------------------------------------------------------------=== #
 # Division Algorithms
 # floor_divide
-# floor_divide_school
+# floor_divide_schoolbook
 # floor_divide_burnikel_ziegler
 # ===----------------------------------------------------------------------=== #
 
@@ -2023,21 +2149,21 @@ def floor_divide(x: BigUInt, y: BigUInt) raises -> BigUInt:
 
         if ndigits_to_shift == 0:
             # No normalization needed, just use the general division algorithm
-            return floor_divide_school(x, y)
+            return floor_divide_schoolbook(x, y)
         else:
             # Normalize the divisor and dividend
             var normalized_x = multiply_by_power_of_ten(x, ndigits_to_shift)
             var normalized_y = multiply_by_power_of_ten(y, ndigits_to_shift)
-            return floor_divide_school(normalized_x, normalized_y)
+            return floor_divide_schoolbook(normalized_x, normalized_y)
 
     # CASE: division of very, very large numbers
     # Use the Burnikel-Ziegler division algorithm
     return floor_divide_burnikel_ziegler(x, y, cut_off=CUTOFF_BURNIKEL_ZIEGLER)
 
 
-# TODO: Implement a `floor_divide_slices_school()` function that
+# TODO: Implement a `floor_divide_slices_schoolbook()` function that
 # can be used for slices of BigUInt numbers.
-def floor_divide_school(x: BigUInt, y: BigUInt) raises -> BigUInt:
+def floor_divide_schoolbook(x: BigUInt, y: BigUInt) raises -> BigUInt:
     """**[PRIVATE]** General schoolbook division algorithm for BigInt10 numbers.
 
     Args:
@@ -2912,7 +3038,7 @@ def floor_divide_two_by_one(
     )
 
     if (n & 1 == 1) or (n <= cut_off):
-        var q = floor_divide_school(a, b)
+        var q = floor_divide_schoolbook(a, b)
         var r = a - q * b
         return (q^, r^)
 
@@ -3072,7 +3198,7 @@ def floor_divide_slices_two_by_one(
         # algorithm.
         var a_slice = BigUInt.from_slice(a, bounds_a)
         var b_slice = BigUInt.from_slice(b, bounds_b)
-        var q = floor_divide_school(a_slice, b_slice)
+        var q = floor_divide_schoolbook(a_slice, b_slice)
         # r = a_slice - q * b_slice
         # We use inplace subtraction to avoid copying
         a_slice -= multiply_slices(q, b, (0, len(q.words)), bounds_b)

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -841,8 +841,8 @@ def multiply(x: BigUInt, y: BigUInt) -> BigUInt:
     Notes:
         This function uses a three-tier dispatch based on operand size:
         schoolbook multiplication for small numbers (≤64 words), Karatsuba
-        multiplication for medium numbers (64–128 words), and Toom-3
-        multiplication for large numbers (>128 words).
+        multiplication for medium numbers (65–256 words), and Toom-3
+        multiplication for large numbers (>256 words).
     """
 
     debug_assert[assert_mode="none"](
@@ -887,7 +887,7 @@ def multiply(x: BigUInt, y: BigUInt) -> BigUInt:
         return multiply_slices_schoolbook(
             x, y, (0, len(x.words)), (0, len(y.words))
         )
-        # multiply_slices_schoolbook can also takes in x, y, and indices
+        # multiply_slices_schoolbook can also take x, y, and indices
 
     # CASE 2
     # Use Toom-3 multiplication for very large numbers
@@ -922,8 +922,8 @@ def multiply_slices(
     Notes:
         This function uses a three-tier dispatch based on operand size:
         schoolbook multiplication for small numbers (≤64 words), Karatsuba
-        multiplication for medium numbers (64–128 words), and Toom-3
-        multiplication for large numbers (>128 words).
+        multiplication for medium numbers (65–256 words), and Toom-3
+        multiplication for large numbers (>256 words).
     """
     n_words_x_slice = bounds_x[1] - bounds_x[0]
     n_words_y_slice = bounds_y[1] - bounds_y[0]
@@ -935,7 +935,7 @@ def multiply_slices(
     if max_words <= CUTOFF_KARATSUBA:
         # return multiply_slices_schoolbook (x, y)
         return multiply_slices_schoolbook(x, y, bounds_x, bounds_y)
-        # multiply_slices_schoolbook can also takes in x, y, and indices
+        # multiply_slices_schoolbook can also take x, y, and indices
 
     # CASE 2
     # Use Toom-3 multiplication for very large numbers

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -1097,52 +1097,72 @@ def multiply_slices_deferred_carry(
     var n_words_y_slice = bounds_y[1] - start_y
 
     comptime SAFE_ROWS = 15
+    comptime BASE = UInt64(BigUInt.BASE)
 
-    var total = n_words_x_slice + n_words_y_slice
-    var acc = List[UInt64](unsafe_uninit_length=total)
-    var ap = acc.unsafe_ptr()
-    memset_zero(ptr=ap, count=total)
+    var result_length = n_words_x_slice + n_words_y_slice
 
-    var xp = x.words.unsafe_ptr()
-    var yp = y.words.unsafe_ptr()
+    # Column accumulator: `column_sums[k]` holds the running sum of every
+    # partial product `x_i * y_j` with `i + j == k`, before the base-10^9
+    # carries are propagated.
+    #
+    # The inner multiply loop is O(n^2). I use raw data pointer for each
+    # of the three buffers it touches and index through those, so the compiler
+    # keeps each buffer's base address in a register for the whole loop instead
+    # reload that List's `_data` field on every element access. That
+    # reload is the bottleneck in the indexed form (measured ~8% slower at
+    # 64-word operands under `-D ASSERT=none`).
+    #
+    # Memory safety: the three buffers all outlive this loop and are never
+    # resized inside it. `x` / `y` are borrowed (`read`, owned by the caller),
+    # and `column_sums` is only element-mutated (never appended). `List.
+    # unsafe_ptr()` returns an origin-parameterized `UnsafePointer` tied to the
+    # List's origin, so Mojo's lifetime tracking keeps `column_sums` alive for
+    # as long as `column_sums_ptr` is used (including the final pass below).
+    # Every index is provably in-bounds:
+    # `start_x + i < bounds_x[1] <= len(x.words)`,
+    # `start_y + j < bounds_y[1] <= len(y.words)`, and the column index
+    # `i + j < result_length` (likewise the carry index `k`).
+    var column_sums = List[UInt64](length=result_length, fill=0)
+    var column_sums_ptr = column_sums.unsafe_ptr()
+    var x_words_ptr = x.words.unsafe_ptr()
+    var y_words_ptr = y.words.unsafe_ptr()
 
-    var rows_since_norm = 0
-    var top = 0  # highest accumulator index touched + 1
+    var rows_since_normalization = 0
+    var highest_column = 0  # highest accumulator index touched + 1
 
     for i in range(n_words_x_slice):
-        var xi = UInt64(xp[start_x + i])
-        if xi == 0:
+        var x_word = UInt64(x_words_ptr[start_x + i])
+        if x_word == 0:
             continue
         for j in range(n_words_y_slice):
-            ap[i + j] += xi * UInt64(yp[start_y + j])
-        if i + n_words_y_slice > top:
-            top = i + n_words_y_slice
-        rows_since_norm += 1
-        if rows_since_norm == SAFE_ROWS:
+            column_sums_ptr[i + j] += x_word * UInt64(y_words_ptr[start_y + j])
+        if i + n_words_y_slice > highest_column:
+            highest_column = i + n_words_y_slice
+        rows_since_normalization += 1
+        if rows_since_normalization == SAFE_ROWS:
             # Propagate base-10^9 carries across the touched range.
             var carry: UInt64 = 0
-            for k in range(top):
-                var v = ap[k] + carry
-                ap[k] = v % UInt64(BigUInt.BASE)
-                carry = v // UInt64(BigUInt.BASE)
-            var kk = top
+            for k in range(highest_column):
+                var column_value = column_sums_ptr[k] + carry
+                column_sums_ptr[k] = column_value % BASE
+                carry = column_value // BASE
+            var k = highest_column
             while carry > 0:
-                var v = ap[kk] + carry
-                ap[kk] = v % UInt64(BigUInt.BASE)
-                carry = v // UInt64(BigUInt.BASE)
-                kk += 1
-                if kk > top:
-                    top = kk
-            rows_since_norm = 0
+                var column_value = column_sums_ptr[k] + carry
+                column_sums_ptr[k] = column_value % BASE
+                carry = column_value // BASE
+                k += 1
+                if k > highest_column:
+                    highest_column = k
+            rows_since_normalization = 0
 
-    # Final normalization into base-10^9 words.
-    var result = BigUInt(unsafe_uninit_length=total)
-    var rp = result.words.unsafe_ptr()
+    # Final normalization into base-10^9 result words.
+    var result = BigUInt(uninitialized_capacity=result_length)
     var carry: UInt64 = 0
-    for k in range(total):
-        var v = ap[k] + carry
-        rp[k] = UInt32(v % UInt64(BigUInt.BASE))
-        carry = v // UInt64(BigUInt.BASE)
+    for k in range(result_length):
+        var column_value = column_sums_ptr[k] + carry
+        result.words.append(UInt32(column_value % BASE))
+        carry = column_value // BASE
 
     result.remove_leading_empty_words()
     return result^

--- a/tests/biguint/test_data/biguint_arithmetics.toml
+++ b/tests/biguint/test_data/biguint_arithmetics.toml
@@ -150,3 +150,21 @@ a = "1{0,10}"
 b = "1{0,10}"
 description = "Very large multiplication"
 expected = "1{0,20}"
+
+[[multiplication_tests]]
+a = "1{0,117}"
+b = "1{0,117}"
+description = "Near deferred-carry cutoff: 14w x 14w stays scalar schoolbook"
+expected = "1{0,234}"
+
+[[multiplication_tests]]
+a = "1{0,126}"
+b = "1{0,117}"
+description = "Cross deferred-carry cutoff: 15w x 14w uses deferred-carry"
+expected = "1{0,243}"
+
+[[multiplication_tests]]
+a = "{9,576}"
+b = "{9,576}"
+description = "64w x 64w all-nines stress (deferred-carry schoolbook base)"
+expected = "{9,575}8{0,575}1"


### PR DESCRIPTION
This PR improves `BigUInt` multiplication performance by adding a deferred-carry (column-accumulation / product-scanning) schoolbook path, and retunes/renames related arithmetic helpers and benchmark artifacts.

**Changes:**
- Add `multiply_slices_deferred_carry()` and dispatch to it from the schoolbook multiply when `n_words_x * n_words_y` crosses `CUTOFF_DEFERRED_CARRY_PRODUCT`.
- Retune `CUTOFF_TOOM3` to 256 words and rename “school” helpers to “schoolbook” for consistency (`multiply_slices_*`, `floor_divide_schoolbook`, `subtract_schoolbook`, BigInt magnitude multiply helper).
- Update benchmark driver and benchmark case TOMLs/docs to reflect new performance-focused scenarios and naming.