### PR TITLE
[core][rational] Refactor `Rational` type conversion and improve Chudnovsky algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ def main() raises:
     var a = Decimal128("123.45")  # From string
     var b = Decimal128(123)  # From integer
     var c = Dec128(123, 2)  # Integer with scale (1.23)
-    var d = Dec128.from_float(3.14159)  # From floating-point
+    var d = Dec128.from_float_scalar(3.14159)  # From floating-point
 
     # === Basic Arithmetic ===
     print(a + b)  # Addition: 246.45

--- a/docs/internal/internal_notes.md
+++ b/docs/internal/internal_notes.md
@@ -34,11 +34,11 @@ record of direction rather than a comparable series. The three below were all
 re-measured together (Apple silicon, best of three runs, `pi(2048)`), so the
 ratios between them are meaningful:
 
-| Stage | `pi(2048)` | vs. previous |
-| --- | --- | --- |
-| `2e81976` - Chudnovsky over `BigInt10` (base 10^9) | 0.2539 s | - |
-| `51e5896` - Chudnovsky over `BigInt` (base 2^32) | 0.1408 s | 1.80x |
-| common powers of two divided out in `combine()` | 0.0974 s | 1.45x |
+| Stage                                              | `pi(2048)` | vs. previous |
+| -------------------------------------------------- | ---------- | ------------ |
+| `2e81976` - Chudnovsky over `BigInt10` (base 10^9) | 0.2539 s   | -            |
+| `51e5896` - Chudnovsky over `BigInt` (base 2^32)   | 0.1408 s   | 1.80x        |
+| common powers of two divided out in `combine()`    | 0.0974 s   | 1.45x        |
 
 Notes on the last two, both in `bigdecimal/constants.mojo`:
 
@@ -59,11 +59,11 @@ Notes on the last two, both in `bigdecimal/constants.mojo`:
 
 Measured over the whole split (not just `pi`), at 640 terms (~9 000 digits):
 
-| Reduction at each combine | Time | Final `p` size |
-| --- | --- | --- |
-| none | 15.2 s | 16 232 668 bits |
+| Reduction at each combine         | Time   | Final `p` size  |
+| --------------------------------- | ------ | --------------- |
+| none                              | 15.2 s | 16 232 668 bits |
 | common powers of two (two shifts) | 10.0 s | 11 958 706 bits |
-| full gcd | 14.8 s | 36 921 bits |
+| full gcd                          | 14.8 s | 36 921 bits     |
 
 The full gcd is not the disaster its cost per step suggests: it collapses the
 operands by a factor of ~440, so it is already break-even at 9 000 digits and
@@ -77,3 +77,79 @@ multiplications per leaf and O(n^2) overall. The textbook `P`/`Q`/`T` binary
 splitting recurrence makes the leaf O(1) and lets those factors telescope
 through the combines instead. At 640 terms the leaves alone cost 0.89 s of the
 total, so this is not yet the bottleneck, but it is where the next big win is.
+
+## Test suite timing
+
+### The harness prints milliseconds, not seconds
+
+`std.testing.TestSuite` renders every duration through `_format_nsec`, which
+divides nanoseconds by 1 000 000 and prints `NNN.NNN` with no unit. So
+
+```
+    PASS [ 118.116 ] test_biguint_truncate_divide_huge_random_numbers_against_python
+```
+
+is 118 **milliseconds**, not 118 seconds. Calibrated against a spin loop:
+
+| Spin  | Reported  |
+| ----- | --------- |
+| 0.1 s |   100.003 |
+| 0.5 s |   500.000 |
+| 1.0 s |  1000.000 |
+
+Worth remembering before optimising anything on the strength of those numbers.
+The slowest-looking test in the repo takes about a tenth of a second.
+
+### Where the wall clock actually goes
+
+Warm compile cache, this machine, `bash tests/test.sh decimo` (50 files):
+
+| Quantity                                   | Time   |
+| ------------------------------------------ | ------ |
+| Sum of all test bodies (harness durations) | 0.78 s |
+| Wall clock, sequential                     | 67.4 s |
+
+About 99% of the run is fixed per-file cost: one `mojo run` process each, with
+process start, compile-cache validation, `decimo.mojoc` load and libpython
+init. A bare `mojo run` on a two-line hello-world is already 0.27 s; a decimo
+test file that asserts nothing measurable still costs ~0.6 s.
+
+Nothing inside the tests is worth optimising at this ratio. The lever is to
+stop paying that cost 50 times in series. The files are independent, so
+`tests/test.sh` takes `DECIMO_TEST_JOBS` (default 1) and runs that many
+concurrently, buffering each file's output and replaying it whole, in the
+original order, so the transcript is unchanged:
+
+| `DECIMO_TEST_JOBS` | `test.sh decimo` | `test.sh all` |
+| ------------------ | ---------------- | ------------- |
+| 1 (default)        | 67.4 s           | 68.4 s        |
+| 4                  | 21.4 s           |               |
+| 8                  | 13.3 s           | 15.2 s        |
+| 14 (= `hw.ncpu`)   | 10.6 s           |               |
+
+Same 1005 passing tests either way, and the normalised transcripts are
+identical. Note that these numbers all assume a warm cache: the first run after
+`src/decimo` changes recompiles every test file and takes ~320 s sequentially.
+
+### Building long decimal literals in tests
+
+Several cross-check tests build a long decimal literal out of random 18-digit
+groups. A review flagged the `result += String(...)` loop as quadratic. It is
+not: `String._iadd` grows through `_realloc_mutable`, which allocates
+`max(requested, capacity * 2)`, so appending is amortised O(1).
+
+Measured, best of 20, including the `random_ui64` draws (which dominate):
+
+| Groups    | `+=`      | `+=` after reserving | `List` + `join` |
+| --------- | --------- | -------------------- | --------------- |
+| 789       | 0.044 ms  | 0.047 ms             | 0.041 ms        |
+| 12 345    | 0.699 ms  | 0.743 ms             | 0.649 ms        |
+| 123 450   | 7.052 ms  | 7.496 ms             | 6.644 ms        |
+| 1 234 500 | 71.450 ms | 75.658 ms            | 67.633 ms       |
+
+Linear across three orders of magnitude, and the three forms are within 10% of
+each other. Reserving up front is *slower* than the naive loop here, because it
+touches the full 18-bytes-per-group upper bound while the doubling strategy
+never allocates more than twice what is used. The tests use
+`decimo.tests.random_decimal_string()` (the `join` form) for the marginal win
+and, mainly, so the intent lives in one place.

--- a/docs/internal/internal_notes.md
+++ b/docs/internal/internal_notes.md
@@ -28,3 +28,52 @@
   precision 2048: 0.60656999994535 seconds.
 - #105. Implementing Burnikel-Ziegler division for BigUInt. Time taken for
   precision 2048: 0.5454419999732636 seconds.
+
+The entries above were each measured on the machine of the day, so they are a
+record of direction rather than a comparable series. The three below were all
+re-measured together (Apple silicon, best of three runs, `pi(2048)`), so the
+ratios between them are meaningful:
+
+| Stage | `pi(2048)` | vs. previous |
+| --- | --- | --- |
+| `2e81976` - Chudnovsky over `BigInt10` (base 10^9) | 0.2539 s | - |
+| `51e5896` - Chudnovsky over `BigInt` (base 2^32) | 0.1408 s | 1.80x |
+| common powers of two divided out in `combine()` | 0.0974 s | 1.45x |
+
+Notes on the last two, both in `bigdecimal/constants.mojo`:
+
+- Moving binary splitting from `BigInt10` to `BigInt` was a 5x *regression*
+  before it was a win. `BigInt` arithmetic is the faster of the two (at 20 000
+  digits: multiply 798 vs. 690 us, divide 2285 vs. 3049 us), but the split
+  hands back two operands of tens of thousands of digits that then have to
+  cross from base 2^32 to base 10^9. Profiling `pi(1000)`: split 15.9 ms, the
+  two base conversions 44.5 ms, the division that consumes them 0.082 ms. Two
+  fixes: `BigInt.to_biguint()` reuses the divide-and-conquer conversion that
+  `to_string()` already had (above 128 words), and both operands are shifted
+  right by a common bit count before the conversion, which leaves their ratio
+  intact but converts only the digits the quotient actually needs.
+- Dividing the common powers of two out of `p` and `q` at each combine is two
+  shifts, no gcd. `q` is dense in factors of two - it is built from `(k!)^3`
+  and `262537412640768000^k`, and 262537412640768000 alone contributes 2^18 per
+  term - so this reclaims a large constant factor for almost nothing.
+
+Measured over the whole split (not just `pi`), at 640 terms (~9 000 digits):
+
+| Reduction at each combine | Time | Final `p` size |
+| --- | --- | --- |
+| none | 15.2 s | 16 232 668 bits |
+| common powers of two (two shifts) | 10.0 s | 11 958 706 bits |
+| full gcd | 14.8 s | 36 921 bits |
+
+The full gcd is not the disaster its cost per step suggests: it collapses the
+operands by a factor of ~440, so it is already break-even at 9 000 digits and
+wins outright beyond that. It is not used because the shifts get most of the
+benefit for a fraction of the cost, and because `BigInt`'s gcd is binary
+(Stein's), which is quadratic; a subquadratic gcd would change this trade-off.
+
+The base cases are the remaining structural inefficiency. Each leaf `k` rebuilds
+`(6k)!/(3k)!`, `(k!)^3` and `C^k` from scratch, which is O(k) big-integer
+multiplications per leaf and O(n^2) overall. The textbook `P`/`Q`/`T` binary
+splitting recurrence makes the leaf O(1) and lets those factors telescope
+through the combines instead. At 640 terms the leaves alone cost 0.89 s of the
+total, so this is not yet the bottleneck, but it is where the next big win is.

--- a/docs/plans/rational_number.md
+++ b/docs/plans/rational_number.md
@@ -202,9 +202,11 @@ and divides both by `g`, then ensures the denominator is positive.
 
 - `__init__(numerator: BigInt, denominator: BigInt)` — auto-normalizes
 - `__init__(numerator: BigInt)` — integer as rational (denominator = 1)
-- `__init__(value: Int)` — convenience for integer literals
+- `__init__(value: Scalar)` — implicit, for any integral scalar
 - `__init__(value: String)` — parse `"3/7"`, `"1.5"`, `"-42"`, `"7e-3"`
-- `from_float(value: Float64) -> Rational` — exact float-to-rational
+- `from_integral_scalar(value: Scalar) -> Rational` — any integral width
+- `from_float(value: Scalar) -> Rational` — exact float-to-rational, for any
+  binary floating-point width
 - `from_bigdecimal(value: BigDecimal) -> Rational` — exact conversion
 
 #### Arithmetic (return new Rational — consider `__iadd__` etc. for in-place)
@@ -269,7 +271,8 @@ and divides both by `g`, then ensures the denominator is positive.
 - [x] Create `src/decimo/rational/` module directory
 - [x] Implement `Rational` struct with `BigInt` numerator/denominator
 - [x] `_normalize()` using `BigInt.gcd()`
-- [x] Constructors: from two BigInts, from single BigInt, from Int
+- [x] Constructors: from two BigInts, from single BigInt, from any integral
+      scalar
 - [x] Basic arithmetic: `+`, `-`, `*`, `/`
 - [x] Comparison operators: `==`, `!=`, `<`, `<=`, `>`, `>=`
 - [x] `__str__`, `__repr__`, `write_to`
@@ -283,7 +286,8 @@ and divides both by `g`, then ensures the denominator is positive.
 ### Phase 2: Conversions & Rounding
 
 - [x] String parsing: `"3/7"`, `"1.5"`, `"-42"`, `"7e-3"`
-- [x] `from_float(Float64)`
+- [x] `from_float(Scalar)` — every binary floating-point width
+- [x] `from_integral_scalar(Scalar)` — every integral width
 - [x] `from_bigdecimal(BigDecimal)`
 - [x] `to_float()`, `to_integer()`, `to_bigdecimal(precision, rounding_mode)`
 - [ ] `floor()`, `ceil()`, `trunc()`, `round()`, `fract()`
@@ -326,14 +330,44 @@ and divides both by `g`, then ensures the denominator is positive.
 
 ### Phase 4: Integration
 
-- [ ] Migrate `constants.mojo`'s internal `Rational` (BigInt10-based) to the new
-      type
+- [x] Migrate `constants.mojo`'s internal `Rational` to `BigInt` (it stays a
+      private, unreduced helper rather than becoming a `Rational` — see the
+      note under Phase 4 below)
 - [ ] Add `Rational` to `decimo/prelude.mojo` exports
 - [ ] Add type alias: `Frac` or `Fraction`
 - [ ] Add examples in `examples/examples_on_rational.mojo`
 - [ ] CLI calculator support for rational expressions
 - [ ] Documentation in user manual
 - [ ] Benchmark suite in `benches/rational/`
+
+> Progress note, 2026-08-23 (second pass): `from_float` and the integral
+> constructors were generalised, and `BigInt10` was cut out of the library.
+>
+> - `from_float` and `from_integral_scalar` are now parametric on the scalar's
+>   dtype, constrained with a `where` clause on the signature rather than a
+>   `comptime assert` in the body. `from_float` widens to `Float64` first,
+>   which is exact for every narrower binary format, so one decoder serves
+>   Float16, BFloat16, Float32 and Float64 alike. The integral constructor is
+>   `@implicit`, so `Rational("1/3") + 1` works; the floating-point one
+>   deliberately is not, because whether `Rational(0.1)` should mean 1/10 or
+>   the binary float that literal denotes is the caller's decision.
+> - Nothing in `src/decimo/` imports `bigint10` any more. `Rational` reaches
+>   `BigDecimal`'s base-10^9 coefficient through the new
+>   `BigInt.from_biguint()` / `BigInt.to_biguint()` pair, `BigDecimal` gained
+>   an implicit constructor from `BigInt` in place of the one from `BigInt10`,
+>   and the legacy bridge now lives on the legacy type as
+>   `BigInt10.to_bigint()` / `BigInt10.from_bigint()`. The module is kept, but
+>   depends on nothing and nothing depends on it.
+> - `constants.mojo`'s Chudnovsky binary splitting moved from `BigInt10` to
+>   `BigInt`. Its `_RationalBigInt` helper stays private and unreduced: taking
+>   a gcd at every combine step, which the public `Rational` would do, costs
+>   far more than it saves. Two changes paid for the base conversion the move
+>   would otherwise have added — `to_biguint()` now uses the divide-and-conquer
+>   path above 128 words, and the splitting's two ~70 000-digit operands are
+>   shifted right by a common number of bits before conversion, which leaves
+>   their ratio intact but converts only the digits the quotient actually
+>   needs. `pi(n)` is byte-identical to before at n = 100, 500, 1000, 2000 and
+>   5000, and 1.4x to 1.7x faster.
 
 ## 6. Key Design Decisions
 

--- a/docs/plans/rational_number.md
+++ b/docs/plans/rational_number.md
@@ -266,38 +266,61 @@ and divides both by `g`, then ensures the denominator is positive.
 
 ### Phase 1: Core Type (Foundation)
 
-- [ ] Create `src/decimo/rational/` module directory
-- [ ] Implement `Rational` struct with `BigInt` numerator/denominator
-- [ ] `_normalize()` using `BigInt.gcd()`
-- [ ] Constructors: from two BigInts, from single BigInt, from Int
-- [ ] Basic arithmetic: `+`, `-`, `*`, `/`
-- [ ] Comparison operators: `==`, `!=`, `<`, `<=`, `>`, `>=`
-- [ ] `__str__`, `__repr__`, `write_to`
-- [ ] `__neg__`, `__abs__`
+- [x] Create `src/decimo/rational/` module directory
+- [x] Implement `Rational` struct with `BigInt` numerator/denominator
+- [x] `_normalize()` using `BigInt.gcd()`
+- [x] Constructors: from two BigInts, from single BigInt, from Int
+- [x] Basic arithmetic: `+`, `-`, `*`, `/`
+- [x] Comparison operators: `==`, `!=`, `<`, `<=`, `>`, `>=`
+- [x] `__str__`, `__repr__`, `write_to`
+- [x] `__neg__`, `__abs__`
 - [ ] Trait conformances: Stringable, Writable, Comparable, EqualityComparable,
       Hashable, Copyable, Movable
-- [ ] Unit tests for all of the above
+      (done except `Hashable`, which needs `__hash__`; `Stringable` is not
+      declared, though `String(r)` already works through `Writable`)
+- [x] Unit tests for all of the above — `tests/rational/test_rational_basic.mojo`
 
 ### Phase 2: Conversions & Rounding
 
-- [ ] String parsing: `"3/7"`, `"1.5"`, `"-42"`, `"7e-3"`
-- [ ] `from_float(Float64)`
-- [ ] `from_bigdecimal(BigDecimal)`
-- [ ] `to_float()`, `to_integer()`, `to_bigdecimal(precision, rounding_mode)`
+- [x] String parsing: `"3/7"`, `"1.5"`, `"-42"`, `"7e-3"`
+- [x] `from_float(Float64)`
+- [x] `from_bigdecimal(BigDecimal)`
+- [x] `to_float()`, `to_integer()`, `to_bigdecimal(precision, rounding_mode)`
 - [ ] `floor()`, `ceil()`, `trunc()`, `round()`, `fract()`
 - [ ] `__floordiv__`, `__mod__`
 - [ ] `__pow__(Int)`
-- [ ] `reciprocal()`
+- [x] `reciprocal()`
 - [ ] In-place operators: `__iadd__`, `__isub__`, `__imul__`, `__itruediv__`
-- [ ] Unit tests
+- [x] Unit tests for the conversions above —
+      `tests/rational/test_rational_conversion.mojo`
+
+> Progress note, 2026-08-23: the conversion half of Phase 2 is in.
+>
+> - `from_string` doubles as the `Parsable` conformance, and takes either one
+>   decimal literal or two separated by `/`. Each side goes through
+>   `BigDecimal`, so it accepts everything `BigDecimal` does — signs, spaces,
+>   commas, underscores, scientific notation — and `"1.5/2.5"` is 3/5.
+> - `to_bigdecimal(precision, rounding_mode)` divides the exact integers and
+>   rounds once, weighing `2 * remainder` against the divisor, so all seven
+>   rounding modes are honoured with no double rounding. A value with a finite
+>   decimal form comes back unpadded (`1/2` is `0.5`).
+> - `to_float()` builds the Float64 bit pattern from a 53-bit quotient rounded
+>   ties-to-even, rather than going through a decimal string. The decimal
+>   detour would lose exact halfway cases — `(2^53 + 1) / 2^53` must round to
+>   `1.0` — and Mojo's `Float64(String)` rejects long literals anyway.
+>   Subnormals, overflow to `inf` and underflow to zero are all covered.
+> - All of it is cross-checked against CPython `fractions.Fraction`,
+>   `float(Fraction)` and `decimal.Decimal` over 200 random cases spanning
+>   small, huge, tiny and dyadic fractions.
 
 ### Phase 3: Advanced Features
 
 - [ ] `limit_denominator(max)` — continued-fraction best-approximation algorithm
 - [ ] `continued_fraction() -> List[BigInt]`
 - [ ] `mediant(other)`
