### PR TITLE
[core][trait] Add `Numeric` trait and conforms `BigInt`, `BigDecimal`, and `Decimal128` to it

### DIFF
--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -175,6 +175,7 @@ These constructors skip validation for performance-sensitive code. The caller mu
 | `a + b`       | Addition                          | No                 |
 | `a - b`       | Subtraction                       | No                 |
 | `a * b`       | Multiplication                    | No                 |
+| `a / b`       | Truncating division (toward zero) | Yes (zero div)     |
 | `a // b`      | Floor division (rounds toward −∞) | Yes (zero div)     |
 | `a % b`       | Floor modulo (Python semantics)   | Yes (zero div)     |
 | `divmod(a,b)` | Floor quotient and remainder      | Yes (zero div)     |
@@ -209,10 +210,16 @@ print(BInt(2) ** 10)  # 1024
 
 BigInt supports two division conventions:
 
-| Name              | Operator / Method                          | Quotient    | Python equivalent |
-| ----------------- | ------------------------------------------ | ----------- | ----------------- |
-| Floor division    | `//`, `%`, `divmod()`                      | Toward −∞   | `//`, `%`         |
-| Truncate division | `.truncate_divide()`, `.truncate_modulo()` | Toward zero | C/Java `/`, `%`   |
+| Name              | Operator / Method                               | Quotient    | Python equivalent |
+| ----------------- | ----------------------------------------------- | ----------- | ----------------- |
+| Floor division    | `//`, `%`, `divmod()`                           | Toward −∞   | `//`, `%`         |
+| Truncate division | `/`, `.truncate_divide()`, `.truncate_modulo()` | Toward zero | C/Java `/`, `%`   |
+
+`/` on a `BInt` is integer division, not a promotion to a decimal type. It
+follows Mojo's own `Int`, where `Int(7) / Int(-2)` is `-3`: the quotient stays
+in the type and rounds toward zero. It is therefore a different operator from
+`//`, not a synonym, and the two disagree exactly when the operands have
+opposite signs.
 
 The difference matters for negative operands:
 
