### PR TITLE
[doc] Update documents for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ Bug reports and feature requests are welcome! If you encounter issues, please [f
 ```text
 decimo/
 ├── src/                          # All source code
-│   ├── decimo/                   # Core library (mojo precompile)
+│   ├── decimo/                   # Core library (mojo pre-compiled package)
 │   │   ├── bigdecimal/           #   Arbitrary-precision decimal (Decimal)
 │   │   ├── bigint/               #   Arbitrary-precision signed integer (Integer)
 │   │   ├── bigint10/             #   Base-10 signed integer (BigInt10)
@@ -410,7 +410,7 @@ decimo/
 │   │   └── ...                   #   Shared utilities (str, errors, rounding)
 │   └── cli/                      # CLI calculator application
 │       ├── main.mojo             #   Entry point (ArgMojo CLI)
-│       └── calculator/           #   Calculator engine (mojo precompile)
+│       └── calculator/           #   Calculator engine (mojo pre-compiled package)
 │           ├── tokenizer.mojo    #     Lexer: expression → tokens
 │           ├── parser.mojo       #     Shunting-yard: infix → RPN
 │           └── evaluator.mojo    #     RPN evaluator using Decimal

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ An arbitrary-precision integer and decimal library for [Mojo](https://www.modula
 
 Comes with an interactive arbitrary-precision calculator (REPL + one-shot mode) powered by [ArgMojo](https://github.com/forfudan/argmojo). Install it with `brew install forfudan/tap/decimo`.
 
-[![Version](https://img.shields.io/badge/version-v0.10.0-blue)](https://github.com/forfudan/decimo/releases/tag/v0.10.0)
-[![Mojo](https://img.shields.io/badge/mojo-1.0.0b1-orange)](https://docs.modular.com/mojo/manual/)
+[![Version](https://img.shields.io/badge/version-v0.11.0-blue)](https://github.com/forfudan/decimo/releases/tag/v0.11.0)
+[![Mojo](https://img.shields.io/badge/mojo-1.0.0b2-orange)](https://docs.modular.com/mojo/manual/)
 [![pixi](https://img.shields.io/badge/pixi%20add-decimo-purple)](https://prefix.dev/channels/modular-community/packages/decimo)
 [![CI](https://img.shields.io/github/actions/workflow/status/forfudan/decimo/run_tests.yaml?branch=main&label=tests)](https://github.com/forfudan/decimo/actions/workflows/run_tests.yaml)
 
@@ -74,7 +74,7 @@ Then, you can install Decimo using any of these methods:
 1. In the `mojoproject.toml` file of your project, add the following dependency:
 
     ```toml
-    decimo = "==0.10.0"
+    decimo = "==0.11.0"
     ```
 
     Then run `pixi install` to download and install the package.
@@ -96,6 +96,7 @@ The following table summarizes the package versions and their corresponding Mojo
 | `decimo`   | v0.8.0  | ==0.26.1      | pixi            |
 | `decimo`   | v0.9.0  | ==0.26.2      | pixi            |
 | `decimo`   | v0.10.0 | ==1.0.0b1     | pixi            |
+| `decimo`   | v0.11.0 | ==1.0.0b2     | pixi            |
 
 ### Install CLI calculator
 
@@ -400,7 +401,7 @@ Bug reports and feature requests are welcome! If you encounter issues, please [f
 ```text
 decimo/
 ├── src/                          # All source code
-│   ├── decimo/                   # Core library (mojo package)
+│   ├── decimo/                   # Core library (mojo precompile)
 │   │   ├── bigdecimal/           #   Arbitrary-precision decimal (Decimal)
 │   │   ├── bigint/               #   Arbitrary-precision signed integer (Integer)
 │   │   ├── bigint10/             #   Base-10 signed integer (BigInt10)
@@ -409,7 +410,7 @@ decimo/
 │   │   └── ...                   #   Shared utilities (str, errors, rounding)
 │   └── cli/                      # CLI calculator application
 │       ├── main.mojo             #   Entry point (ArgMojo CLI)
-│       └── calculator/           #   Calculator engine (mojo package)
+│       └── calculator/           #   Calculator engine (mojo precompile)
 │           ├── tokenizer.mojo    #     Lexer: expression → tokens
 │           ├── parser.mojo       #     Shunting-yard: infix → RPN
 │           └── evaluator.mojo    #     RPN evaluator using Decimal
@@ -425,7 +426,7 @@ decimo/
 └── pixi.toml                     # Project configuration and tasks
 ```
 
-`src/decimo/` is a Mojo package — it is compiled with `mojo package` and can be imported by external projects. The TOML parser (`decimo.toml`) is included as a subpackage. `src/cli/` is an application that consumes the `decimo` package and compiles to a standalone binary via `mojo build`.
+`src/decimo/` is a Mojo package — it is compiled with `mojo precompile` and can be imported by external projects. The TOML parser (`decimo.toml`) is included as a subpackage. `src/cli/` is an application that consumes the `decimo` package and compiles to a standalone binary via `mojo build`.
 
 ## Tests and benches
 
@@ -446,7 +447,7 @@ If you find Decimo useful, consider listing it in your citations.
     year         = {2026},
     title        = {Decimo: An arbitrary-precision integer and decimal library for Mojo},
     url          = {https://github.com/forfudan/decimo},
-    version      = {0.10.0},
+    version      = {0.11.0},
     note         = {Computer Software}
 }
 ```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,32 +2,42 @@
 
 This is a list of changes for the Decimo package (formerly DeciMojo).
 
-## Unreleased
+## 20260701 (v0.11.0)
 
-1. **Migrated the codebase to Mojo v1.0.0b2.** Bumped the Pixi `mojo`
-   dependency to `>=1.0.0b2` and `argmojo` to `0.7.0`. Switched packaging
-   from the deprecated `mojo package` / `.mojopkg` to `mojo precompile` /
-   `.mojoc` across Pixi tasks, CI workflows, and helper scripts, and
-   updated the `Decimal128` string formatter to the
-   `StringSlice(unsafe_from_utf8=Span(...))` constructor (PR #257).
-1. **Renamed `BigDecimal` rounding APIs to `*_inplace`.**
-   The free function `decimo.bigdecimal.rounding.round_to_precision` and
-   the `BigDecimal.round_to_precision` method were renamed to
-   `round_to_precision_inplace` to make their mutating semantics
-   explicit. Callers must update import and call sites. The
-   out-of-place, Python-compatible `BigDecimal.round(ndigits=...)` API
-   is unchanged. See PR #245 / roadmap task T-R2.
-1. Routed `round_to_precision` through a fully in-place path, removing
-   one `BigUInt` allocation + buffer copy from 6 call sites in
-   `bigdecimal/arithmetics.mojo` (3 × `divide`) and
-   `bigdecimal/exponential.mojo`. The out-of-place
-   `BigUInt.remove_trailing_digits_with_rounding` is now a thin
-   `copy + inplace` wrapper (~110 LOC removed). Added an optional
-   `ndigits_before_removal` hint parameter so callers that already know
-   `self.number_of_digits()` skip the redundant inner pass.
-   Measured impact on `divide` (p = 100 / 1000 / 10000) is within ±1 %
-   run-to-run noise; the cleanup is kept for code quality and will
-   compound on future rounding-dominated fast paths.
+Decimo v0.11.0 retargets the codebase to **Mojo v1.0.0b2**, adds the `factorial()` and `permutation()` functions to `BigInt` and `BigDecimal`, and includes a series of performance improvements for `BigDecimal` and `BigUInt` arithmetic. It also renames the `BigDecimal` `round_to_precision` APIs to `*_inplace`, which is a breaking change for code that calls them directly.
+
+### ⭐️ New in v0.11.0
+
+**Number-theoretic functions:**
+
+1. **`factorial()`** for `BigInt` and `BigDecimal` — a standalone function in the new `special` modules and an instance method on both types. `BigDecimal.factorial(precision=0)` returns the exact value by default and a rounded value when a positive `precision` is given. The exact path uses balanced binary splitting (`product_range`) with in-place single-word multiplication at the recursion leaves, which is much faster than a naive running product for large arguments (PR #254, #255, #256).
+1. **`permutation()`** — the number of `k`-permutations of `n`, `P(n, k) = n! / (n − k)!`, likewise provided as a `special`-module function and as a method on `BigInt` / `BigDecimal` (with optional rounding for `BigDecimal`). For `BigInt`, `n` is restricted to a single word (PR #255).
+
+### 🦋 Changed in v0.11.0
+
+**Mojo v1.0.0b2 migration** (PR #257):
+
+1. Retarget the codebase to **Mojo v1.0.0b2**, and bump the Pixi dependencies to `mojo >=1.0.0b2` and `argmojo 0.7.0`.
+1. Switch packaging from the deprecated `mojo package` / `.mojopkg` to `mojo precompile` / `.mojoc` across the Pixi tasks, CI workflows, and helper scripts.
+1. Update the `Decimal128` string formatter to the `StringSlice(unsafe_from_utf8=Span(...))` constructor, replacing the deprecated `StringSlice(ptr=, length=)` form.
+
+**BigDecimal — rounding API rename:**
+
+1. The free function `round_to_precision` and the matching `BigDecimal` method are renamed to **`round_to_precision_inplace`**, which makes their mutating semantics explicit, and now run through an allocation-free in-place path. The out-of-place, Python-compatible `BigDecimal.round(ndigits=...)` is unchanged. Code that calls the renamed APIs must update its import and call sites (PR #245).
+
+**Performance:**
+
+1. **`BigDecimal` addition / subtraction** — a same-scale fast path avoids the scale-alignment work when both operands share a scale (and, for `add`, a sign) (PR #247).
+1. **`BigDecimal` multiplication** — compute the exact coefficient product in a single pass and round only afterwards when a precision is requested, removing a recursive call and a duplicated zero fast-path (PR #248).
+1. **`BigDecimal` division and string conversion** — fewer allocations in `divide`, `from_string` parsing, and `to_string` rendering, through in-place batching and an exact-size output buffer (PR #249).
+1. **`BigUInt` multiplication** — a deferred-carry (product-scanning) schoolbook path is selected once the operand size crosses a threshold; the Toom-3 cutoff is retuned and the "school" helpers are renamed to "schoolbook" (PR #250).
+1. **Logarithm constants** — `compute_ln2` and `compute_ln1d25` fold their series factor into a single `UInt32` division per term, and `BigUInt.floor_divide_by_uint32` hoists its buffer pointers out of the inner loop (PR #251).
+
+**Code quality and tooling:**
+
+1. **`BigInt.from_integral_scalar()`** is simplified into one generic word-peeling loop over any integral scalar type, backed by a new `unsigned_counterpart` type helper (PR #253).
+1. The **`BigInt` benchmarks** are refactored into a cross-language harness that compares `decimo.BigInt` against Python `int` and Rust `num-bigint`, with a Markdown report aggregator (PR #252).
+1. **Documentation** — added `Raises:` sections across the public API, replaced banner-style header comments with module docstrings, and introduced local import aliases in place of fully-qualified references (PR #245, #246).
 
 ## 20260514 (v0.10.0)
 

--- a/docs/readme_unreleased.md
+++ b/docs/readme_unreleased.md
@@ -401,7 +401,7 @@ Bug reports and feature requests are welcome! If you encounter issues, please [f
 ```text
 decimo/
 ├── src/                          # All source code
-│   ├── decimo/                   # Core library (mojo precompile)
+│   ├── decimo/                   # Core library (mojo pre-compiled package)
 │   │   ├── bigdecimal/           #   Arbitrary-precision decimal (Decimal)
 │   │   ├── bigint/               #   Arbitrary-precision signed integer (Integer)
 │   │   ├── bigint10/             #   Base-10 signed integer (BigInt10)
@@ -410,7 +410,7 @@ decimo/
 │   │   └── ...                   #   Shared utilities (str, errors, rounding)
 │   └── cli/                      # CLI calculator application
 │       ├── main.mojo             #   Entry point (ArgMojo CLI)
-│       └── calculator/           #   Calculator engine (mojo precompile)
+│       └── calculator/           #   Calculator engine (mojo pre-compiled package)
 │           ├── tokenizer.mojo    #     Lexer: expression → tokens
 │           ├── parser.mojo       #     Shunting-yard: infix → RPN
 │           └── evaluator.mojo    #     RPN evaluator using Decimal

--- a/docs/readme_unreleased.md
+++ b/docs/readme_unreleased.md
@@ -4,8 +4,8 @@ An arbitrary-precision integer and decimal library for [Mojo](https://www.modula
 
 Comes with an interactive arbitrary-precision calculator (REPL + one-shot mode) powered by [ArgMojo](https://github.com/forfudan/argmojo). Install it with `brew install forfudan/tap/decimo`.
 
-[![Version](https://img.shields.io/badge/version-v0.10.0-blue)](https://github.com/forfudan/decimo/releases/tag/v0.10.0)
-[![Mojo](https://img.shields.io/badge/mojo-1.0.0b1-orange)](https://docs.modular.com/mojo/manual/)
+[![Version](https://img.shields.io/badge/version-v0.11.0-blue)](https://github.com/forfudan/decimo/releases/tag/v0.11.0)
+[![Mojo](https://img.shields.io/badge/mojo-1.0.0b2-orange)](https://docs.modular.com/mojo/manual/)
 [![pixi](https://img.shields.io/badge/pixi%20add-decimo-purple)](https://prefix.dev/channels/modular-community/packages/decimo)
 [![CI](https://img.shields.io/github/actions/workflow/status/forfudan/decimo/run_tests.yaml?branch=main&label=tests)](https://github.com/forfudan/decimo/actions/workflows/run_tests.yaml)
 
@@ -74,7 +74,7 @@ Then, you can install Decimo using any of these methods:
 1. In the `mojoproject.toml` file of your project, add the following dependency:
 
     ```toml
-    decimo = "==0.10.0"
+    decimo = "==0.11.0"
     ```
 
     Then run `pixi install` to download and install the package.
@@ -96,6 +96,7 @@ The following table summarizes the package versions and their corresponding Mojo
 | `decimo`   | v0.8.0  | ==0.26.1      | pixi            |
 | `decimo`   | v0.9.0  | ==0.26.2      | pixi            |
 | `decimo`   | v0.10.0 | ==1.0.0b1     | pixi            |
+| `decimo`   | v0.11.0 | ==1.0.0b2     | pixi            |
 
 ### Install CLI calculator
 
@@ -446,7 +447,7 @@ If you find Decimo useful, consider listing it in your citations.
     year         = {2026},
     title        = {Decimo: An arbitrary-precision integer and decimal library for Mojo},
     url          = {https://github.com/forfudan/decimo},
-    version      = {0.10.0},
+    version      = {0.11.0},
     note         = {Computer Software}
 }
 ```

--- a/docs/readme_zht.md
+++ b/docs/readme_zht.md
@@ -68,18 +68,20 @@ channels = ["https://conda.modular.com/max", "https://repo.prefix.dev/modular-co
 
 下表總結了包版本及其對應的 Mojo 版本：
 
-| 包名       | 版本   | Mojo 版本     | 包管理器 |
-| ---------- | ------ | ------------- | -------- |
-| `decimojo` | v0.1.0 | ==25.1        | magic    |
-| `decimojo` | v0.2.0 | ==25.2        | magic    |
-| `decimojo` | v0.3.0 | ==25.2        | magic    |
-| `decimojo` | v0.3.1 | >=25.2, <25.4 | pixi     |
-| `decimojo` | v0.4.x | ==25.4        | pixi     |
-| `decimojo` | v0.5.0 | ==25.5        | pixi     |
-| `decimojo` | v0.6.0 | ==0.25.7      | pixi     |
-| `decimojo` | v0.7.0 | ==0.26.1      | pixi     |
-| `decimo`   | v0.8.0 | ==0.26.1      | pixi     |
-| `decimo`   | v0.9.0 | ==0.26.2      | pixi     |
+| 包名       | 版本    | Mojo 版本     | 包管理器 |
+| ---------- | ------- | ------------- | -------- |
+| `decimojo` | v0.1.0  | ==25.1        | magic    |
+| `decimojo` | v0.2.0  | ==25.2        | magic    |
+| `decimojo` | v0.3.0  | ==25.2        | magic    |
+| `decimojo` | v0.3.1  | >=25.2, <25.4 | pixi     |
+| `decimojo` | v0.4.x  | ==25.4        | pixi     |
+| `decimojo` | v0.5.0  | ==25.5        | pixi     |
+| `decimojo` | v0.6.0  | ==0.25.7      | pixi     |
+| `decimojo` | v0.7.0  | ==0.26.1      | pixi     |
+| `decimo`   | v0.8.0  | ==0.26.1      | pixi     |
+| `decimo`   | v0.9.0  | ==0.26.2      | pixi     |
+| `decimo`   | v0.10.0 | ==1.0.0b1     | pixi     |
+| `decimo`   | v0.11.0 | ==1.0.0b2     | pixi     |
 
 ## 快速開始
 

--- a/docs/readme_zht.md
+++ b/docs/readme_zht.md
@@ -59,7 +59,7 @@ channels = ["https://conda.modular.com/max", "https://repo.prefix.dev/modular-co
 1. 在您項目的 `mojoproject.toml` 文件中，添加以下依賴：
 
     ```toml
-    decimo = "==0.9.0"
+    decimo = "==0.11.0"
     ```
 
     然後運行 `pixi install` 來下載並安裝包。

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -62,7 +62,7 @@ pixi add decimo
 Or add it manually to `pixi.toml`:
 
 ```toml
-decimo = "==0.10.0"
+decimo = "==0.11.0"
 ```
 
 Then run `pixi install`.

--- a/pixi.toml
+++ b/pixi.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "decimo"
 platforms = ["osx-arm64", "linux-64"]
 readme = "README.md"
-version = "0.10.0"
+version = "0.11.0"
 
 [dependencies]
 argmojo = ">=0.7,<0.8" # CLI argument parsing for the Decimo calculator


### PR DESCRIPTION
This PR updates release documentation across the repository to reflect the v0.11.0 release (including the Mojo v1.0.0b2 target) and publishes the v0.11.0 changelog entry.