### PR TITLE
[core][trait] Implement `Parsable` trait

### DIFF
--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -1252,12 +1252,19 @@ from decimo.expression import tokenize, parse_to_rpn, evaluate_rpn
 
 ### Appendix B — Traits Implemented
 
-All of these come from the Mojo standard library except **`Numeric`**, which
-Decimo defines in `decimo.numeric` and `BigInt`, `BigDecimal` and `Decimal128`
-all conform to. It gathers `zero()`, `one()`, `-x`, `+`, `-`, `*` and `/`, so a
-generic routine — a matrix or polynomial library, say — can be written once
-against `T: Numeric` and run over any of the three. Mojo checks conformance
-nominally, which is why the trait lives in Decimo rather than in the consumer.
+All of these come from the Mojo standard library except **`Numeric`** and
+**`Parsable`**, which Decimo defines in `decimo.traits` and `BigInt`,
+`BigDecimal` and `Decimal128` all conform to. Mojo checks conformance
+nominally, which is why they live in Decimo rather than in the consumer.
+
+`Numeric` gathers `zero()`, `one()`, `-x`, `+`, `-`, `*` and `/`, so a generic
+routine — a matrix or polynomial library, say — can be written once against
+`T: Numeric` and run over any of the three.
+
+`Parsable` requires the static `from_string(value)`, so the same generic
+routine can also fill itself from text. The two are separate because the
+capabilities are: `BigFloat` parses but is `Movable` without being `Copyable`,
+so it can never be `Numeric`. Ask for `T: Numeric & Parsable` to get both.
 
 #### BigInt <!-- omit from toc -->
 
@@ -1270,6 +1277,7 @@ nominally, which is why the trait lives in Decimo rather than in the consumer.
 | `FloatableRaising` | `Float64(x)`                     |
 | `IntableRaising`   | `Int(x)`                         |
 | `Numeric`          | Generic code over Decimo numbers |
+| `Parsable`         | `T.from_string(text)` in generic code |
 | `Representable`    | `repr(x)`                        |
 | `Stringable`       | `String(x)`, `str(x)`            |
 | `Writable`         | `print(x)`, writer protocol      |
@@ -1285,6 +1293,7 @@ nominally, which is why the trait lives in Decimo rather than in the consumer.
 | `FloatableRaising` | `Float64(x)`                     |
 | `IntableRaising`   | `Int(x)`                         |
 | `Numeric`          | Generic code over Decimo numbers |
+| `Parsable`         | `T.from_string(text)` in generic code |
 | `Representable`    | `repr(x)`                        |
 | `Roundable`        | `round(x)`, `round(x, ndigits)`  |
 | `Stringable`       | `String(x)`, `str(x)`            |

--- a/src/decimo/__init__.mojo
+++ b/src/decimo/__init__.mojo
@@ -38,7 +38,7 @@ comptime DECIMO_VERSION_TAG = "v" + DECIMO_VERSION
 """
 
 # Traits
-from .numeric import Numeric
+from .traits import Numeric, Parsable
 
 # Core types
 from .decimal128.decimal128 import Decimal128, Dec128

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -28,7 +28,7 @@ from std.python import PythonObject
 from std import testing
 
 from decimo.errors import ConversionError, ValueError
-from decimo.numeric import Numeric
+from decimo.traits import Numeric, Parsable
 from decimo.rounding_mode import RoundingMode
 from decimo.numerals.chinese import ChineseNumeralStyle
 from decimo.bigdecimal.exponential import MathCache
@@ -113,6 +113,7 @@ struct BigDecimal(
     IntableRaising,
     Movable,
     Numeric,
+    Parsable,
     Roundable,
     Writable,
 ):

--- a/src/decimo/bigint/bigint.mojo
+++ b/src/decimo/bigint/bigint.mojo
@@ -38,7 +38,7 @@ import decimo.bigint.exponential as bigint_exponential
 import decimo.bigint.number_theory as bigint_number_theory
 import decimo.bigint.special as bigint_special
 import decimo.str as decimo_str
-from decimo.numeric import Numeric
+from decimo.traits import Numeric, Parsable
 import decimo.numerals.chinese as decimo_chinese
 from decimo.numerals.chinese import ChineseNumeralStyle
 from decimo.bigint10.bigint10 import BigInt10
@@ -66,6 +66,7 @@ struct BigInt(
     IntableRaising,
     Movable,
     Numeric,
+    Parsable,
     Writable,
 ):
     """An arbitrary-precision signed integer, similar to Python's `int`.

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -40,7 +40,7 @@ from decimo.errors import (
 )
 import decimo.decimal128.utility as decimal128_utility
 from decimo.bigdecimal.bigdecimal import BigDecimal