@@ -225,6 +232,7 @@ print(a // b)                    # -4
 print(a % b)                     # -1
 
 # Truncate division (C/Java semantics)
+print(a / b)                     # -3
 print(a.truncate_divide(b))      # -3
 print(a.truncate_modulo(b))      #  1
 ```
@@ -1188,6 +1196,13 @@ from decimo.expression import tokenize, parse_to_rpn, evaluate_rpn
 
 ### Appendix B — Traits Implemented
 
+All of these come from the Mojo standard library except **`Numeric`**, which
+Decimo defines in `decimo.numeric` and `BigInt`, `BigDecimal` and `Decimal128`
+all conform to. It gathers `zero()`, `one()`, `-x`, `+`, `-`, `*` and `/`, so a
+generic routine — a matrix or polynomial library, say — can be written once
+against `T: Numeric` and run over any of the three. Mojo checks conformance
+nominally, which is why the trait lives in Decimo rather than in the consumer.
+
 #### BigInt <!-- omit from toc -->
 
 | Trait              | What it enables                  |
@@ -1198,6 +1213,7 @@ from decimo.expression import tokenize, parse_to_rpn, evaluate_rpn
 | `Movable`          | Move semantics                   |
 | `FloatableRaising` | `Float64(x)`                     |
 | `IntableRaising`   | `Int(x)`                         |
+| `Numeric`          | Generic code over Decimo numbers |
 | `Representable`    | `repr(x)`                        |
 | `Stringable`       | `String(x)`, `str(x)`            |
 | `Writable`         | `print(x)`, writer protocol      |
@@ -1212,6 +1228,7 @@ from decimo.expression import tokenize, parse_to_rpn, evaluate_rpn
 | `Movable`          | Move semantics                   |
 | `FloatableRaising` | `Float64(x)`                     |
 | `IntableRaising`   | `Int(x)`                         |
+| `Numeric`          | Generic code over Decimo numbers |
 | `Representable`    | `repr(x)`                        |
 | `Roundable`        | `round(x)`, `round(x, ndigits)`  |
 | `Stringable`       | `String(x)`, `str(x)`            |
@@ -1226,6 +1243,7 @@ from decimo.expression import tokenize, parse_to_rpn, evaluate_rpn
 | `a + b`             | `BInt`, `Int`        | No      | Addition               |
 | `a - b`             | `BInt`, `Int`        | No      | Subtraction            |
 | `a * b`             | `BInt`, `Int`        | No      | Multiplication         |
+| `a / b`             | `BInt`, `Int`        | Yes     | Truncating division    |
 | `a // b`            | `BInt`, `Int`        | Yes     | Floor division         |
 | `a % b`             | `BInt`, `Int`        | Yes     | Floor modulo           |
 | `a ** b`            | `BInt`, `Int`        | Yes     | Power                  |

--- a/src/decimo/__init__.mojo
+++ b/src/decimo/__init__.mojo
@@ -37,6 +37,9 @@ comptime DECIMO_VERSION_TAG = "v" + DECIMO_VERSION
 """Display version of the Decimo library, prefixed with `v` (e.g. `v0.12.0`).
 """
 
+# Traits
+from .numeric import Numeric
+
 # Core types
 from .decimal128.decimal128 import Decimal128, Dec128
 from .bigint.bigint import BigInt, BInt, Integer

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -28,6 +28,7 @@ from std.python import PythonObject
 from std import testing
 
 from decimo.errors import ConversionError, ValueError
+from decimo.numeric import Numeric
 from decimo.rounding_mode import RoundingMode
 from decimo.numerals.chinese import ChineseNumeralStyle
 from decimo.bigdecimal.exponential import MathCache
@@ -111,6 +112,7 @@ struct BigDecimal(
     FloatableRaising,
     IntableRaising,
     Movable,
+    Numeric,
     Roundable,
     Writable,
 ):
@@ -166,6 +168,26 @@ struct BigDecimal(
     # ===------------------------------------------------------------------=== #
     # Constructors and life time dunder methods
     # ===------------------------------------------------------------------=== #
+
+    @always_inline
+    @staticmethod
+    def zero() -> Self:
+        """Returns a BigDecimal with value 0.
+
+        Returns:
+            A `BigDecimal` with value 0.
+        """
+        return Self()
+
+    @always_inline
+    @staticmethod
+    def one() -> Self:
+        """Returns a BigDecimal with value 1.
+
+        Returns:
+            A `BigDecimal` with value 1.
+        """
+        return Self(BigUInt.one(), scale=0, sign=False)
 
     def __init__(out self):
         """Initializes to zero by default."""

--- a/src/decimo/bigint/bigint.mojo
+++ b/src/decimo/bigint/bigint.mojo
@@ -38,6 +38,7 @@ import decimo.bigint.exponential as bigint_exponential
 import decimo.bigint.number_theory as bigint_number_theory
 import decimo.bigint.special as bigint_special
 import decimo.str as decimo_str
+from decimo.numeric import Numeric
 import decimo.numerals.chinese as decimo_chinese
 from decimo.numerals.chinese import ChineseNumeralStyle
 from decimo.bigint10.bigint10 import BigInt10
@@ -64,6 +65,7 @@ struct BigInt(
     FloatableRaising,
     IntableRaising,
     Movable,
+    Numeric,
     Writable,
 ):
     """An arbitrary-precision signed integer, similar to Python's `int`.
@@ -898,6 +900,34 @@ struct BigInt(
             The product of the two values.
         """
         return bigint_arithmetics.multiply(self, other)
+
+    @always_inline
+    def __truediv__(self, other: Self) raises -> Self:
+        """Divides two values, truncating toward zero.
+
+        `/` on integers is closed and truncating, matching Mojo's own `Int`:
+        `Int(-7) / Int(2)` is `-3` while `Int(-7) // Int(2)` is `-4`. The two
+        operators are therefore different operations on a `BigInt`, not
+        synonyms, and they differ exactly when the operands have opposite
+        signs.
+
+        Args:
+            other: The right-hand side operand.
+
+        Returns:
+            The quotient, rounded toward zero.
+
+        Raises:
+            ZeroDivisionError: If the divisor is zero.
+        """
+        try:
+            return bigint_arithmetics.truncate_divide(self, other)
+        except e:
+            raise ZeroDivisionError(
+                message="See the above exception.",
+                function="BigInt.__truediv__()",
+                previous_error=e^,
+            )
 
     @always_inline
     def __floordiv__(self, other: Self) raises -> Self:

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -40,6 +40,7 @@ from decimo.errors import (
 )
 import decimo.decimal128.utility as decimal128_utility
 from decimo.bigdecimal.bigdecimal import BigDecimal
+from decimo.numeric import Numeric
 
 comptime Dec128 = Decimal128
 """A 128-bit fixed-point decimal number."""
@@ -52,6 +53,7 @@ struct Decimal128(
     Floatable,
     Hashable,
     IntableRaising,
+    Numeric,
     Roundable,
     TrivialRegisterPassable,
     Writable,
@@ -132,6 +134,28 @@ struct Decimal128(
     """Bits 16 to 23 must contain a scale between 0 and 28."""
     # TODO: Move these special values to top of the module
     # when Mojo support global variables in the future.
+
+    # `zero()` and `one()` are the `Numeric` spelling of `ZERO()` and `ONE()`
+    # below, which predate the trait and stay as they are.
+    @always_inline
+    @staticmethod
+    def zero() -> Self:
+        """Returns a Decimal128 representing 0.
+
+        Returns:
+            A `Decimal128` representing zero.
+        """
+        return Self.ZERO()
+
+    @always_inline
+    @staticmethod
+    def one() -> Self:
+        """Returns a Decimal128 representing 1.
+
+        Returns:
+            A `Decimal128` representing one.
+        """
+        return Self.ONE()
 
     # Special values
     @always_inline

--- a/src/decimo/numeric.mojo
+++ b/src/decimo/numeric.mojo
@@ -1,0 +1,77 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright 2025-2026 Yuhao Zhu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""
+Traits describing what Decimo's number types can do.
+
+These exist so that code outside Decimo can be written once and run over
+`BigInt`, `BigDecimal` and `Decimal128` alike --- a matrix library being the
+motivating case. Mojo's trait conformance is nominal and has to be declared
+where the struct is defined, so the traits live here rather than in the
+consumer.
+
+One trait covers `BigInt`, `BigDecimal` and `Decimal128` alike, division
+included. Integer division is closed as long as it is understood the way Mojo's
+own `Int` understands it: `/` truncates toward zero and stays in the type, and
+`//` --- which floors, and so differs whenever the signs differ --- is a
+separate operator that this trait does not require.
+
+Every operation is declared `raises`, which is the widest signature: a
+non-raising implementation satisfies a raising requirement, so `BigInt.__add__`
+conforms unchanged while `BigDecimal.__add__` -- which really can raise --
+conforms too.
+"""
+
+
+trait Numeric(Copyable, Deinitable, Writable):
+    """A type closed under addition, subtraction and multiplication.
+
+    Enough for the whole of dense linear algebra: matrix addition, scaling,
+    multiplication, a trace, and the elimination algorithms that divide.
+    """
+
+    @staticmethod
+    def zero() -> Self:
+        """Returns the additive identity."""
+        ...
+
+    @staticmethod
+    def one() -> Self:
+        """Returns the multiplicative identity."""
+        ...
+
+    def __neg__(self) raises -> Self:
+        """Returns the additive inverse."""
+        ...
+
+    def __add__(self, other: Self) raises -> Self:
+        """Returns the sum of `self` and `other`."""
+        ...
+
+    def __sub__(self, other: Self) raises -> Self:
+        """Returns `other` subtracted from `self`."""
+        ...
+
+    def __mul__(self, other: Self) raises -> Self:
+        """Returns the product of `self` and `other`."""
+        ...
+
+    def __truediv__(self, other: Self) raises -> Self:
+        """Returns `self` divided by `other`.
+
+        On an integral type this truncates toward zero, as `Int` does.
+        """
+        ...

--- a/src/decimo/numeric.mojo
+++ b/src/decimo/numeric.mojo
@@ -18,7 +18,7 @@
 Traits describing what Decimo's number types can do.
 
 These exist so that code outside Decimo can be written once and run over
-`BigInt`, `BigDecimal` and `Decimal128` alike --- a matrix library being the
+`BigInt`, `BigDecimal` and `Decimal128` alike - a matrix library being the
 motivating case. Mojo's trait conformance is nominal and has to be declared
 where the struct is defined, so the traits live here rather than in the
 consumer.
@@ -26,17 +26,25 @@ consumer.
 One trait covers `BigInt`, `BigDecimal` and `Decimal128` alike, division
 included. Integer division is closed as long as it is understood the way Mojo's
 own `Int` understands it: `/` truncates toward zero and stays in the type, and
-`//` --- which floors, and so differs whenever the signs differ --- is a
+`//` (which floors, and so differs whenever the signs differ) is a
 separate operator that this trait does not require.
 
 Every operation is declared `raises`, which is the widest signature: a
 non-raising implementation satisfies a raising requirement, so `BigInt.__add__`
 conforms unchanged while `BigDecimal.__add__` -- which really can raise --
 conforms too.
+
+`Movable` sits alongside `Copyable` in the supertraits because every method
+here hands back an owned `Self`. A caller that stores such a result, or returns
+it onward, moves it; without the bound each consumer would have to spell
+`T: Numeric & Movable` to do the obvious thing with a result. The two are
+separate capabilities in this codebase (`BigFloat` is `Movable` but not
+`Copyable`) so requiring both is a real statement, and one all three
+conforming types already satisfy.
 """
 
 
-trait Numeric(Copyable, Deinitable, Writable):
+trait Numeric(Copyable, Deinitable, Movable, Writable):
     """A type closed under addition, subtraction and multiplication.
 
     Enough for the whole of dense linear algebra: matrix addition, scaling,

--- a/tests/bigint/test_bigint_arithmetics.mojo
+++ b/tests/bigint/test_bigint_arithmetics.mojo
@@ -314,6 +314,78 @@ def test_bigint_division_by_zero() raises:
 
     testing.assert_true(raised, "Truncate division by zero should raise")
 
+    raised = False
+    try:
+        _ = a / zero
+    except:
+        raised = True
+
+    testing.assert_true(raised, "True division by zero should raise")
+
+
+def test_bigint_true_divide_operator() raises:
+    """Test `/` on BigInt: closed, truncating toward zero, as Mojo's `Int` is.
+
+    `/` and `//` are different operations on an integer type and agree only
+    when the operands share a sign, so both halves are checked here.
+    """
+    # Exact quotients: the sign rule is invisible, both operators agree.
+    testing.assert_equal(String(BigInt(6) / BigInt(3)), "2", "6 / 3")
+    testing.assert_equal(String(BigInt(-6) / BigInt(3)), "-2", "-6 / 3")
+    testing.assert_equal(String(BigInt(6) / BigInt(-3)), "-2", "6 / -3")
+    testing.assert_equal(String(BigInt(-6) / BigInt(-3)), "2", "-6 / -3")
+
+    # Inexact and same-signed: truncation and flooring coincide.
+    testing.assert_equal(String(BigInt(7) / BigInt(2)), "3", "7 / 2")
+    testing.assert_equal(String(BigInt(-7) / BigInt(-2)), "3", "-7 / -2")
+    testing.assert_equal(String(BigInt(7) // BigInt(2)), "3", "7 // 2")
+
+    # Inexact and mixed-signed: this is where the two operators part ways.
+    testing.assert_equal(String(BigInt(-7) / BigInt(2)), "-3", "-7 / 2")
+    testing.assert_equal(String(BigInt(7) / BigInt(-2)), "-3", "7 / -2")
+    testing.assert_equal(String(BigInt(-7) // BigInt(2)), "-4", "-7 // 2")
+    testing.assert_equal(String(BigInt(7) // BigInt(-2)), "-4", "7 // -2")
+
+    # Magnitude smaller than the divisor truncates to zero, not to -1.
+    testing.assert_equal(String(BigInt(-1) / BigInt(2)), "0", "-1 / 2")
+    testing.assert_equal(String(BigInt(-1) // BigInt(2)), "-1", "-1 // 2")
+
+    # Zero dividend keeps a positive sign whatever the divisor's sign.
+    var zero_quotient = BigInt(0) / BigInt(-5)
+    testing.assert_equal(String(zero_quotient), "0", "0 / -5")
+    testing.assert_equal(
+        zero_quotient.sign, False, "0 / -5 must not be a negative zero"
+    )
+
+    # Values past 64 bits take the general path rather than a fast one.
+    var big = BigInt("123456789012345678901234567891")
+    testing.assert_equal(
+        String(-big / BigInt(7)),
+        "-17636684144620811271604938270",
+        "-big / 7 truncates toward zero",
+    )
+    testing.assert_equal(
+        String(-big // BigInt(7)),
+        "-17636684144620811271604938271",
+        "-big // 7 floors",
+    )
+
+
+def test_bigint_true_divide_matches_truncate_divide() raises:
+    """`/` is the operator spelling of `truncate_divide`, over every sign pair.
+    """
+    var values: List[Int] = [-97, -12, -1, 0, 1, 12, 97]
+    var divisors: List[Int] = [-11, -3, -1, 1, 3, 11]
+    for a in values:
+        for b in divisors:
+            var lhs = BigInt(a)
+            var rhs = BigInt(b)
+            testing.assert_equal(
+                String(lhs / rhs),
+                String(lhs.truncate_divide(rhs)),
+                String(a) + " / " + String(b),
+            )
+
 
 def test_bigint_zero_quotient_mixed_sign() raises:
     """Regression test: 0 // negative should be +0 with sign == False."""

--- a/tests/numeric/test_numeric_trait.mojo
+++ b/tests/numeric/test_numeric_trait.mojo
@@ -1,0 +1,143 @@
+"""
+Test that `BigInt`, `BigDecimal` and `Decimal128` are usable *through* the
+`Numeric` trait, not merely declared to conform to it.
+
+The helpers below are written once, against the trait alone. They can only
+compile if every required operation is present with the declared signature, and
+they can only produce the right answer if the conforming type's own method is
+the one that runs. Each concrete test then checks the result with the operators
+the concrete type has and the trait does not, `==` foremost.
+
+`_sum` additionally stores the element type in a `List` and returns an owned
+value, which is the case the `Movable` supertrait exists to serve.
+"""
+
+from std import testing
+
+from decimo.numeric import Numeric
+from decimo.bigint.bigint import BigInt
+from decimo.bigdecimal.bigdecimal import BigDecimal
+from decimo.decimal128.decimal128 import Decimal128
+
+
+def _sum[T: Numeric](values: List[T]) raises -> T:
+    """Adds a list of values, starting from the additive identity."""
+    var acc = T.zero()
+    for value in values:
+        acc = acc + value
+    return acc^
+
+
+def _horner[T: Numeric](c2: T, c1: T, c0: T, x: T) raises -> T:
+    """Evaluates `c2*x^2 + c1*x + c0` using only `+` and `*`."""
+    var acc = c2 * x + c1
+    acc = acc * x + c0
+    return acc^
+
+
+def _negated_difference[T: Numeric](a: T, b: T) raises -> T:
+    """Returns `-(a - b)`, exercising subtraction and negation together."""
+    return -(a - b)
+
+
+def _ratio_plus_one[T: Numeric](a: T, b: T) raises -> T:
+    """Returns `a / b + 1`, exercising division and the multiplicative identity.
+    """
+    return a / b + T.one()
+
+
+def test_bigint_through_numeric() raises:
+    """`BigInt` used through the trait."""
+    testing.assert_equal(BigInt.zero(), BigInt(0), "BigInt.zero()")
+    testing.assert_equal(BigInt.one(), BigInt(1), "BigInt.one()")
+
+    var values: List[BigInt] = [BigInt(1), BigInt(2), BigInt(3), BigInt(4)]
+    testing.assert_equal(_sum(values), BigInt(10), "sum of 1..4")
+
+    testing.assert_equal(
+        _horner(BigInt(2), BigInt(3), BigInt(4), BigInt(5)),
+        BigInt(69),
+        "2*5^2 + 3*5 + 4",
+    )
+    testing.assert_equal(
+        _negated_difference(BigInt(3), BigInt(10)),
+        BigInt(7),
+        "-(3 - 10)",
+    )
+    # Division truncates toward zero on an integer type: -7/2 is -3, not -4.
+    testing.assert_equal(
+        _ratio_plus_one(BigInt(-7), BigInt(2)),
+        BigInt(-2),
+        "-7 / 2 + 1",
+    )
+
+
+def test_bigdecimal_through_numeric() raises:
+    """`BigDecimal` used through the trait."""
+    testing.assert_equal(
+        BigDecimal.zero(), BigDecimal("0"), "BigDecimal.zero()"
+    )
+    testing.assert_equal(BigDecimal.one(), BigDecimal("1"), "BigDecimal.one()")
+
+    var values: List[BigDecimal] = [
+        BigDecimal("0.1"),
+        BigDecimal("0.2"),
+        BigDecimal("0.3"),
+    ]
+    testing.assert_equal(_sum(values), BigDecimal("0.6"), "0.1 + 0.2 + 0.3")
+
+    testing.assert_equal(
+        _horner(
+            BigDecimal("2"), BigDecimal("3"), BigDecimal("4"), BigDecimal("5")
+        ),
+        BigDecimal("69"),
+        "2*5^2 + 3*5 + 4",
+    )
+    testing.assert_equal(
+        _negated_difference(BigDecimal("3"), BigDecimal("10")),
+        BigDecimal("7"),
+        "-(3 - 10)",
+    )
+    # Division is exact here, so no rounding mode is in play: -7/2 is -3.5.
+    testing.assert_equal(
+        _ratio_plus_one(BigDecimal("-7"), BigDecimal("2")),
+        BigDecimal("-2.5"),
+        "-7 / 2 + 1",
+    )
+
+
+def test_decimal128_through_numeric() raises:
+    """`Decimal128` used through the trait."""
+    testing.assert_equal(
+        Decimal128.zero(), Decimal128("0"), "Decimal128.zero()"
+    )
+    testing.assert_equal(Decimal128.one(), Decimal128("1"), "Decimal128.one()")
+
+    var values: List[Decimal128] = [
+        Decimal128("0.1"),
+        Decimal128("0.2"),
+        Decimal128("0.3"),
+    ]
+    testing.assert_equal(_sum(values), Decimal128("0.6"), "0.1 + 0.2 + 0.3")
+
+    testing.assert_equal(
+        _horner(
+            Decimal128("2"), Decimal128("3"), Decimal128("4"), Decimal128("5")
+        ),
+        Decimal128("69"),
+        "2*5^2 + 3*5 + 4",
+    )
+    testing.assert_equal(
+        _negated_difference(Decimal128("3"), Decimal128("10")),
+        Decimal128("7"),
+        "-(3 - 10)",
+    )
+    testing.assert_equal(
+        _ratio_plus_one(Decimal128("-7"), Decimal128("2")),
+        Decimal128("-2.5"),
+        "-7 / 2 + 1",
+    )
+
+
+def main() raises:
+    testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -20,12 +20,13 @@
 #   rational    rat   frac      → Rational number tests
 #   expression  expr  eval      → Expression engine tests
 #   numerals    numeral chinese → Numeral system tests
+#   numeric     num             → Numeric trait conformance tests
 #   bigfloat    bfloat float    → BigFloat tests (requires MPFR)
 #   toml                        → TOML parser tests
 #   cli                         → CLI calculator tests
 #   python      py              → Python binding tests
 #   decimo      core            → All core suites (bigdecimal+bigint+biguint+bigint10+
-#                                 decimal128+rational+expression+numerals)
+#                                 decimal128+rational+expression+numerals+numeric)
 #   all                         → Everything (decimo + toml + cli)
 
 set -eo pipefail
@@ -82,6 +83,7 @@ run_decimal128()  { run_mojo_suite decimal128; }
 run_rational()    { run_mojo_suite rational; }
 run_expression()  { run_mojo_suite expression; }
 run_numerals()    { run_mojo_suite numerals; }
+run_numeric()     { run_mojo_suite numeric; }
 run_toml()        { run_mojo_suite toml; }
 
 run_bigfloat() {
@@ -332,6 +334,7 @@ run_decimo() {
     run_rational
     run_expression
     run_numerals
+    run_numeric
 }
 
 run_all() {
@@ -354,6 +357,7 @@ resolve() {
         rational|rat|frac)        echo "run_rational" ;;
         expression|expr|eval)     echo "run_expression" ;;
         numerals|numeral|chinese) echo "run_numerals" ;;
+        numeric|num)              echo "run_numeric" ;;
         bigfloat|bfloat|float)    echo "run_bigfloat" ;;
         toml)                     echo "run_toml" ;;
         cli)                      echo "run_cli" ;;