-- [ ] `is_integer()`, `is_zero()`, `is_positive()`, `is_negative()`, `sign()`
-- [ ] Predefined constants: `ZERO`, `ONE`, `ONE_HALF`
+- [x] `is_integer()`, `is_zero()`, `is_positive()`, `is_negative()`, `sign()`
+- [x] Predefined constants — as the static methods `zero()`, `one()`, `two()`,
+      `minus_one()`, `one_half()`, `one_third()`
 - [ ] Mixed-type arithmetic: `Rational + BigInt`, `Rational + Int`, etc.
 - [ ] Unit tests
 

--- a/docs/plans/rational_number.md
+++ b/docs/plans/rational_number.md
@@ -73,7 +73,7 @@ This plan proposes a full public type.
 | From single integer | `Fraction(5)`              | `BigFraction(5)`          | `Ratio::from_integer(5)` | `rational<int>(5)`    | `Rational(5)`              |
 | From string `"3/7"` | `Fraction("3/7")`          | ✗                         | ✗ (via parse)            | `cin >> r`            | `Rational("3/7")`          |
 | From decimal string | `Fraction("1.5")`          | ✗                         | ✗                        | ✗                     | `Rational("1.5")`          |
-| From float          | `Fraction.from_float(1.5)` | `BigFraction(1.5)`        | ✗                        | ✗                     | `Rational.from_float(1.5)` |
+| From float          | `Fraction.from_float(1.5)` | `BigFraction(1.5)`        | ✗                        | ✗                     | `Rational.from_float_scalar(1.5)` |
 | From BigDecimal     | —                          | `BigFraction(bigDecimal)` | —                        | —                     | `Rational(big_decimal)`    |
 
 ### 3.3 Arithmetic Operations
@@ -205,7 +205,7 @@ and divides both by `g`, then ensures the denominator is positive.
 - `__init__(value: Scalar)` — implicit, for any integral scalar
 - `__init__(value: String)` — parse `"3/7"`, `"1.5"`, `"-42"`, `"7e-3"`
 - `from_integral_scalar(value: Scalar) -> Rational` — any integral width
-- `from_float(value: Scalar) -> Rational` — exact float-to-rational, for any
+- `from_float_scalar(value: Scalar) -> Rational` — exact float-to-rational, for any
   binary floating-point width
 - `from_bigdecimal(value: BigDecimal) -> Rational` — exact conversion
 
@@ -286,7 +286,7 @@ and divides both by `g`, then ensures the denominator is positive.
 ### Phase 2: Conversions & Rounding
 
 - [x] String parsing: `"3/7"`, `"1.5"`, `"-42"`, `"7e-3"`
-- [x] `from_float(Scalar)` — every binary floating-point width
+- [x] `from_float_scalar(Scalar)` — every binary floating-point width
 - [x] `from_integral_scalar(Scalar)` — every integral width
 - [x] `from_bigdecimal(BigDecimal)`
 - [x] `to_float()`, `to_integer()`, `to_bigdecimal(precision, rounding_mode)`
@@ -359,15 +359,40 @@ and divides both by `g`, then ensures the denominator is positive.
 >   `BigInt10.to_bigint()` / `BigInt10.from_bigint()`. The module is kept, but
 >   depends on nothing and nothing depends on it.
 > - `constants.mojo`'s Chudnovsky binary splitting moved from `BigInt10` to
->   `BigInt`. Its `_RationalBigInt` helper stays private and unreduced: taking
->   a gcd at every combine step, which the public `Rational` would do, costs
->   far more than it saves. Two changes paid for the base conversion the move
+>   `BigInt`. Its `_UnreducedFraction` helper stays private: the public
+>   `Rational` documents lowest terms as an invariant, and `__eq__` compares
+>   the two fields directly, so an unreduced value stored in a `Rational` would
+>   be unsound. Two changes paid for the base conversion the move
 >   would otherwise have added — `to_biguint()` now uses the divide-and-conquer
 >   path above 128 words, and the splitting's two ~70 000-digit operands are
 >   shifted right by a common number of bits before conversion, which leaves
 >   their ratio intact but converts only the digits the quotient actually
 >   needs. `pi(n)` is byte-identical to before at n = 100, 500, 1000, 2000 and
 >   5000, and 1.4x to 1.7x faster.
+
+> Progress note, 2026-08-23 (third pass): scalar-factory symmetry, and a second
+> round on pi. See `docs/internal/internal_notes.md` for the pi measurements.
+>
+> - The scalar factories now have parallel names and parallel signatures across
+>   `BigUInt`, `BigInt`, `BigDecimal`, `Decimal128` and `Rational`:
+>   `from_integral_scalar[dtype](Scalar[dtype]) where dtype.is_integral()` and
+>   `from_float_scalar[dtype](Scalar[dtype]) where dtype.is_floating_point()`.
+>   `from_float` survives as a deprecated forwarder on `BigDecimal` and
+>   `Decimal128`, which shipped it in v0.13.0; `Rational.from_float` was one
+>   commit old and unreleased, so it was simply renamed. `Decimal128` gained
+>   the parametric pair it never had - it only accepted `Int` and `Float64`.
+> - Every remaining `comptime assert dtype.is_...()` guarding a signature moved
+>   onto the signature as a `where` clause. Two did not, for a reason worth
+>   recording: a `where` clause has to be *discharged by the caller*, so
+>   `BigUInt.from_unsigned_integral_scalar` cannot have one - its only caller
+>   reaches it through `unsigned_counterpart[dtype]()`, whose result the
+>   compiler will not evaluate while proving a constraint. A `comptime assert`
+>   in a caller does count as evidence, which is why
+>   `BigDecimal.__init__(Scalar)` keeps its long "quote the literal instead"
+>   message and still satisfies `from_integral_scalar`'s `where`.
+> - The Chudnovsky combine now divides the common powers of two out of `p` and
+>   `q` - two shifts, no gcd. `q` is dense in factors of two, and this is worth
+>   1.45x on `pi(2048)` on top of the previous pass.
 
 ## 6. Key Design Decisions
 

--- a/docs/readme_zht.md
+++ b/docs/readme_zht.md
@@ -266,7 +266,7 @@ def main() raises:
     var a = Dec128("123.45")                         # 從字符串
     var b = Dec128(123)                              # 從整數
     var c = Dec128(123, 2)                           # 帶精度的整數 (1.23)
-    var d = Dec128.from_float(3.14159)               # 從浮點數
+    var d = Dec128.from_float_scalar(3.14159)         # 從浮點數
     
     # === 基本算術 ===
     print(a + b)                                     # 加法: 246.45

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -564,10 +564,10 @@ var y = Decimal(UInt128(99999999999999))
 ```
 
 Works with all integral SIMD types.
-**Floating-point scalars are rejected at compile time** — use `from_float()`
-instead.
+**Floating-point scalars are rejected at compile time** — use
+`from_float_scalar()` instead.
 
-#### From floating-point — `from_float()` <!-- omit from toc -->
+#### From floating-point — `from_float_scalar()` <!-- omit from toc -->
 
 When constructing a `Decimal` from a floating-point number, the number is first
 converted to its string representation and then parsed as a `Decimal`.
@@ -578,15 +578,21 @@ floating-point. You may lose precision without awareness.
 To make the conversion from float to `Decimal` more explicit so that you are
 aware of the potential precision issues, the `Decimal()` constructor does not
 accept floating-point numbers directly. Instead, to create a `Decimal` from a
-float, you must use the `from_float()` factory method.
+float, you must use the `from_float_scalar()` factory method. It accepts any
+floating-point width — `Float16`, `BFloat16`, `Float32`, `Float64` and the
+8-bit formats — since every one of them widens to `Float64` exactly.
 
-Consider never using `Decimal.from_float()` in performance-sensitive code, but
-use string construction instead.
+Consider never using `Decimal.from_float_scalar()` in performance-sensitive
+code, but use string construction instead.
 
 ```mojo
-var x = Decimal.from_float(3.14159)
-var y = Decimal.from_float(Float64(2.71828))
+var x = Decimal.from_float_scalar(3.14159)
+var y = Decimal.from_float_scalar(Float32(2.71828))
 ```
+
+`from_float()` is the former name and still works, forwarding unchanged. It is
+deprecated in favour of `from_float_scalar()`, which lines up with
+`from_integral_scalar()`.
 
 #### From Python — `from_python_decimal()` <!-- omit from toc -->
 
@@ -612,7 +618,8 @@ var b = Decimal(py=py_dec)  # Alternative keyword-only syntax
 | `Decimal(value: Scalar)`              | From any integral scalar (impl) |
 | `Decimal(py=py_obj)`                  | From Python `Decimal` (raises)  |
 | `Decimal.from_integral_scalar(value)` | From any integral scalar type   |
-| `Decimal.from_float(value)`           | From floating-point (raises)    |
+| `Decimal.from_float_scalar(value)`    | From any float scalar (raises)  |
+| `Decimal.from_float(value)`           | Deprecated alias of the above   |
 | `Decimal.from_string(value)`          | Explicit factory from string    |
 | `Decimal.from_python_decimal(py_obj)` | From Python `Decimal` (raises)  |
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -165,7 +165,7 @@ Accepts any integral scalar type (`Int8` through `Int256`, `UInt8` through
 | `BInt(value: Scalar)`              | From any integral scalar (implicit)   |
 | `BInt.from_integral_scalar(value)` | From any integral scalar type         |
 | `BInt.from_string(value)`          | Explicit factory from string (raises) |
-| `BInt.from_bigint10(value)`        | Convert from `BigInt10`               |
+| `BInt.from_biguint(value, sign)`   | From a base-10^9 magnitude and a sign |
 
 #### Unsafe constructors <!-- omit from toc -->
 
@@ -403,7 +403,7 @@ print(mod_inverse(BInt(3), BInt(7)))      # 5
 | ----------------- | ------------------------------------------------- |
 | `int(x)`          | Convert to `Int` (raises if exceeds 64-bit range) |
 | `float(x)`        | Convert to `Float64` (may lose precision)         |
-| `x.to_bigint10()` | Convert to `BigInt10` (base-10^9)                 |
+| `x.to_biguint()`  | Convert the magnitude to `BigUInt` (base-10^9)    |
 
 ```mojo
 var x = BInt("123456789012345678901234567890")

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -32,7 +32,7 @@ from decimo.traits import Numeric, Parsable, Rootable
 from decimo.rounding_mode import RoundingMode
 from decimo.numerals.chinese import ChineseNumeralStyle
 from decimo.bigdecimal.exponential import MathCache
-from decimo.bigint10.bigint10 import BigInt10
+from decimo.bigint.bigint import BigInt
 import decimo.str as decimo_str
 import decimo.numerals.chinese as decimo_chinese
 import decimo.bigdecimal.arithmetics as bigdecimal_arithmetics
