### PR TITLE
[trait] Add `Rootable` trait

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -284,6 +284,34 @@ jobs:
             sleep 5
           done
 
+  # ── Test: Traits ──────────────────────────────────────────────────────────
+  # `Numeric`, `Parsable` and `Rootable`. These suites are generic code, so a
+  # conformance that no longer holds is a compile error rather than a failed
+  # assertion, and only a job that builds them catches it.
+  test-traits:
+    name: Test Traits
+    needs: build
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-decimo
+      - name: Run tests (with retry for Mojo compiler intermittent crashes)
+        run: |
+          for attempt in 1 2 3; do
+            echo "=== test attempt $attempt ==="
+            if bash tests/test.sh traits; then
+              echo "=== tests passed on attempt $attempt ==="
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "=== tests failed after 3 attempts ==="
+              exit 1
+            fi
+            echo "=== test run crashed, retrying in 5s... ==="
+            sleep 5
+          done
+
   # ── Test: BigFloat ─────────────────────────────────────────────────────────
   test-bigfloat:
     name: Test BigFloat

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Comes with an interactive arbitrary-precision calculator (REPL + one-shot mode)
 powered by [ArgMojo](https://github.com/forfudan/argmojo). Install it with
 `brew install forfudan/tap/decimo`.
 
-[![Version](https://img.shields.io/badge/version-v0.12.0-blue)](https://github.com/forfudan/decimo/releases/tag/v0.12.0)
+[![Version](https://img.shields.io/badge/version-v0.13.0-blue)](https://github.com/forfudan/decimo/releases/tag/v0.13.0)
 [![Mojo](https://img.shields.io/badge/mojo-1.0.0-orange)](https://docs.modular.com/mojo/manual/)
 [![pixi](https://img.shields.io/badge/pixi%20add-decimo-purple)](https://prefix.dev/channels/modular-community/packages/decimo)
 [![CI](https://img.shields.io/github/actions/workflow/status/forfudan/decimo/run_tests.yaml?branch=main&label=tests)](https://github.com/forfudan/decimo/actions/workflows/run_tests.yaml)
@@ -21,7 +21,7 @@ powered by [ArgMojo](https://github.com/forfudan/argmojo). Install it with
 | `Decimal128` | `Dec128`          | 128-bit fixed-precision decimal type     | 32-bit words |
 | `BigFloat`   | `Float`           | Arbitrary-precision floating-point type  | MPFR/GMP     |
 
-<!-- 
+<!--
 [![License](https://img.shields.io/github/license/forfudan/decimo)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/forfudan/decimo?style=flat)](https://github.com/forfudan/decimo/stargazers)
 [![Issues](https://img.shields.io/github/issues/forfudan/decimo)](https://github.com/forfudan/decimo/issues)
@@ -29,7 +29,7 @@ powered by [ArgMojo](https://github.com/forfudan/argmojo). Install it with
 [![Last Commit](https://img.shields.io/github/last-commit/forfudan/decimo?color=red)](https://github.com/forfudan/decimo/commits/main)
 -->
 
-<!-- 
+<!--
 [![中文](https://img.shields.io/badge/中文-介紹-red)](https://github.com/forfudan/decimo/blob/main/docs/readme_zht.md)
 [![Changelog](https://img.shields.io/badge/change-log-yellow)](https://github.com/forfudan/decimo/blob/main/docs/changelog.md)
 [![Repository on GitHub](https://img.shields.io/badge/repo-GitHub-black)](https://github.com/forfudan/decimo)
@@ -111,7 +111,7 @@ Then, you can install Decimo using any of these methods:
 1. In the `mojoproject.toml` file of your project, add the following dependency:
 
     ```toml
-    decimo = "==0.12.0"
+    decimo = ">=0.13.0, <0.14.0"
     ```
 
     Then run `pixi install` to download and install the package.
@@ -123,21 +123,22 @@ Then, you can install Decimo using any of these methods:
 The following table summarizes the package versions and their corresponding Mojo
 versions:
 
-| library    | version | Mojo version  | package manager |
-| ---------- | ------- | ------------- | --------------- |
-| `decimojo` | v0.1.0  | ==25.1        | magic           |
-| `decimojo` | v0.2.0  | ==25.2        | magic           |
-| `decimojo` | v0.3.0  | ==25.2        | magic           |
-| `decimojo` | v0.3.1  | >=25.2, <25.4 | pixi            |
-| `decimojo` | v0.4.x  | ==25.4        | pixi            |
-| `decimojo` | v0.5.0  | ==25.5        | pixi            |
-| `decimojo` | v0.6.0  | ==0.25.7      | pixi            |
-| `decimojo` | v0.7.0  | ==0.26.1      | pixi            |
-| `decimo`   | v0.8.0  | ==0.26.1      | pixi            |
-| `decimo`   | v0.9.0  | ==0.26.2      | pixi            |
-| `decimo`   | v0.10.0 | ==1.0.0b1     | pixi            |
-| `decimo`   | v0.11.0 | ==1.0.0b2     | pixi            |
-| `decimo`   | v0.12.0 | ==1.0.0       | pixi            |
+| library    | version | Mojo version    | package manager |
+| ---------- | ------- | --------------- | --------------- |
+| `decimojo` | v0.1.0  | ==25.1          | magic           |
+| `decimojo` | v0.2.0  | ==25.2          | magic           |
+| `decimojo` | v0.3.0  | ==25.2          | magic           |
+| `decimojo` | v0.3.1  | >=25.2, <25.4   | pixi            |
+| `decimojo` | v0.4.x  | ==25.4          | pixi            |
+| `decimojo` | v0.5.0  | ==25.5          | pixi            |
+| `decimojo` | v0.6.0  | ==0.25.7        | pixi            |
+| `decimojo` | v0.7.0  | ==0.26.1        | pixi            |
+| `decimo`   | v0.8.0  | ==0.26.1        | pixi            |
+| `decimo`   | v0.9.0  | ==0.26.2        | pixi            |
+| `decimo`   | v0.10.0 | ==1.0.0b1       | pixi            |
+| `decimo`   | v0.11.0 | ==1.0.0b2       | pixi            |
+| `decimo`   | v0.12.0 | >=1.0.0, <1.1.0 | pixi            |
+| `decimo`   | v0.13.0 | >=1.0.0, <1.1.0 | pixi            |
 
 ### Install CLI calculator
 
@@ -545,7 +546,7 @@ If you find Decimo useful, consider listing it in your citations.
     year         = {2026},
     title        = {Decimo: An arbitrary-precision integer and decimal library for Mojo},
     url          = {https://github.com/forfudan/decimo},
-    version      = {0.12.0},
+    version      = {0.13.0},
     note         = {Computer Software}
 }
 ```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,90 @@
 
 This is a list of changes for the Decimo package (formerly DeciMojo).
 
+## 20260822 (v0.13.0)
+
+Decimo v0.13.0 is a **traits** release. `Numeric`, `Parsable` and `Rootable`
+let code be written once and run over `BigInt`, `BigUInt`, `BigDecimal`,
+`Decimal128` and `BigFloat` alike — a matrix library asking for
+`T: Numeric & Rootable` is the motivating case. `BigInt` gains `/`. The errors
+module is reworked so that the error kinds are functions returning a plain
+`Error`, which is a breaking change for code that spells a typed raise such as
+`raises ValueError` in its own signatures.
+
+### ⭐️ New in v0.13.0
+
+**Traits (`decimo.traits`)**:
+
+1. **`Numeric`** — `zero()`, `one()`, `-x`, `+`, `-`, `*` and `/`, conformed to
+   by `BigInt`, `BigDecimal` and `Decimal128`. Enough for the whole of dense
+   linear algebra. Every operation is declared `raises`, the widest signature,
+   so a non-raising implementation conforms unchanged (PR #265).
+1. **`Parsable`** — the static `from_string()`, and the counterpart of
+   `Writable`: it lets a container be filled from a literal without knowing
+   which number type it holds. Same three types (PR #266).
+1. **`Rootable`** — `sqrt()`, conformed to by five types, `BigUInt` and
+   `BigFloat` included. It is separate from `Numeric` because those two can
+   never be `Numeric`: `BigUInt` is unsigned and so has no `__neg__`, and
+   `BigFloat` is `Movable` without being `Copyable`. What the root means stays
+   the implementing type's business — on an integral type it truncates, so
+   `BigInt("10").sqrt()` is `3` (PR #268).
+
+**Other additions**:
+
+1. **`BigInt.__truediv__`** — `/` on integers is closed and truncates toward
+   zero, matching Mojo's own `Int`: `BInt(-7) / BInt(2)` is `-3` where
+   `BInt(-7) // BInt(2)` is `-4`. The two operators differ exactly when the
+   operands have opposite signs (PR #265).
+1. **`BigDecimal.zero()` / `one()`** and **`Decimal128.zero()` / `one()`**, the
+   `Numeric` spelling of the identities. `Decimal128.ZERO()` and `ONE()` stay
+   as they are (PR #265).
+1. **`PRECISION`** (28, the same default as Python's `decimal`) is exported
+   from the top level, so a caller can name the default it is getting (PR
+   #268).
+
+### 🦋 Changed in v0.13.0
+
+**Errors** (PR #267):
+
+1. **The error kinds are now functions**, not aliases for a parametrised
+   payload type: `ValueError`, `OverflowError` and the rest return a plain
+   **`Error`**, so an enclosing function needs nothing beyond a bare `raises`.
+   Raise sites are unchanged, but a signature can no longer be spelled
+   `raises ValueError` — a typed raise is invariant in Mojo v1.0.0, which cuts
+   such a function off from `std.testing` and from any ordinary helper.
+   `BaseError` is now the payload only.
+1. A new comptime toggle **`_USE_COLOUR`** blanks every ANSI escape, for when
+   the tracebacks go to a log file rather than a terminal. Chained tracebacks
+   gain a blank line after the separator, and a frame now names the function it
+   was raised in.
+
+**Signatures** (PR #268):
+
+1. **`BigDecimal.sqrt()`** splits its defaulted `precision` into the overloads
+   `sqrt(self)` and `sqrt(self, precision)`, since in Mojo a default argument
+   does not satisfy a trait signature. Existing calls are unaffected.
+1. **`root()` converges on one spelling**, `root(self, n: Int)`, which
+   `BigDecimal`, `Decimal128` and `BigFloat` now all accept. `BigDecimal` keeps
+   its `BigDecimal`-degree overloads for non-integral roots and `BigFloat` its
+   `UInt32` one. Every existing call keeps working. `root` is deliberately not
+   part of `Rootable`: `BigInt` and `BigUInt` have no nth root to offer.
+
+**Documentation and tooling:**
+
+1. Markdown across the repository is **reformatted** — long lines rewrapped and
+   list formatting made uniform — and **`argmojo`** is an active Pixi
+   dependency again, pinned to `>=0.8.0,<0.9.0` now that modular-community
+   ships it (PR #264).
+1. The user manual's **Appendix B** documents the three traits and which types
+   conform; the `BigInt` division section covers the new `/` (PR #265, #266,
+   #268).
+1. The test suite **`numeric` is renamed to `traits`**, with `numeric` and
+   `num` kept as aliases and the tests moved to `tests/traits/` (PR #266,
+   #267).
+1. **`tests/test.sh` bug fix**: the retry loop read `$?` after an `if`, which
+   is the `if` statement's own status — zero — so a suite that failed to
+   compile was reported as passing. It now uses `&&` (PR #268).
+
 ## 20260812 (v0.12.0)
 
 Decimo v0.12.0 retargets the codebase to **Mojo v1.0.0**, promotes the CLI's

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,7 +28,8 @@ module is reworked so that the error kinds are functions returning a plain
    never be `Numeric`: `BigUInt` is unsigned and so has no `__neg__`, and
    `BigFloat` is `Movable` without being `Copyable`. What the root means stays
    the implementing type's business — on an integral type it truncates, so
-   `BigInt("10").sqrt()` is `3` (PR #268).
+   `BigInt("10").sqrt()` is `3`, and a negative value raises on the four exact
+   types but yields `nan` on `BigFloat` (PR #268).
 
 **Other additions**:
 

--- a/docs/readme_zht.md
+++ b/docs/readme_zht.md
@@ -1,6 +1,7 @@
 # Decimo（原名 DeciMojo） <!-- omit from toc -->
 
-由 [Mojo 程序設計語言 🔥](https://www.modular.com/mojo) 實現的任意精度整數和小數運算庫，靈感來源自 Python 的 `int` 和 `Decimal`。
+由 [Mojo 程序設計語言 🔥](https://www.modular.com/mojo)
+實現的任意精度整數和小數運算庫，靈感來源自 Python 的 `int` 和 `Decimal`。
 
 **[English](https://zhuyuhao.com/decimo/)**　|　**[更新日誌](https://github.com/forfudan/decimo/blob/main/docs/changelog.md)**　|　**[GitHub 倉庫»](https://github.com/forfudan/decimo)**　|　**[Discord 頻道»](https://discord.gg/3rGH87uZTk)**
 
@@ -15,15 +16,19 @@
 
 ## 概述
 
-Decimo 爲 Mojo 提供任意精度整數和小數運算庫，爲金融建模、科學計算以及浮點近似誤差不可接受的應用提供精確計算。除了基本算術運算外，該庫還包括具有保證精度的高級數學函數。
+Decimo 爲 Mojo
+提供任意精度整數和小數運算庫，爲金融建模、科學計算以及浮點近似誤差不可接受的應用提供精確計算。除了基本算術運算外，該庫還包括具有保證精度的高級數學函數。
 
-對於 Python 用戶，`decimo.BInt` 之於 Mojo 就如同 `int` 之於 Python，`decimo.Decimal` 之於 Mojo 就如同 `decimal.Decimal` 之於 Python。
+對於 Python 用戶，`decimo.BInt` 之於 Mojo 就如同 `int` 之於
+Python，`decimo.Decimal` 之於 Mojo 就如同 `decimal.Decimal` 之於 Python。
 
 核心類型包括:
 
 - 任意精度有符號整數類型 `BInt`[^bigint]，是 Python `int` 的 Mojo 原生等價實現。
-- 任意精度小數實現 (`Decimal`)，允許進行無限位數和小數位的計算[^arbitrary]，是 Python `decimal.Decimal` 的 Mojo 原生等價實現。
-- 128 位定點小數實現 (`Dec128`)，支持最多 29 位有效數字，小數點後最多 28 位數字[^fixed]。
+- 任意精度小數實現 (`Decimal`)，允許進行無限位數和小數位的計算[^arbitrary]，是
+  Python `decimal.Decimal` 的 Mojo 原生等價實現。
+- 128 位定點小數實現 (`Dec128`)，支持最多 29 位有效數字，小數點後最多 28
+  位數字[^fixed]。
 
 | 類型      | 別名                 | 信息                               | 內部表示     |
 | --------- | -------------------- | ---------------------------------- | ------------ |
@@ -31,22 +36,30 @@ Decimo 爲 Mojo 提供任意精度整數和小數運算庫，爲金融建模、�
 | `Decimal` | `BigDecimal`, `BDec` | 等價於 Python 的 `decimal.Decimal` | Base-10^9    |
 | `Dec128`  | `Decimal128`         | 128 位定點精度小數類型             | 三個 32 位字 |
 
-輔助類型包括基於 10 進制的任意精度有符號整數類型 (`BigInt10`) 和任意精度無符號整數類型 (`BigUInt`)，支持無限位數[^bigint10]。`BigUInt` 是 `BigInt10` 和 `Decimal` 的內部表示。
+輔助類型包括基於 10 進制的任意精度有符號整數類型 (`BigInt10`)
+和任意精度無符號整數類型 (`BigUInt`)，支持無限位數[^bigint10]。`BigUInt` 是
+`BigInt10` 和 `Decimal` 的內部表示。
 
 ---
 
 > 得此魔咒者，即脱凡相，識天數，斬三尸，二十七日飛升。
 > —— 《太上靈通感應二十七章經》
 
-Decimo 是 Decimal 和 Mojo 的組合，既反映了它的目的，也反應了它的設計語言。Decimo本身也是拉丁語的詞，意爲「第十」，即「十進制」一詞的詞源。
+Decimo 是 Decimal 和 Mojo
+的組合，既反映了它的目的，也反應了它的設計語言。Decimo本身也是拉丁語的詞，意爲「第十」，即「十進制」一詞的詞源。
 
 ---
 
-此倉庫包含內建的 [TOML 解析器](./docs/readme_toml.md)（`decimo.toml`），一個純 Mojo 實現的輕量級 TOML v1.0 解析器。它解析配置文件和測試數據，支持基本類型、數組和嵌套表。雖然爲 Decimo 的測試框架而創建，但它提供通用的結構化數據解析，具有簡潔的 API。
+此倉庫包含內建的 [TOML 解析器](./docs/readme_toml.md)（`decimo.toml`），一個純
+Mojo 實現的輕量級 TOML v1.0
+解析器。它解析配置文件和測試數據，支持基本類型、數組和嵌套表。雖然爲 Decimo
+的測試框架而創建，但它提供通用的結構化數據解析，具有簡潔的 API。
 
 ## 安裝
 
-Decimo 可在 modular-community `https://repo.prefix.dev/modular-community` 包倉庫中獲取。爲了訪問此倉庫，請將其添加到您的 `pixi.toml` 文件中的 `channels` 列表：
+Decimo 可在 modular-community `https://repo.prefix.dev/modular-community`
+包倉庫中獲取。爲了訪問此倉庫，請將其添加到您的 `pixi.toml` 文件中的 `channels`
+列表：
 
 ```toml
 channels = ["https://conda.modular.com/max", "https://repo.prefix.dev/modular-community", "conda-forge"]
@@ -54,17 +67,20 @@ channels = ["https://conda.modular.com/max", "https://repo.prefix.dev/modular-co
 
 接下來，您可以使用以下任一方法進行安裝：
 
-1. 從 `pixi` CLI，運行命令 ```pixi add decimo```。這會獲取最新版本並使其立即可用於導入。
+1. 從 `pixi`
+   CLI，運行命令 ```pixi add decimo```。這會獲取最新版本並使其立即可用於導入。
 
 1. 在您項目的 `mojoproject.toml` 文件中，添加以下依賴：
 
     ```toml
-    decimo = "==0.12.0"
+    decimo = "==0.13.0"
     ```
 
     然後運行 `pixi install` 來下載並安裝包。
 
-1. 對於 `main` 分支中的最新開發版本，請克隆 [此 GitHub 倉庫](https://github.com/forfudan/decimo) 並使用命令 `pixi run package` 在本地構建包。
+1. 對於 `main` 分支中的最新開發版本，請克隆
+   [此 GitHub 倉庫](https://github.com/forfudan/decimo) 並使用命令
+   `pixi run package` 在本地構建包。
 
 下表總結了包版本及其對應的 Mojo 版本：
 
@@ -83,10 +99,12 @@ channels = ["https://conda.modular.com/max", "https://repo.prefix.dev/modular-co
 | `decimo`   | v0.10.0 | ==1.0.0b1     | pixi     |
 | `decimo`   | v0.11.0 | ==1.0.0b2     | pixi     |
 | `decimo`   | v0.12.0 | ==1.0.0       | pixi     |
+| `decimo`   | v0.13.0 | ==1.0.0       | pixi     |
 
 ## 快速開始
 
-您可以通過導入 `decimo` 模塊開始使用 Decimo。一個簡單的方法是從 `prelude` 模塊導入所有內容，它提供最常用的類型。
+您可以通過導入 `decimo` 模塊開始使用 Decimo。一個簡單的方法是從 `prelude`
+模塊導入所有內容，它提供最常用的類型。
 
 ```mojo
 from decimo import *
@@ -95,14 +113,18 @@ from decimo import *
 這將導入以下類型或別名到您的命名空間：
 
 - `BInt`（`BigInt` 的別名）：任意精度有符號整數類型，等價於 Python 的 `int`。
-- `Decimal`（也可用 `BigDecimal` 或 `BDec`）：任意精度小數類型，等價於 Python 的 `decimal.Decimal`。
+- `Decimal`（也可用 `BigDecimal` 或 `BDec`）：任意精度小數類型，等價於 Python 的
+  `decimal.Decimal`。
 - `Dec128`（`Decimal128` 的別名）：128 位定點精度小數類型。
 - `RoundingMode`：捨入模式的枚舉。
 - `ROUND_DOWN`、`ROUND_HALF_UP`、`ROUND_HALF_EVEN`、`ROUND_UP`：常用捨入模式的常量。
 
 ---
 
-以下是一些展示 `Decimal` 類型任意精度特性的例子。對於某些數學運算，默認精度（有效數字位數）設為 `28`。您可以通過向函數傳遞 `precision` 參數來更改精度。當 Mojo 支持全局變量時，此默認精度將可以全局配置。
+以下是一些展示 `Decimal`
+類型任意精度特性的例子。對於某些數學運算，默認精度（有效數字位數）設為
+`28`。您可以通過向函數傳遞 `precision` 參數來更改精度。當 Mojo
+支持全局變量時，此默認精度將可以全局配置。
 
 ```mojo
 from decimo.prelude import *
@@ -299,17 +321,23 @@ def main() raises:
 
 ## 目標
 
-金融計算和數據分析需要精確的小數算術，而浮點數無法可靠地提供這種精確性。作爲一名從事金融學研究和信用風險模型驗證工作的人員，在將個人項目從 Python 遷移到 Mojo 時，我需要一個可靠的、能够正確捨入的、固定精度的數值類型。
+金融計算和數據分析需要精確的小數算術，而浮點數無法可靠地提供這種精確性。作爲一名從事金融學研究和信用風險模型驗證工作的人員，在將個人項目從
+Python 遷移到 Mojo 時，我需要一個可靠的、能够正確捨入的、固定精度的數值類型。
 
-由於 Mojo 目前在其標準庫中缺乏原生的 Decimal 類型，我決定創建自己的實現來填補這一空白。
+由於 Mojo 目前在其標準庫中缺乏原生的 Decimal
+類型，我決定創建自己的實現來填補這一空白。
 
-本項目從多個已建立的小數實現和文檔中汲取靈感，例如 [Python 内置的 `Decimal` 類型](https://docs.python.org/3/library/decimal.html)，[Rust 的 `rust_decimal` crate](https://docs.rs/rust_decimal/latest/rust_decimal/index.html)，[Microsoft 的 `Decimal` 實現](https://learn.microsoft.com/en-us/dotnet/api/system.decimal.getbits?view=net-9.0&redirectedfrom=MSDN#System_Decimal_GetBits_System_Decimal_)，[通用小數算術規範](https://speleotrove.com/decimal/decarith.html) 等。非常感謝前輩們的貢獻及其對開放知識共享的促進。
+本項目從多個已建立的小數實現和文檔中汲取靈感，例如
+[Python 内置的 `Decimal` 類型](https://docs.python.org/3/library/decimal.html)，[Rust 的 `rust_decimal` crate](https://docs.rs/rust_decimal/latest/rust_decimal/index.html)，[Microsoft 的 `Decimal` 實現](https://learn.microsoft.com/en-us/dotnet/api/system.decimal.getbits?view=net-9.0&redirectedfrom=MSDN#System_Decimal_GetBits_System_Decimal_)，[通用小數算術規範](https://speleotrove.com/decimal/decarith.html)
+等。非常感謝前輩們的貢獻及其對開放知識共享的促進。
 
 ## 狀態
 
-羅馬不是一日建成的。Decimo 目前正在積極開發中。它已成功通過 **"讓它工作"** 階段和 **"讓它正確"** 階段，現已深入 **"讓它快速"** 階段。
+羅馬不是一日建成的。Decimo 目前正在積極開發中。它已成功通過 **"讓它工作"**
+階段和 **"讓它正確"** 階段，現已深入 **"讓它快速"** 階段。
 
-`BInt` 類型已經完全實現並優化。它已經與 Python 的 `int` 進行了基準測試，並在大多數情況下表現出優越的性能。
+`BInt` 類型已經完全實現並優化。它已經與 Python 的 `int`
+進行了基準測試，並在大多數情況下表現出優越的性能。
 
 歡迎錯誤報告和功能請求！如果您遇到問題，請[在此提交](https://github.com/forfudan/decimo/issues)。
 
@@ -339,7 +367,21 @@ def main() raises:
 
 本倉庫及其所有貢獻内容均採用 Apache 許可證 2.0 版本授權。
 
-[^fixed]: `Decimal128` 類型可以表示最多 29 位有效數字，小數點後最多 28 位數字的值。當數值超過最大可表示值（`2^96 - 1`）時，Decimo 會拋出錯誤或將數值捨入以符合這些約束。例如，`8.8888888888888888888888888888`（總共 29 個 8，小數點後 28 位）的有效數字超過了最大可表示值（`2^96 - 1`），會自動捨入爲 `8.888888888888888888888888889`（總共 28 個 8，小數點後 27 位）。Decimo 的 `Decimal128` 類型類似於 `System.Decimal`（C#/.NET）、Rust 中的 `rust_decimal`、SQL Server 中的 `DECIMAL/NUMERIC` 等。
-[^bigint]: `BigInt` 使用 base-2^32 表示，採用小端格式，最低有效字存儲在索引 0。每個字是一個 `UInt32`，允許對大整數進行高效存儲和算術運算。這種設計優化了二進制計算的性能，同時支持任意精度。
-[^bigint10]: BigInt10 使用基於 10 的表示（保持十進制語義），而內部使用優化的基於 10^9 的存儲系統進行高效計算。這種方法在人類可讀的十進制操作與高性能計算之間取得平衡。它提供向下整除（向負無窮舍入）和截斷除法（向零舍入）語義，無論操作數符號如何，都能確保除法操作具有正確的數學行爲。
-[^arbitrary]: 建立在已完成的 BigInt10 實現之上，Decimal 支持整數和小數部分的任意精度，類似於 Python 中的 `decimal` 和 `mpmath`、Java 中的 `java.math.BigDecimal` 等。
+[^fixed]: `Decimal128` 類型可以表示最多 29 位有效數字，小數點後最多 28
+    位數字的值。當數值超過最大可表示值（`2^96 - 1`）時，Decimo
+    會拋出錯誤或將數值捨入以符合這些約束。例如，`8.8888888888888888888888888888`（總共
+    29 個 8，小數點後 28
+    位）的有效數字超過了最大可表示值（`2^96 - 1`），會自動捨入爲
+    `8.888888888888888888888888889`（總共 28 個 8，小數點後 27
+    位）。Decimo 的 `Decimal128` 類型類似於
+    `System.Decimal`（C#/.NET）、Rust 中的 `rust_decimal`、SQL Server 中的
+    `DECIMAL/NUMERIC` 等。
+[^bigint]: `BigInt` 使用 base-2^32 表示，採用小端格式，最低有效字存儲在索引
+    0。每個字是一個
+    `UInt32`，允許對大整數進行高效存儲和算術運算。這種設計優化了二進制計算的性能，同時支持任意精度。
+[^bigint10]: BigInt10 使用基於 10 的表示（保持十進制語義），而內部使用優化的基於
+    10^9
+    的存儲系統進行高效計算。這種方法在人類可讀的十進制操作與高性能計算之間取得平衡。它提供向下整除（向負無窮舍入）和截斷除法（向零舍入）語義，無論操作數符號如何，都能確保除法操作具有正確的數學行爲。
+[^arbitrary]: 建立在已完成的 BigInt10 實現之上，Decimal
+    支持整數和小數部分的任意精度，類似於 Python 中的 `decimal` 和
+    `mpmath`、Java 中的 `java.math.BigDecimal` 等。

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -1276,42 +1276,44 @@ can conform.
 `BigFloat` and `BigUInt` therefore conform to `Rootable` as well, five types
 in all. Ask for `T: Numeric & Rootable` in a routine that needs both. What the
 root means stays the implementing type's business: on an integral type it
-truncates, so `BigInt("10").sqrt()` is `3`, exactly as `/` truncates there.
+truncates, so `BigInt("10").sqrt()` is `3`, exactly as `/` truncates there. So
+does what a negative value does — the four exact types raise, and `BigFloat`
+returns `nan`, as it does for every other function outside its domain.
 
 #### BigInt <!-- omit from toc -->
 
-| Trait              | What it enables                  |
-| ------------------ | -------------------------------- |
-| `Absable`          | `abs(x)`                         |
-| `Comparable`       | `<`, `<=`, `>`, `>=`, `==`, `!=` |
-| `Copyable`         | Value-semantic copy              |
-| `Movable`          | Move semantics                   |
-| `FloatableRaising` | `Float64(x)`                     |
-| `IntableRaising`   | `Int(x)`                         |
-| `Numeric`          | Generic code over Decimo numbers |
+| Trait              | What it enables                       |
+| ------------------ | ------------------------------------- |
+| `Absable`          | `abs(x)`                              |
+| `Comparable`       | `<`, `<=`, `>`, `>=`, `==`, `!=`      |
+| `Copyable`         | Value-semantic copy                   |
+| `Movable`          | Move semantics                        |
+| `FloatableRaising` | `Float64(x)`                          |
+| `IntableRaising`   | `Int(x)`                              |
+| `Numeric`          | Generic code over Decimo numbers      |
 | `Parsable`         | `T.from_string(text)` in generic code |
-| `Rootable`         | `x.sqrt()` in generic code       |
-| `Representable`    | `repr(x)`                        |
-| `Stringable`       | `String(x)`, `str(x)`            |
-| `Writable`         | `print(x)`, writer protocol      |
+| `Rootable`         | `x.sqrt()` in generic code            |
+| `Representable`    | `repr(x)`                             |
+| `Stringable`       | `String(x)`, `str(x)`                 |
+| `Writable`         | `print(x)`, writer protocol           |
 
 #### Decimal <!-- omit from toc -->
 
-| Trait              | What it enables                  |
-| ------------------ | -------------------------------- |
-| `Absable`          | `abs(x)`                         |
-| `Comparable`       | `<`, `<=`, `>`, `>=`, `==`, `!=` |
-| `Copyable`         | Value-semantic copy              |
-| `Movable`          | Move semantics                   |
-| `FloatableRaising` | `Float64(x)`                     |
-| `IntableRaising`   | `Int(x)`                         |
-| `Numeric`          | Generic code over Decimo numbers |
+| Trait              | What it enables                       |
+| ------------------ | ------------------------------------- |
+| `Absable`          | `abs(x)`                              |
+| `Comparable`       | `<`, `<=`, `>`, `>=`, `==`, `!=`      |
+| `Copyable`         | Value-semantic copy                   |
+| `Movable`          | Move semantics                        |
+| `FloatableRaising` | `Float64(x)`                          |
+| `IntableRaising`   | `Int(x)`                              |
+| `Numeric`          | Generic code over Decimo numbers      |
 | `Parsable`         | `T.from_string(text)` in generic code |
-| `Rootable`         | `x.sqrt()` in generic code       |
-| `Representable`    | `repr(x)`                        |
-| `Roundable`        | `round(x)`, `round(x, ndigits)`  |
-| `Stringable`       | `String(x)`, `str(x)`            |
-| `Writable`         | `print(x)`, writer protocol      |
+| `Rootable`         | `x.sqrt()` in generic code            |
+| `Representable`    | `repr(x)`                             |
+| `Roundable`        | `round(x)`, `round(x, ndigits)`       |
+| `Stringable`       | `String(x)`, `str(x)`                 |
+| `Writable`         | `print(x)`, writer protocol           |
 
 ### Appendix C — Complete API Tables
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -67,7 +67,7 @@ pixi add decimo
 Or add it manually to `pixi.toml`:
 
 ```toml
-decimo = "==0.12.0"
+decimo = "==0.13.0"
 ```
 
 Then run `pixi install`.
@@ -1252,10 +1252,11 @@ from decimo.expression import tokenize, parse_to_rpn, evaluate_rpn
 
 ### Appendix B — Traits Implemented
 
-All of these come from the Mojo standard library except **`Numeric`** and
-**`Parsable`**, which Decimo defines in `decimo.traits` and `BigInt`,
-`BigDecimal` and `Decimal128` all conform to. Mojo checks conformance
-nominally, which is why they live in Decimo rather than in the consumer.
+All of these come from the Mojo standard library except **`Numeric`**,
+**`Parsable`** and **`Rootable`**, which Decimo defines in `decimo.traits`.
+`BigInt`, `BigDecimal` and `Decimal128` conform to all three. Mojo checks
+conformance nominally, which is why the traits live in Decimo rather than in
+the consumer.
 
 `Numeric` gathers `zero()`, `one()`, `-x`, `+`, `-`, `*` and `/`, so a generic
 routine — a matrix or polynomial library, say — can be written once against
@@ -1265,6 +1266,17 @@ routine — a matrix or polynomial library, say — can be written once against
 routine can also fill itself from text. The two are separate because the
 capabilities are: `BigFloat` parses but is `Movable` without being `Copyable`,
 so it can never be `Numeric`. Ask for `T: Numeric & Parsable` to get both.
+
+`Rootable` requires `sqrt()`, the one operation a Cholesky or QR factorisation
+needs beyond arithmetic. It is separate for the same reason, and here the
+evidence is sharper: `BigUInt` has a square root but is unsigned, so it has no
+`__neg__` and can never be `Numeric` either. Its supertraits are `Deinitable`
+and `Movable` and no more — `Copyable` is pointedly absent, so that `BigFloat`
+can conform.
+`BigFloat` and `BigUInt` therefore conform to `Rootable` as well, five types
+in all. Ask for `T: Numeric & Rootable` in a routine that needs both. What the
+root means stays the implementing type's business: on an integral type it
+truncates, so `BigInt("10").sqrt()` is `3`, exactly as `/` truncates there.
 
 #### BigInt <!-- omit from toc -->
 
@@ -1278,6 +1290,7 @@ so it can never be `Numeric`. Ask for `T: Numeric & Parsable` to get both.
 | `IntableRaising`   | `Int(x)`                         |
 | `Numeric`          | Generic code over Decimo numbers |
 | `Parsable`         | `T.from_string(text)` in generic code |
+| `Rootable`         | `x.sqrt()` in generic code       |
 | `Representable`    | `repr(x)`                        |
 | `Stringable`       | `String(x)`, `str(x)`            |
 | `Writable`         | `print(x)`, writer protocol      |
@@ -1294,6 +1307,7 @@ so it can never be `Numeric`. Ask for `T: Numeric & Parsable` to get both.
 | `IntableRaising`   | `Int(x)`                         |
 | `Numeric`          | Generic code over Decimo numbers |
 | `Parsable`         | `T.from_string(text)` in generic code |
+| `Rootable`         | `x.sqrt()` in generic code       |
 | `Representable`    | `repr(x)`                        |
 | `Roundable`        | `round(x)`, `round(x, ndigits)`  |
 | `Stringable`       | `String(x)`, `str(x)`            |

--- a/pixi.toml
+++ b/pixi.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "decimo"
 platforms = ["osx-arm64", "linux-64"]
 readme = "README.md"
-version = "0.12.0"
+version = "0.13.0"
 
 [dependencies]
 # CLI argument parsing for the Decimo calculator. `pixi run buildcli`

--- a/src/decimo/__init__.mojo
+++ b/src/decimo/__init__.mojo
@@ -24,7 +24,7 @@ from decimo import Decimal, BInt, RoundingMode
 ```
 """
 
-comptime DECIMO_VERSION = "0.12.0"
+comptime DECIMO_VERSION = "0.13.0"
 """Canonical semantic version of the Decimo library (no leading `v`).
 
 Keep in sync with `pixi.toml`'s `[project].version`.  This is the single
@@ -34,17 +34,17 @@ should use `DECIMO_VERSION_TAG`.
 """
 
 comptime DECIMO_VERSION_TAG = "v" + DECIMO_VERSION
-"""Display version of the Decimo library, prefixed with `v` (e.g. `v0.12.0`).
+"""Display version of the Decimo library, prefixed with `v` (e.g. `v0.13.0`).
 """
 
 # Traits
-from .traits import Numeric, Parsable
+from .traits import Numeric, Parsable, Rootable
 
 # Core types
 from .decimal128.decimal128 import Decimal128, Dec128
 from .bigint.bigint import BigInt, BInt, Integer
 from .biguint.biguint import BigUInt, BUInt
-from .bigdecimal.bigdecimal import BigDecimal, BDec, Decimal
+from .bigdecimal.bigdecimal import BigDecimal, BDec, Decimal, PRECISION
 from .bigfloat.bigfloat import BigFloat, BFlt, Float
 from .rational.rational import Rational
 from .rounding_mode import (

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -28,7 +28,7 @@ from std.python import PythonObject
 from std import testing
 
 from decimo.errors import ConversionError, ValueError
-from decimo.traits import Numeric, Parsable
+from decimo.traits import Numeric, Parsable, Rootable
 from decimo.rounding_mode import RoundingMode
 from decimo.numerals.chinese import ChineseNumeralStyle
 from decimo.bigdecimal.exponential import MathCache
@@ -114,6 +114,7 @@ struct BigDecimal(
     Movable,
     Numeric,
     Parsable,
+    Rootable,
     Roundable,
     Writable,
 ):
@@ -1957,11 +1958,70 @@ struct BigDecimal(
         return bigdecimal_exponential.log10(self, precision)
 
     @always_inline
-    def root(self, root: Self, precision: Int = PRECISION) raises -> Self:
+    def root(self, n: Int) raises -> Self:
+        """Returns the nth root of the BigDecimal number with default
+        precision.
+
+        This is the spelling `Decimal128.root` and `BigFloat.root` share.
+
+        Args:
+            n: The degree of the root (e.g. 2 for square root, 3 for cube
+                root).
+
+        Returns:
+            The nth root of this value.
+
+        Raises:
+            ValueError: If the value is negative for an even root, or if
+                the root degree is invalid.
+        """
+        return bigdecimal_exponential.root(self, Self(n), precision=PRECISION)
+
+    @always_inline
+    def root(self, n: Int, precision: Int) raises -> Self:
+        """Returns the nth root of the BigDecimal number.
+
+        Args:
+            n: The degree of the root (e.g. 2 for square root, 3 for cube
+                root).
+            precision: The number of significant digits for the result.
+
+        Returns:
+            The nth root of this value.
+
+        Raises:
+            ValueError: If the value is negative for an even root, or if
+                the root degree is invalid.
+        """
+        return bigdecimal_exponential.root(self, Self(n), precision)
+
+    @always_inline
+    def root(self, root: Self) raises -> Self:
+        """Returns the root of the BigDecimal number with default precision.
+
+        A non-integral degree is permitted here, which is why the degree may
+        be a `BigDecimal` at all.
+
+        Args:
+            root: The degree of the root (e.g. 2 for square root, 3 for cube
+                root).
+
+        Returns:
+            The nth root of this value.
+
+        Raises:
+            ValueError: If the value is negative for an even root, or if
+                the root degree is invalid.
+        """
+        return bigdecimal_exponential.root(self, root, precision=PRECISION)
+
+    @always_inline
+    def root(self, root: Self, precision: Int) raises -> Self:
         """Returns the root of the BigDecimal number.
 
         Args:
-            root: The degree of the root (e.g. 2 for square root, 3 for cube root).
+            root: The degree of the root (e.g. 2 for square root, 3 for cube
+                root).
             precision: The number of significant digits for the result.
 
         Returns:
@@ -1974,7 +2034,20 @@ struct BigDecimal(
         return bigdecimal_exponential.root(self, root, precision)
 
     @always_inline
-    def sqrt(self, precision: Int = PRECISION) raises -> Self:
+    def sqrt(self) raises -> Self:
+        """Returns the square root of the BigDecimal number with default
+        precision.
+
+        Returns:
+            The square root of this value.
+
+        Raises:
+            ValueError: If the value is negative.
+        """
+        return bigdecimal_exponential.sqrt(self, precision=PRECISION)
+
+    @always_inline
+    def sqrt(self, precision: Int) raises -> Self:
         """Returns the square root of the BigDecimal number.
 
         Args:

--- a/src/decimo/bigfloat/bigfloat.mojo
+++ b/src/decimo/bigfloat/bigfloat.mojo
@@ -760,12 +760,19 @@ struct BigFloat(Comparable, Movable, Rootable, Writable):
             The n-th root of this value.
 
         Raises:
-            ValueError: If `n` is not positive.
+            ValueError: If `n` is not positive, or is larger than `UInt32.MAX`.
             RuntimeError: If MPFR handle allocation fails.
         """
         if n <= 0:
             raise ValueError(
                 message="Cannot compute non-positive root.",
+                function="BigFloat.root()",
+            )
+        # The degree reaches MPFR as a `UInt32`. Without this bound a larger
+        # `n` would wrap and quietly compute a different root.
+        if n > Int(UInt32.MAX):
+            raise ValueError(
+                message="Root degree is too large.",
                 function="BigFloat.root()",
             )
         return self.root(UInt32(n))

--- a/src/decimo/bigfloat/bigfloat.mojo
+++ b/src/decimo/bigfloat/bigfloat.mojo
@@ -38,7 +38,8 @@ from std.memory import Pointer
 
 from decimo.bigdecimal.bigdecimal import BigDecimal
 from decimo.biguint.biguint import BigUInt
-from decimo.errors import ConversionError, RuntimeError
+from decimo.errors import ConversionError, RuntimeError, ValueError
+from decimo.traits import Rootable
 from decimo.bigfloat.mpfr_wrapper import (
     mpfrw_available,
     mpfrw_init,
@@ -116,7 +117,7 @@ def _read_c_string(address: Int) -> String:
 # ===----------------------------------------------------------------------=== #
 
 
-struct BigFloat(Comparable, Movable, Writable):
+struct BigFloat(Comparable, Movable, Rootable, Writable):
     """Arbitrary-precision binary floating-point type backed by MPFR.
 
     Each BigFloat owns a single MPFR handle (index into the C wrapper's pool).
@@ -746,6 +747,28 @@ struct BigFloat(Comparable, Movable, Writable):
             )
         mpfrw_pow(h, self.handle, exponent.handle)
         return Self(_handle=h, _precision=prec)
+
+    def root(self, n: Int) raises -> Self:
+        """Computes the n-th root.
+
+        This is the spelling `BigDecimal.root` and `Decimal128.root` share.
+
+        Args:
+            n: The root degree (e.g. 2 for square root, 3 for cube root).
+
+        Returns:
+            The n-th root of this value.
+
+        Raises:
+            ValueError: If `n` is not positive.
+            RuntimeError: If MPFR handle allocation fails.
+        """
+        if n <= 0:
+            raise ValueError(
+                message="Cannot compute non-positive root.",
+                function="BigFloat.root()",
+            )
+        return self.root(UInt32(n))
 
     def root(self, n: UInt32) raises -> Self:
         """Computes the n-th root.

--- a/src/decimo/bigint/bigint.mojo
+++ b/src/decimo/bigint/bigint.mojo
@@ -38,7 +38,7 @@ import decimo.bigint.exponential as bigint_exponential
 import decimo.bigint.number_theory as bigint_number_theory
 import decimo.bigint.special as bigint_special
 import decimo.str as decimo_str
-from decimo.traits import Numeric, Parsable
+from decimo.traits import Numeric, Parsable, Rootable
 import decimo.numerals.chinese as decimo_chinese
 from decimo.numerals.chinese import ChineseNumeralStyle
 from decimo.bigint10.bigint10 import BigInt10
@@ -67,6 +67,7 @@ struct BigInt(
     Movable,
     Numeric,
     Parsable,
+    Rootable,
     Writable,
 ):
     """An arbitrary-precision signed integer, similar to Python's `int`.

--- a/src/decimo/biguint/biguint.mojo
+++ b/src/decimo/biguint/biguint.mojo
@@ -39,6 +39,7 @@ from decimo.errors import (
 )
 import decimo.str as decimo_str
 from decimo.rounding_mode import RoundingMode
+from decimo.traits import Rootable
 from decimo.utility import unsigned_counterpart
 
 # Type aliases
@@ -46,7 +47,7 @@ comptime BUInt = BigUInt
 """A shorthand alias for `BigUInt`."""
 
 
-struct BigUInt(Absable, Copyable, IntableRaising, Movable, Writable):
+struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
     """Represents a base-10 arbitrary-precision unsigned integer.
 
     Notes:

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -40,7 +40,7 @@ from decimo.errors import (
 )
 import decimo.decimal128.utility as decimal128_utility
 from decimo.bigdecimal.bigdecimal import BigDecimal
-from decimo.traits import Numeric, Parsable
+from decimo.traits import Numeric, Parsable, Rootable
 
 comptime Dec128 = Decimal128
 """A 128-bit fixed-point decimal number."""
@@ -55,6 +55,7 @@ struct Decimal128(
     IntableRaising,
     Numeric,
     Parsable,
+    Rootable,
     Roundable,
     TrivialRegisterPassable,
     Writable,

--- a/src/decimo/traits.mojo
+++ b/src/decimo/traits.mojo
@@ -161,8 +161,11 @@ trait Rootable(Deinitable, Movable):
 
     What the root means is the implementing type's business. On an integral
     type it truncates -- `BigInt("10").sqrt()` is `3` -- exactly as
-    `Numeric.__truediv__` truncates there. A caller that cannot accept that
-    should bound on a type that does not.
+    `Numeric.__truediv__` truncates there. A negative value is the type's
+    business too: four of the five implementations raise, and `BigFloat`
+    returns `nan`, because it has a `nan` and every other function it offers
+    returns one there as well. A caller that cannot accept either should bound
+    on a type that does not do it.
 
     The supertraits are `Deinitable` and `Movable`, and no more. `sqrt` hands
     back an owned `Self`, so a caller that stores or returns that result moves
@@ -175,12 +178,17 @@ trait Rootable(Deinitable, Movable):
         """Returns the square root of `self`.
 
         Returns:
-            The non-negative value whose square is `self`, truncated toward
-            zero on a type that cannot represent it exactly.
+            The non-negative value whose square is `self`, exact where the
+            type can represent it. Where it cannot, the rule is the
+            implementation's own: an integral type truncates, a decimal or
+            floating type rounds at its working precision.
 
         Raises:
-            Error: If `self` is negative, or the root is not representable in
-                this type.
+            Error: If `self` is negative and the type has no value standing
+                for a root it cannot give, or if the root is not
+                representable. A type that has such a value returns it
+                instead -- `BigFloat("-4").sqrt()` is `nan` -- so generic
+                code must tolerate either outcome.
         """
         ...
 

--- a/src/decimo/traits.mojo
+++ b/src/decimo/traits.mojo
@@ -34,6 +34,13 @@ independent. `BigFloat` parses but is `Movable` without being `Copyable`, so it
 can never be `Numeric`; a numeric type with no decimal spelling is equally
 imaginable. Splitting them lets each consumer ask for what it actually uses.
 
+`Rootable` is separate for the same reason, and the evidence is sharper. Two
+types here have a square root and can never be `Numeric`: `BigFloat`, again for
+want of `Copyable`, and `BigUInt`, which is unsigned and so has no `__neg__`.
+Folding `sqrt` into `Numeric` would leave both unable to advertise a capability
+they demonstrably have, and would oblige every future numeric type to grow one.
+A consumer that needs both asks for `T: Numeric & Rootable`.
+
 Every operation is declared `raises`, which is the widest signature: a
 non-raising implementation satisfies a raising requirement, so `BigInt.__add__`
 conforms unchanged while `BigDecimal.__add__` -- which really can raise --
@@ -58,34 +65,122 @@ trait Numeric(Copyable, Deinitable, Movable, Writable):
 
     @staticmethod
     def zero() -> Self:
-        """Returns the additive identity."""
+        """Returns the additive identity.
+
+        Returns:
+            The value that leaves any other unchanged under addition.
+        """
         ...
 
     @staticmethod
     def one() -> Self:
-        """Returns the multiplicative identity."""
+        """Returns the multiplicative identity.
+
+        Returns:
+            The value that leaves any other unchanged under multiplication.
+        """
         ...
 
     def __neg__(self) raises -> Self:
-        """Returns the additive inverse."""
+        """Returns the additive inverse.
+
+        Returns:
+            The value that sums with `self` to `zero()`.
+
+        Raises:
+            Error: If the negation is not representable in this type.
+        """
         ...
 
     def __add__(self, other: Self) raises -> Self:
-        """Returns the sum of `self` and `other`."""
+        """Returns the sum of `self` and `other`.
+
+        Args:
+            other: The value to add to `self`.
+
+        Returns:
+            The sum of `self` and `other`.
+
+        Raises:
+            Error: If the sum is not representable in this type.
+        """
         ...
 
     def __sub__(self, other: Self) raises -> Self:
-        """Returns `other` subtracted from `self`."""
+        """Returns `other` subtracted from `self`.
+
+        Args:
+            other: The value to subtract from `self`.
+
+        Returns:
+            The difference of `self` and `other`.
+
+        Raises:
+            Error: If the difference is not representable in this type.
+        """
         ...
 
     def __mul__(self, other: Self) raises -> Self:
-        """Returns the product of `self` and `other`."""
+        """Returns the product of `self` and `other`.
+
+        Args:
+            other: The value to multiply `self` by.
+
+        Returns:
+            The product of `self` and `other`.
+
+        Raises:
+            Error: If the product is not representable in this type.
+        """
         ...
 
     def __truediv__(self, other: Self) raises -> Self:
         """Returns `self` divided by `other`.
 
         On an integral type this truncates toward zero, as `Int` does.
+
+        Args:
+            other: The divisor.
+
+        Returns:
+            The quotient of `self` and `other`.
+
+        Raises:
+            Error: If `other` is zero, or the quotient is not representable in
+                this type.
+        """
+        ...
+
+
+trait Rootable(Deinitable, Movable):
+    """A type that can take the square root of one of its values.
+
+    The bound that a Cholesky or QR factorisation needs, and nothing more. It
+    is deliberately narrow: `sqrt` is the only operation dense linear algebra
+    asks for, so it is the only one required here.
+
+    What the root means is the implementing type's business. On an integral
+    type it truncates -- `BigInt("10").sqrt()` is `3` -- exactly as
+    `Numeric.__truediv__` truncates there. A caller that cannot accept that
+    should bound on a type that does not.
+
+    The supertraits are `Deinitable` and `Movable`, and no more. `sqrt` hands
+    back an owned `Self`, so a caller that stores or returns that result moves
+    it, and something has to destroy it. `Copyable` is pointedly absent:
+    `BigFloat` is `Movable` without it, and requiring it would exclude a type
+    that has had a square root all along.
+    """
+
+    def sqrt(self) raises -> Self:
+        """Returns the square root of `self`.
+
+        Returns:
+            The non-negative value whose square is `self`, truncated toward
+            zero on a type that cannot represent it exactly.
+
+        Raises:
+            Error: If `self` is negative, or the root is not representable in
+                this type.
         """
         ...
 

--- a/tests/bigfloat/test_bigfloat.mojo
+++ b/tests/bigfloat/test_bigfloat.mojo
@@ -18,6 +18,7 @@
 
 from decimo.bigfloat.bigfloat import BigFloat, PRECISION
 from decimo.bigfloat.mpfr_wrapper import mpfrw_available
+from decimo.traits import Rootable
 
 
 def test_mpfr_available() raises:
@@ -179,7 +180,20 @@ def test_power_and_root() raises:
     var x = BigFloat("8.0", precision=30)
     var third = BigFloat("0.333333333333333333", precision=30)
     var cube_root = x.root(UInt32(3))
+    # The `Int` spelling `BigDecimal` and `Decimal128` share.
+    var cube_root_int = x.root(3)
     var power_result = x.power(third)
+    if not cube_root_int.to_string(10).startswith("2"):
+        raise Error(
+            "FAIL test_power_and_root got: " + cube_root_int.to_string(10)
+        )
+    var raised = False
+    try:
+        _ = x.root(0)
+    except:
+        raised = True
+    if not raised:
+        raise Error("FAIL test_power_and_root: root(0) did not raise")
     print("OK  cbrt(8) =", cube_root, " 8^(1/3) =", power_result)
 
 
@@ -210,6 +224,27 @@ def test_high_precision_sqrt() raises:
     print("OK  sqrt(2) to 100 digits verified")
 
 
+def _root_of[T: Rootable](var x: T) raises -> T:
+    """Returns `x.sqrt()` through the trait alone.
+
+    `Rootable` carries `Deinitable` and `Movable` and nothing else, which is
+    what lets it reach `BigFloat`: a type that moves without copying.
+    """
+    return x^.sqrt()
+
+
+def test_rootable_conformance() raises:
+    print("test_rootable_conformance ... ", end="")
+    if not mpfrw_available():
+        print("SKIPPED")
+        return
+    var s = _root_of(BigFloat("2.0", precision=50))
+    var result = s.to_string(50)
+    if not result.startswith("1.4142"):
+        raise Error("FAIL test_rootable_conformance got: " + result)
+    print("OK  sqrt(2) through Rootable =", result)
+
+
 def main() raises:
     test_mpfr_available()
     test_construct_from_string()
@@ -225,4 +260,5 @@ def main() raises:
     test_power_and_root()
     test_neg_and_abs()
     test_high_precision_sqrt()
+    test_rootable_conformance()
     print("\nAll BigFloat smoke tests completed.")

--- a/tests/bigfloat/test_bigfloat.mojo
+++ b/tests/bigfloat/test_bigfloat.mojo
@@ -194,6 +194,14 @@ def test_power_and_root() raises:
         raised = True
     if not raised:
         raise Error("FAIL test_power_and_root: root(0) did not raise")
+    # One past `UInt32.MAX`, which would wrap to 0 if it reached the cast.
+    raised = False
+    try:
+        _ = x.root(Int(UInt32.MAX) + 1)
+    except:
+        raised = True
+    if not raised:
+        raise Error("FAIL test_power_and_root: oversized root did not raise")
     print("OK  cbrt(8) =", cube_root, " 8^(1/3) =", power_result)
 
 
@@ -242,7 +250,15 @@ def test_rootable_conformance() raises:
     var result = s.to_string(50)
     if not result.startswith("1.4142"):
         raise Error("FAIL test_rootable_conformance got: " + result)
-    print("OK  sqrt(2) through Rootable =", result)
+    # `Rootable` lets a type with a `nan` return one where the four exact
+    # types raise. `BigFloat` has one, and every function of it outside its
+    # domain gives one, so `sqrt` does too.
+    var negative = _root_of(BigFloat("-4.0", precision=50))
+    if String(negative) != "nan":
+        raise Error(
+            "FAIL test_rootable_conformance: sqrt(-4) gave " + String(negative)
+        )
+    print("OK  sqrt(2) through Rootable =", result, " sqrt(-4) = nan")
 
 
 def main() raises:

--- a/tests/biguint/test_biguint_arithmetics.mojo
+++ b/tests/biguint/test_biguint_arithmetics.mojo
@@ -206,9 +206,9 @@ def test_biguint_truncate_divide_random_numbers_against_python() raises:
     for _test_case in range(10):
         number_a = String("")
         number_b = String("")
-        for _i in range(12345):
+        for _i in range(123):
             number_a += String(random_ui64(0, 999_999_999_999_999_999))
-        for _i in range(789):
+        for _i in range(45):
             number_b += String(random_ui64(0, 999_999_999_999_999_999))
         decimo_result = String(BigUInt(number_a) // BigUInt(number_b))
         python_result = String(Python.int(number_a) // Python.int(number_b))

--- a/tests/biguint/test_biguint_arithmetics.mojo
+++ b/tests/biguint/test_biguint_arithmetics.mojo
@@ -228,6 +228,42 @@ def test_biguint_truncate_divide_random_numbers_against_python() raises:
     # print("BigUInt truncate division tests passed!")
 
 
+def test_biguint_truncate_divide_huge_random_numbers_against_python() raises:
+    # The dividend here is some two hundred thousand digits over a divisor of
+    # some fourteen thousand, which is the size at which truncated division
+    # recurses through Burnikel-Ziegler rather than taking the schoolbook
+    # path the smaller random cases above exercise. One case rather than ten:
+    # the size is what is being covered, and each one costs a couple of
+    # minutes against Python.
+
+    _set_max_str_digits(500000)
+
+    var number_a: String = String("")
+    var number_b: String = String("")
+    var decimo_result: String
+    var python_result: String
+
+    for _i in range(123):
+        number_a += String(random_ui64(0, 999_999_999_999_999_999))
+    for _i in range(78):
+        number_b += String(random_ui64(0, 999_999_999_999_999_999))
+    decimo_result = String(BigUInt(number_a) // BigUInt(number_b))
+    python_result = String(Python.int(number_a) // Python.int(number_b))
+    assert_equal(
+        lhs=decimo_result,
+        rhs=python_result,
+        msg="Python int division does not match BigUInt division\n"
+        + "number a: \n"
+        + number_a
+        + "\n\nnumber b: \n"
+        + number_b
+        + "\n\nDecimo BigUInt division: \n"
+        + decimo_result
+        + "\n\nPython int division: \n"
+        + python_result,
+    )
+
+
 def main() raises:
     # test_biguint_arithmetics()
     # test_biguint_truncate_divide()

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -20,7 +20,8 @@
 #   rational    rat   frac      → Rational number tests
 #   expression  expr  eval      → Expression engine tests
 #   numerals    numeral chinese → Numeral system tests
-#   traits      numeric num     → Trait conformance tests (`Numeric`, `Parsable`)
+#   traits      numeric num     → Trait conformance tests (`Numeric`,
+#                                 `Parsable`, `Rootable`)
 #   bigfloat    bfloat float    → BigFloat tests (requires MPFR)
 #   toml                        → TOML parser tests
 #   cli                         → CLI calculator tests
@@ -60,9 +61,12 @@ run_mojo_suite() {
         local attempt=1
         local max_attempts=2
         while (( attempt <= max_attempts )); do
-            if pixi run mojo run -I tests -D ASSERT=all --debug-level=full "$f"; then
-                break
-            fi
+            # `&&` rather than `if`: after an `if ... fi` whose condition was
+            # false, `$?` is the `if` statement's own status, which is 0. The
+            # `return $rc` below would then hand back success for a suite that
+            # failed to compile, and the whole run would exit green.
+            pixi run mojo run -I tests -D ASSERT=all --debug-level=full "$f" \
+                && break
             local rc=$?
             if (( attempt < max_attempts )); then
                 echo "WARN: $f failed (rc=$rc), retrying (attempt $((attempt + 1))/$max_attempts)..."

--- a/tests/traits/test_rootable_trait.mojo
+++ b/tests/traits/test_rootable_trait.mojo
@@ -89,7 +89,11 @@ def test_integral_root_truncates() raises:
 
 
 def test_negative_root_raises() raises:
-    """A negative value raises rather than returning a wrong root."""
+    """A negative value raises rather than returning a wrong root.
+
+    The four exact types only. `BigFloat` has a `nan` and returns one, which
+    `Rootable` permits; the BigFloat suite pins that half.
+    """
     var raised = False
     try:
         _ = _root_of(BigInt(-1))

--- a/tests/traits/test_rootable_trait.mojo
+++ b/tests/traits/test_rootable_trait.mojo
@@ -1,0 +1,116 @@
+"""
+Test that Decimo's number types are usable *through* the `Rootable` trait,
+not merely declared to conform to it.
+
+`_hypotenuse` is the shape the motivating consumer has: a Cholesky or QR
+factorisation needs exactly one operation beyond arithmetic, and asks for it
+as `T: Numeric & Rootable`. It compiles only if `sqrt` is present with the
+declared signature, and it gives the right answer only if the conforming
+type's own root is the one that runs.
+
+`BigUInt` is here because it is the case that justifies the trait being
+separate from `Numeric`: it has had a square root all along and, being
+unsigned, has no `__neg__`, so it can never be `Numeric`. `BigFloat` is the
+other such case and is exercised in the `bigfloat` suite, which is separate
+because it needs MPFR at runtime.
+"""
+
+from std import testing
+
+from decimo.traits import Numeric, Rootable
+from decimo.bigint.bigint import BigInt
+from decimo.biguint.biguint import BigUInt
+from decimo.bigdecimal.bigdecimal import BigDecimal
+from decimo.decimal128.decimal128 import Decimal128
+
+
+def _hypotenuse[T: Numeric & Rootable](a: T, b: T) raises -> T:
+    """Returns `sqrt(a*a + b*b)`, naming no concrete type."""
+    return (a * a + b * b).sqrt()
+
+
+def _root_of[T: Rootable](var x: T) raises -> T:
+    """Returns `x.sqrt()` through the trait alone.
+
+    The bound is `Rootable` unaccompanied, which is the point: it carries
+    `Movable` and nothing else, so it reaches a type that moves without
+    copying.
+    """
+    return x^.sqrt()
+
+
+def test_bigint_through_rootable() raises:
+    """`BigInt` rooted through the trait, past the range of any fixed width."""
+    testing.assert_equal(_hypotenuse(BigInt(3), BigInt(4)), BigInt(5), "3-4-5")
+    testing.assert_equal(
+        _root_of(BigInt(2) ** BigInt(128)),
+        BigInt(2) ** BigInt(64),
+        "sqrt(2^128), one past what a 128-bit integer holds",
+    )
+
+
+def test_biguint_through_rootable() raises:
+    """`BigUInt` conforms though it can never be `Numeric`.
+
+    Compared as text because `BigUInt` has `__eq__` but does not declare
+    `Equatable`, which is what `assert_equal` bounds on.
+    """
+    testing.assert_equal(String(_root_of(BigUInt(144))), "12", "sqrt(144)")
+
+
+def test_bigdecimal_through_rootable() raises:
+    """`BigDecimal` rooted through the trait, at the default precision."""
+    testing.assert_equal(
+        _hypotenuse(BigDecimal("3"), BigDecimal("4")), BigDecimal("5"), "3-4-5"
+    )
+    testing.assert_equal(
+        _root_of(BigDecimal("2")),
+        BigDecimal("1.414213562373095048801688724"),
+        "sqrt(2) to the 28 significant digits `PRECISION` names",
+    )
+
+
+def test_decimal128_through_rootable() raises:
+    """`Decimal128` rooted through the trait."""
+    testing.assert_equal(
+        _hypotenuse(Decimal128("3"), Decimal128("4")), Decimal128("5"), "3-4-5"
+    )
+
+
+def test_integral_root_truncates() raises:
+    """On an integral type the root truncates, as `/` does there.
+
+    Stated as a test because a generic routine bounded on
+    `T: Numeric & Rootable` inherits this silently, and a caller who cannot
+    accept it has to bound on a type that does not truncate.
+    """
+    testing.assert_equal(BigInt(10).sqrt(), BigInt(3), "sqrt(10) is 3")
+    testing.assert_equal(String(BigUInt(10).sqrt()), "3", "sqrt(10) is 3")
+
+
+def test_negative_root_raises() raises:
+    """A negative value raises rather than returning a wrong root."""
+    var raised = False
+    try:
+        _ = _root_of(BigInt(-1))
+    except:
+        raised = True
+    testing.assert_true(raised, "BigInt(-1).sqrt()")
+
+    raised = False
+    try:
+        _ = _root_of(BigDecimal("-1"))
+    except:
+        raised = True
+    testing.assert_true(raised, "BigDecimal('-1').sqrt()")
+
+    raised = False
+    try:
+        _ = _root_of(Decimal128("-1"))
+    except:
+        raised = True
+    testing.assert_true(raised, "Decimal128('-1').sqrt()")
+
+
+def main() raises:
+    testing.TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
This PR adds the `Rootable` trait and square-root support across Decimo numeric types, with tests, documentation, tooling update.

**Changes:**
- Defines and exports `Rootable` for five numeric types.
- Adds root overloads and generic conformance tests.
- Updates test tooling, documentation, changelog, and package metadata.