@@ -377,11 +381,12 @@ list_suites() {
     printf "  %-28s %s\n" "rational, rat, frac"         "Rational number tests"
     printf "  %-28s %s\n" "expression, expr, eval"      "Expression engine tests"
     printf "  %-28s %s\n" "numerals, numeral, chinese"  "Numeral system tests"
+    printf "  %-28s %s\n" "numeric, num"                "Numeric trait conformance tests"
     printf "  %-28s %s\n" "bigfloat, bfloat, float"     "BigFloat tests (requires MPFR)"
     printf "  %-28s %s\n" "toml"                        "TOML parser tests"
     printf "  %-28s %s\n" "cli"                         "CLI calculator tests"
     printf "  %-28s %s\n" "python, py"                  "Python binding tests"
-    printf "  %-28s %s\n" "decimo, core"                "All core suites (bdec+bint+buint+bint10+dec128+rational+expression)"
+    printf "  %-28s %s\n" "decimo, core"                "All core suites (bdec+bint+buint+bint10+dec128+rational+expression+numeric)"
     printf "  %-28s %s\n" "all"                         "Everything (decimo + toml + cli)"
 }
 


### PR DESCRIPTION
This PR adds a public `Numeric` trait and conforms `BigInt`, `BigDecimal`, and `Decimal128` to it.

**Changes:**
- Defines shared numeric operations and identities.
- Adds trait conformance and BigInt truncating division.
- Exports `Numeric` publicly.