@@ -221,13 +221,13 @@ struct BigDecimal(
         self.sign = sign
 
     @implicit
-    def __init__(out self, value: BigInt10):
-        """Constructs a BigDecimal from a base-10 big integer.
+    def __init__(out self, value: BigInt):
+        """Constructs a BigDecimal from an arbitrary-precision integer.
 
         Args:
-            value: The `BigInt10` to convert.
+            value: The `BigInt` to convert.
         """
-        self.coefficient = value.magnitude.copy()
+        self.coefficient = value.to_biguint()
         self.scale = 0
         self.sign = value.sign
 

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -263,7 +263,7 @@ struct BigDecimal(
             " avoid unintentional loss of precision. If you want to create"
             " a BigDecimal from a floating-point number, please consider"
             " wrapping it with quotation marks or using the"
-            " `Decimal.from_float()` method"
+            " `BigDecimal.from_float_scalar()` method"
             " instead."
             "\n***********************************************************"
         )
@@ -284,7 +284,7 @@ struct BigDecimal(
     # ===------------------------------------------------------------------=== #
     # Constructing methods that are not dunders
     # from_integral_scalar[dtype: DType](value: Scalar[dtype]) -> Self
-    # from_float[dtype: DType](value: Scalar[dtype]) -> Self
+    # from_float_scalar[dtype: DType](value: Scalar[dtype]) -> Self
     # from_string(value: String) -> Self
     # ===------------------------------------------------------------------=== #
 
@@ -330,7 +330,9 @@ struct BigDecimal(
         return Self(BigUInt(raw_words=[word]), scale, sign)
 
     @staticmethod
-    def from_integral_scalar[dtype: DType, //](value: SIMD[dtype, 1]) -> Self:
+    def from_integral_scalar[
+        dtype: DType, //
+    ](value: Scalar[dtype]) -> Self where dtype.is_integral():
         """Initializes a BigDecimal from an integral scalar.
         This includes all SIMD integral types, such as Int8, Int16, UInt32, etc.
 
@@ -344,8 +346,6 @@ struct BigDecimal(
             dtype: The data type of the scalar.
         """
 
-        comptime assert dtype.is_integral(), "dtype must be integral."
-
         if value == 0:
             return Self(coefficient=BigUInt.zero(), scale=0, sign=False)
 
@@ -356,7 +356,33 @@ struct BigDecimal(
         )
 
     @staticmethod
-    def from_float[dtype: DType, //](value: Scalar[dtype]) raises -> Self:
+    def from_float[
+        dtype: DType, //
+    ](value: Scalar[dtype]) raises -> Self where dtype.is_floating_point():
+        """Initializes a BigDecimal from a floating-point scalar.
+
+        Deprecated: use `from_float_scalar()`, which is the name that lines up
+        with `from_integral_scalar()`. This forwards to it unchanged.
+
+        Args:
+            value: The Scalar value to be converted to BigDecimal.
+
+        Returns:
+            The BigDecimal representation of the Scalar value.
+
+        Raises:
+            ValueError: If the value is NaN.
+            ConversionError: If the conversion from scalar to BigDecimal fails.
+
+        Parameters:
+            dtype: The data type of the scalar.
+        """
+        return Self.from_float_scalar(value)
+
+    @staticmethod
+    def from_float_scalar[
+        dtype: DType, //
+    ](value: Scalar[dtype]) raises -> Self where dtype.is_floating_point():
         """Initializes a BigDecimal from a floating-point scalar.
 
         Args:
@@ -378,17 +404,13 @@ struct BigDecimal(
             dtype: The data type of the scalar.
         """
 
-        comptime assert (
-            dtype.is_floating_point()
-        ), "dtype must be floating-point."
-
         if value == 0:
             return Self(coefficient=BigUInt.zero(), scale=0, sign=False)
 
         if value != value:  # Check for NaN
             raise ValueError(
                 message="Cannot convert NaN to BigDecimal.",
-                function="BigDecimal.from_scalar()",
+                function="BigDecimal.from_float_scalar()",
             )
         # Convert to string with full precision
         try:
@@ -396,7 +418,7 @@ struct BigDecimal(
         except e:
             raise ConversionError(
                 message="Cannot convert scalar to BigDecimal.",
-                function="BigDecimal.from_scalar()",
+                function="BigDecimal.from_float_scalar()",
                 previous_error=e^,
             )
 

--- a/src/decimo/bigdecimal/constants.mojo
+++ b/src/decimo/bigdecimal/constants.mojo
@@ -20,6 +20,7 @@
 from decimo.bigdecimal.bigdecimal import BigDecimal
 from decimo.errors import ValueError
 from decimo.bigint.bigint import BigInt
+from decimo.bigint.number_theory import _count_trailing_zeros
 from decimo.biguint.biguint import BigUInt
 from decimo.rounding_mode import RoundingMode
 import decimo.bigdecimal.trigonometric as bigdecimal_trigonometric
@@ -190,13 +191,23 @@ def pi(precision: Int) raises -> BigDecimal:
     return pi_chudnovsky_binary_split(precision)
 
 
-struct _RationalBigInt:
-    """Internal rational number p/q used for Chudnovsky binary splitting.
+struct _UnreducedFraction:
+    """Internal fraction p/q used for Chudnovsky binary splitting.
 
-    Note: This is an internal helper, kept separate from the public `Rational`
-    type in `decimo.rational.rational` because binary splitting wants the
-    fraction left unreduced - taking a gcd at every combine step would cost
-    far more than it saves.
+    Deliberately not the public `Rational` type in `decimo.rational.rational`:
+    binary splitting carries the fraction *unreduced*, and `Rational` documents
+    lowest terms as an invariant (`__eq__` compares the two fields directly and
+    would be unsound without it). This struct is the same pair of BigInts with
+    that invariant dropped, so the difference is a contract, not duplication.
+
+    Note: unreduced does not mean untouched. `combine()` divides out the common
+    powers of two, which is two shifts rather than a gcd. That is worth doing:
+    measured over the whole split at 640 terms (~9 000 digits of pi), leaving
+    the fraction fully unreduced takes 15.2 s, stripping the common twos takes
+    10.0 s, and a full gcd at every step takes 14.8 s. A full gcd is therefore
+    not the disaster it looks like - it is roughly break-even here and wins
+    outright beyond this size - but the shifts get most of the benefit for
+    almost none of the cost.
     """
 
     var p: BigInt  # numerator
@@ -205,7 +216,7 @@ struct _RationalBigInt:
     """The denominator of the rational number."""
 
     def __init__(out self, p: BigInt, q: BigInt):
-        """Initializes a rational number from a numerator and denominator.
+        """Initializes a fraction from a numerator and denominator.
 
         Args:
             p: The numerator.
@@ -213,6 +224,33 @@ struct _RationalBigInt:
         """
         self.p = p.copy()
         self.q = q.copy()
+
+    @staticmethod
+    def combine(left: Self, right: Self) raises -> Self:
+        """Adds two partial sums: left.p/left.q + right.p/right.q.
+
+        The common powers of two are divided out of the result. Both operands
+        grow by roughly the sum of their sizes at every level of the split, and
+        `q` is dense in factors of two - it is built from `(k!)^3` and from
+        `262537412640768000^k`, and 262537412640768000 alone contributes 2^18
+        per term - so this reclaims a large constant factor for two shifts.
+
+        Args:
+            left: The partial sum over the lower half of the range.
+            right: The partial sum over the upper half of the range.
+
+        Returns:
+            The combined partial sum.
+        """
+        var p = left.p * right.q + right.p * left.q
+        var q = left.q * right.q
+        var common_twos = min(
+            _count_trailing_zeros(p.words), _count_trailing_zeros(q.words)
+        )
+        if common_twos > 0:
+            p >>= common_twos
+            q >>= common_twos
+        return Self(p^, q^)
 
 
 def pi_chudnovsky_binary_split(precision: Int) raises -> BigDecimal:
@@ -285,7 +323,9 @@ def pi_chudnovsky_binary_split(precision: Int) raises -> BigDecimal:
     return result^
 
 
-def chudnovsky_split(a: Int, b: Int, precision: Int) raises -> _RationalBigInt:
+def chudnovsky_split(
+    a: Int, b: Int, precision: Int
+) raises -> _UnreducedFraction:
     """Conducts binary splitting for Chudnovsky series from term a to b-1.
 
     Args:
@@ -294,7 +334,8 @@ def chudnovsky_split(a: Int, b: Int, precision: Int) raises -> _RationalBigInt:
         precision: The working precision for intermediate calculations.
 
     Returns:
-        A `_RationalBigInt` representing the partial sum of the Chudnovsky series.
+        A `_UnreducedFraction` representing the partial sum of the
+        Chudnovsky series.
 
     Raises:
         Error: If an arithmetic error occurs during computation.
@@ -309,7 +350,7 @@ def chudnovsky_split(a: Int, b: Int, precision: Int) raises -> _RationalBigInt:
         # Base case: compute single term as exact rational
         if a == 0:
             # Special case for k=0: M(0)=1, L(0)=13591409, X(0)=1
-            return _RationalBigInt(bint_13591409, bint_1)
+            return _UnreducedFraction(bint_13591409, bint_1)
 
         # For k > 0: compute M(k), L(k), X(k)
         var m_k_rational = compute_m_k_rational(a)
@@ -328,28 +369,24 @@ def chudnovsky_split(a: Int, b: Int, precision: Int) raises -> _RationalBigInt:
         var term_p = m_k_rational.p * l_k
         var term_q = m_k_rational.q * x_k
 
-        return _RationalBigInt(term_p^, term_q^)
+        return _UnreducedFraction(term_p^, term_q^)
 
     # Recursive case: split range in half
     var mid = (a + b) // 2
     var left = chudnovsky_split(a, mid, precision)
     var right = chudnovsky_split(mid, b, precision)
 
-    # Combine fractions: left.p/left.q + right.p/right.q
-    var combined_p = left.p * right.q + right.p * left.q
-    var combined_q = left.q * right.q
-
-    return _RationalBigInt(combined_p^, combined_q^)
+    return _UnreducedFraction.combine(left, right)
 
 
-def compute_m_k_rational(k: Int) raises -> _RationalBigInt:
+def compute_m_k_rational(k: Int) raises -> _UnreducedFraction:
     """Computes M(k) = (6k)! / ((3k)! * (k!)³) as exact rational.
 
     Args:
         k: The term index in the Chudnovsky series.
 
     Returns:
-        A `_RationalBigInt` with numerator (6k)!/(3k)! and denominator (k!)³.
+        A `_UnreducedFraction` with numerator (6k)!/(3k)! and denominator (k!)³.
 
     Raises:
         Error: If an arithmetic error occurs during computation.
@@ -358,7 +395,7 @@ def compute_m_k_rational(k: Int) raises -> _RationalBigInt:
     var bint_1 = BigInt(1)
 
     if k == 0:
-        return _RationalBigInt(bint_1, bint_1)
+        return _UnreducedFraction(bint_1, bint_1)
 
     # Compute numerator: (6k)! / (3k)! = (3k+1) * (3k+2) * ... * (6k)
     var numerator = bint_1.copy()
@@ -372,7 +409,7 @@ def compute_m_k_rational(k: Int) raises -> _RationalBigInt:
 
     var denominator = k_factorial * k_factorial * k_factorial
 
-    return _RationalBigInt(numerator, denominator)
+    return _UnreducedFraction(numerator, denominator)
 
 
 def pi_machin(precision: Int) raises -> BigDecimal:

--- a/src/decimo/bigdecimal/constants.mojo
+++ b/src/decimo/bigdecimal/constants.mojo
@@ -19,7 +19,7 @@
 
 from decimo.bigdecimal.bigdecimal import BigDecimal
 from decimo.errors import ValueError
-from decimo.bigint10.bigint10 import BigInt10
+from decimo.bigint.bigint import BigInt
 from decimo.biguint.biguint import BigUInt
 from decimo.rounding_mode import RoundingMode
 import decimo.bigdecimal.trigonometric as bigdecimal_trigonometric
@@ -190,20 +190,21 @@ def pi(precision: Int) raises -> BigDecimal:
     return pi_chudnovsky_binary_split(precision)
 
 
-struct _RationalBigInt10:
-    """Internal rational number p/q using BigInt10 for Chudnovsky binary splitting.
+struct _RationalBigInt:
+    """Internal rational number p/q used for Chudnovsky binary splitting.
 
-    Note: This is a legacy internal helper. The public Rational type lives in
-    `decimo.rational.rational` and uses BigInt instead. This struct will be
-    migrated in a future release.
+    Note: This is an internal helper, kept separate from the public `Rational`
+    type in `decimo.rational.rational` because binary splitting wants the
+    fraction left unreduced - taking a gcd at every combine step would cost
+    far more than it saves.
     """
 
-    var p: BigInt10  # numerator
+    var p: BigInt  # numerator
     """The numerator of the rational number."""
-    var q: BigInt10  # denominator
+    var q: BigInt  # denominator
     """The denominator of the rational number."""
 
-    def __init__(out self, p: BigInt10, q: BigInt10):
+    def __init__(out self, p: BigInt, q: BigInt):
         """Initializes a rational number from a numerator and denominator.
 
         Args:
@@ -247,9 +248,27 @@ def pi_chudnovsky_binary_split(precision: Int) raises -> BigDecimal:
     # Binary splitting to compute the series sum as a single rational number
     var result_fraction = chudnovsky_split(0, iterations, working_precision)
 
-    # Convert rational result to BigDecimal: q/p
-    var sum_series = BigDecimal(result_fraction.q).true_divide(
-        BigDecimal(result_fraction.p), working_precision
+    # Convert rational result to BigDecimal: q/p.
+    #
+    # Binary splitting hands back two operands of tens of thousands of digits,
+    # of which only `working_precision` survive the division. Shifting both by
+    # the same number of bits leaves the ratio unchanged to within a relative
+    # error of 2^-guard_bits, and keeps the base-2^32 to base-10^9 conversion
+    # proportional to the digits actually wanted rather than to the digits the
+    # splitting happened to produce.
+    var guard_bits = (working_precision + 32) * 10 // 3  # 10/3 > log2(10)
+    var shared_bits = min(
+        result_fraction.p.bit_length(), result_fraction.q.bit_length()
+    )
+    var numerator = result_fraction.q.copy()
+    var denominator = result_fraction.p.copy()
+    if shared_bits > guard_bits:
+        var shift = shared_bits - guard_bits
+        numerator = numerator >> shift
+        denominator = denominator >> shift
+
+    var sum_series = BigDecimal(numerator).true_divide(
+        BigDecimal(denominator), working_precision
     )
 
     # Final formula: π = 426880 * √10005 / sum_series
@@ -266,9 +285,7 @@ def pi_chudnovsky_binary_split(precision: Int) raises -> BigDecimal:
     return result^
 
 
-def chudnovsky_split(
-    a: Int, b: Int, precision: Int
-) raises -> _RationalBigInt10:
+def chudnovsky_split(a: Int, b: Int, precision: Int) raises -> _RationalBigInt:
     """Conducts binary splitting for Chudnovsky series from term a to b-1.
 
     Args:
@@ -277,26 +294,26 @@ def chudnovsky_split(
         precision: The working precision for intermediate calculations.
 
     Returns:
-        A `_RationalBigInt10` representing the partial sum of the Chudnovsky series.
+        A `_RationalBigInt` representing the partial sum of the Chudnovsky series.
 
     Raises:
         Error: If an arithmetic error occurs during computation.
     """
 
-    var bint_1 = BigInt10(1)
-    var bint_13591409 = BigInt10(13591409)
-    var bint_545140134 = BigInt10(545140134)
-    var bint_262537412640768000 = BigInt10(262537412640768000)
+    var bint_1 = BigInt(1)
+    var bint_13591409 = BigInt(13591409)
+    var bint_545140134 = BigInt(545140134)
+    var bint_262537412640768000 = BigInt(262537412640768000)
 
     if b - a == 1:
         # Base case: compute single term as exact rational
         if a == 0:
             # Special case for k=0: M(0)=1, L(0)=13591409, X(0)=1
-            return _RationalBigInt10(bint_13591409, bint_1)
+            return _RationalBigInt(bint_13591409, bint_1)
 
         # For k > 0: compute M(k), L(k), X(k)
         var m_k_rational = compute_m_k_rational(a)
-        var l_k = bint_545140134 * BigInt10(a) + bint_13591409
+        var l_k = bint_545140134 * BigInt(a) + bint_13591409
 
         # X(k) = (-262537412640768000)^k
         var x_k = bint_1^
@@ -311,7 +328,7 @@ def chudnovsky_split(
         var term_p = m_k_rational.p * l_k
         var term_q = m_k_rational.q * x_k
 
-        return _RationalBigInt10(term_p^, term_q^)
+        return _RationalBigInt(term_p^, term_q^)
 
     # Recursive case: split range in half
     var mid = (a + b) // 2
@@ -322,40 +339,40 @@ def chudnovsky_split(
     var combined_p = left.p * right.q + right.p * left.q
     var combined_q = left.q * right.q
 
-    return _RationalBigInt10(combined_p^, combined_q^)
+    return _RationalBigInt(combined_p^, combined_q^)
 
 
-def compute_m_k_rational(k: Int) raises -> _RationalBigInt10:
+def compute_m_k_rational(k: Int) raises -> _RationalBigInt:
     """Computes M(k) = (6k)! / ((3k)! * (k!)³) as exact rational.
 
     Args:
         k: The term index in the Chudnovsky series.
 
     Returns:
-        A `_RationalBigInt10` with numerator (6k)!/(3k)! and denominator (k!)³.
+        A `_RationalBigInt` with numerator (6k)!/(3k)! and denominator (k!)³.
 
     Raises:
         Error: If an arithmetic error occurs during computation.
     """
 
-    var bint_1 = BigInt10(1)
+    var bint_1 = BigInt(1)
 
     if k == 0:
-        return _RationalBigInt10(bint_1, bint_1)
+        return _RationalBigInt(bint_1, bint_1)
 
     # Compute numerator: (6k)! / (3k)! = (3k+1) * (3k+2) * ... * (6k)
     var numerator = bint_1.copy()
     for i in range(3 * k + 1, 6 * k + 1):
-        numerator *= BigInt10(i)
+        numerator *= BigInt(i)
 
     # Compute denominator: (k!)³
     var k_factorial = bint_1.copy()
     for i in range(1, k + 1):
-        k_factorial *= BigInt10(i)
+        k_factorial *= BigInt(i)
 
     var denominator = k_factorial * k_factorial * k_factorial
 
-    return _RationalBigInt10(numerator, denominator)
+    return _RationalBigInt(numerator, denominator)
 
 
 def pi_machin(precision: Int) raises -> BigDecimal:

--- a/src/decimo/bigint/__init__.mojo
+++ b/src/decimo/bigint/__init__.mojo
@@ -19,9 +19,11 @@
 BigInt is a signed arbitrary-precision integer that uses base-2^32
 representation internally. This is the binary counterpart to BigInt10 (base-10^9).
 
-Once BigInt is stable and performant, the naming plan is:
-- The alias `BInt` will be reassigned from BigInt10 to BigInt
-- BigInt10 will be kept for decimal-friendly use cases but hidden from users
+`BInt` now names BigInt. BigInt10 is no longer referenced by any other module
+of the library: the base-10^9 side of the bridge is `to_biguint()` /
+`from_biguint()`, which speak `BigUInt` directly, and BigInt10 itself carries
+`to_bigint()` / `from_bigint()` for the code that still wants it. The module is
+kept for now, but nothing depends on it.
 
 Modules:
 - bigint: Core struct with constructors, conversions, dunders

--- a/src/decimo/bigint/bigint.mojo
+++ b/src/decimo/bigint/bigint.mojo
@@ -41,7 +41,6 @@ import decimo.str as decimo_str
 from decimo.traits import Numeric, Parsable, Rootable
 import decimo.numerals.chinese as decimo_chinese
 from decimo.numerals.chinese import ChineseNumeralStyle
-from decimo.bigint10.bigint10 import BigInt10
 from decimo.biguint.biguint import BigUInt
 from decimo.utility import unsigned_counterpart
 from decimo.errors import (
@@ -401,24 +400,25 @@ struct BigInt(
         return result^
 
     @staticmethod
-    def from_bigint10(value: BigInt10) -> Self:
-        """Converts a base-10^9 BigInt10 to a base-2^32 BigInt.
+    def from_biguint(magnitude: BigUInt, sign: Bool = False) -> Self:
+        """Converts a base-10^9 magnitude and a sign to a base-2^32 BigInt.
 
         Args:
-            value: The BigInt10 (base-10^9) to convert.
+            magnitude: The unsigned base-10^9 magnitude to convert.
+            sign: Whether the result is negative. Ignored when the magnitude
+                is zero, which is always stored unsigned.
 
         Returns:
             The BigInt (base-2^32) representation.
         """
-        if value.is_zero():
+        if magnitude.is_zero():
             return Self()
 
         # Convert from base 10^9 to base 2^32 using repeated division
-        # Work on the magnitude words (base-10^9)
-        var div_words = List[UInt32](capacity=len(value.magnitude.words))
-        for word in value.magnitude.words:
+        var div_words = List[UInt32](capacity=len(magnitude.words))
+        for word in magnitude.words:
             div_words.append(word)
-        var result = Self(uninitialized_capacity=len(value.magnitude.words))
+        var result = Self(uninitialized_capacity=len(magnitude.words))
 
         var all_zero = False
         while not all_zero:
@@ -443,7 +443,7 @@ struct BigInt(
                     all_zero = False
                     break
 
-        result.sign = value.sign
+        result.sign = sign
         return result^
 
     # ===------------------------------------------------------------------=== #
@@ -543,14 +543,35 @@ struct BigInt(
                 )
             return Int(magnitude)
 
-    def to_bigint10(self) -> BigInt10:
-        """Converts the BigInt to a base-10^9 BigInt10.
+    def to_biguint(self) -> BigUInt:
+        """Converts the magnitude of the BigInt to a base-10^9 BigUInt.
+
+        The sign is dropped: the result is the absolute value. Use
+        `is_negative()` to recover it.
 
         Returns:
-            The BigInt10 (base-10^9) representation with the same value.
+            The magnitude as a `BigUInt` (base-10^9).
         """
         if self.is_zero():
-            return BigInt10()
+            return BigUInt()
+
+        # Above the divide-and-conquer threshold, borrow the base conversion
+        # `to_string()` already has: repeated division below is O(n^2), while
+        # `to_string()` is O(M(n) log n) and re-packing a decimal string into
+        # base-10^9 words is linear. Measured on a 20 000-digit value, the
+        # detour through the string is about three times faster.
+        var effective_words = len(self.words)
+        while effective_words > 1 and self.words[effective_words - 1] == 0:
+            effective_words -= 1
+        if effective_words > _DC_TO_STR_ENTRY_THRESHOLD:
+            try:
+                return BigUInt(
+                    _magnitude_to_decimal_dc(self.words, effective_words),
+                    ignore_sign=True,
+                )
+            except:
+                # Fall through to the simple path if D&C raises.
+                pass
 
         # Convert from base 2^32 to base 10^9 using repeated division
         var dividend = self.copy()
@@ -572,7 +593,7 @@ struct BigInt(
 
             decimal_words.append(UInt32(remainder))
 
-        return BigInt10(raw_words=decimal_words^, sign=self.sign)
+        return BigUInt(raw_words=decimal_words^)
 
     def to_string(self, line_width: Int = 0) -> String:
         """Returns the decimal string representation of the BigInt.
@@ -1893,8 +1914,8 @@ struct BigInt(
         if self.is_zero():
             return 1
 
-        # Convert to BigInt10 and use its digit counting
-        return self.to_bigint10().magnitude.number_of_digits()
+        # Convert to base-10^9 and use its digit counting
+        return self.to_biguint().number_of_digits()
 
     # ===------------------------------------------------------------------=== #
     # Internal utility methods

--- a/src/decimo/bigint10/bigint10.mojo
+++ b/src/decimo/bigint10/bigint10.mojo
@@ -172,7 +172,7 @@ struct BigInt10(
             )
 
     @implicit
-    def __init__(out self, value: Scalar):
+    def __init__(out self, value: Scalar) where value.dtype.is_integral():
         """Constructs a BigInt10 from an integral scalar.
         This includes all SIMD integral types, such as Int8, Int16, UInt32, etc.
 
@@ -269,7 +269,9 @@ struct BigInt10(
         return Self(BigUInt(raw_words=list_of_words^), sign)
 
     @staticmethod
-    def from_integral_scalar[dtype: DType, //](value: SIMD[dtype, 1]) -> Self:
+    def from_integral_scalar[
+        dtype: DType, //
+    ](value: Scalar[dtype]) -> Self where dtype.is_integral():
         """Initializes a BigInt10 from an integral scalar.
         This includes all SIMD integral types, such as Int8, Int16, UInt32, etc.
 
@@ -285,8 +287,6 @@ struct BigInt10(
         Parameters:
             dtype: The data type of the input scalar.
         """
-
-        comptime assert dtype.is_integral(), "dtype must be integral."
 
         if value == 0:
             return Self()

--- a/src/decimo/bigint10/bigint10.mojo
+++ b/src/decimo/bigint10/bigint10.mojo
@@ -30,6 +30,7 @@ import decimo.bigint10.arithmetics as bigint10_arithmetics
 import decimo.bigint10.comparison as bigint10_comparison
 import decimo.biguint.arithmetics as biguint_arithmetics
 from decimo.bigdecimal.bigdecimal import BigDecimal
+from decimo.bigint.bigint import BigInt
 from decimo.biguint.biguint import BigUInt
 from decimo.errors import (
     ValueError,
@@ -419,6 +420,29 @@ struct BigInt10(
             writer: The writer instance.
         """
         writer.write(self.to_string())
+
+    @staticmethod
+    def from_bigint(value: BigInt) -> Self:
+        """Converts a base-2^32 BigInt to a base-10^9 BigInt10.
+
+        This bridge lives here, rather than on `BigInt`, so that nothing
+        outside this legacy module has to know that `BigInt10` exists.
+
+        Args:
+            value: The BigInt (base-2^32) to convert.
+
+        Returns:
+            The BigInt10 (base-10^9) representation with the same value.
+        """
+        return Self(value.to_biguint(), value.sign)
+
+    def to_bigint(self) -> BigInt:
+        """Converts the BigInt10 to a base-2^32 BigInt.
+
+        Returns:
+            The BigInt (base-2^32) representation with the same value.
+        """
+        return BigInt.from_biguint(self.magnitude, self.sign)
 
     def to_int(self) raises -> Int:
         """Returns the number as Int.
@@ -975,7 +999,9 @@ struct BigInt10(
         Returns:
             A BigDecimal value.
         """
-        return BigDecimal(self)
+        return BigDecimal(
+            coefficient=self.magnitude.copy(), scale=0, sign=self.sign
+        )
 
     # ===------------------------------------------------------------------=== #
     # Mathematical methods that do not implement a trait (not a dunder)

--- a/src/decimo/biguint/biguint.mojo
+++ b/src/decimo/biguint/biguint.mojo
@@ -26,7 +26,6 @@ mathematical methods that do not implement a trait.
 from std.memory import Pointer, unsafe_memcpy, memcmp
 from std.sys import size_of
 
-from decimo.bigint10.bigint10 import BigInt10
 import decimo.biguint.arithmetics as biguint_arithmetics
 import decimo.biguint.comparison as biguint_comparison
 import decimo.biguint.exponential as biguint_exponential

--- a/src/decimo/biguint/biguint.mojo
+++ b/src/decimo/biguint/biguint.mojo
@@ -511,7 +511,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
     @staticmethod
     def from_unsigned_integral_scalar[
         dtype: DType, //
-    ](value: SIMD[dtype, 1]) -> Self:
+    ](value: Scalar[dtype]) -> Self:
         """Initializes a BigUInt from an unsigned integral scalar.
         This includes all SIMD unsigned integral types, such as UInt8, UInt16,
         UInt32, UInt64, etc.
@@ -543,6 +543,10 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
             dtype: The scalar data type, must be integral and unsigned.
         """
 
+        # Not a `where` clause: the only in-library caller reaches this through
+        # `unsigned_counterpart[dtype]()`, whose result the compiler cannot
+        # evaluate while discharging a constraint. An in-body assert checks the
+        # same thing at instantiation without demanding a proof from the caller.
         comptime assert (
             dtype.is_integral() and dtype.is_unsigned()
         ), "dtype must be unsigned integral."
@@ -596,7 +600,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
     @staticmethod
     def from_absolute_integral_scalar[
         dtype: DType, //
-    ](value: SIMD[dtype, 1]) -> Self:
+    ](value: Scalar[dtype]) -> Self where dtype.is_integral():
         """Initializes a BigUInt from an integral scalar and ignores the sign.
         This includes all SIMD integral types, such as UInt8, UInt16, Int32,
         Int64, Int128, etc.
@@ -613,8 +617,6 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
         Parameters:
             dtype: The scalar data type, must be integral.
         """
-
-        comptime assert dtype.is_integral(), "dtype must be integral."
 
         comptime if (dtype == DType.uint8) or (dtype == DType.uint16):
             # For types that are smaller than word size

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -1039,7 +1039,7 @@ struct Decimal128(
 
         The reliability of this method is limited by the precision of Float64.
         Float64 is reliable up to 15 significant digits and marginally
-        reliable up to 16 siginficant digits. Be careful when using this method.
+        reliable up to 16 significant digits. Be careful when using this method.
 
         Args:
             value: The floating-point value to convert to Decimal128.

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -25,6 +25,7 @@ mathematical methods that do not implement a trait.
 
 from std.collections import Span
 from std.memory import Pointer
+from std.sys import bit_width_of
 from std.hashlib.hasher import Hasher
 
 import decimo.decimal128.arithmetics as decimal128_arithmetics
@@ -347,7 +348,7 @@ struct Decimal128(
 
     def __init__(out self, value: Float64) raises:
         """Initializes a Decimal128 from a floating-point value.
-        See `from_float` for more information.
+        See `from_float_scalar()` for more information.
 
         Args:
             value: The floating-point value to convert.
@@ -357,7 +358,7 @@ struct Decimal128(
         """
 
         try:
-            self = Decimal128.from_float(value)
+            self = Decimal128.from_float_scalar(value)
         except e:
             raise ConversionError(
                 message="Cannot initialize Decimal128 from Float64.",
@@ -928,8 +929,114 @@ struct Decimal128(
             )
 
     @staticmethod
+    def from_integral_scalar[
+        dtype: DType, //
+    ](value: Scalar[dtype]) raises -> Self where dtype.is_integral():
+        """Initializes a Decimal128 from an integral scalar, with scale 0.
+        This includes all SIMD integral types, both signed (Int8, Int16, Int32,
+        Int64, Int128, Int256 and the platform-sized `Int`) and unsigned
+        (UInt8 ... UInt256 and `UInt`).
+
+        Constraints:
+            The dtype must be integral.
+
+        Args:
+            value: The integral scalar to convert to Decimal128.
+
+        Returns:
+            The Decimal128 representation of the integral scalar.
+
+        Raises:
+            OverflowError: If the magnitude exceeds the 96-bit coefficient,
+                which only 128- and 256-bit scalars can do.
+
+        Notes:
+
+        The `from_int()` fast path is taken only where `Int` can hold the value
+        without reinterpreting it. `Int` is 64-bit and signed, so that is every
+        signed scalar up to 64 bits but only unsigned scalars narrower than 64:
+        `Int(UInt64.MAX)` would come out as -1. Everything else goes through the
+        256-bit path, which range checks first - that is also what makes the
+        negation there safe, since `Int256.MIN` has no positive counterpart and
+        is rejected before it is negated.
+
+        Examples:
+        ```mojo
+        from decimo import Decimal128
+        var a = Decimal128.from_integral_scalar(Int8(-123))  # -123
+        # 18446744073709551615
+        var b = Decimal128.from_integral_scalar(UInt64.MAX)
+        ```
+        End of examples.
+
+        Parameters:
+            dtype: The data type of the scalar value.
+        """
+
+        comptime width = bit_width_of[Scalar[dtype]]()
+        comptime fits_in_int = (width <= 64) if dtype.is_signed() else (
+            width < 64
+        )
+
+        comptime if fits_in_int:
+            return Self.from_int(Int(value))
+
+        elif dtype.is_unsigned():
+            var magnitude = UInt256(value)
+            if magnitude > UInt256(Self.MAX_AS_UINT128):
+                raise OverflowError(
+                    message=String(
+                        "The value {} is too large (>=2^96) to be transformed"
+                        " into Decimal128."
+                    ).format(value),
+                    function="Decimal128.from_integral_scalar()",
+                )
+            return Self.from_uint128(UInt128(magnitude), 0, False)
+
+        else:
+            var signed = Int256(value)
+            if (signed > Self.MAX_AS_INT256) or (signed < -Self.MAX_AS_INT256):
+                raise OverflowError(
+                    message=String(
+                        "The value {} is out of range (>=2^96 in magnitude) to"
+                        " be transformed into Decimal128."
+                    ).format(value),
+                    function="Decimal128.from_integral_scalar()",
+                )
+            var is_negative = signed < 0
+            var magnitude = UInt256(-signed) if is_negative else UInt256(signed)
+            return Self.from_uint128(UInt128(magnitude), 0, is_negative)
+
+    @staticmethod
     def from_float(value: Float64) raises -> Self:
-        """Initializes a Decimal128 from a floating-point value.
+        """Initializes a Decimal128 from a Float64.
+
+        Deprecated: use `from_float_scalar()`, which accepts any floating-point
+        scalar and is the name that lines up with `from_integral_scalar()`.
+        This forwards to it unchanged.
+
+        Args:
+            value: The floating-point value to convert to Decimal128.
+
+        Returns:
+            The Decimal128 representation of the floating-point value.
+
+        Raises:
+            OverflowError: If the value is too large for Decimal128.
+            ValueError: If the value is infinity or NaN.
+        """
+        return Self.from_float_scalar(value)
+
+    @staticmethod
+    def from_float_scalar[
+        dtype: DType, //
+    ](value: Scalar[dtype]) raises -> Self where dtype.is_floating_point():
+        """Initializes a Decimal128 from a floating-point scalar.
+        This includes all SIMD floating-point types, such as Float16,
+        BFloat16, Float32, Float64, and the 8-bit formats. Narrower formats are
+        widened to Float64 first, which is exact: every one of them has both
+        fewer significand bits and a narrower exponent range.
+
         The reliability of this method is limited by the precision of Float64.
         Float64 is reliable up to 15 significant digits and marginally
         reliable up to 16 siginficant digits. Be careful when using this method.
@@ -947,25 +1054,27 @@ struct Decimal128(
         Example:
         ```mojo
         from decimo import Decimal128
-        print(Decimal128.from_float(Float64(3.1415926535897932383279502)))
         # 3.1415926535897932 (17 significant digits)
-        print(Decimal128.from_float(12345678901234567890.12345678901234567890))
-        # 12345678901234567168 (20 significant digits, but only 15 are reliable)
+        print(Decimal128.from_float_scalar(3.1415926535897932383279502))
+        # 12345678901234567168 (20 digits, but only 15 are reliable)
+        print(Decimal128.from_float_scalar(12345678901234567890.1234567890))
         ```
         .
         """
 
+        var widened = value.cast[DType.float64]()
+
         # CASE: Zero
-        if value == Float64(0):
+        if widened == Float64(0):
             return Decimal128.ZERO()
 
         # Get the positive value of the input
         var abs_value: Float64
-        var is_negative: Bool = value < 0
+        var is_negative: Bool = widened < 0
         if is_negative:
-            abs_value = -value
+            abs_value = -widened
         else:
-            abs_value = value
+            abs_value = widened
 
         # Early exit if the value is too large
         if UInt128(abs_value) > Decimal128.MAX_AS_UINT128:
@@ -974,7 +1083,7 @@ struct Decimal128(
                     "The float value {} is too large (>=2^96) to be"
                     " transformed into Decimal128."
                 ).format(value),
-                function="Decimal128.from_float()",
+                function="Decimal128.from_float_scalar()",
             )
 
         # Extract binary exponent using IEEE 754 bit manipulation
@@ -995,7 +1104,7 @@ struct Decimal128(
                 message=(
                     "Cannot convert IEEE 754 infinity or NaN to Decimal128."
                 ),
-                function="Decimal128.from_float()",
+                function="Decimal128.from_float_scalar()",
             )
 
         # Get unbias exponent

--- a/src/decimo/decimal128/utility.mojo
+++ b/src/decimo/decimal128/utility.mojo
@@ -721,7 +721,9 @@ def number_of_digits[dtype: DType, //](value: Scalar[dtype]) -> Int:
 
 
 @always_inline
-def number_of_bits[dtype: DType, //](var value: Scalar[dtype]) -> Int:
+def number_of_bits[
+    dtype: DType, //
+](var value: Scalar[dtype]) -> Int where dtype.is_integral():
     """
     Returns the number of significant bits in an integer value.
 
@@ -737,8 +739,6 @@ def number_of_bits[dtype: DType, //](var value: Scalar[dtype]) -> Int:
     Returns:
         The number of significant bits in the value.
     """
-
-    comptime assert dtype.is_integral(), "must be integral"
 
     # Delegate to `std.bit.bit_width`, which lowers to a hardware
     # `count_leading_zeros` (single-instruction for ≤ 64-bit, two CLZs

--- a/src/decimo/rational/rational.mojo
+++ b/src/decimo/rational/rational.mojo
@@ -31,7 +31,6 @@ from std.memory import bitcast
 from decimo.bigdecimal.bigdecimal import BigDecimal, PRECISION
 from decimo.bigint.bigint import BigInt
 from decimo.bigint.number_theory import gcd
-from decimo.bigint10.bigint10 import BigInt10
 from decimo.errors import ConversionError, ValueError, ZeroDivisionError
 from decimo.rounding_mode import RoundingMode
 from decimo.traits import Parsable
@@ -168,14 +167,23 @@ struct Rational(
         self.numerator = value.copy()
         self.denominator = BigInt(UInt32(1))
 
-    def __init__(out self, value: Int):
-        """Initializes a rational number from an Int (denominator = 1).
+    @implicit
+    def __init__(out self, value: Scalar) where value.dtype.is_integral():
+        """Initializes a rational number from an integral scalar
+        (denominator = 1). This includes all SIMD integral types, such as
+        Int8, Int16, UInt32, etc.
+
+        Constraints:
+            The dtype of the scalar must be integral. A floating-point value
+            is not accepted here, because whether `Rational(0.1)` should mean
+            1/10 or the binary float that literal denotes is a question the
+            caller has to answer: use `from_float()` for the latter and
+            `Rational("0.1")` for the former.
 
         Args:
-            value: The integer value.
+            value: The integral scalar value to convert.
         """
-        self.numerator = BigInt(value)
-        self.denominator = BigInt(UInt32(1))
+        self = Self.from_integral_scalar(value)
 
     def __init__(
         out self, var numerator: BigInt, var denominator: BigInt, *, raw: Bool
@@ -220,12 +228,33 @@ struct Rational(
         """
         self = Self.from_bigdecimal(value)
 
-    # TODO:
-    # Initializes a Rational from a integral scalar.
-
     # ===------------------------------------------------------------------=== #
     # Constructing methods that are not dunders
     # ===------------------------------------------------------------------=== #
+
+    @staticmethod
+    def from_integral_scalar[
+        dtype: DType, //
+    ](value: SIMD[dtype, 1]) -> Self where dtype.is_integral():
+        """Creates a Rational from an integral scalar, with denominator 1.
+        This includes all SIMD integral types:
+        Int8, Int16, Int32, Int64, Int128, Int256,
+        UInt8, UInt16, UInt32, UInt64, UInt128, UInt256,
+        and the platform-sized Int (DType.int) and UInt (DType.uint).
+
+        Constraints:
+            The dtype must be integral.
+
+        Args:
+            value: The Scalar value to be converted to Rational.
+
+        Returns:
+            The value as a Rational, already in lowest terms.
+
+        Parameters:
+            dtype: The data type of the scalar value.
+        """
+        return Self(BigInt.from_integral_scalar(value))
 
     @staticmethod
     def from_string(value: String) raises -> Self:
@@ -330,9 +359,7 @@ struct Rational(
         Raises:
             Error: If the underlying integer arithmetic fails.
         """
-        var numerator = BigInt.from_bigint10(
-            BigInt10(value.coefficient, value.sign)
-        )
+        var numerator = BigInt.from_biguint(value.coefficient, value.sign)
 
         if value.scale > 0:
             return Self(numerator, BigInt(10) ** value.scale)
@@ -344,13 +371,20 @@ struct Rational(
         return Self(numerator)
 
     @staticmethod
-    def from_float(value: Float64) raises -> Self:
-        """Creates a Rational from a Float64, losslessly.
+    def from_float[
+        dtype: DType, //
+    ](value: SIMD[dtype, 1]) raises -> Self where dtype.is_floating_point():
+        """Creates a Rational from a floating-point scalar, losslessly.
+        This includes all SIMD floating-point types, such as Float16,
+        BFloat16, Float32, Float64, and the 8-bit formats.
 
         Every finite binary float is a fraction whose denominator is a power
         of two, so the result is the exact value of `value`, not the decimal
         literal that was written to produce it: `from_float(0.1)` is
         3602879701896397/36028797018963968, not 1/10.
+
+        Constraints:
+            The dtype must be floating-point.
 
         Args:
             value: The floating-point value to convert.
@@ -361,15 +395,25 @@ struct Rational(
         Raises:
             ConversionError: If `value` is infinite or NaN, neither of which
                 is a rational number.
+
+        Parameters:
+            dtype: The data type of the scalar value.
+
+        Notes:
+
+        Every narrower binary format is a subset of Float64 - fewer
+        significand bits and a narrower exponent range - so widening first is
+        exact, and one decoder then serves them all.
         """
-        var bits = value.to_bits()
+        var widened = value.cast[DType.float64]()
+        var bits = widened.to_bits()
         var exponent_field = Int((bits >> 52) & 0x7FF)
         var mantissa_field = bits & 0x000F_FFFF_FFFF_FFFF
         var negative = Bool((bits >> 63) != 0)
 
         if exponent_field == 0x7FF:
             raise ConversionError(
-                function="Rational.from_float(value: Float64)",
+                function="Rational.from_float(value: Scalar[dtype])",
                 message=(
                     "The input value "
                     + String(value)
@@ -758,7 +802,7 @@ struct Rational(
                     exponent -= 1
 
         return BigDecimal(
-            coefficient=quotient.to_bigint10().magnitude,
+            coefficient=quotient.to_biguint(),
             scale=exponent,
             sign=sign,
         )

--- a/src/decimo/rational/rational.mojo
+++ b/src/decimo/rational/rational.mojo
@@ -26,16 +26,25 @@ Invariants maintained by all constructors and operations:
     3. If value is zero: numerator == 0, denominator == 1
 """
 
+from std.memory import bitcast
+
+from decimo.bigdecimal.bigdecimal import BigDecimal, PRECISION
 from decimo.bigint.bigint import BigInt
 from decimo.bigint.number_theory import gcd
-from decimo.errors import ZeroDivisionError
+from decimo.bigint10.bigint10 import BigInt10
+from decimo.errors import ConversionError, ValueError, ZeroDivisionError
+from decimo.rounding_mode import RoundingMode
+from decimo.traits import Parsable
 
 
 struct Rational(
     Absable,
     Comparable,
     Copyable,
+    FloatableRaising,
+    IntableRaising,
     Movable,
+    Parsable,
     Writable,
 ):
     """An arbitrary-precision exact rational number p/q.
@@ -47,6 +56,18 @@ struct Rational(
     """The numerator of the rational number."""
     var denominator: BigInt
     """The denominator of the rational number. Always positive."""
+
+    comptime _SIGNIFICAND_BITS = 53
+    """Bits in the significand of a Float64, the implicit leading one
+    included."""
+    comptime _MIN_FLOAT_EXPONENT = -1074
+    """The exponent every Float64 subnormal is written at: the smallest
+    positive Float64 is 1 * 2^-1074."""
+    comptime _MAX_FLOAT_EXPONENT = 971
+    """The largest exponent a 53-bit significand can carry before the value
+    leaves the range of a Float64."""
+    comptime _FLOAT_INFINITY_BITS = UInt64(0x7FF0_0000_0000_0000)
+    """The bit pattern of a positive Float64 infinity."""
 
     # ===------------------------------------------------------------------=== #
     # Constants
@@ -174,15 +195,210 @@ struct Rational(
         self.numerator = numerator^
         self.denominator = denominator^
 
+    def __init__(out self, value: String) raises:
+        """Initializes a rational number from a string representation.
+        See `from_string()` for the accepted formats.
+
+        Args:
+            value: The string representation, e.g. "3/7", "1.5", "-42",
+                "7e-3".
+
+        Raises:
+            ConversionError: If the string cannot be parsed as a rational.
+            ZeroDivisionError: If the parsed denominator is zero.
+        """
+        self = Self.from_string(value)
+
+    def __init__(out self, value: BigDecimal) raises:
+        """Initializes a rational number from a decimal, losslessly.
+
+        Args:
+            value: The decimal value to convert.
+
+        Raises:
+            Error: If the conversion fails.
+        """
+        self = Self.from_bigdecimal(value)
+
     # TODO:
-    # Initializes a Rational from a integral scalar, from_scalar()
-    # Initializes a Rational from a decimal string, from_decimal()
-    # Initializes a Rational from a string like "123/456", from_string()
-    # Initializes a Rational from a float, from_float(). Do not make it `__init__`.
-    #   Note that float can be converted to rational exactly by interpreting
-    #   its bits as a fraction of binary integers.
-    #   Maybe we can use it as a bridge Float -> Rational -> Decimal conversion,
-    #   so that we do not need the Float -> String -> Decimal path.
+    # Initializes a Rational from a integral scalar.
+
+    # ===------------------------------------------------------------------=== #
+    # Constructing methods that are not dunders
+    # ===------------------------------------------------------------------=== #
+
+    @staticmethod
+    def from_string(value: String) raises -> Self:
+        """Creates a Rational from a string representation.
+
+        Two forms are accepted:
+
+        - A single decimal literal, e.g. "42", "-1.5", "7e-3". It is read
+          exactly, so "1.5" is 3/2 and "7e-3" is 7/1000.
+        - Two decimal literals separated by "/", e.g. "3/7". Each side is
+          read exactly and the first is divided by the second, so "3/7" is
+          3/7 and "1.5/2.5" is 3/5.
+
+        Each side accepts everything `BigDecimal` accepts, including signs,
+        spaces, commas, underscores and scientific notation.
+
+        Args:
+            value: The string to parse, e.g. "3/7", "1.5", "-42", "7e-3".
+
+        Returns:
+            The parsed value, in lowest terms.
+
+        Raises:
+            ConversionError: If the string is not one of the two forms above.
+            ZeroDivisionError: If the denominator is zero.
+        """
+        var separator = value.find("/")
+
+        if separator < 0:
+            return Self._from_decimal_literal(value, literal=value)
+
+        if value.find("/", separator + 1) >= 0:
+            raise ConversionError(
+                function="Rational.from_string(value: String)",
+                message=(
+                    'The input value "'
+                    + value
+                    + '" cannot be parsed as a rational.\n'
+                    + 'It contains more than one "/".'
+                ),
+            )
+
+        var numerator = Self._from_decimal_literal(
+            String(value[byte=:separator]), literal=value
+        )
+        var denominator = Self._from_decimal_literal(
+            String(value[byte = separator + 1 :]), literal=value
+        )
+
+        if denominator.is_zero():
+            raise ZeroDivisionError(
+                function="Rational.from_string(value: String)",
+                message=(
+                    'The input value "' + value + '" has a zero denominator.'
+                ),
+            )
+
+        return numerator / denominator
+
+    @staticmethod
+    def _from_decimal_literal(value: String, *, literal: String) raises -> Self:
+        """Reads one decimal literal exactly, as a Rational.
+
+        Args:
+            value: The decimal literal, i.e. one side of a "p/q" string, or
+                the whole string when there is no "/".
+            literal: The full string the caller was given, quoted in the
+                error message so that it names what the user wrote.
+
+        Returns:
+            The exact value of the literal.
+
+        Raises:
+            ConversionError: If `value` is not a decimal literal.
+        """
+        try:
+            return Self.from_bigdecimal(BigDecimal(value))
+        except e:
+            raise ConversionError(
+                function="Rational.from_string(value: String)",
+                message=(
+                    'The input value "'
+                    + literal
+                    + '" cannot be parsed as a rational.'
+                ),
+                previous_error=e^,
+            )
+
+    @staticmethod
+    def from_bigdecimal(value: BigDecimal) raises -> Self:
+        """Creates a Rational from a BigDecimal, losslessly.
+
+        A decimal is `coefficient * 10^(-scale)`, which is already a
+        fraction, so the conversion is exact for every input.
+
+        Args:
+            value: The decimal value to convert.
+
+        Returns:
+            The same value as a Rational in lowest terms.
+
+        Raises:
+            Error: If the underlying integer arithmetic fails.
+        """
+        var numerator = BigInt.from_bigint10(
+            BigInt10(value.coefficient, value.sign)
+        )
+
+        if value.scale > 0:
+            return Self(numerator, BigInt(10) ** value.scale)
+
+        if value.scale < 0:
+            # A negative scale means trailing zeros: 4.2E+4 is 42 * 10^3.
+            numerator = numerator * (BigInt(10) ** (-value.scale))
+
+        return Self(numerator)
+
+    @staticmethod
+    def from_float(value: Float64) raises -> Self:
+        """Creates a Rational from a Float64, losslessly.
+
+        Every finite binary float is a fraction whose denominator is a power
+        of two, so the result is the exact value of `value`, not the decimal
+        literal that was written to produce it: `from_float(0.1)` is
+        3602879701896397/36028797018963968, not 1/10.
+
+        Args:
+            value: The floating-point value to convert.
+
+        Returns:
+            The exact value of `value` as a Rational in lowest terms.
+
+        Raises:
+            ConversionError: If `value` is infinite or NaN, neither of which
+                is a rational number.
+        """
+        var bits = value.to_bits()
+        var exponent_field = Int((bits >> 52) & 0x7FF)
+        var mantissa_field = bits & 0x000F_FFFF_FFFF_FFFF
+        var negative = Bool((bits >> 63) != 0)
+
+        if exponent_field == 0x7FF:
+            raise ConversionError(
+                function="Rational.from_float(value: Float64)",
+                message=(
+                    "The input value "
+                    + String(value)
+                    + " is not a rational number."
+                ),
+            )
+
+        var mantissa = UInt64(mantissa_field)
+        var exponent: Int
+        if exponent_field == 0:
+            # Subnormal: no implicit leading bit, fixed exponent.
+            exponent = -1074
+        else:
+            # Normal: restore the implicit leading bit. The bias is 1023 and
+            # the mantissa is read as a 53-bit integer, hence 1023 + 52.
+            mantissa |= UInt64(1) << 52
+            exponent = exponent_field - 1075
+
+        if mantissa == 0:
+            return Self.zero()
+
+        var numerator = BigInt(mantissa)
+        if negative:
+            numerator = -numerator
+
+        if exponent >= 0:
+            return Self(numerator << exponent)
+
+        return Self(numerator, BigInt(1) << (-exponent))
 
     # ===------------------------------------------------------------------=== #
     # Normalization
@@ -268,6 +484,284 @@ struct Rational(
         writer.write(self.numerator.to_string())
         if not self.denominator.is_one():
             writer.write("/", self.denominator.to_string())
+
+    # ===------------------------------------------------------------------=== #
+    # Type-transfer dunders and other type-transfer methods
+    # ===------------------------------------------------------------------=== #
+
+    def __float__(self) raises -> Float64:
+        """Converts the Rational to a floating-point number.
+        See `to_float()` for more information.
+
+        Returns:
+            The nearest Float64 to this value.
+
+        Raises:
+            Error: If the underlying arithmetic fails.
+        """
+        return self.to_float()
+
+    def __int__(self) raises -> Int:
+        """Returns the value truncated toward zero, as an Int.
+        See `to_int()` for more information.
+
+        Returns:
+            The truncated value.
+
+        Raises:
+            OverflowError: If the truncated value exceeds the size of Int.
+        """
+        return self.to_int()
+
+    def to_float(self) raises -> Float64:
+        """Returns the nearest Float64 to this value.
+
+        The result is correctly rounded. The division is carried out on the
+        exact integers and the 53-bit significand is rounded once, ties to
+        even, so no intermediate is rounded twice. A value too large for a
+        Float64 becomes `inf`, matching `BigInt.__float__()`; one too small
+        becomes zero.
+
+        Returns:
+            The nearest Float64, ties to even.
+
+        Raises:
+            Error: If the underlying arithmetic fails.
+        """
+        if self.numerator.is_zero():
+            return Float64(0)
+
+        var negative = self.numerator.is_negative()
+        var dividend = abs(self.numerator)
+        var divisor = self.denominator.copy()
+
+        # |numerator| / denominator lies in (2^(b - 1), 2^(b + 1)) for
+        # b = bits(numerator) - bits(denominator), so scaling by this shift
+        # leaves a quotient of 53 or 54 bits.
+        var shift = Self._SIGNIFICAND_BITS - (
+            dividend.bit_length() - divisor.bit_length()
+        )
+        var division = Self._shifted_divmod(dividend, divisor, shift)
+        if division[0].bit_length() > Self._SIGNIFICAND_BITS:
+            # One bit too many: take one binary place back and redo it.
+            shift -= 1
+            division = Self._shifted_divmod(dividend, divisor, shift)
+
+        # The value is now `significand * 2^exponent`.
+        var exponent = -shift
+        if exponent < Self._MIN_FLOAT_EXPONENT:
+            # Below the smallest normal Float64. Such a value is held with
+            # fewer than 53 bits, so the significand has to be rounded at the
+            # fixed exponent of the subnormal range instead.
+            exponent = Self._MIN_FLOAT_EXPONENT
+            division = Self._shifted_divmod(dividend, divisor, -exponent)
+
+        var significand = division[0].copy()
+        var remainder = division[1].copy()
+
+        if not remainder.is_zero():
+            # `2 * remainder` against the divisor is the exact comparison of
+            # the dropped tail against one half of the last kept bit.
+            var half = (remainder * BigInt(2)).compare(division[2])
+            if (half > 0) or (
+                half == 0 and not (significand % BigInt(2)).is_zero()
+            ):
+                significand = significand + BigInt(1)
+                if significand.bit_length() > Self._SIGNIFICAND_BITS:
+                    # The significand reached 2^53: carry it to the exponent.
+                    significand = significand >> 1
+                    exponent += 1
+
+        var bits: UInt64
+        if exponent > Self._MAX_FLOAT_EXPONENT:
+            bits = Self._FLOAT_INFINITY_BITS
+        else:
+            # A 53-bit significand at `exponent` is written with its leading
+            # bit implicit and `exponent + 1075` in the exponent field; a
+            # shorter one, which only happens at the subnormal exponent,
+            # keeps every bit and leaves that field zero. Adding the fields
+            # rather than packing them gets both cases right, because the
+            # leading bit of a 53-bit significand carries into the field
+            # exactly where the implicit bit would have been dropped.
+            bits = UInt64(significand.to_int()) + (
+                UInt64(exponent - Self._MIN_FLOAT_EXPONENT) << 52
+            )
+
+        if negative:
+            bits |= UInt64(1) << 63
+
+        return bitcast[DType.float64](bits)
+
+    @staticmethod
+    def _shifted_divmod(
+        dividend: BigInt, divisor: BigInt, shift: Int
+    ) raises -> Tuple[BigInt, BigInt, BigInt]:
+        """Divides `dividend * 2^shift` by `divisor`, exactly.
+
+        A negative `shift` scales the divisor instead, which is the same
+        quotient without the fractional shift.
+
+        Args:
+            dividend: The dividend, before scaling.
+            divisor: The divisor, before scaling.
+            shift: The power of two to scale the dividend by.
+
+        Returns:
+            The quotient, the remainder, and the scaled divisor, which the
+            caller needs in order to weigh the remainder against it.
+
+        Raises:
+            Error: If the underlying division fails.
+        """
+        var scaled_dividend = dividend.copy()
+        var scaled_divisor = divisor.copy()
+        if shift >= 0:
+            scaled_dividend = dividend << shift
+        else:
+            scaled_divisor = divisor << (-shift)
+
+        var division = scaled_dividend.__divmod__(scaled_divisor)
+        return (division[0].copy(), division[1].copy(), scaled_divisor^)
+
+    def to_integer(self) raises -> BigInt:
+        """Returns the value truncated toward zero, as a BigInt.
+
+        Truncation, not flooring: `(-7/2).to_integer()` is -3, as
+        `math.trunc()` gives in Python.
+
+        Returns:
+            The integer part of this value.
+
+        Raises:
+            Error: If the underlying division fails.
+        """
+        return self.numerator.truncate_divide(self.denominator)
+
+    def to_int(self) raises -> Int:
+        """Returns the value truncated toward zero, as an Int.
+
+        Returns:
+            The integer part of this value.
+
+        Raises:
+            OverflowError: If the truncated value exceeds the size of Int.
+        """
+        return self.to_integer().to_int()
+
+    def to_bigdecimal(
+        self,
+        precision: Int = PRECISION,
+        rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,
+    ) raises -> BigDecimal:
+        """Returns this value as a BigDecimal of at most `precision` digits.
+
+        The division is carried out on the exact integers and rounded once,
+        by `rounding_mode`, so there is no intermediate result to round
+        twice. Where the value has an exact decimal form within `precision`
+        significant digits, that form is returned with no trailing padding:
+        `Rational(1, 2).to_bigdecimal()` is `0.5`, not `0.500...0`.
+
+        Args:
+            precision: The maximum number of significant digits. Must be
+                positive.
+            rounding_mode: How to round a value that needs more digits than
+                `precision`.
+
+        Returns:
+            The value as a BigDecimal.
+
+        Raises:
+            ValueError: If `precision` is not positive.
+            Error: If the underlying integer arithmetic fails.
+        """
+        if precision <= 0:
+            raise ValueError(
+                function=(
+                    "Rational.to_bigdecimal(precision: Int, rounding_mode:"
+                    " RoundingMode)"
+                ),
+                message=(
+                    "The precision must be positive, got "
+                    + String(precision)
+                    + "."
+                ),
+            )
+
+        if self.numerator.is_zero():
+            return BigDecimal.zero()
+
+        var sign = self.numerator.is_negative()
+        var dividend = abs(self.numerator)
+        var divisor = self.denominator.copy()
+
+        # |numerator| / denominator lies in (10^(d - 1), 10^(d + 1)) for
+        # d = digits(numerator) - digits(denominator), so scaling by this
+        # exponent leaves a quotient of `precision` or `precision + 1` digits.
+        var exponent = precision - (
+            dividend.number_of_digits() - divisor.number_of_digits()
+        )
+        var scaled_dividend = dividend.copy()
+        var scaled_divisor = divisor.copy()
+        if exponent >= 0:
+            scaled_dividend = dividend * (BigInt(10) ** exponent)
+        else:
+            scaled_divisor = divisor * (BigInt(10) ** (-exponent))
+
+        var division = scaled_dividend.__divmod__(scaled_divisor)
+        if division[0].number_of_digits() > precision:
+            # One digit too many: take one decimal place back and redo it.
+            exponent -= 1
+            scaled_dividend = dividend.copy()
+            scaled_divisor = divisor.copy()
+            if exponent >= 0:
+                scaled_dividend = dividend * (BigInt(10) ** exponent)
+            else:
+                scaled_divisor = divisor * (BigInt(10) ** (-exponent))
+            division = scaled_dividend.__divmod__(scaled_divisor)
+
+        var quotient = division[0].copy()
+        var remainder = division[1].copy()
+
+        if remainder.is_zero():
+            # The value fits exactly. Drop the padding zeros the scaling
+            # added, so that 1/2 reads as 0.5 rather than 0.500...0.
+            while exponent > 0 and (quotient % BigInt(10)).is_zero():
+                quotient = quotient // BigInt(10)
+                exponent -= 1
+        else:
+            # `2 * remainder` against the divisor is the exact comparison of
+            # the dropped tail against one half of the last kept digit.
+            var half = (remainder * BigInt(2)).compare(scaled_divisor)
+            var round_away: Bool
+            if rounding_mode == RoundingMode.ROUND_DOWN:
+                round_away = False
+            elif rounding_mode == RoundingMode.ROUND_UP:
+                round_away = True
+            elif rounding_mode == RoundingMode.ROUND_CEILING:
+                round_away = not sign
+            elif rounding_mode == RoundingMode.ROUND_FLOOR:
+                round_away = sign
+            elif rounding_mode == RoundingMode.ROUND_HALF_UP:
+                round_away = half >= 0
+            elif rounding_mode == RoundingMode.ROUND_HALF_DOWN:
+                round_away = half > 0
+            else:  # ROUND_HALF_EVEN
+                round_away = (half > 0) or (
+                    half == 0 and not (quotient % BigInt(2)).is_zero()
+                )
+
+            if round_away:
+                quotient = quotient + BigInt(1)
+                if quotient.number_of_digits() > precision:
+                    # 999...9 became 1000...0: drop the digit it gained.
+                    quotient = quotient // BigInt(10)
+                    exponent -= 1
+
+        return BigDecimal(
+            coefficient=quotient.to_bigint10().magnitude,
+            scale=exponent,
+            sign=sign,
+        )
 
     # ===------------------------------------------------------------------=== #
     # Comparison operators

--- a/src/decimo/rational/rational.mojo
+++ b/src/decimo/rational/rational.mojo
@@ -177,7 +177,7 @@ struct Rational(
             The dtype of the scalar must be integral. A floating-point value
             is not accepted here, because whether `Rational(0.1)` should mean
             1/10 or the binary float that literal denotes is a question the
-            caller has to answer: use `from_float()` for the latter and
+            caller has to answer: use `from_float_scalar()` for the latter and
             `Rational("0.1")` for the former.
 
         Args:
@@ -235,7 +235,7 @@ struct Rational(
     @staticmethod
     def from_integral_scalar[
         dtype: DType, //
-    ](value: SIMD[dtype, 1]) -> Self where dtype.is_integral():
+    ](value: Scalar[dtype]) -> Self where dtype.is_integral():
         """Creates a Rational from an integral scalar, with denominator 1.
         This includes all SIMD integral types:
         Int8, Int16, Int32, Int64, Int128, Int256,
@@ -371,16 +371,16 @@ struct Rational(
         return Self(numerator)
 
     @staticmethod
-    def from_float[
+    def from_float_scalar[
         dtype: DType, //
-    ](value: SIMD[dtype, 1]) raises -> Self where dtype.is_floating_point():
+    ](value: Scalar[dtype]) raises -> Self where dtype.is_floating_point():
         """Creates a Rational from a floating-point scalar, losslessly.
         This includes all SIMD floating-point types, such as Float16,
         BFloat16, Float32, Float64, and the 8-bit formats.
 
         Every finite binary float is a fraction whose denominator is a power
         of two, so the result is the exact value of `value`, not the decimal
-        literal that was written to produce it: `from_float(0.1)` is
+        literal that was written to produce it: `from_float_scalar(0.1)` is
         3602879701896397/36028797018963968, not 1/10.
 
         Constraints:
@@ -413,7 +413,7 @@ struct Rational(
 
         if exponent_field == 0x7FF:
             raise ConversionError(
-                function="Rational.from_float(value: Scalar[dtype])",
+                function="Rational.from_float_scalar(value: Scalar[dtype])",
                 message=(
                     "The input value "
                     + String(value)

--- a/src/decimo/tests.mojo
+++ b/src/decimo/tests.mojo
@@ -20,6 +20,7 @@ Shared infrastructure for Decimo tests and benchmarks.
 Provides:
 - Test case and benchmark case loading from TOML files (via decimo.toml)
 - Pattern expansion: {C,N} repeats string C exactly N times
+- Random decimal literals for cross-checks against Python
 - Log file management and formatted output (console + log)
 - Summary statistics reporting for benchmarks
 
@@ -54,6 +55,7 @@ from .toml import parse_file as parse_toml_file
 from .toml.parser import TOMLDocument
 from .errors import ValueError
 from std.python import Python, PythonObject
+from std.random import random_ui64
 from std.collections import List
 from std import os
 
@@ -298,6 +300,50 @@ def expand_value(s: String) raises -> String:
             i += 1
 
     return result
+
+
+# ===----------------------------------------------------------------------=== #
+# Random test data
+# ===----------------------------------------------------------------------=== #
+
+
+def random_decimal_string(chunks: Int) raises -> String:
+    """Builds a decimal string out of `chunks` random 18-digit groups.
+
+    Several cross-check tests need a very long decimal literal to hand to both
+    Decimo and Python. They used to grow one with `result += String(...)` in a
+    loop; this assembles the pieces in a pre-sized `List[String]` and joins
+    them once instead.
+
+    That is a smaller win than it looks. `String.__iadd__` already grows the
+    buffer geometrically (`_realloc_mutable` reallocs to
+    `max(requested, capacity * 2)`), so the naive loop is amortised linear, not
+    quadratic - measured over 789 to 1,234,500 chunks the two differ by under
+    10%, and both are dwarfed by `random_ui64` itself. The reason to prefer
+    this form is that the intent is stated once, in one place, rather than
+    re-derived at each call site.
+
+    Args:
+        chunks: How many random groups to concatenate. Each contributes up to
+            18 digits, so the result is at most `18 * chunks` characters.
+
+    Returns:
+        The concatenated decimal string. The leading chunk is never zero-padded,
+        so the value has no leading zeros unless the first draw is small.
+
+    Raises:
+        ValueError: If `chunks` is negative.
+    """
+    if chunks < 0:
+        raise ValueError(
+            message="chunks must be non-negative, got " + String(chunks),
+            function="random_decimal_string()",
+        )
+
+    var parts = List[String](capacity=chunks)
+    for _i in range(chunks):
+        parts.append(String(random_ui64(0, 999_999_999_999_999_999)))
+    return String("").join(parts)
 
 
 # ===----------------------------------------------------------------------=== #

--- a/tests/bigdecimal/test_bigdecimal_methods.mojo
+++ b/tests/bigdecimal/test_bigdecimal_methods.mojo
@@ -350,7 +350,8 @@ def test_as_tuple_reconstruct() raises:
         var d = BigDecimal(values[vi])
         var t = d.as_tuple()
         # Rebuild coefficient string from digit list
-        var coef_str = String()
+        # One character per digit, so the final length is known up front.
+        var coef_str = String(capacity=len(t[1]))
         for i in range(len(t[1])):
             coef_str += String(Int(t[1][i]))
         # exponent = -scale  =>  scale = -exponent

--- a/tests/bigint/test_bigint_arithmetics.mojo
+++ b/tests/bigint/test_bigint_arithmetics.mojo
@@ -9,6 +9,7 @@ use decimal string representations that are valid for both BigInt10 and BigInt.
 from std.python import Python
 from std import testing
 from decimo.bigint.bigint import BigInt
+from decimo.bigint10.bigint10 import BigInt10
 from decimo.tests import TestCase, parse_file, load_test_cases
 
 comptime file_path_arithmetics = (
@@ -560,7 +561,7 @@ def test_bigint_floor_divide_burnikel_ziegler() raises:
     # Cross-check D&C string conversion against BigInt10 path
     testing.assert_equal(
         lhs=String(a1),
-        rhs=String(a1.to_bigint10()),
+        rhs=String(BigInt10.from_bigint(a1)),
         msg="[B-Z case 1] D&C to_string matches BigInt10 path",
     )
 
@@ -580,7 +581,7 @@ def test_bigint_floor_divide_burnikel_ziegler() raises:
     )
     testing.assert_equal(
         lhs=String(a2),
-        rhs=String(a2.to_bigint10()),
+        rhs=String(BigInt10.from_bigint(a2)),
         msg="[B-Z case 2] D&C to_string matches BigInt10 path",
     )
 

--- a/tests/bigint/test_bigint_conversion.mojo
+++ b/tests/bigint/test_bigint_conversion.mojo
@@ -7,6 +7,7 @@ point), and D&C from_string for large numbers.
 from std import testing
 from decimo.bigint.bigint import BigInt
 from decimo.bigint10.bigint10 import BigInt10
+from decimo.biguint.biguint import BigUInt
 
 
 # ===----------------------------------------------------------------------=== #
@@ -265,7 +266,7 @@ def test_from_string_large_dc() raises:
     var a4 = BigInt(10).power(599) + BigInt(10).power(300) + BigInt(7)
     testing.assert_equal(
         lhs=String(a4),
-        rhs=String(a4.to_bigint10()),
+        rhs=String(BigInt10.from_bigint(a4)),
         msg="[D&C from_string] D&C to_string matches BigInt10 for 600-digit",
     )
 
@@ -289,7 +290,7 @@ def test_from_string_dc_path() raises:
     )
 
     # Cross-check with BigInt10 (independent reference implementation)
-    var b = BigInt.from_bigint10(BigInt10(s))
+    var b = BigInt10(s).to_bigint()
     testing.assert_true(
         a == b,
         msg="[D&C from_string] 10501-digit D&C matches BigInt10 path",
@@ -300,7 +301,7 @@ def test_from_string_dc_path() raises:
     var s2 = String("7") + String("0") * 10490 + String("123456789")
     var a2 = BigInt(s2)
     # Cross-check against an independent BigInt10-based reference
-    var b2 = BigInt.from_bigint10(BigInt10(s2))
+    var b2 = BigInt10(s2).to_bigint()
     testing.assert_true(
         a2 == b2,
         msg="[D&C from_string] 10500-digit non-trivial round-trip",
@@ -404,6 +405,60 @@ def test_float_small() raises:
 def test_float_large() raises:
     """Tests __float__ with a large-ish integer."""
     testing.assert_equal(Float64(BigInt(1000000)), 1000000.0)
+
+
+# ===----------------------------------------------------------------------=== #
+# Test: to_biguint / from_biguint
+# ===----------------------------------------------------------------------=== #
+
+
+def test_biguint_round_trip() raises:
+    """A BigInt survives the trip through base-10^9 and back."""
+    for value in [
+        String("0"),
+        String("1"),
+        String("-1"),
+        String("999999999"),
+        String("1000000000"),
+        String("-123456789012345678901234567890"),
+    ]:
+        var n = BigInt(value)
+        var back = BigInt.from_biguint(n.to_biguint(), n.is_negative())
+        testing.assert_equal(String(back), String(n))
+
+
+def test_to_biguint_drops_the_sign() raises:
+    """`to_biguint` hands back the magnitude, not the value."""
+    testing.assert_equal(String(BigInt("-42").to_biguint()), "42")
+    testing.assert_equal(String(BigInt("42").to_biguint()), "42")
+    # Zero is unsigned whatever sign is asked for.
+    testing.assert_equal(String(BigInt.from_biguint(BigUInt(), True)), "0")
+
+
+def test_to_biguint_large_takes_the_dc_path() raises:
+    """Above the D&C threshold the fast path must agree with the slow one.
+
+    2000 digits is well past `_DC_TO_STR_ENTRY_THRESHOLD` (128 words, about
+    1230 digits), so this exercises the divide-and-conquer conversion; the
+    decimal string is the independent reference.
+    """
+    var digits = String("1234567890") * 200
+    var n = BigInt(digits)
+    testing.assert_equal(String(n.to_biguint()), digits)
+    testing.assert_equal(String(BigInt("-" + digits).to_biguint()), digits)
+
+
+def test_bigint10_bridge() raises:
+    """The legacy BigInt10 bridge round-trips through BigInt."""
+    for value in [
+        String("0"),
+        String("-1"),
+        String("123456789012345678901234567890"),
+        String("-987654321098765432109876543210"),
+    ]:
+        var b10 = BigInt10(value)
+        testing.assert_equal(String(b10.to_bigint()), value)
+        testing.assert_equal(String(BigInt10.from_bigint(BigInt(value))), value)
 
 
 def main() raises:

--- a/tests/biguint/test_biguint_arithmetics.mojo
+++ b/tests/biguint/test_biguint_arithmetics.mojo
@@ -229,12 +229,18 @@ def test_biguint_truncate_divide_random_numbers_against_python() raises:
 
 
 def test_biguint_truncate_divide_huge_random_numbers_against_python() raises:
-    # The dividend here is some two hundred thousand digits over a divisor of
-    # some fourteen thousand, which is the size at which truncated division
-    # recurses through Burnikel-Ziegler rather than taking the schoolbook
-    # path the smaller random cases above exercise. One case rather than ten:
-    # the size is what is being covered, and each one costs a couple of
-    # minutes against Python.
+    # Some two hundred thousand digits over a divisor of some fourteen
+    # thousand. The smaller random cases above already clear
+    # `CUTOFF_BURNIKEL_ZIEGLER` (32 words, 288 digits) and so take the
+    # Burnikel-Ziegler path too; what this size adds is the depth. A divisor
+    # of ~1,570 words recurses six levels deep on blocks of n = 2048 words,
+    # against two levels on n = 128 for the cases above, and the dividend
+    # splits into thirteen blocks, so the remainder is carried across twelve
+    # iterations of the outer loop rather than two. At that block size the
+    # multiplications *inside* the division cross `CUTOFF_KARATSUBA` (64) and
+    # `CUTOFF_TOOM3` (256), which the smaller cases never reach. One case
+    # rather than ten: the size is what is being covered, and it costs a
+    # fraction of a second.
 
     _set_max_str_digits(500000)
 
@@ -243,9 +249,9 @@ def test_biguint_truncate_divide_huge_random_numbers_against_python() raises:
     var decimo_result: String
     var python_result: String
 
-    for _i in range(123):
+    for _i in range(12345):
         number_a += String(random_ui64(0, 999_999_999_999_999_999))
-    for _i in range(78):
+    for _i in range(789):
         number_b += String(random_ui64(0, 999_999_999_999_999_999))
     decimo_result = String(BigUInt(number_a) // BigUInt(number_b))
     python_result = String(Python.int(number_a) // Python.int(number_b))

--- a/tests/biguint/test_biguint_arithmetics.mojo
+++ b/tests/biguint/test_biguint_arithmetics.mojo
@@ -5,11 +5,15 @@ BigUInt is an unsigned integer type, so it doesn't support negative values.
 
 
 from std.python import Python
-from std.random import random_ui64
 from std import testing
 from std.testing import assert_equal, assert_true
 from decimo.biguint.biguint import BigUInt
-from decimo.tests import TestCase, parse_file, load_test_cases
+from decimo.tests import (
+    TestCase,
+    load_test_cases,
+    parse_file,
+    random_decimal_string,
+)
 
 comptime file_path_arithmetics = (
     "tests/biguint/test_data/biguint_arithmetics.toml"
@@ -204,12 +208,8 @@ def test_biguint_truncate_divide_random_numbers_against_python() raises:
     var python_result: String
 
     for _test_case in range(10):
-        number_a = String("")
-        number_b = String("")
-        for _i in range(123):
-            number_a += String(random_ui64(0, 999_999_999_999_999_999))
-        for _i in range(45):
-            number_b += String(random_ui64(0, 999_999_999_999_999_999))
+        number_a = random_decimal_string(123)
+        number_b = random_decimal_string(45)
         decimo_result = String(BigUInt(number_a) // BigUInt(number_b))
         python_result = String(Python.int(number_a) // Python.int(number_b))
         assert_equal(
@@ -244,15 +244,11 @@ def test_biguint_truncate_divide_huge_random_numbers_against_python() raises:
 
     _set_max_str_digits(500000)
 
-    var number_a: String = String("")
-    var number_b: String = String("")
     var decimo_result: String
     var python_result: String
 
-    for _i in range(12345):
-        number_a += String(random_ui64(0, 999_999_999_999_999_999))
-    for _i in range(789):
-        number_b += String(random_ui64(0, 999_999_999_999_999_999))
+    var number_a = random_decimal_string(12345)
+    var number_b = random_decimal_string(789)
     decimo_result = String(BigUInt(number_a) // BigUInt(number_b))
     python_result = String(Python.int(number_a) // Python.int(number_b))
     assert_equal(

--- a/tests/biguint/test_biguint_exponential.mojo
+++ b/tests/biguint/test_biguint_exponential.mojo
@@ -4,11 +4,15 @@ Test BigUInt exponential functions.
 
 
 from std.python import Python
-from std.random import random_ui64
 from std import testing
 from std.testing import assert_equal, assert_true
 from decimo.biguint.biguint import BigUInt
-from decimo.tests import TestCase, parse_file, load_test_cases
+from decimo.tests import (
+    TestCase,
+    load_test_cases,
+    parse_file,
+    random_decimal_string,
+)
 
 comptime file_path_sqrt = "tests/biguint/test_data/biguint_sqrt.toml"
 
@@ -70,9 +74,7 @@ def test_biguint_sqrt_random_numbers_against_python() raises:
     var python_result: String
 
     for _test_case in range(10):
-        number_a = String("")
-        for _i in range(666):
-            number_a += String(random_ui64(0, 999_999_999_999_999_999))
+        number_a = random_decimal_string(666)
         decimo_result = String(BigUInt(number_a).sqrt())
         python_result = String(pymath.isqrt(Python.int(number_a)))
         assert_equal(

--- a/tests/decimal128/test_decimal128_creation.mojo
+++ b/tests/decimal128/test_decimal128_creation.mojo
@@ -528,5 +528,106 @@ def test_from_decimal_overflow() raises:
         var _d = Dec128.from_decimal(huge)
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# from_integral_scalar / from_float_scalar (parametric on dtype)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_from_integral_scalar_widths() raises:
+    """Every integral width lands on the same value as `from_int` would."""
+    testing.assert_equal(
+        String(Decimal128.from_integral_scalar(Int8(-123))), "-123"
+    )
+    testing.assert_equal(
+        String(Decimal128.from_integral_scalar(Int8.MIN)), "-128"
+    )
+    testing.assert_equal(
+        String(Decimal128.from_integral_scalar(UInt8.MAX)), "255"
+    )
+    testing.assert_equal(String(Decimal128.from_integral_scalar(Int32(0))), "0")
+    testing.assert_equal(
+        String(Decimal128.from_integral_scalar(Int64.MIN)),
+        "-9223372036854775808",
+    )
+    testing.assert_equal(
+        String(Decimal128.from_integral_scalar(UInt64.MAX)),
+        "18446744073709551615",
+    )
+
+
+def test_from_integral_scalar_wide_types() raises:
+    """128- and 256-bit scalars are the only ones that can overflow."""
+    # The largest coefficient Decimal128 can hold, exactly.
+    testing.assert_equal(
+        String(Decimal128.from_integral_scalar(Decimal128.MAX_AS_UINT128)),
+        "79228162514264337593543950335",
+    )
+    testing.assert_equal(
+        String(Decimal128.from_integral_scalar(Decimal128.MAX_AS_INT128)),
+        "79228162514264337593543950335",
+    )
+    testing.assert_equal(
+        String(Decimal128.from_integral_scalar(-Decimal128.MAX_AS_INT128)),
+        "-79228162514264337593543950335",
+    )
+    testing.assert_equal(
+        String(Decimal128.from_integral_scalar(Int128(-7))), "-7"
+    )
+
+    # One past the top overflows, in both directions.
+    with testing.assert_raises():
+        var _a = Decimal128.from_integral_scalar(
+            Decimal128.MAX_AS_UINT128 + UInt128(1)
+        )
+    with testing.assert_raises():
+        var _b = Decimal128.from_integral_scalar(
+            -Decimal128.MAX_AS_INT256 - Int256(1)
+        )
+    # Int256.MIN has no positive counterpart; it must be rejected, not negated.
+    with testing.assert_raises():
+        var _c = Decimal128.from_integral_scalar(Int256.MIN)
+
+
+def test_from_float_scalar_narrower_types() raises:
+    """Narrower binary formats widen to Float64 exactly."""
+    # 0.5 and -2.5 are exact in every one of these formats.
+    testing.assert_equal(
+        String(Decimal128.from_float_scalar(Float16(0.5))), "0.5"
+    )
+    testing.assert_equal(
+        String(Decimal128.from_float_scalar(BFloat16(0.5))), "0.5"
+    )
+    testing.assert_equal(
+        String(Decimal128.from_float_scalar(Float32(0.5))), "0.5"
+    )
+    testing.assert_equal(
+        String(Decimal128.from_float_scalar(Float64(0.5))), "0.5"
+    )
+    testing.assert_equal(
+        String(Decimal128.from_float_scalar(Float16(-2.5))), "-2.5"
+    )
+    testing.assert_equal(
+        String(Decimal128.from_float_scalar(Float32(-2.5))), "-2.5"
+    )
+
+    # Float16(0.1) is 819/8192 = 0.0999755859375, and that is what we get -
+    # not the 0.1 the literal was written as.
+    testing.assert_equal(
+        String(Decimal128.from_float_scalar(Float16(0.1))), "0.0999755859375"
+    )
+
+
+def test_from_float_is_a_forwarding_alias() raises:
+    """The deprecated `from_float` still agrees with `from_float_scalar`."""
+    testing.assert_equal(
+        String(Decimal128.from_float(Float64(3.25))),
+        String(Decimal128.from_float_scalar(Float64(3.25))),
+    )
+    testing.assert_equal(
+        String(Decimal128.from_float(Float64(-0.125))),
+        String(Decimal128.from_float_scalar(Float32(-0.125))),
+    )
+
+
 def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/expression/test_parser.mojo
+++ b/tests/expression/test_parser.mojo
@@ -26,15 +26,10 @@ from decimo.expression import (
 
 def rpn_to_string(rpn: List[Token]) -> String:
     """Convert an RPN token list to a space-separated string."""
-    var parts = List[String]()
+    var parts = List[String](capacity=len(rpn))
     for i in range(len(rpn)):
         parts.append(rpn[i].value)
-    var result = String("")
-    for i in range(len(parts)):
-        if i > 0:
-            result += " "
-        result += parts[i]
-    return result^
+    return String(" ").join(parts)
 
 
 def parse_expr(expr: String) raises -> String:

--- a/tests/rational/test_rational_conversion.mojo
+++ b/tests/rational/test_rational_conversion.mojo
@@ -128,29 +128,29 @@ def test_parsable_conformance() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-def test_from_float_exact() raises:
+def test_from_float_scalar_exact() raises:
     """A float that is a dyadic fraction converts to that fraction."""
-    assert_equal(String(Rational.from_float(0.5)), "1/2")
-    assert_equal(String(Rational.from_float(-2.5)), "-5/2")
-    assert_equal(String(Rational.from_float(0.0)), "0")
-    assert_equal(String(Rational.from_float(-0.0)), "0")
-    assert_equal(String(Rational.from_float(1.0)), "1")
-    assert_equal(String(Rational.from_float(-3.0)), "-3")
+    assert_equal(String(Rational.from_float_scalar(0.5)), "1/2")
+    assert_equal(String(Rational.from_float_scalar(-2.5)), "-5/2")
+    assert_equal(String(Rational.from_float_scalar(0.0)), "0")
+    assert_equal(String(Rational.from_float_scalar(-0.0)), "0")
+    assert_equal(String(Rational.from_float_scalar(1.0)), "1")
+    assert_equal(String(Rational.from_float_scalar(-3.0)), "-3")
 
 
-def test_from_float_is_the_float_not_the_literal() raises:
+def test_from_float_scalar_is_the_float_not_the_literal() raises:
     """0.1 converts to the value the Float64 holds, not to one tenth."""
     assert_equal(
-        String(Rational.from_float(0.1)),
+        String(Rational.from_float_scalar(0.1)),
         "3602879701896397/36028797018963968",
     )
     assert_true(
-        Rational.from_float(0.1) != Rational("1/10"),
+        Rational.from_float_scalar(0.1) != Rational("1/10"),
         "the Float64 0.1 is not one tenth",
     )
 
 
-def test_from_float_extremes() raises:
+def test_from_float_scalar_extremes() raises:
     """The ends of the Float64 range survive the round trip."""
     var values: List[Float64] = [
         5e-324,  # smallest positive subnormal
@@ -161,27 +161,27 @@ def test_from_float_extremes() raises:
     ]
     for value in values:
         assert_equal(
-            Rational.from_float(value).to_float(),
+            Rational.from_float_scalar(value).to_float(),
             value,
             "round trip of " + String(value),
         )
 
 
-def test_from_float_rejects_non_finite() raises:
+def test_from_float_scalar_rejects_non_finite() raises:
     """Infinity and NaN are not rational numbers."""
     var raised = False
     try:
-        _ = Rational.from_float(Float64("1e400"))
+        _ = Rational.from_float_scalar(Float64("1e400"))
     except:
         raised = True
-    assert_true(raised, "from_float(inf) should raise")
+    assert_true(raised, "from_float_scalar(inf) should raise")
 
     raised = False
     try:
-        _ = Rational.from_float(Float64("1e400") - Float64("1e400"))
+        _ = Rational.from_float_scalar(Float64("1e400") - Float64("1e400"))
     except:
         raised = True
-    assert_true(raised, "from_float(nan) should raise")
+    assert_true(raised, "from_float_scalar(nan) should raise")
 
 
 # ===----------------------------------------------------------------------=== #
@@ -464,57 +464,57 @@ def test_to_bigdecimal_rejects_non_positive_precision() raises:
 # ===----------------------------------------------------------------------=== #
 
 
-def test_from_float_narrower_types() raises:
-    """`from_float` reads every binary format exactly, not just Float64.
+def test_from_float_scalar_narrower_types() raises:
+    """`from_float_scalar` reads every binary format exactly, not just Float64.
 
     The references are CPython's `Fraction` of the same bit pattern, so a
     difference here is a difference in what the bits are taken to mean.
     """
     assert_equal(
-        String(Rational.from_float(Float32(0.1))),
+        String(Rational.from_float_scalar(Float32(0.1))),
         "13421773/134217728",
         "Float32(0.1) is 13421773 * 2^-27",
     )
     assert_equal(
-        String(Rational.from_float(Float16(0.1))),
+        String(Rational.from_float_scalar(Float16(0.1))),
         "819/8192",
         "Float16(0.1) is 819 * 2^-13",
     )
     assert_equal(
-        String(Rational.from_float(BFloat16(0.1))),
+        String(Rational.from_float_scalar(BFloat16(0.1))),
         "205/2048",
         "BFloat16(0.1) is 205 * 2^-11",
     )
 
     # A value every format holds exactly reads the same out of all of them.
-    assert_equal(String(Rational.from_float(Float16(-2.5))), "-5/2")
-    assert_equal(String(Rational.from_float(BFloat16(-2.5))), "-5/2")
-    assert_equal(String(Rational.from_float(Float32(-2.5))), "-5/2")
-    assert_equal(String(Rational.from_float(Float64(-2.5))), "-5/2")
+    assert_equal(String(Rational.from_float_scalar(Float16(-2.5))), "-5/2")
+    assert_equal(String(Rational.from_float_scalar(BFloat16(-2.5))), "-5/2")
+    assert_equal(String(Rational.from_float_scalar(Float32(-2.5))), "-5/2")
+    assert_equal(String(Rational.from_float_scalar(Float64(-2.5))), "-5/2")
 
-    assert_equal(String(Rational.from_float(Float32(0.0))), "0")
-    assert_equal(String(Rational.from_float(Float16(0.0))), "0")
+    assert_equal(String(Rational.from_float_scalar(Float32(0.0))), "0")
+    assert_equal(String(Rational.from_float_scalar(Float16(0.0))), "0")
 
 
-def test_from_float_narrower_subnormals_and_non_finite() raises:
+def test_from_float_scalar_narrower_subnormals_and_non_finite() raises:
     """The narrow formats keep their subnormals, and still reject inf/NaN."""
     # 2^-24 is the smallest positive Float16, a subnormal.
     assert_equal(
-        String(Rational.from_float(Float16(6e-8))),
+        String(Rational.from_float_scalar(Float16(6e-8))),
         "1/16777216",
         "the smallest Float16 subnormal is 2^-24",
     )
 
     var raised = False
     try:
-        _ = Rational.from_float(Float32.MAX * Float32(2.0))
+        _ = Rational.from_float_scalar(Float32.MAX * Float32(2.0))
     except:
         raised = True
     assert_true(raised, "an infinite Float32 is not a rational")
 
     raised = False
     try:
-        _ = Rational.from_float(Float16(0.0) / Float16(0.0))
+        _ = Rational.from_float_scalar(Float16(0.0) / Float16(0.0))
     except:
         raised = True
     assert_true(raised, "a Float16 NaN is not a rational")

--- a/tests/rational/test_rational_conversion.mojo
+++ b/tests/rational/test_rational_conversion.mojo
@@ -1,0 +1,463 @@
+"""
+Test Rational conversions: parsing, and the bridges to and from Float64,
+BigInt and BigDecimal.
+
+The expected values are the ones CPython gives for `fractions.Fraction`,
+`float(Fraction)` and `decimal.Decimal`, so a difference here is a real
+difference in behaviour rather than a difference of convention.
+"""
+
+from std import testing
+from std.testing import assert_equal, assert_true
+
+from decimo.bigdecimal.bigdecimal import BigDecimal
+from decimo.bigint.bigint import BigInt
+from decimo.rational.rational import Rational
+from decimo.rounding_mode import RoundingMode
+from decimo.traits import Parsable
+
+
+# ===----------------------------------------------------------------------=== #
+# Parsing
+# ===----------------------------------------------------------------------=== #
+
+
+def test_parse_fraction_form() raises:
+    """A "p/q" string is read exactly and reduced."""
+    assert_equal(String(Rational("3/7")), "3/7")
+    assert_equal(String(Rational("6/14")), "3/7")
+    assert_equal(String(Rational("-6/14")), "-3/7")
+    assert_equal(String(Rational("6/-14")), "-3/7")
+    assert_equal(String(Rational("-6/-14")), "3/7")
+    assert_equal(String(Rational("8/4")), "2")
+    assert_equal(String(Rational("0/5")), "0")
+
+
+def test_parse_decimal_form() raises:
+    """A single decimal literal is read exactly, not as a float would be."""
+    assert_equal(String(Rational("42")), "42")
+    assert_equal(String(Rational("-42")), "-42")
+    assert_equal(String(Rational("1.5")), "3/2")
+    assert_equal(String(Rational("-0.125")), "-1/8")
+    assert_equal(String(Rational("7e-3")), "7/1000")
+    assert_equal(String(Rational("1.23e5")), "123000")
+    assert_equal(String(Rational("-0.00100e-2")), "-1/100000")
+    # 0.1 as a decimal literal is exactly one tenth, unlike the Float64 of
+    # the same name.
+    assert_equal(String(Rational("0.1")), "1/10")
+
+
+def test_parse_accepts_what_bigdecimal_accepts() raises:
+    """Separators and spaces are allowed on both sides of the slash."""
+    assert_equal(String(Rational("  1_000, 000 / 3 ")), "1000000/3")
+    assert_equal(String(Rational("+1.5")), "3/2")
+
+
+def test_parse_mixed_form() raises:
+    """Either side of the slash may itself be a decimal literal."""
+    assert_equal(String(Rational("1.5/2.5")), "3/5")
+    assert_equal(String(Rational("1e2/4")), "25")
+
+
+def test_parse_rejects_nonsense() raises:
+    """A string that is not a rational raises rather than parsing to zero."""
+    var raised = False
+    try:
+        _ = Rational("not a number")
+    except:
+        raised = True
+    assert_true(raised, "Rational('not a number') should raise")
+
+    raised = False
+    try:
+        _ = Rational("1/2/3")
+    except:
+        raised = True
+    assert_true(raised, "Rational('1/2/3') should raise")
+
+    raised = False
+    try:
+        _ = Rational("3/")
+    except:
+        raised = True
+    assert_true(raised, "Rational('3/') should raise")
+
+
+def test_parse_rejects_zero_denominator() raises:
+    """A zero denominator raises, as no rational has one."""
+    var raised = False
+    try:
+        _ = Rational("3/0")
+    except:
+        raised = True
+    assert_true(raised, "Rational('3/0') should raise")
+
+    raised = False
+    try:
+        _ = Rational("3/0.0")
+    except:
+        raised = True
+    assert_true(raised, "Rational('3/0.0') should raise")
+
+
+def _parse_all[
+    T: Movable & Deinitable & Parsable
+](tokens: List[String]) raises -> List[T]:
+    """Parses every token into `T`, naming no concrete type."""
+    var out = List[T](capacity=len(tokens))
+    for token in tokens:
+        out.append(T.from_string(token))
+    return out^
+
+
+def test_parsable_conformance() raises:
+    """`Rational` is usable through the `Parsable` trait, not just declared."""
+    var tokens: List[String] = ["3/7", "0.1", "-42"]
+    var values = _parse_all[Rational](tokens)
+
+    assert_true(values[0] == Rational("3/7"), "3/7 through the trait")
+    assert_true(
+        values[1] + values[1] == Rational(1, 5),
+        "0.1 + 0.1 is exactly 1/5 through the trait",
+    )
+    assert_true(values[2] == Rational(-42), "-42 through the trait")
+
+
+# ===----------------------------------------------------------------------=== #
+# From Float64
+# ===----------------------------------------------------------------------=== #
+
+
+def test_from_float_exact() raises:
+    """A float that is a dyadic fraction converts to that fraction."""
+    assert_equal(String(Rational.from_float(0.5)), "1/2")
+    assert_equal(String(Rational.from_float(-2.5)), "-5/2")
+    assert_equal(String(Rational.from_float(0.0)), "0")
+    assert_equal(String(Rational.from_float(-0.0)), "0")
+    assert_equal(String(Rational.from_float(1.0)), "1")
+    assert_equal(String(Rational.from_float(-3.0)), "-3")
+
+
+def test_from_float_is_the_float_not_the_literal() raises:
+    """0.1 converts to the value the Float64 holds, not to one tenth."""
+    assert_equal(
+        String(Rational.from_float(0.1)),
+        "3602879701896397/36028797018963968",
+    )
+    assert_true(
+        Rational.from_float(0.1) != Rational("1/10"),
+        "the Float64 0.1 is not one tenth",
+    )
+
+
+def test_from_float_extremes() raises:
+    """The ends of the Float64 range survive the round trip."""
+    var values: List[Float64] = [
+        5e-324,  # smallest positive subnormal
+        1e-320,  # a subnormal with trailing zero bits
+        2.2250738585072014e-308,  # smallest normal
+        1.7976931348623157e308,  # largest finite
+        -1.7976931348623157e308,
+    ]
+    for value in values:
+        assert_equal(
+            Rational.from_float(value).to_float(),
+            value,
+            "round trip of " + String(value),
+        )
+
+
+def test_from_float_rejects_non_finite() raises:
+    """Infinity and NaN are not rational numbers."""
+    var raised = False
+    try:
+        _ = Rational.from_float(Float64("1e400"))
+    except:
+        raised = True
+    assert_true(raised, "from_float(inf) should raise")
+
+    raised = False
+    try:
+        _ = Rational.from_float(Float64("1e400") - Float64("1e400"))
+    except:
+        raised = True
+    assert_true(raised, "from_float(nan) should raise")
+
+
+# ===----------------------------------------------------------------------=== #
+# From BigDecimal
+# ===----------------------------------------------------------------------=== #
+
+
+def test_from_bigdecimal() raises:
+    """A decimal is a fraction already, so the conversion is exact."""
+    assert_equal(
+        String(Rational.from_bigdecimal(BigDecimal("123.456"))), "15432/125"
+    )
+    assert_equal(String(Rational.from_bigdecimal(BigDecimal("-0.125"))), "-1/8")
+    assert_equal(String(Rational.from_bigdecimal(BigDecimal("0"))), "0")
+    assert_equal(String(Rational.from_bigdecimal(BigDecimal("42"))), "42")
+    # A negative scale is trailing zeros, not a fraction.
+    assert_equal(
+        String(Rational.from_bigdecimal(BigDecimal("4.2E+4"))), "42000"
+    )
+
+
+def test_bigdecimal_constructor() raises:
+    """The BigDecimal constructor is the same conversion."""
+    assert_true(
+        Rational(BigDecimal("-0.125")) == Rational(-1, 8),
+        "Rational(BigDecimal) should convert exactly",
+    )
+
+
+def test_bigdecimal_round_trip() raises:
+    """Every exactly-representable value survives both directions."""
+    var values: List[String] = ["0.5", "-0.125", "123.456", "0", "1e-9"]
+    for value in values:
+        var rational = Rational(BigDecimal(value))
+        assert_true(
+            Rational(rational.to_bigdecimal()) == rational,
+            "round trip of " + value,
+        )
+
+
+# ===----------------------------------------------------------------------=== #
+# To Float64
+# ===----------------------------------------------------------------------=== #
+
+
+def test_to_float() raises:
+    """The nearest Float64, matching CPython's `float(Fraction(...))`."""
+    assert_equal(Rational("1/3").to_float(), 0.3333333333333333)
+    assert_equal(Rational("2/3").to_float(), 0.6666666666666666)
+    assert_equal(Rational("1/7").to_float(), 0.14285714285714285)
+    assert_equal(Rational("22/7").to_float(), 3.142857142857143)
+    assert_equal(Rational("355/113").to_float(), 3.1415929203539825)
+    assert_equal(Rational("-7/2").to_float(), -3.5)
+    assert_equal(Rational(0).to_float(), 0.0)
+    assert_equal(Rational("1/10").to_float(), 0.1)
+    assert_equal(
+        Rational(BigInt(2) ** 100, BigInt(3) ** 50).to_float(),
+        1765780.963259017,
+    )
+
+
+def test_to_float_ties_to_even() raises:
+    """A value exactly halfway between two floats rounds to the even one.
+
+    This is the case a decimal detour gets wrong: the halfway point has 53
+    decimal digits, so rounding it to a working precision first moves it off
+    the tie and the second rounding then goes the wrong way.
+    """
+    # 1 + 2^-53 sits halfway between 1.0 and the next float up. The even
+    # significand is 1.0's.
+    var lower_tie = Rational(BigInt(2) ** 53 + BigInt(1), BigInt(2) ** 53)
+    assert_equal(lower_tie.to_float(), 1.0, "1 + 2^-53 rounds down to 1.0")
+
+    # 1 + 3 * 2^-53 sits halfway one ULP further up, where the even
+    # significand is the upper one.
+    var upper_tie = Rational(BigInt(2) ** 53 + BigInt(3), BigInt(2) ** 53)
+    assert_equal(
+        upper_tie.to_float(),
+        1.0000000000000004,
+        "1 + 3 * 2^-53 rounds up",
+    )
+
+
+def test_to_float_out_of_range() raises:
+    """Beyond the Float64 range the result saturates, as BigInt's does."""
+    assert_equal(Rational(BigInt(10) ** 400).to_float(), Float64("1e400"))
+    assert_equal(Rational(-(BigInt(10) ** 400)).to_float(), -Float64("1e400"))
+    assert_equal(Rational(BigInt(1), BigInt(10) ** 400).to_float(), 0.0)
+
+
+def test_float_dunder() raises:
+    """`Float64(x)` is `x.to_float()`."""
+    assert_equal(Float64(Rational("1/4")), 0.25)
+    assert_equal(Float64(Rational("1/3")), Rational("1/3").to_float())
+
+
+# ===----------------------------------------------------------------------=== #
+# To integer
+# ===----------------------------------------------------------------------=== #
+
+
+def test_to_integer_truncates_toward_zero() raises:
+    """Truncation, not flooring: -7/2 is -3, not -4."""
+    assert_equal(String(Rational("7/2").to_integer()), "3")
+    assert_equal(String(Rational("-7/2").to_integer()), "-3")
+    assert_equal(String(Rational("-1/2").to_integer()), "0")
+    assert_equal(String(Rational("42").to_integer()), "42")
+    assert_equal(String(Rational(0).to_integer()), "0")
+
+
+def test_to_int_and_dunder() raises:
+    """The Int forms agree with the BigInt one."""
+    assert_equal(Rational("7/2").to_int(), 3)
+    assert_equal(Int(Rational("-9/4")), -2)
+    assert_equal(Int(Rational(-42)), -42)
+
+
+def test_to_int_overflow_raises() raises:
+    """A value past the range of Int raises rather than wrapping."""
+    var raised = False
+    try:
+        _ = Rational(BigInt(10) ** 30).to_int()
+    except:
+        raised = True
+    assert_true(raised, "to_int() of 10^30 should raise")
+
+
+# ===----------------------------------------------------------------------=== #
+# To BigDecimal
+# ===----------------------------------------------------------------------=== #
+
+
+def test_to_bigdecimal_exact() raises:
+    """A value with a finite decimal form keeps that form, unpadded."""
+    assert_equal(String(Rational("1/2").to_bigdecimal()), "0.5")
+    assert_equal(String(Rational("-1/8").to_bigdecimal()), "-0.125")
+    assert_equal(String(Rational(42).to_bigdecimal()), "42")
+    assert_equal(String(Rational(0).to_bigdecimal()), "0")
+    assert_equal(String(Rational("3/2").to_bigdecimal(precision=5)), "1.5")
+
+
+def test_to_bigdecimal_inexact() raises:
+    """A repeating value is cut to `precision` significant digits."""
+    assert_equal(
+        String(Rational("1/3").to_bigdecimal()),
+        "0.3333333333333333333333333333",
+    )
+    assert_equal(String(Rational("1/3").to_bigdecimal(precision=5)), "0.33333")
+    assert_equal(
+        String(Rational("-1/3").to_bigdecimal(precision=5)), "-0.33333"
+    )
+    assert_equal(String(Rational("2/3").to_bigdecimal(precision=5)), "0.66667")
+    # Significant digits, not decimal places: the exponent moves instead.
+    assert_equal(
+        String(Rational("100000/3").to_bigdecimal(precision=3)), "3.33E+4"
+    )
+
+
+def test_to_bigdecimal_rounding_modes() raises:
+    """Each mode decides the last digit of 2/3 and -2/3 its own way."""
+    var two_thirds = Rational("2/3")
+    var minus_two_thirds = Rational("-2/3")
+
+    assert_equal(
+        String(
+            two_thirds.to_bigdecimal(
+                precision=5, rounding_mode=RoundingMode.ROUND_DOWN
+            )
+        ),
+        "0.66666",
+    )
+    assert_equal(
+        String(
+            two_thirds.to_bigdecimal(
+                precision=5, rounding_mode=RoundingMode.ROUND_UP
+            )
+        ),
+        "0.66667",
+    )
+    assert_equal(
+        String(
+            two_thirds.to_bigdecimal(
+                precision=5, rounding_mode=RoundingMode.ROUND_CEILING
+            )
+        ),
+        "0.66667",
+    )
+    assert_equal(
+        String(
+            two_thirds.to_bigdecimal(
+                precision=5, rounding_mode=RoundingMode.ROUND_FLOOR
+            )
+        ),
+        "0.66666",
+    )
+    assert_equal(
+        String(
+            minus_two_thirds.to_bigdecimal(
+                precision=5, rounding_mode=RoundingMode.ROUND_CEILING
+            )
+        ),
+        "-0.66666",
+    )
+    assert_equal(
+        String(
+            minus_two_thirds.to_bigdecimal(
+                precision=5, rounding_mode=RoundingMode.ROUND_FLOOR
+            )
+        ),
+        "-0.66667",
+    )
+
+
+def test_to_bigdecimal_half_modes() raises:
+    """1/8 is exactly 0.125, so two digits is a tie the modes split."""
+    var one_eighth = Rational("1/8")
+
+    assert_equal(
+        String(
+            one_eighth.to_bigdecimal(
+                precision=2, rounding_mode=RoundingMode.ROUND_HALF_EVEN
+            )
+        ),
+        "0.12",
+    )
+    assert_equal(
+        String(
+            one_eighth.to_bigdecimal(
+                precision=2, rounding_mode=RoundingMode.ROUND_HALF_UP
+            )
+        ),
+        "0.13",
+    )
+    assert_equal(
+        String(
+            one_eighth.to_bigdecimal(
+                precision=2, rounding_mode=RoundingMode.ROUND_HALF_DOWN
+            )
+        ),
+        "0.12",
+    )
+    # 3/8 is 0.375: half-even now rounds up, to the even digit 8.
+    assert_equal(
+        String(
+            Rational("3/8").to_bigdecimal(
+                precision=2, rounding_mode=RoundingMode.ROUND_HALF_EVEN
+            )
+        ),
+        "0.38",
+    )
+
+
+def test_to_bigdecimal_carries_into_a_new_digit() raises:
+    """Rounding 999.999 to three digits carries the whole way."""
+    assert_equal(
+        String(Rational("999999/1000").to_bigdecimal(precision=3)), "1.00E+3"
+    )
+    assert_equal(String(Rational("99/100").to_bigdecimal(precision=1)), "1")
+
+
+def test_to_bigdecimal_rejects_non_positive_precision() raises:
+    """A precision of zero digits has no result to give."""
+    var raised = False
+    try:
+        _ = Rational("1/3").to_bigdecimal(precision=0)
+    except:
+        raised = True
+    assert_true(raised, "precision=0 should raise")
+
+    raised = False
+    try:
+        _ = Rational("1/3").to_bigdecimal(precision=-1)
+    except:
+        raised = True
+    assert_true(raised, "precision=-1 should raise")
+
+
+def main() raises:
+    testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/rational/test_rational_conversion.mojo
+++ b/tests/rational/test_rational_conversion.mojo
@@ -459,5 +459,98 @@ def test_to_bigdecimal_rejects_non_positive_precision() raises:
     assert_true(raised, "precision=-1 should raise")
 
 
+# ===----------------------------------------------------------------------=== #
+# Narrower floating-point types and integral scalars
+# ===----------------------------------------------------------------------=== #
+
+
+def test_from_float_narrower_types() raises:
+    """`from_float` reads every binary format exactly, not just Float64.
+
+    The references are CPython's `Fraction` of the same bit pattern, so a
+    difference here is a difference in what the bits are taken to mean.
+    """
+    assert_equal(
+        String(Rational.from_float(Float32(0.1))),
+        "13421773/134217728",
+        "Float32(0.1) is 13421773 * 2^-27",
+    )
+    assert_equal(
+        String(Rational.from_float(Float16(0.1))),
+        "819/8192",
+        "Float16(0.1) is 819 * 2^-13",
+    )
+    assert_equal(
+        String(Rational.from_float(BFloat16(0.1))),
+        "205/2048",
+        "BFloat16(0.1) is 205 * 2^-11",
+    )
+
+    # A value every format holds exactly reads the same out of all of them.
+    assert_equal(String(Rational.from_float(Float16(-2.5))), "-5/2")
+    assert_equal(String(Rational.from_float(BFloat16(-2.5))), "-5/2")
+    assert_equal(String(Rational.from_float(Float32(-2.5))), "-5/2")
+    assert_equal(String(Rational.from_float(Float64(-2.5))), "-5/2")
+
+    assert_equal(String(Rational.from_float(Float32(0.0))), "0")
+    assert_equal(String(Rational.from_float(Float16(0.0))), "0")
+
+
+def test_from_float_narrower_subnormals_and_non_finite() raises:
+    """The narrow formats keep their subnormals, and still reject inf/NaN."""
+    # 2^-24 is the smallest positive Float16, a subnormal.
+    assert_equal(
+        String(Rational.from_float(Float16(6e-8))),
+        "1/16777216",
+        "the smallest Float16 subnormal is 2^-24",
+    )
+
+    var raised = False
+    try:
+        _ = Rational.from_float(Float32.MAX * Float32(2.0))
+    except:
+        raised = True
+    assert_true(raised, "an infinite Float32 is not a rational")
+
+    raised = False
+    try:
+        _ = Rational.from_float(Float16(0.0) / Float16(0.0))
+    except:
+        raised = True
+    assert_true(raised, "a Float16 NaN is not a rational")
+
+
+def test_from_integral_scalar() raises:
+    """Every integral width lands on an exact integer with denominator 1."""
+    assert_equal(String(Rational.from_integral_scalar(Int8(-5))), "-5")
+    assert_equal(String(Rational.from_integral_scalar(Int8.MIN)), "-128")
+    assert_equal(String(Rational.from_integral_scalar(UInt8.MAX)), "255")
+    assert_equal(String(Rational.from_integral_scalar(Int32(0))), "0")
+    assert_equal(
+        String(Rational.from_integral_scalar(Int64.MIN)),
+        "-9223372036854775808",
+    )
+    assert_equal(
+        String(Rational.from_integral_scalar(UInt64.MAX)),
+        "18446744073709551615",
+    )
+
+    var one = Rational.from_integral_scalar(Int(7))
+    assert_equal(String(one.denominator), "1", "an integer has denominator 1")
+
+
+def test_integral_scalar_constructor_is_implicit() raises:
+    """An integral scalar converts to a Rational wherever one is wanted."""
+    assert_equal(String(Rational(42)), "42")
+    assert_equal(String(Rational(Int64(-7))), "-7")
+    assert_equal(String(Rational(UInt32(9))), "9")
+
+    var coerced: Rational = 12
+    assert_equal(String(coerced), "12")
+
+    # And it composes with the arithmetic, which is the point of @implicit.
+    assert_equal(String(Rational("1/3") + 1), "4/3")
+
+
 def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -29,11 +29,29 @@
 #   decimo      core            → All core suites (bigdecimal+bigint+biguint+bigint10+
 #                                 decimal128+rational+expression+numerals+traits)
 #   all                         → Everything (decimo + toml + cli)
+#
+# Environment:
+#   DECIMO_TEST_JOBS=N   Run up to N Mojo test files concurrently (default 1).
+#                        Output is buffered per file and replayed in order.
 
 set -eo pipefail
 
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+SELF="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
 cd "$REPO_ROOT"
+
+# ── Parallelism ──────────────────────────────────────────────────────────────
+# Every Mojo test file is its own `mojo run` process, and on a warm compile
+# cache that process spends far more time starting up than running tests: the
+# whole core suite is ~0.8 s of test bodies inside ~71 s of wall clock, i.e.
+# ~99% fixed per-file overhead. The files are independent, so they can run
+# concurrently; at DECIMO_TEST_JOBS=8 the same run takes ~13 s.
+#
+# Default 1 (sequential, unchanged) because a serialized run is easier to watch
+# and easier to attribute a crash to. The parallel path still replays each
+# file's output whole and in the original order, so a failing run reads the
+# same - it just arrives all at once at the end of the suite.
+DECIMO_TEST_JOBS="${DECIMO_TEST_JOBS:-1}"
 
 # ── Preflight: ensure tests/decimo.mojoc exists ─────────────────────────────
 # All Mojo test invocations below use `-I tests` to pick up the prebuilt
@@ -52,31 +70,78 @@ ensure_decimo_package() {
 
 # ── Suite definitions ────────────────────────────────────────────────────────
 
-run_mojo_suite() {
-    local dir="$1"
-    ensure_decimo_package
-    for f in tests/"$dir"/*.mojo; do
-        echo "=== $f ==="
-        # Retry once on transient Python init crash (libpython sporadic load failure).
-        local attempt=1
-        local max_attempts=2
-        while (( attempt <= max_attempts )); do
-            # `&&` rather than `if`: after an `if ... fi` whose condition was
-            # false, `$?` is the `if` statement's own status, which is 0. The
-            # `return $rc` below would then hand back success for a suite that
-            # failed to compile, and the whole run would exit green.
-            pixi run mojo run -I tests -D ASSERT=all --debug-level=full "$f" \
-                && break
-            local rc=$?
-            if (( attempt < max_attempts )); then
-                echo "WARN: $f failed (rc=$rc), retrying (attempt $((attempt + 1))/$max_attempts)..."
-                attempt=$((attempt + 1))
-            else
-                echo "ERROR: $f failed after $max_attempts attempts"
-                return $rc
-            fi
-        done
+run_one_mojo_file() {
+    local f="$1"
+    # Retry once on transient Python init crash (libpython sporadic load failure).
+    local attempt=1
+    local max_attempts=2
+    while (( attempt <= max_attempts )); do
+        # `&&` rather than `if`: after an `if ... fi` whose condition was
+        # false, `$?` is the `if` statement's own status, which is 0. The
+        # `return $rc` below would then hand back success for a suite that
+        # failed to compile, and the whole run would exit green.
+        pixi run mojo run -I tests -D ASSERT=all --debug-level=full "$f" \
+            && break
+        local rc=$?
+        if (( attempt < max_attempts )); then
+            echo "WARN: $f failed (rc=$rc), retrying (attempt $((attempt + 1))/$max_attempts)..."
+            attempt=$((attempt + 1))
+        else
+            echo "ERROR: $f failed after $max_attempts attempts"
+            return $rc
+        fi
     done
+}
+
+# Log path for one test file inside a scratch directory. `/` is not legal in a
+# filename, so flatten the path rather than recreating the tree.
+mojo_log_path() {
+    printf '%s/%s.log' "$1" "$(printf '%s' "$2" | tr '/' '_')"
+}
+
+run_mojo_files() {
+    ensure_decimo_package
+
+    if (( DECIMO_TEST_JOBS <= 1 )); then
+        local f
+        for f in "$@"; do
+            echo "=== $f ==="
+            run_one_mojo_file "$f" || return $?
+        done
+        return 0
+    fi
+
+    local tmpdir
+    tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/decimo-tests.XXXXXX")
+
+    # `--run-one` always exits 0 and records failure as a marker file, so xargs
+    # never aborts the batch early; the verdict is collected in the replay loop
+    # below, which also keeps the output in the caller's order.
+    printf '%s\n' "$@" \
+        | xargs -P "$DECIMO_TEST_JOBS" -I{} bash "$SELF" --run-one {} "$tmpdir" \
+        || true
+
+    local rc=0 f log
+    for f in "$@"; do
+        echo "=== $f ==="
+        log=$(mojo_log_path "$tmpdir" "$f")
+        if [[ -f "$log" ]]; then
+            cat "$log"
+        else
+            echo "ERROR: $f produced no output (worker did not run)"
+            rc=1
+        fi
+        if [[ -f "$log.fail" ]]; then
+            rc=1
+        fi
+    done
+
+    rm -rf "$tmpdir"
+    return $rc
+}
+
+run_mojo_suite() {
+    run_mojo_files tests/"$1"/*.mojo
 }
 
 run_bigdecimal()  { run_mojo_suite bigdecimal; }
@@ -330,15 +395,20 @@ run_python() {
 
 # Composite suites
 run_decimo() {
-    run_bigdecimal
-    run_bigint
-    run_biguint
-    run_bigint10
-    run_decimal128
-    run_rational
-    run_expression
-    run_numerals
-    run_traits
+    # One batch rather than nine sequential ones: with DECIMO_TEST_JOBS > 1 a
+    # per-suite batch drains to a handful of stragglers before the next suite
+    # can start, so the pool sits half idle. Sequentially this is the same
+    # ordering as before, since the directories are listed in the same order.
+    run_mojo_files \
+        tests/bigdecimal/*.mojo \
+        tests/bigint/*.mojo \
+        tests/biguint/*.mojo \
+        tests/bigint10/*.mojo \
+        tests/decimal128/*.mojo \
+        tests/rational/*.mojo \
+        tests/expression/*.mojo \
+        tests/numerals/*.mojo \
+        tests/traits/*.mojo
 }
 
 run_all() {
@@ -395,6 +465,16 @@ list_suites() {
 }
 
 # ── Main ─────────────────────────────────────────────────────────────────────
+
+# Internal: run one test file into a log under a scratch directory. Used by the
+# parallel path in `run_mojo_files`; always exits 0 so the batch is not aborted.
+if [ "${1:-}" = "--run-one" ]; then
+    log=$(mojo_log_path "$3" "$2")
+    if ! run_one_mojo_file "$2" > "$log" 2>&1; then
+        : > "$log.fail"
+    fi
+    exit 0
+fi
 
 if [ "${1:-}" = "--list" ] || [ "${1:-}" = "-l" ]; then
     list_suites


### PR DESCRIPTION
This PR expands and refines core numeric conversion APIs (notably `Rational`) while continuing the migration away from `BigInt10` in favor of `BigInt`/`BigUInt`, and it optimizes the Chudnovsky π implementation for performance.

**Changes:**
- Add/standardize scalar conversion factories (`from_integral_scalar` / `from_float_scalar`) across numeric types and implement rich `Rational` conversion support (string/float/decimal/int).
- Replace cross-library `BigInt10` dependencies with `BigInt.to_biguint()` / `BigInt.from_biguint()` bridges and move legacy bridging logic into `BigInt10` itself.
- Improve π (Chudnovsky binary splitting) performance by switching internals to `BigInt`, reducing factors of two during combine, and reducing base-conversion overhead.