-from decimo.numeric import Numeric
+from decimo.traits import Numeric, Parsable
 
 comptime Dec128 = Decimal128
 """A 128-bit fixed-point decimal number."""
@@ -54,6 +54,7 @@ struct Decimal128(
     Hashable,
     IntableRaising,
     Numeric,
+    Parsable,
     Roundable,
     TrivialRegisterPassable,
     Writable,

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -161,7 +161,7 @@ struct Decimal128(
     # Special values
     @always_inline
     @staticmethod
-    def ZERO() -> Decimal128:
+    def ZERO() -> Self:
         """Returns a Decimal128 representing 0.
 
         Returns:
@@ -171,7 +171,7 @@ struct Decimal128(
 
     @always_inline
     @staticmethod
-    def ONE() -> Decimal128:
+    def ONE() -> Self:
         """Returns a Decimal128 representing 1.
 
         Returns:
@@ -181,7 +181,7 @@ struct Decimal128(
 
     @always_inline
     @staticmethod
-    def MAX() -> Decimal128:
+    def MAX() -> Self:
         """
         Returns the maximum possible Decimal128 value.
         This is equivalent to 79228162514264337593543950335.
@@ -193,7 +193,7 @@ struct Decimal128(
 
     @always_inline
     @staticmethod
-    def MIN() -> Decimal128:
+    def MIN() -> Self:
         """Returns the minimum possible Decimal128 value (negative of MAX).
         This is equivalent to -79228162514264337593543950335.
 
@@ -204,7 +204,7 @@ struct Decimal128(
 
     @always_inline
     @staticmethod
-    def PI() -> Decimal128:
+    def PI() -> Self:
         """Returns the value of pi (π) as a Decimal128.
 
         Returns:
@@ -214,7 +214,7 @@ struct Decimal128(
 
     @always_inline
     @staticmethod
-    def E() -> Decimal128:
+    def E() -> Self:
         """Returns the value of Euler's number (e) as a Decimal128.
 
         Returns:
@@ -626,7 +626,7 @@ struct Decimal128(
     @always_inline
     def from_uint128(
         value: UInt128, scale: UInt32 = 0, sign: Bool = False
-    ) raises -> Decimal128:
+    ) raises -> Self:
         """Initializes a Decimal128 from a UInt128 value.
 
         Args:
@@ -655,7 +655,7 @@ struct Decimal128(
         return result
 
     @staticmethod
-    def from_string(value: String) raises -> Decimal128:
+    def from_string(value: String) raises -> Self:
         """Initializes a Decimal128 from a string representation.
 
         Args:
@@ -927,7 +927,7 @@ struct Decimal128(
             )
 
     @staticmethod
-    def from_float(value: Float64) raises -> Decimal128:
+    def from_float(value: Float64) raises -> Self:
         """Initializes a Decimal128 from a floating-point value.
         The reliability of this method is limited by the precision of Float64.
         Float64 is reliable up to 15 significant digits and marginally
@@ -2033,7 +2033,7 @@ struct Decimal128(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    def max(self, other: Decimal128) -> Decimal128:
+    def max(self, other: Decimal128) -> Self:
         """Returns the larger of `self` and `other`.
         See `max()` for more information.
 
@@ -2046,7 +2046,7 @@ struct Decimal128(
         return decimal128_comparison.max(self, other)
 
     @always_inline
-    def min(self, other: Decimal128) -> Decimal128:
+    def min(self, other: Decimal128) -> Self:
         """Returns the smaller of `self` and `other`.
         See `min()` for more information.
 
@@ -2059,7 +2059,7 @@ struct Decimal128(
         return decimal128_comparison.min(self, other)
 
     @always_inline
-    def clamp(self, lower: Decimal128, upper: Decimal128) raises -> Decimal128:
+    def clamp(self, lower: Decimal128, upper: Decimal128) raises -> Self:
         """Clamps `self` into the closed interval `[lower, upper]`.
         See `clamp()` for more information.
 
@@ -2268,7 +2268,7 @@ struct Decimal128(
         return decimal128_exponential.ln(self)
 
     @always_inline
-    def log10(self) raises -> Decimal128:
+    def log10(self) raises -> Self:
         """Computes the base-10 logarithm of this Decimal128.
 
         Returns:
@@ -2280,7 +2280,7 @@ struct Decimal128(
         return decimal128_exponential.log10(self)
 
     @always_inline
-    def log(self, base: Decimal128) raises -> Decimal128:
+    def log(self, base: Decimal128) raises -> Self:
         """Computes the logarithm of this Decimal128 with an arbitrary base.
 
         Args:
@@ -2295,7 +2295,7 @@ struct Decimal128(
         return decimal128_exponential.log(self, base)
 
     @always_inline
-    def power(self, exponent: Int) raises -> Decimal128:
+    def power(self, exponent: Int) raises -> Self:
         """Raises this Decimal128 to the power of an integer.
 
         Args:
@@ -2311,7 +2311,7 @@ struct Decimal128(
         return decimal128_exponential.power(self, Self(exponent))
 
     @always_inline
-    def power(self, exponent: Decimal128) raises -> Decimal128:
+    def power(self, exponent: Decimal128) raises -> Self:
         """Raises this Decimal128 to the power of another Decimal128.
 
         Args:
@@ -2795,7 +2795,7 @@ struct Decimal128(
         #     | UInt128(self.low)
         # )
 
-    def extend_precision(self, var precision_diff: Int) raises -> Decimal128:
+    def extend_precision(self, var precision_diff: Int) raises -> Self:
         """Returns a number with additional decimal128 places (trailing zeros).
         This multiplies the coefficient by 10^precision_diff and increases
         the scale accordingly, preserving the numeric value.

--- a/src/decimo/traits.mojo
+++ b/src/decimo/traits.mojo
@@ -23,11 +23,16 @@ motivating case. Mojo's trait conformance is nominal and has to be declared
 where the struct is defined, so the traits live here rather than in the
 consumer.
 
-One trait covers `BigInt`, `BigDecimal` and `Decimal128` alike, division
+`Numeric` covers `BigInt`, `BigDecimal` and `Decimal128` alike, division
 included. Integer division is closed as long as it is understood the way Mojo's
 own `Int` understands it: `/` truncates toward zero and stays in the type, and
 `//` (which floors, and so differs whenever the signs differ) is a
 separate operator that this trait does not require.
+
+`Parsable` is separate from `Numeric` because the two capabilities are
+independent. `BigFloat` parses but is `Movable` without being `Copyable`, so it
+can never be `Numeric`; a numeric type with no decimal spelling is equally
+imaginable. Splitting them lets each consumer ask for what it actually uses.
 
 Every operation is declared `raises`, which is the widest signature: a
 non-raising implementation satisfies a raising requirement, so `BigInt.__add__`
@@ -81,5 +86,30 @@ trait Numeric(Copyable, Deinitable, Movable, Writable):
         """Returns `self` divided by `other`.
 
         On an integral type this truncates toward zero, as `Int` does.
+        """
+        ...
+
+
+trait Parsable:
+    """A type that can be built from its decimal string form.
+
+    The counterpart of `Writable`: `Parsable` reads a number back out of the
+    text that `write_to` produced. It is what lets a container be filled from a
+    literal - a matrix parsed out of `"[[1.1, 2.2], [3.3, 4.4]]"` - without the
+    container knowing which number type it holds.
+    """
+
+    @staticmethod
+    def from_string(value: String) raises -> Self:
+        """Returns the value the decimal literal `value` denotes.
+
+        Args:
+            value: The decimal literal to parse.
+
+        Returns:
+            The parsed value.
+
+        Raises:
+            Error: If `value` is not a decimal literal this type accepts.
         """
         ...

--- a/tests/traits/test_numeric_trait.mojo
+++ b/tests/traits/test_numeric_trait.mojo
@@ -14,7 +14,7 @@ value, which is the case the `Movable` supertrait exists to serve.
 
 from std import testing
 
-from decimo.numeric import Numeric
+from decimo.traits import Numeric
 from decimo.bigint.bigint import BigInt
 from decimo.bigdecimal.bigdecimal import BigDecimal
 from decimo.decimal128.decimal128 import Decimal128

--- a/tests/traits/test_parsable_trait.mojo
+++ b/tests/traits/test_parsable_trait.mojo
@@ -22,9 +22,14 @@ from decimo.decimal128.decimal128 import Decimal128
 
 
 def _parse_all[
-    T: Copyable & Deinitable & Parsable
+    T: Movable & Deinitable & Parsable
 ](tokens: List[String]) raises -> List[T]:
-    """Parses every token into `T`, naming no concrete type."""
+    """Parses every token into `T`, naming no concrete type.
+
+    The bound is `Movable` rather than `Copyable` because nothing here
+    copies, and because `Parsable` is meant to reach types like
+    `BigFloat` that move without copying.
+    """
     var out = List[T](capacity=len(tokens))
     for token in tokens:
         out.append(T.from_string(token))

--- a/tests/traits/test_parsable_trait.mojo
+++ b/tests/traits/test_parsable_trait.mojo
@@ -1,0 +1,85 @@
+"""
+Test that `BigInt`, `BigDecimal` and `Decimal128` are usable *through* the
+`Parsable` trait, not merely declared to conform to it.
+
+`_parse_all` is written once, against the trait alone, and is the shape every
+real consumer has: text goes in, a container of some number type comes out,
+and the code doing the filling never names the type. It compiles only if
+`from_string` is present with the declared signature, and it produces the right
+answer only if the conforming type's own parser is the one that runs.
+
+The values are chosen so a binary float cannot stand in for the result. `0.1`
+has no exact `Float64`, so a type that quietly went through one would fail the
+sum below rather than merely lose a digit somewhere invisible.
+"""
+
+from std import testing
+
+from decimo.traits import Parsable
+from decimo.bigint.bigint import BigInt
+from decimo.bigdecimal.bigdecimal import BigDecimal
+from decimo.decimal128.decimal128 import Decimal128
+
+
+def _parse_all[
+    T: Copyable & Deinitable & Parsable
+](tokens: List[String]) raises -> List[T]:
+    """Parses every token into `T`, naming no concrete type."""
+    var out = List[T](capacity=len(tokens))
+    for token in tokens:
+        out.append(T.from_string(token))
+    return out^
+
+
+def test_bigint_through_parsable() raises:
+    """`BigInt` parsed through the trait, past the range of any fixed width."""
+    var tokens: List[String] = [
+        "0",
+        "-42",
+        "170141183460469231731687303715884105728",
+    ]
+    var values = _parse_all[BigInt](tokens)
+
+    testing.assert_equal(values[0], BigInt(0), "0")
+    testing.assert_equal(values[1], BigInt(-42), "-42")
+    testing.assert_equal(
+        values[2],
+        BigInt(2) ** BigInt(127),
+        "2^127, one past what a 128-bit signed integer holds",
+    )
+
+
+def test_bigdecimal_through_parsable() raises:
+    """`BigDecimal` parsed through the trait, with the digits kept exactly."""
+    var tokens: List[String] = ["0.1", "0.2", "1e-3"]
+    var values = _parse_all[BigDecimal](tokens)
+
+    testing.assert_equal(
+        values[0] + values[1], BigDecimal("0.3"), "0.1 + 0.2 is exactly 0.3"
+    )
+    testing.assert_equal(values[2], BigDecimal("0.001"), "1e-3")
+
+
+def test_decimal128_through_parsable() raises:
+    """`Decimal128` parsed through the trait."""
+    var tokens: List[String] = ["0.1", "0.2", "-7.25"]
+    var values = _parse_all[Decimal128](tokens)
+
+    testing.assert_equal(
+        values[0] + values[1], Decimal128("0.3"), "0.1 + 0.2 is exactly 0.3"
+    )
+    testing.assert_equal(values[2], Decimal128("-7.25"), "-7.25")
+
+
+def test_parsable_rejects_nonsense() raises:
+    """A token that is not a number raises rather than parsing to zero."""
+    var raised = False
+    try:
+        _ = BigInt.from_string("not a number")
+    except:
+        raised = True
+    testing.assert_true(raised, "BigInt.from_string('not a number')")
+
+
+def main() raises:
+    testing.TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
This PR introduces a new `Parsable` trait in Decimo’s core traits module so generic consumers can construct numeric values from decimal string literals without naming a concrete number type, and updates core types/docs/tests to use it alongside the existing `Numeric` trait.

**Changes:**
- Add `Parsable` trait (with `from_string`) to `decimo.traits` and export it from the package init.
- Declare `Parsable` conformance for `BigInt`, `BigDecimal`, and `Decimal128`, and update imports to reference `decimo.traits`.
- Add trait-level test coverage for parsing through the trait and update the user manual trait appendix.