### PR TITLE
[core][decimal] Improve performance of pi calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ powered by [ArgMojo](https://github.com/forfudan/argmojo). Install it with
 
 | Type         | Alias             | Information                              | Layout       |
 | ------------ | ----------------- | ---------------------------------------- | ------------ |
-| `BigInt`     | `BInt`, `Integer` | Equivalent to Python's `int`             | Base-2^32    |
+| `BigInt`     | `BInt`            | Equivalent to Python's `int`             | Base-2^32    |
 | `BigDecimal` | `BDec`, `Decimal` | Equivalent to Python's `decimal.Decimal` | Base-10^9    |
 | `Decimal128` | `Dec128`          | 128-bit fixed-precision decimal type     | 32-bit words |
 | `BigFloat`   | `Float`           | Arbitrary-precision floating-point type  | MPFR/GMP     |
@@ -68,7 +68,7 @@ The core types are[^auxiliary]:
   a wide exponent range. Unlike `BigDecimal`, which uses base-10 arithmetic,
   `BigFloat` uses binary floating-point internally. This type is optional and
   requires MPFR/GMP to be installed on the user's system.
-<!-- - An arbitrary-precision exact rational number type (`Rational`) represented as a reduced fraction of two `Integer`s (numerator and denominator). It supports exact arithmetic and comparisons without any loss of precision, making it ideal for applications that require precise fractional calculations. -->
+<!-- - An arbitrary-precision exact rational number type (`Rational`) represented as a reduced fraction of two `BigInt`s (numerator and denominator). It supports exact arithmetic and comparisons without any loss of precision, making it ideal for applications that require precise fractional calculations. -->
 
 **Decimo** combines "**Deci**mal" and "**Mo**jo" - reflecting its purpose and
 implementation language. "Decimo" is also a Latin word meaning "tenth" and is
@@ -233,7 +233,7 @@ from decimo import *
 
 This will import the following types or aliases into your namespace:
 
-- `BigInt` (and its aliases `BInt`, `Integer`): An arbitrary-precision signed
+- `BigInt` (and its alias `BInt`): An arbitrary-precision signed
   integer type, equivalent to Python's `int`.
 - `BigDecimal` (and its aliases `BDec`, `Decimal`): An arbitrary-precision
   decimal type, equivalent to Python's `decimal.Decimal`.
@@ -327,7 +327,7 @@ def main() raises:
 ---
 
 Here is a comprehensive quick-start guide showcasing each major function of the
-`BigInt` (`BInt`, `Integer`) type.
+`BigInt` (`BInt`) type.
 
 ```mojo
 from decimo.prelude import *
@@ -476,7 +476,7 @@ Rome wasn't built in a day. Decimo is currently under active development. It has
 successfully progressed through the **"make it work"** phase and the
 **"make it right"**, and is now well into the **"make it fast"** phase.
 
-The `Integer` type is fully implemented and optimized. It has been benchmarked
+The `BigInt` type is fully implemented and optimized. It has been benchmarked
 against Python's `int` and demonstrates superior performance in most cases.
 
 Bug reports and feature requests are welcome! If you encounter issues, please
@@ -489,7 +489,7 @@ decimo/
 ├── src/                          # All source code
 │   ├── decimo/                   # Core library (mojo pre-compiled package)
 │   │   ├── bigdecimal/           #   Arbitrary-precision decimal (Decimal)
-│   │   ├── bigint/               #   Arbitrary-precision signed integer (Integer)
+│   │   ├── bigint/               #   Arbitrary-precision signed integer (BigInt)
 │   │   ├── bigint10/             #   Base-10 signed integer (BigInt10)
 │   │   ├── biguint/              #   Base-10 unsigned integer (BigUInt)
 │   │   ├── bigfloat/             #   Arbitrary-precision binary float (MPFR)
@@ -575,7 +575,7 @@ for details.
     eights total with 27 after the decimal point). Decimo's `Dec128` type
     is similar to `System.Decimal` (C#/.NET), `rust_decimal` in Rust,
     `DECIMAL/NUMERIC` in SQL Server, etc.
-[^bigint]: The `Integer` implementation uses a base-2^32 representation with a
+[^bigint]: The `BigInt` implementation uses a base-2^32 representation with a
     little-endian format, where the least significant word is stored at
     index 0. Each word is a `UInt32`, allowing for efficient storage and
     arithmetic operations on large integers. This design choice optimizes

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,76 @@
 
 This is a list of changes for the Decimo package (formerly DeciMojo).
 
+## Unreleased
+
+Work since v0.13.0. `Rational` grows a full set of conversions and joins the
+`from_integral_scalar()` / `from_float_scalar()` naming used by the other
+numeric types, `BigInt10` is no longer referenced by the rest of the library,
+and `BigDecimal.pi()` gets two to three orders of magnitude faster.
+
+### ⭐️ New in Unreleased
+
+1. **`Rational` conversions.** Constructors from an integral scalar, a `String`
+   and a `BigDecimal`; the factories `from_string()`, `from_integral_scalar()`,
+   `from_float_scalar()` and `from_bigdecimal()`; and the outbound
+   `__int__()`, `__float__()`, `to_int()`, `to_integer()`, `to_float()` and
+   `to_bigdecimal()` (PR #269).
+1. **`from_integral_scalar()` and `from_float_scalar()` on `BigInt`,
+   `BigDecimal`, `Decimal128` and `Rational`.** One pair of names across the
+   library, constrained with `where` clauses instead of `comptime assert`, so
+   the wrong scalar kind is an overload mismatch rather than an assertion
+   (PR #269).
+1. **`BigInt.from_biguint()` and `BigInt.to_biguint()`**, plus
+   `BigInt10.from_bigint()` and `BigInt10.to_bigint()` (PR #269).
+
+### 🦋 Changed in Unreleased
+
+1. **`BigDecimal.pi()` is two to three orders of magnitude faster.** The
+   Chudnovsky binary splitting now uses the `P`/`Q`/`T` recurrence: each leaf
+   is O(1) instead of rebuilding `(6k)!/(3k)!`, `(k!)^3` and `C^k` from
+   scratch, and the root denominator is the size of a single term rather than
+   the product of every term's denominator. `pi(10000)` goes from 13.7 s to
+   8.8 ms; `pi(100000)`, out of practical reach before, takes 0.28 s. The
+   earlier half of the work moved the split to `BigInt` and cut the
+   base-conversion overhead (PR #269). Everything that range-reduces against
+   π — `sin()`, `cos()`, `tan()` — inherits the gain.
+1. **`Rational.__add__` and `__sub__` cancel before they multiply**, using
+   Algorithm A of Knuth 4.5.1: the denominators are reduced by their gcd
+   first, and the result is in lowest terms without a second gcd over two
+   full-width operands. This is the cross-cancellation `__mul__` and
+   `__truediv__` already did. Summing `1/k^2` to 1 200 terms goes from 123 ms
+   to 3.1 ms.
+1. **`gcd()` balances its operands before entering the binary loop.** Stein's
+   algorithm makes about one bit of progress per full-width subtraction, which
+   is quadratic when one operand dwarfs the other, so `gcd()` now takes
+   Euclidean steps while the bit-length gap exceeds two words.
+   `gcd(17 940-bit, 20-bit)` drops from 4.85 ms to 0.003 ms; balanced operands
+   are untouched. This is what makes the `Rational` change above pay.
+1. **`BigInt10` is no longer used by any other module.** Bridging goes through
+   `BigUInt`, and `BigInt10` keeps its own conversions for code that still
+   wants them (PR #269).
+1. **Faster tests.** Test helpers that built large decimal strings by repeated
+   appending now pre-size the `String`, and `decimo.tests` gains
+   `random_decimal_string()` (PR #269).
+
+### 🗑️ Deprecated in Unreleased
+
+1. **`BigDecimal.from_float()` and `Decimal128.from_float()`** are deprecated in
+   favour of `from_float_scalar()`, the name that lines up with
+   `from_integral_scalar()`. They forward unchanged (PR #269).
+
+### 💥 Breaking in Unreleased
+
+1. **The `Integer` alias for `BigInt` is removed.** `BInt` remains, and matches
+   `BDec` and `Dec128` in shape. `Integer` named a general concept rather than
+   one concrete type, and collided with the ordinary English word used
+   throughout the documentation. Replace `Integer` with `BInt` or `BigInt`.
+1. **`gcd()` and `BigInt.gcd()` are now `raises`.** They take a remainder on
+   unbalanced operands, and `BigInt` division raises. Callers already inside a
+   `raises` function need no change.
+1. **`BigInt.from_bigint10()` and `BigInt.to_bigint10()` are removed.** Use
+   `BigInt10.from_bigint()` and `BigInt10.to_bigint()` (PR #269).
+
 ## 20260822 (v0.13.0)
 
 Decimo v0.13.0 is a **traits** release. `Numeric`, `Parsable` and `Rootable`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,9 +2,9 @@
 
 This is a list of changes for the Decimo package (formerly DeciMojo).
 
-## Unreleased
+## Unreleased (v0.14.0)
 
-Work since v0.13.0. `Rational` grows a full set of conversions and joins the
+`Rational` grows a full set of conversions and joins the
 `from_integral_scalar()` / `from_float_scalar()` naming used by the other
 numeric types, `BigInt10` is no longer referenced by the rest of the library,
 and `BigDecimal.pi()` gets two to three orders of magnitude faster.

--- a/docs/internal/internal_notes.md
+++ b/docs/internal/internal_notes.md
@@ -175,6 +175,23 @@ The balanced row is the control: the loop never fires there, and the difference
 is noise. With that in place the `Rational` change pays - summing `1/k^2` to
 1 200 terms goes from 123 ms to 3.1 ms, a 39x improvement.
 
+One trap worth recording, caught in review of PR #270. `bit_length()` returns a
+signed `Int`, so for `gcd(small, big)` the gap is simply negative, the
+balancing loop never runs, and the call drops straight back into the quadratic
+binary loop. Both argument orders still return the right answer, so no
+correctness test can see it:
+
+| `gcd(a, b)`            | forward  | reversed, unordered | reversed, ordered |
+| ---------------------- | -------- | ------------------- | ----------------- |
+| 1 329 bits, 41 bits    | 0.000 ms | 0.014 ms            | 0.000 ms          |
+| 5 980 bits, 7 bits     | 0.001 ms | 0.268 ms            | 0.001 ms          |
+| 17 939 bits, 7 bits    | 0.002 ms | 2.367 ms            | 0.003 ms          |
+
+`gcd()` therefore orders its operands by magnitude before measuring the gap.
+Each Euclidean step preserves that order on its own - the new pair is
+`(v, u mod v)`, and a remainder is smaller than what it was taken modulo - so
+one comparison at the top is enough.
+
 The balanced case is still Stein's, which is quadratic. A subquadratic gcd
 (Lehmer, or half-gcd) would be the next step, and would also change the
 full-gcd-per-combine trade-off recorded above.

--- a/docs/internal/internal_notes.md
+++ b/docs/internal/internal_notes.md
@@ -39,6 +39,7 @@ ratios between them are meaningful:
 | `2e81976` - Chudnovsky over `BigInt10` (base 10^9) | 0.2539 s   | -            |
 | `51e5896` - Chudnovsky over `BigInt` (base 2^32)   | 0.1408 s   | 1.80x        |
 | common powers of two divided out in `combine()`    | 0.0974 s   | 1.45x        |
+| `P`/`Q`/`T` binary splitting recurrence            | 0.0007 s   | 139x         |
 
 Notes on the last two, both in `bigdecimal/constants.mojo`:
 
@@ -71,12 +72,112 @@ wins outright beyond that. It is not used because the shifts get most of the
 benefit for a fraction of the cost, and because `BigInt`'s gcd is binary
 (Stein's), which is quadratic; a subquadratic gcd would change this trade-off.
 
-The base cases are the remaining structural inefficiency. Each leaf `k` rebuilds
-`(6k)!/(3k)!`, `(k!)^3` and `C^k` from scratch, which is O(k) big-integer
-multiplications per leaf and O(n^2) overall. The textbook `P`/`Q`/`T` binary
-splitting recurrence makes the leaf O(1) and lets those factors telescope
-through the combines instead. At 640 terms the leaves alone cost 0.89 s of the
-total, so this is not yet the bottleneck, but it is where the next big win is.
+### The `P`/`Q`/`T` recurrence
+
+The base cases used to be the remaining structural inefficiency: each leaf `k`
+rebuilt `(6k)!/(3k)!`, `(k!)^3` and `C^k` from scratch, O(k) big-integer
+multiplications per leaf and O(n^2) overall. That has been replaced with the
+textbook `P`/`Q`/`T` recurrence, in which the leaf is O(1) and those factors
+telescope through the combines.
+
+The leaf cost was the visible half of the problem and the smaller half. The
+larger half was what the old shape did to the operands. Carrying each term as
+an evaluated fraction means `combine()` multiplies the two denominators, so the
+denominator at the root is the *product* of all `n` term denominators - about
+O(n^2 log n) bits. With `P`/`Q`/`T` the same root denominator is
+`((n-1)!)^3 (C^3/24)^(n-1)`, the denominator of a *single* term, about
+O(n log n) bits. That is where the two-to-three orders of magnitude come from,
+and why the win grows with precision:
+
+| `pi(n)`   | Fraction leaves | `P`/`Q`/`T` | Speedup |
+| --------- | --------------- | ----------- | ------- |
+| 1 000     | 10.46 ms        | 0.25 ms     | 43x     |
+| 2 048     | 86.01 ms        | 0.69 ms     | 125x    |
+| 5 000     | 1.464 s         | 3.30 ms     | 443x    |
+| 10 000    | 13.658 s        | 8.81 ms     | 1 551x  |
+| 20 000    | -               | 27.92 ms    | -       |
+| 50 000    | -               | 96.89 ms    | -       |
+| 100 000   | -               | 288.84 ms   | -       |
+
+Two consequences worth recording:
+
+- **The common-powers-of-two trick is gone, and it is not a loss.** The triple
+  is homogeneous of degree one in each child, so dividing all three fields of a
+  subrange by a common factor does propagate correctly. But `P` is a product of
+  `(6k-5)(2k-1)(6k-1)`, all three of which are odd, so `P` is always odd and
+  the common factor is always one. There is nothing left to strip. The
+  reduction the old code did was reclaiming bloat the old shape created.
+- **The split is no longer where the time goes.** At `pi(100000)`, the split is
+  66 ms of the 289 ms total; the rest is the base-2^32 to base-10^9 conversion,
+  the final division, and `sqrt(10005)`. Further work on the series itself has
+  little left to win.
+
+### Could the public `Rational` carry the split?
+
+Asked and measured, because it would be one type fewer. The answer is no, but
+not for the reason the old `_UnreducedFraction` docstring gave.
+
+The natural `Rational` formulation carries two fractions per node - the partial
+sum `S` and the running term ratio `R` - and combines them as
+`S = S_left + R_left * S_right`, `R = R_left * R_right`. That is a faithful
+translation, and it agrees with the `P`/`Q`/`T` result exactly at every size
+tested, which is a useful independent check on the implementation. It is also
+much slower, and falls further behind as the range grows:
+
+| Terms | `P`/`Q`/`T` | Two `Rational`s | Root denominator, reduced |
+| ----- | ----------- | --------------- | ------------------------- |
+| 80    | 0.17 ms     | 2.60 ms         | 84% of unreduced          |
+| 160   | 0.28 ms     | 8.77 ms         | 81%                       |
+| 320   | 0.58 ms     | 31.24 ms        | 78%                       |
+| 640   | 1.60 ms     | 119.72 ms       | 75%                       |
+| 1 280 | 4.65 ms     | 481.02 ms       | 72%                       |
+
+The reason is in the last column. `Rational`'s invariant forces a gcd at every
+node, and here it buys almost nothing: the operands are only about a quarter
+smaller after full reduction, because the `P`/`Q`/`T` products are already
+close to coprime by construction. Paying a gcd per node to shave 25% off the
+operands is a bad trade at any size, and it gets worse, not better, as the
+numbers grow. `Rational` is the right type for exact fractions; it is the wrong
+type for a splitting tree whose whole point is that the fractions never need to
+be in lowest terms.
+
+## `Rational` addition and unbalanced `gcd`
+
+Two changes that came out of the question above, and that stand on their own.
+
+`Rational.__add__` used to form `(a.n*b.d + b.n*a.d) / (a.d*b.d)` and then
+normalize, which pays a gcd over two full-width operands to throw away a
+denominator it just built. `__mul__` and `__truediv__` already cross-cancelled;
+addition now does the equivalent, via Algorithm A of Knuth 4.5.1: gcd the two
+denominators first, and both branches return a fraction already in lowest
+terms.
+
+That change on its own was *slower*, which is the interesting part. Knuth's
+form replaces one gcd of two big operands with `gcd(big denominator, small
+denominator)` - and Stein's binary algorithm is close to its worst case on
+exactly that shape. It makes about one bit of progress per iteration and every
+iteration costs a subtraction over the larger operand, so gcd(18 000-bit,
+20-bit) spends 18 000 full-width subtractions to reach what a single remainder
+reaches at once. Euclidean steps have the opposite profile: worth their
+division cost only while they shrink the operand by a large factor.
+
+So `gcd()` now takes Euclidean steps while the bit-length gap exceeds two
+words, and hands over to Stein as soon as it does not:
+
+| `gcd(a, b)`             | Stein only | Euclid-balanced |
+| ----------------------- | ---------- | --------------- |
+| 1 795 bits, 20 bits     | 0.049 ms   | 0.002 ms        |
+| 5 981 bits, 20 bits     | 0.534 ms   | 0.002 ms        |
+| 17 940 bits, 20 bits    | 4.850 ms   | 0.003 ms        |
+| 5 980 bits, 5 980 bits  | 0.805 ms   | 0.818 ms        |
+
+The balanced row is the control: the loop never fires there, and the difference
+is noise. With that in place the `Rational` change pays - summing `1/k^2` to
+1 200 terms goes from 123 ms to 3.1 ms, a 39x improvement.
+
+The balanced case is still Stein's, which is quadratic. A subquadratic gcd
+(Lehmer, or half-gcd) would be the next step, and would also change the
+full-gcd-per-combine trade-off recorded above.
 
 ## Test suite timing
 

--- a/docs/plans/advanced_math_optimization.md
+++ b/docs/plans/advanced_math_optimization.md
@@ -55,25 +55,27 @@ range.
 to `sin()`'s range reduction) that directly calls `cos_taylor_series()` for the
 base case. This avoids the double π computation entirely.
 
-### 4. Chudnovsky Binary Splitting: Factorial/Power Recomputation (High Impact, Medium Effort)
+### 4. Chudnovsky Binary Splitting: Factorial/Power Recomputation — DONE
 
-**Current behavior:** Each leaf node in `chudnovsky_split()` calls
-`compute_m_k_rational(k)`, which computes `(6k)! / (3k)!` and `(k!)^3` from
-scratch using loops. Similarly, `X(k) = (-262537412640768000)^k` is computed by
-multiplying in a loop `k` times. This means factorial products are rebuilt from
-1 for every single term.
+**Was:** Each leaf node in `chudnovsky_split()` called `compute_m_k_rational(k)`,
+which computed `(6k)! / (3k)!` and `(k!)^3` from scratch using loops, and
+`X(k) = (-262537412640768000)^k` by multiplying in a loop `k` times. Factorial
+products were rebuilt from 1 for every single term.
 
-**What can be done:** The standard approach for Chudnovsky binary splitting uses
-a 3-variable recursion `(P, Q, B)` where each recursive level combines its
-children's partial products — no per-leaf factorial computation is needed. The
-recurrence relations are:
+**Now:** `chudnovsky_split()` uses the standard 3-variable `P`/`Q`/`T`
+recurrence — the formulation used by y-cruncher, GMP's `mpfr_const_pi`, and
+mpmath — where each level combines its children's partial products and no
+per-leaf factorial computation happens at all:
 
-- `P(a,b) = P(a,m) * Q(m,b) + P(m,b) * Q(a,m)`
+- `P(a,b) = P(a,m) * P(m,b)`
 - `Q(a,b) = Q(a,m) * Q(m,b)`
-- `B(a,b) = B(a,m) * B(m,b)`
+- `T(a,b) = T(a,m) * Q(m,b) + P(a,m) * T(m,b)`
 
-This is the standard formulation used by y-cruncher, GMP's `mpfr_const_pi`, and
-mpmath.
+`pi(2048)` went from 86.0 ms to 0.69 ms and `pi(10000)` from 13.66 s to 8.81 ms.
+The leaf cost was the smaller half of the win; the larger half was that an
+evaluated-fraction leaf makes the root denominator the product of all `n` term
+denominators rather than the size of one. See `docs/internal/internal_notes.md`
+for the measurements and for why the split is no longer the bottleneck.
 
 ### 5. tan() Redundant Range Reduction (Medium Impact, Low Effort)
 

--- a/docs/plans/rational_number.md
+++ b/docs/plans/rational_number.md
@@ -359,10 +359,12 @@ and divides both by `g`, then ensures the denominator is positive.
 >   `BigInt10.to_bigint()` / `BigInt10.from_bigint()`. The module is kept, but
 >   depends on nothing and nothing depends on it.
 > - `constants.mojo`'s Chudnovsky binary splitting moved from `BigInt10` to
->   `BigInt`. Its `_UnreducedFraction` helper stays private: the public
->   `Rational` documents lowest terms as an invariant, and `__eq__` compares
->   the two fields directly, so an unreduced value stored in a `Rational` would
->   be unsound. Two changes paid for the base conversion the move
+>   `BigInt`. Its fraction helper stays private, and has since been replaced by
+>   the `P`/`Q`/`T` triple `_ChudnovskyPartialSum`; a `Rational`-based split was
+>   measured against it and is 15-100x slower, because `Rational`'s
+>   lowest-terms invariant forces a gcd per node that shrinks the operands by
+>   only about a quarter. See `docs/internal/internal_notes.md`. Two changes
+>   paid for the base conversion the move
 >   would otherwise have added — `to_biguint()` now uses the divide-and-conquer
 >   path above 128 words, and the splitting's two ~70 000-digit operands are
 >   shifted right by a common number of bits before conversion, which leaves

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -98,7 +98,7 @@ def main() raises:
 
 ### Overview
 
-`BigInt` (aliases `BInt`, `Integer`) is an arbitrary-precision signed integer
+`BigInt` (alias `BInt`) is an arbitrary-precision signed integer
 type — the Mojo-native equivalent of Python's `int`. It supports
 unlimited-precision integer arithmetic, bitwise operations, and number-theoretic
 functions.
@@ -106,7 +106,7 @@ functions.
 | Property          | Value                        |
 | ----------------- | ---------------------------- |
 | Full name         | `BigInt`                     |
-| Aliases           | `BInt`, `Integer`            |
+| Alias             | `BInt`                       |
 | Internal base     | 2^32 (binary representation) |
 | Word type         | `UInt32` (little-endian)     |
 | Python equivalent | `int`                        |
@@ -1231,12 +1231,12 @@ print(evaluate_rpn(rpn^, precision=50))         # 7
 ```mojo
 # Recommended: import everything commonly needed
 from decimo.prelude import *
-# Brings in: BigInt, BInt, Integer, Decimal, BigDecimal, BDec, Dec128,
+# Brings in: BigInt, BInt, Decimal, BigDecimal, BDec, Dec128,
 #   RoundingMode, ROUND_DOWN, ROUND_HALF_UP, ROUND_HALF_EVEN,
 #   ROUND_UP, ROUND_CEILING, ROUND_FLOOR
 
 # Or import specific types
-from decimo import BInt, BigInt, Integer
+from decimo import BInt, BigInt
 from decimo import Decimal  # also available as BigDecimal or BDec
 from decimo import RoundingMode
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "decimo"
 platforms = ["osx-arm64", "linux-64"]
 readme = "README.md"
-version = "0.13.0"
+version = "0.14.0"
 
 [dependencies]
 # CLI argument parsing for the Decimo calculator. `pixi run buildcli`

--- a/src/decimo/__init__.mojo
+++ b/src/decimo/__init__.mojo
@@ -42,7 +42,7 @@ from .traits import Numeric, Parsable, Rootable
 
 # Core types
 from .decimal128.decimal128 import Decimal128, Dec128
-from .bigint.bigint import BigInt, BInt, Integer
+from .bigint.bigint import BigInt, BInt
 from .biguint.biguint import BigUInt, BUInt
 from .bigdecimal.bigdecimal import BigDecimal, BDec, Decimal, PRECISION
 from .bigfloat.bigfloat import BigFloat, BFlt, Float

--- a/src/decimo/bigdecimal/constants.mojo
+++ b/src/decimo/bigdecimal/constants.mojo
@@ -202,9 +202,12 @@ struct _ChudnovskyPartialSum:
 
     the three values for a range are the two running products and the sum:
 
-    - `p` is `P(a+1) * ... * P(b-1)`,
-    - `q` is `Q(a+1) * ... * Q(b-1)`,
+    - `p` is `P(a) * ... * P(b-1)`,
+    - `q` is `Q(a) * ... * Q(b-1)`,
     - `t` is chosen so that the partial sum over `[a, b)` equals `t / q`.
+
+    Index `0` has no predecessor to form a ratio with, so `P(0)` and `Q(0)`
+    are taken to be `1` and the leaf at `0` contributes `t = L(0)` alone.
 
     Carrying `p` as well as `q` is what makes the leaves O(1). The previous
     formulation stored each term as an already-evaluated fraction, so every

--- a/src/decimo/bigdecimal/constants.mojo
+++ b/src/decimo/bigdecimal/constants.mojo
@@ -20,7 +20,6 @@
 from decimo.bigdecimal.bigdecimal import BigDecimal
 from decimo.errors import ValueError
 from decimo.bigint.bigint import BigInt
-from decimo.bigint.number_theory import _count_trailing_zeros
 from decimo.biguint.biguint import BigUInt
 from decimo.rounding_mode import RoundingMode
 import decimo.bigdecimal.trigonometric as bigdecimal_trigonometric
@@ -191,66 +190,80 @@ def pi(precision: Int) raises -> BigDecimal:
     return pi_chudnovsky_binary_split(precision)
 
 
-struct _UnreducedFraction:
-    """Internal fraction p/q used for Chudnovsky binary splitting.
+struct _ChudnovskyPartialSum:
+    """Partial sum of the Chudnovsky series over a range, in `P`/`Q`/`T` form.
 
-    Deliberately not the public `Rational` type in `decimo.rational.rational`:
-    binary splitting carries the fraction *unreduced*, and `Rational` documents
-    lowest terms as an invariant (`__eq__` compares the two fields directly and
-    would be unsound without it). This struct is the same pair of BigInts with
-    that invariant dropped, so the difference is a contract, not duplication.
+    Binary splitting a hypergeometric series carries three integers per range
+    `[a, b)` rather than one fraction. Writing the ratio of consecutive terms
+    as `-P(k)/Q(k)` with
 
-    Note: unreduced does not mean untouched. `combine()` divides out the common
-    powers of two, which is two shifts rather than a gcd. That is worth doing:
-    measured over the whole split at 640 terms (~9 000 digits of pi), leaving
-    the fraction fully unreduced takes 15.2 s, stripping the common twos takes
-    10.0 s, and a full gcd at every step takes 14.8 s. A full gcd is therefore
-    not the disaster it looks like - it is roughly break-even here and wins
-    outright beyond this size - but the shifts get most of the benefit for
-    almost none of the cost.
+    - `P(k) = (6k-5)(2k-1)(6k-1)`,
+    - `Q(k) = k^3 * 640320^3 / 24`,
+
+    the three values for a range are the two running products and the sum:
+
+    - `p` is `P(a+1) * ... * P(b-1)`,
+    - `q` is `Q(a+1) * ... * Q(b-1)`,
+    - `t` is chosen so that the partial sum over `[a, b)` equals `t / q`.
+
+    Carrying `p` as well as `q` is what makes the leaves O(1). The previous
+    formulation stored each term as an already-evaluated fraction, so every
+    leaf `k` had to rebuild `(6k)!/(3k)!`, `(k!)^3` and `C^k` from scratch -
+    O(k) big-integer multiplications per leaf, O(n^2) over the whole tree, and
+    a `q` that was the *product* of all the individual denominators. Here those
+    factors telescope through `combine()` instead: `q` at the root is the
+    denominator of a single term rather than the product of `n` of them, which
+    is the difference between O(n^2 log n) and O(n log n) bits at the top.
+
+    Note on reduction: `combine()` deliberately does no cancelling. Scaling all
+    three fields of a subrange by a common factor does propagate correctly
+    (the recurrence is homogeneous of degree one in each child), so the common
+    powers of two that the old `_UnreducedFraction.combine()` divided out
+    *could* be divided out here - but `p` is a product of odd numbers and is
+    therefore always odd, so the common factor is always one. There is nothing
+    left to strip.
     """
 
-    var p: BigInt  # numerator
-    """The numerator of the rational number."""
-    var q: BigInt  # denominator
-    """The denominator of the rational number."""
+    var p: BigInt
+    """The running product of the term-ratio numerators over the range."""
+    var q: BigInt
+    """The running product of the term-ratio denominators over the range."""
+    var t: BigInt
+    """The partial sum over the range, scaled by `q`."""
 
-    def __init__(out self, p: BigInt, q: BigInt):
-        """Initializes a fraction from a numerator and denominator.
+    def __init__(out self, var p: BigInt, var q: BigInt, var t: BigInt):
+        """Initializes a partial sum from its three components.
 
         Args:
-            p: The numerator.
-            q: The denominator.
+            p: The running product of the term-ratio numerators.
+            q: The running product of the term-ratio denominators.
+            t: The partial sum over the range, scaled by `q`.
         """
-        self.p = p.copy()
-        self.q = q.copy()
+        self.p = p^
+        self.q = q^
+        self.t = t^
 
     @staticmethod
     def combine(left: Self, right: Self) raises -> Self:
-        """Adds two partial sums: left.p/left.q + right.p/right.q.
+        """Joins the partial sums of two adjacent ranges.
 
-        The common powers of two are divided out of the result. Both operands
-        grow by roughly the sum of their sizes at every level of the split, and
-        `q` is dense in factors of two - it is built from `(k!)^3` and from
-        `262537412640768000^k`, and 262537412640768000 alone contributes 2^18
-        per term - so this reclaims a large constant factor for two shifts.
+        With `left` covering `[a, m)` and `right` covering `[m, b)`, the sum
+        over `[a, b)` is `left.t / left.q + (left.p / left.q) * right.t /
+        right.q`, which clears denominators to the three products below. Four
+        big-integer multiplications per node, none of them growing faster than
+        the operands themselves.
 
         Args:
             left: The partial sum over the lower half of the range.
             right: The partial sum over the upper half of the range.
 
         Returns:
-            The combined partial sum.
+            The partial sum over the union of the two ranges.
         """
-        var p = left.p * right.q + right.p * left.q
+        var p = left.p * right.p
         var q = left.q * right.q
-        var common_twos = min(
-            _count_trailing_zeros(p.words), _count_trailing_zeros(q.words)
-        )
-        if common_twos > 0:
-            p >>= common_twos
-            q >>= common_twos
-        return Self(p^, q^)
+        var t = left.t * right.q + left.p * right.t
+        return Self(p^, q^, t^)
 
 
 def pi_chudnovsky_binary_split(precision: Int) raises -> BigDecimal:
@@ -264,6 +277,11 @@ def pi_chudnovsky_binary_split(precision: Int) raises -> BigDecimal:
     (1) M(k) = (6k)! / ((3k)! * (k!)³)
     (2) L(k) = 545140134*k + 13591409
     (3) X(k) = (-262537412640768000)^k
+
+    The series is evaluated with the `P`/`Q`/`T` binary splitting recurrence
+    (see `_ChudnovskyPartialSum`), which never forms `M(k)` or `X(k)` for any
+    individual `k`: the sum over the whole range comes back as the single exact
+    fraction `T / Q`, and π = 426880 * √10005 * Q / T.
 
     Args:
         precision: The number of significant digits to compute.
@@ -284,9 +302,9 @@ def pi_chudnovsky_binary_split(precision: Int) raises -> BigDecimal:
     var bdec_426880 = BigDecimal.from_raw_components(UInt32(426880))
 
     # Binary splitting to compute the series sum as a single rational number
-    var result_fraction = chudnovsky_split(0, iterations, working_precision)
+    var series = chudnovsky_split(0, iterations)
 
-    # Convert rational result to BigDecimal: q/p.
+    # Convert rational result to BigDecimal: q/t.
     #
     # Binary splitting hands back two operands of tens of thousands of digits,
     # of which only `working_precision` survive the division. Shifting both by
@@ -295,11 +313,9 @@ def pi_chudnovsky_binary_split(precision: Int) raises -> BigDecimal:
     # proportional to the digits actually wanted rather than to the digits the
     # splitting happened to produce.
     var guard_bits = (working_precision + 32) * 10 // 3  # 10/3 > log2(10)
-    var shared_bits = min(
-        result_fraction.p.bit_length(), result_fraction.q.bit_length()
-    )
-    var numerator = result_fraction.q.copy()
-    var denominator = result_fraction.p.copy()
+    var shared_bits = min(series.q.bit_length(), series.t.bit_length())
+    var numerator = series.q.copy()
+    var denominator = series.t.copy()
     if shared_bits > guard_bits:
         var shift = shared_bits - guard_bits
         numerator = numerator >> shift
@@ -309,7 +325,7 @@ def pi_chudnovsky_binary_split(precision: Int) raises -> BigDecimal:
         BigDecimal(denominator), working_precision
     )
 
-    # Final formula: π = 426880 * √10005 / sum_series
+    # Final formula: π = 426880 * √10005 * (q / t)
     var result = bdec_426880.multiply(
         bdec_10005.sqrt(working_precision)
     ).multiply(sum_series)
@@ -323,93 +339,49 @@ def pi_chudnovsky_binary_split(precision: Int) raises -> BigDecimal:
     return result^
 
 
-def chudnovsky_split(
-    a: Int, b: Int, precision: Int
-) raises -> _UnreducedFraction:
+def chudnovsky_split(a: Int, b: Int) raises -> _ChudnovskyPartialSum:
     """Conducts binary splitting for Chudnovsky series from term a to b-1.
 
     Args:
         a: The start index of the splitting range (inclusive).
         b: The end index of the splitting range (exclusive).
-        precision: The working precision for intermediate calculations.
 
     Returns:
-        A `_UnreducedFraction` representing the partial sum of the
-        Chudnovsky series.
+        A `_ChudnovskyPartialSum` holding the partial sum over `[a, b)`.
 
     Raises:
         Error: If an arithmetic error occurs during computation.
     """
 
-    var bint_1 = BigInt(1)
-    var bint_13591409 = BigInt(13591409)
-    var bint_545140134 = BigInt(545140134)
-    var bint_262537412640768000 = BigInt(262537412640768000)
-
     if b - a == 1:
-        # Base case: compute single term as exact rational
+        # Base case. Everything here is O(1): a handful of multiplications of
+        # machine-sized values, no factorials and no powers.
         if a == 0:
-            # Special case for k=0: M(0)=1, L(0)=13591409, X(0)=1
-            return _UnreducedFraction(bint_13591409, bint_1)
+            # P(0) and Q(0) are empty products; the sum is just L(0).
+            return _ChudnovskyPartialSum(BigInt(1), BigInt(1), BigInt(13591409))
 
-        # For k > 0: compute M(k), L(k), X(k)
-        var m_k_rational = compute_m_k_rational(a)
-        var l_k = bint_545140134 * BigInt(a) + bint_13591409
+        # P(a) = (6a-5) * (2a-1) * (6a-1). Built out of `BigInt` rather than
+        # `Int` so that the product cannot overflow for very large `a`.
+        var p = BigInt(6 * a - 5) * BigInt(2 * a - 1) * BigInt(6 * a - 1)
 
-        # X(k) = (-262537412640768000)^k
-        var x_k = bint_1^
-        for _ in range(a):
-            x_k *= bint_262537412640768000
+        # Q(a) = a^3 * 640320^3 / 24, and 640320^3 / 24 = 10939058860032000.
+        var bint_a = BigInt(a)
+        var q = bint_a * bint_a * bint_a * BigInt(10939058860032000)
 
-        # Apply sign: (-1)^k
+        # T(a) = (-1)^a * P(a) * L(a), with L(a) = 545140134*a + 13591409.
+        var l = BigInt(545140134) * bint_a + BigInt(13591409)
+        var t = p * l
         if a % 2 == 1:
-            x_k = -x_k
+            t = -t
 
-        # Term = M(k) * L(k) / X(k) = (m_k_p * l_k) / (m_k_q * x_k)
-        var term_p = m_k_rational.p * l_k
-        var term_q = m_k_rational.q * x_k
-
-        return _UnreducedFraction(term_p^, term_q^)
+        return _ChudnovskyPartialSum(p^, q^, t^)
 
     # Recursive case: split range in half
     var mid = (a + b) // 2
-    var left = chudnovsky_split(a, mid, precision)
-    var right = chudnovsky_split(mid, b, precision)
+    var left = chudnovsky_split(a, mid)
+    var right = chudnovsky_split(mid, b)
 
-    return _UnreducedFraction.combine(left, right)
-
-
-def compute_m_k_rational(k: Int) raises -> _UnreducedFraction:
-    """Computes M(k) = (6k)! / ((3k)! * (k!)³) as exact rational.
-
-    Args:
-        k: The term index in the Chudnovsky series.
-
-    Returns:
-        A `_UnreducedFraction` with numerator (6k)!/(3k)! and denominator (k!)³.
-
-    Raises:
-        Error: If an arithmetic error occurs during computation.
-    """
-
-    var bint_1 = BigInt(1)
-
-    if k == 0:
-        return _UnreducedFraction(bint_1, bint_1)
-
-    # Compute numerator: (6k)! / (3k)! = (3k+1) * (3k+2) * ... * (6k)
-    var numerator = bint_1.copy()
-    for i in range(3 * k + 1, 6 * k + 1):
-        numerator *= BigInt(i)
-
-    # Compute denominator: (k!)³
-    var k_factorial = bint_1.copy()
-    for i in range(1, k + 1):
-        k_factorial *= BigInt(i)
-
-    var denominator = k_factorial * k_factorial * k_factorial
-
-    return _UnreducedFraction(numerator, denominator)
+    return _ChudnovskyPartialSum.combine(left, right)
 
 
 def pi_machin(precision: Int) raises -> BigDecimal:

--- a/src/decimo/bigint/bigint.mojo
+++ b/src/decimo/bigint/bigint.mojo
@@ -53,8 +53,6 @@ from decimo.errors import (
 # Type aliases
 comptime BInt = BigInt
 """An arbitrary-precision signed integer, similar to Python's `int`."""
-comptime Integer = BigInt
-"""An arbitrary-precision signed integer, similar to Python's `int`."""
 
 
 struct BigInt(
@@ -1703,7 +1701,7 @@ struct BigInt(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    def gcd(self, other: Self) -> Self:
+    def gcd(self, other: Self) raises -> Self:
         """Returns the greatest common divisor of self and other.
 
         Args:
@@ -1711,6 +1709,9 @@ struct BigInt(
 
         Returns:
             The greatest common divisor of the two values.
+
+        Raises:
+            Error: Propagated from underlying BigInt arithmetic.
         """
         return bigint_number_theory.gcd(self, other)
 

--- a/src/decimo/bigint/number_theory.mojo
+++ b/src/decimo/bigint/number_theory.mojo
@@ -69,16 +69,24 @@ def _count_trailing_zeros(words: List[UInt32]) -> Int:
 
 
 # ===----------------------------------------------------------------------=== #
-# GCD — Binary GCD (Stein's Algorithm)
+# GCD — Euclid-balanced Binary GCD (Stein's Algorithm)
 # ===----------------------------------------------------------------------=== #
 
+comptime _GCD_EUCLID_GAP_BITS = 64
+"""Bit-length gap at which `gcd()` prefers a Euclidean step over a binary one.
 
-def gcd(a: BigInt, b: BigInt) -> BigInt:
+Two words. Below this the remainder costs more than the subtractions it saves;
+above it the remainder wins by orders of magnitude.
+"""
+
+
+def gcd(a: BigInt, b: BigInt) raises -> BigInt:
     """Computes the greatest common divisor of two integers.
 
     Uses the binary GCD (Stein's) algorithm, which is efficient for the
     base-2^32 representation since it relies only on subtraction and
-    right-shifts rather than expensive division.
+    right-shifts rather than expensive division. Operands of very different
+    sizes are balanced with Euclidean steps first (see below).
 
     Follows Python semantics:
     - gcd(0, 0) = 0
@@ -91,6 +99,9 @@ def gcd(a: BigInt, b: BigInt) -> BigInt:
 
     Returns:
         The greatest common divisor, always >= 0.
+
+    Raises:
+        Error: Propagated from underlying BigInt arithmetic.
     """
     # Work with absolute values — GCD is always non-negative
     var u = absolute(a)
@@ -101,6 +112,28 @@ def gcd(a: BigInt, b: BigInt) -> BigInt:
         return v^
     if v.is_zero():
         return u^
+
+    # Balance the operands before entering the binary loop.
+    #
+    # Stein's algorithm makes progress of roughly one bit per iteration, and
+    # every iteration costs a subtraction over the *larger* operand. That is
+    # fine when the two are comparable, and terrible when they are not:
+    # gcd(18 000-bit, 20-bit) spends 18 000 full-width subtractions to reach
+    # what a single remainder gets to at once. Euclidean steps, on the other
+    # hand, are only worth their division cost while they shrink the operand
+    # by a large factor - which is exactly the unbalanced case.
+    #
+    # So take Euclidean steps while the gap is wide and hand over to Stein as
+    # soon as it is not. Measured on this machine, gcd of a 17 940-bit value
+    # with a 20-bit one: 4.85 ms before, 0.003 ms after. Balanced operands
+    # skip the loop entirely and are unaffected (5 980 bits: 0.805 vs 0.818
+    # ms, i.e. noise).
+    while u.bit_length() - v.bit_length() >= _GCD_EUCLID_GAP_BITS:
+        var remainder = floor_modulo(u, v)
+        u = v^
+        v = remainder^
+        if v.is_zero():
+            return u^
 
     # Factor out common powers of 2
     var u_tz = _count_trailing_zeros(u.words)

--- a/src/decimo/bigint/number_theory.mojo
+++ b/src/decimo/bigint/number_theory.mojo
@@ -113,6 +113,15 @@ def gcd(a: BigInt, b: BigInt) raises -> BigInt:
     if v.is_zero():
         return u^
 
+    # Order the operands by magnitude, so that `gcd(a, b)` and `gcd(b, a)`
+    # take the same path from here on. `bit_length()` returns a signed `Int`,
+    # so without this the gap below is simply negative for the reversed
+    # argument order and the balancing loop never runs.
+    if compare_magnitudes(u, v) < 0:
+        var larger = v^
+        v = u^
+        u = larger^
+
     # Balance the operands before entering the binary loop.
     #
     # Stein's algorithm makes progress of roughly one bit per iteration, and
@@ -128,6 +137,10 @@ def gcd(a: BigInt, b: BigInt) raises -> BigInt:
     # with a 20-bit one: 4.85 ms before, 0.003 ms after. Balanced operands
     # skip the loop entirely and are unaffected (5 980 bits: 0.805 vs 0.818
     # ms, i.e. noise).
+    #
+    # `u` is the larger operand on entry, and each step keeps it that way:
+    # the new pair is `(v, u mod v)` and a remainder is smaller than what it
+    # was taken modulo.
     while u.bit_length() - v.bit_length() >= _GCD_EUCLID_GAP_BITS:
         var remainder = floor_modulo(u, v)
         u = v^

--- a/src/decimo/prelude.mojo
+++ b/src/decimo/prelude.mojo
@@ -29,7 +29,7 @@ import decimo
 import decimo as dm
 from decimo.decimal128.decimal128 import Decimal128, Dec128
 from decimo.bigdecimal.bigdecimal import BigDecimal, BDec, Decimal
-from decimo.bigint.bigint import BigInt, BInt, Integer
+from decimo.bigint.bigint import BigInt, BInt
 from decimo.rounding_mode import (
     RoundingMode,
     ROUND_DOWN,

--- a/src/decimo/rational/rational.mojo
+++ b/src/decimo/rational/rational.mojo
@@ -467,7 +467,7 @@ struct Rational(
         # 1. Prime factorization of numerator and denominator, cancel common factors.
         # 2. Combine gcd with division.
         # 3. Since we know that the division will be exact, we can add a method
-        #   to Integer, e.g., `exact_divide`. The user must ensure the exactness.
+        #   to BigInt, e.g., `exact_divide`. The user must ensure the exactness.
         var g = gcd(self.numerator, self.denominator)
         if g > BigInt(1):
             self.numerator = self.numerator // g
@@ -917,9 +917,6 @@ struct Rational(
     def __add__(self, other: Self) raises -> Self:
         """Returns self + other.
 
-        Uses the formula: a/b + c/d = (a*d + c*b) / (b*d),
-        then normalizes to lowest terms.
-
         Args:
             other: The other rational.
 
@@ -929,12 +926,7 @@ struct Rational(
         Raises:
             Error: Propagated from underlying BigInt arithmetic.
         """
-        var num = (
-            self.numerator * other.denominator
-            + other.numerator * self.denominator
-        )
-        var den = self.denominator * other.denominator
-        return Self(num, den)
+        return Self._add_or_subtract(self, other, subtract=False)
 
     def __sub__(self, other: Self) raises -> Self:
         """Returns self - other.
@@ -948,12 +940,69 @@ struct Rational(
         Raises:
             Error: Propagated from underlying BigInt arithmetic.
         """
-        var num = (
-            self.numerator * other.denominator
-            - other.numerator * self.denominator
+        return Self._add_or_subtract(self, other, subtract=True)
+
+    @staticmethod
+    def _add_or_subtract(a: Self, b: Self, *, subtract: Bool) raises -> Self:
+        """Returns `a + b` or `a - b`, already in lowest terms.
+
+        The obvious route - `(a.n*b.d +- b.n*a.d) / (a.d*b.d)` followed by
+        `_normalize()` - forms a denominator as large as the product of the two
+        and then pays a gcd over both full-width operands to throw most of it
+        away again. Algorithm A of Knuth 4.5.1 gcds the *denominators* first,
+        which is the same cancellation `__mul__` and `__truediv__` already do
+        on the cross terms:
+
+            g1 = gcd(a.d, b.d)
+            g1 == 1  ->  (a.n*b.d +- b.n*a.d) / (a.d*b.d), already reduced
+            else     ->  t = a.n*(b.d/g1) +- b.n*(a.d/g1)
+                         g2 = gcd(t, g1)
+                         t/g2  /  (a.d/g1)*(b.d/g2)
+
+        Both branches return a fraction that is already in lowest terms, so
+        neither pays a second gcd. When the denominators are coprime - the
+        common case for unrelated values - the only gcd is the one on the
+        denominators, and it is on operands no larger than the inputs.
+
+        Args:
+            a: The left operand.
+            b: The right operand.
+            subtract: If True, compute `a - b`; otherwise `a + b`.
+
+        Returns:
+            The sum or difference, in lowest terms with a positive denominator.
+
+        Raises:
+            Error: Propagated from underlying BigInt arithmetic.
+        """
+        var common = gcd(a.denominator, b.denominator)
+
+        if common.is_one():
+            var scaled_a = a.numerator * b.denominator
+            var scaled_b = b.numerator * a.denominator
+            var num = scaled_a - scaled_b if subtract else scaled_a + scaled_b
+            var den = a.denominator * b.denominator
+            return Self(num^, den^, raw=True)
+
+        var a_den_reduced = a.denominator // common
+        var b_den_reduced = b.denominator // common
+        var scaled_a = a.numerator * b_den_reduced
+        var scaled_b = b.numerator * a_den_reduced
+        var t = scaled_a - scaled_b if subtract else scaled_a + scaled_b
+
+        # Zero has a canonical representation of 0/1, which the general
+        # expression below would not produce.
+        if t.is_zero():
+            return Self.zero()
+
+        var residual = gcd(t, common)
+        if residual.is_one():
+            return Self(t^, a_den_reduced * b.denominator, raw=True)
+        return Self(
+            t // residual,
+            a_den_reduced * (b.denominator // residual),
+            raw=True,
         )
-        var den = self.denominator * other.denominator
-        return Self(num, den)
 
     def __mul__(self, other: Self) raises -> Self:
         """Returns self * other.

--- a/tests/bigdecimal/test_bigdecimal_constants.mojo
+++ b/tests/bigdecimal/test_bigdecimal_constants.mojo
@@ -1,0 +1,127 @@
+# ===----------------------------------------------------------------------=== #
+# Test BigDecimal constants (pi)
+# ===----------------------------------------------------------------------=== #
+#
+# Reference digits were produced independently of the implementation under
+# test, with the Machin-like arctan series `pi = 16*atan(1/5) - 4*atan(1/239)`
+# evaluated in exact integer arithmetic, then rounded half-even. Chudnovsky
+# binary splitting and a Machin arctan share no code and no series, so a
+# systematic error in one cannot hide in the other.
+
+from std import testing
+from decimo.bigdecimal.bigdecimal import BigDecimal
+
+
+def test_pi_small_precisions() raises:
+    """Test pi() at precisions that fit comfortably in a single word."""
+    testing.assert_equal(
+        String(BigDecimal.pi(1)),
+        "3",
+    )
+    testing.assert_equal(
+        String(BigDecimal.pi(2)),
+        "3.1",
+    )
+    testing.assert_equal(
+        String(BigDecimal.pi(5)),
+        "3.1416",
+    )
+    testing.assert_equal(
+        String(BigDecimal.pi(10)),
+        "3.141592654",
+    )
+    testing.assert_equal(
+        String(BigDecimal.pi(16)),
+        "3.141592653589793",
+    )
+    testing.assert_equal(
+        String(BigDecimal.pi(20)),
+        "3.1415926535897932385",
+    )
+    testing.assert_equal(
+        String(BigDecimal.pi(50)),
+        "3.1415926535897932384626433832795028841971693993751",
+    )
+    testing.assert_equal(
+        String(BigDecimal.pi(100)),
+        "3.141592653589793238462643383279502884197169399375105820974944592307816406286208998628034825342117068",
+    )
+    testing.assert_equal(
+        String(BigDecimal.pi(200)),
+        "3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679821480865132823066470938446095505822317253594081284811174502841027019385211055596446229489549303820",
+    )
+
+
+def test_pi_500_digits() raises:
+    """Test pi() at 500 significant digits."""
+    var expected = String(
+        "3.1415926535897932384626433832795028841971693993751058209749"
+        "445923078164062862089986280348253421170679821480865132823066"
+        "470938446095505822317253594081284811174502841027019385211055"
+        "596446229489549303819644288109756659334461284756482337867831"
+        "652712019091456485669234603486104543266482133936072602491412"
+        "737245870066063155881748815209209628292540917153643678925903"
+        "600113305305488204665213841469519415116094330572703657595919"
+        "530921861173819326117931051185480744623799627495673518857527"
+        "248912279381830119491"
+    )
+    testing.assert_equal(String(BigDecimal.pi(500)), expected)
+
+
+def test_pi_1000_digits() raises:
+    """Test pi() at 1000 significant digits."""
+    var expected = String(
+        "3.1415926535897932384626433832795028841971693993751058209749"
+        "445923078164062862089986280348253421170679821480865132823066"
+        "470938446095505822317253594081284811174502841027019385211055"
+        "596446229489549303819644288109756659334461284756482337867831"
+        "652712019091456485669234603486104543266482133936072602491412"
+        "737245870066063155881748815209209628292540917153643678925903"
+        "600113305305488204665213841469519415116094330572703657595919"
+        "530921861173819326117931051185480744623799627495673518857527"
+        "248912279381830119491298336733624406566430860213949463952247"
+        "371907021798609437027705392171762931767523846748184676694051"
+        "320005681271452635608277857713427577896091736371787214684409"
+        "012249534301465495853710507922796892589235420199561121290219"
+        "608640344181598136297747713099605187072113499999983729780499"
+        "510597317328160963185950244594553469083026425223082533446850"
+        "352619311881710100031378387528865875332083814206171776691473"
+        "035982534904287554687311595628638823537875937519577818577805"
+        "32171226806613001927876611195909216420199"
+    )
+    testing.assert_equal(String(BigDecimal.pi(1000)), expected)
+
+
+def test_pi_prefixes_are_consistent() raises:
+    """Every precision must agree with a longer one on the digits they share.
+
+    Guards against an off-by-one in the term count or in the guard digits: a
+    series stopped one term early shows up as a prefix that diverges partway
+    through, which last-digit spot checks would miss.
+
+    The last few digits are excluded because rounding at the requested
+    precision can carry backwards into them - `pi(13)` is 3.141592653590,
+    whose 12th digit is a 9 where the untruncated expansion has an 8.
+    """
+    var reference = String(BigDecimal.pi(220)).replace(".", "")
+    for precision in range(4, 200):
+        var digits = String(BigDecimal.pi(precision)).replace(".", "")
+        testing.assert_equal(
+            digits[byte = 0 : precision - 3],
+            reference[byte = 0 : precision - 3],
+            "pi(" + String(precision) + ") disagrees with pi(220)",
+        )
+
+
+def test_pi_negative_precision_raises() raises:
+    """Test that pi() rejects a negative precision."""
+    var raised = False
+    try:
+        var _ = BigDecimal.pi(-1)
+    except:
+        raised = True
+    testing.assert_true(raised, "pi(-1) should raise")
+
+
+def main() raises:
+    testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/bigint/test_bigint_number_theory.mojo
+++ b/tests/bigint/test_bigint_number_theory.mojo
@@ -421,6 +421,41 @@ def test_mod_inverse_not_exists() raises:
     testing.assert_true(raised, "mod_inverse(0, 5) should raise")
 
 
+def test_gcd_unbalanced_operands() raises:
+    """Test GCD where one operand is vastly larger than the other.
+
+    The binary (Stein) loop makes about one bit of progress per full-width
+    subtraction, so this shape is where it is at its worst and where `gcd()`
+    takes Euclidean steps instead. Correctness must not depend on which of the
+    two paths a given pair happens to take, so each case is checked against a
+    value whose factorisation is known by construction.
+    """
+    # 10^400 = 2^400 * 5^400, so gcd(10^400, 2^k) = 2^k for k <= 400.
+    var big = BigInt(10) ** BigInt(400)
+    testing.assert_equal(
+        String(gcd(big, BigInt(1) << 40)), String(BigInt(1) << 40)
+    )
+    testing.assert_equal(
+        String(gcd(BigInt(1) << 40, big)), String(BigInt(1) << 40)
+    )
+
+    # A large value built to be a multiple of a small one.
+    var multiple = big * BigInt(97)
+    testing.assert_equal(String(gcd(multiple, BigInt(97))), "97")
+
+    # Coprime: 10^400 has only the factors 2 and 5.
+    testing.assert_equal(String(gcd(big, BigInt(2187))), "1")  # 3^7
+
+    # Crossing the balance threshold in both directions must agree.
+    var a = (BigInt(3) ** BigInt(200)) * (BigInt(7) ** BigInt(50))
+    var b = BigInt(7) ** BigInt(50)
+    testing.assert_equal(String(gcd(a, b)), String(b))
+    testing.assert_equal(String(gcd(b, a)), String(b))
+
+    # One Euclidean step lands exactly on zero.
+    testing.assert_equal(String(gcd(big, big)), String(big))
+
+
 # ===----------------------------------------------------------------------=== #
 # Main
 # ===----------------------------------------------------------------------=== #

--- a/tests/bigint/test_bigint_number_theory.mojo
+++ b/tests/bigint/test_bigint_number_theory.mojo
@@ -429,6 +429,13 @@ def test_gcd_unbalanced_operands() raises:
     takes Euclidean steps instead. Correctness must not depend on which of the
     two paths a given pair happens to take, so each case is checked against a
     value whose factorisation is known by construction.
+
+    Every case is also checked with the arguments reversed. `gcd()` orders its
+    operands by magnitude before measuring the bit-length gap, and a
+    regression there is invisible to the result - both orders still return the
+    right answer, but the reversed one silently falls back to the quadratic
+    binary loop. `gcd(97, 10^5400)` cost 2.4 ms against 0.002 ms for the
+    forward order before that ordering step was added.
     """
     # 10^400 = 2^400 * 5^400, so gcd(10^400, 2^k) = 2^k for k <= 400.
     var big = BigInt(10) ** BigInt(400)
@@ -442,9 +449,16 @@ def test_gcd_unbalanced_operands() raises:
     # A large value built to be a multiple of a small one.
     var multiple = big * BigInt(97)
     testing.assert_equal(String(gcd(multiple, BigInt(97))), "97")
+    testing.assert_equal(String(gcd(BigInt(97), multiple)), "97")
 
     # Coprime: 10^400 has only the factors 2 and 5.
     testing.assert_equal(String(gcd(big, BigInt(2187))), "1")  # 3^7
+    testing.assert_equal(String(gcd(BigInt(2187), big)), "1")
+
+    # A gap far wider than the balance threshold, in both orders.
+    var huge = BigInt(10) ** BigInt(1800)
+    testing.assert_equal(String(gcd(huge, BigInt(97))), "1")
+    testing.assert_equal(String(gcd(BigInt(97), huge)), "1")
 
     # Crossing the balance threshold in both directions must agree.
     var a = (BigInt(3) ** BigInt(200)) * (BigInt(7) ** BigInt(50))

--- a/tests/rational/test_rational_basic.mojo
+++ b/tests/rational/test_rational_basic.mojo
@@ -262,6 +262,75 @@ def test_sub() raises:
     print("  PASS: sub")
 
 
+def test_add_sub_reduction_paths() raises:
+    """Test every branch of the gcd-aware add/subtract.
+
+    `_add_or_subtract()` splits on `gcd(a.d, b.d)` and then on
+    `gcd(t, that gcd)`, and returns each result unnormalized, so a wrong
+    branch shows up as a fraction that is correct in value but not in lowest
+    terms - which `__eq__` compares field-by-field and would report as
+    unequal. Each case below names the branch it exercises.
+    """
+    # gcd(denominators) == 1: the result is already reduced.
+    var r = Rational(BigInt(3), BigInt(7)) + Rational(BigInt(2), BigInt(5))
+    assert_true(
+        String(r) == "29/35", "3/7 + 2/5 should be '29/35', got: " + String(r)
+    )
+
+    # Shared factor in the denominators, nothing left to cancel afterwards.
+    var r2 = Rational(BigInt(3), BigInt(10)) + Rational(BigInt(1), BigInt(15))
+    assert_true(
+        String(r2) == "11/30",
+        "3/10 + 1/15 should be '11/30', got: " + String(r2),
+    )
+
+    # Shared factor, and the sum cancels against it a second time.
+    var r3 = Rational(BigInt(5), BigInt(12)) + Rational(BigInt(1), BigInt(12))
+    assert_true(
+        String(r3) == "1/2", "5/12 + 1/12 should be '1/2', got: " + String(r3)
+    )
+
+    var r4 = Rational(BigInt(1), BigInt(4)) + Rational(BigInt(1), BigInt(4))
+    assert_true(
+        String(r4) == "1/2", "1/4 + 1/4 should be '1/2', got: " + String(r4)
+    )
+
+    # Cancelling to zero must produce the canonical 0/1, not 0/n.
+    var z = Rational(BigInt(7), BigInt(12)) - Rational(BigInt(7), BigInt(12))
+    assert_true(z.is_zero(), "7/12 - 7/12 should be zero")
+    assert_true(String(z) == "0", "zero should print as '0', got: " + String(z))
+    assert_true(z == Rational(0), "7/12 - 7/12 should equal Rational(0)")
+
+    # Negative operands, on both branches.
+    var n1 = Rational(BigInt(-3), BigInt(7)) + Rational(BigInt(2), BigInt(5))
+    assert_true(
+        String(n1) == "-1/35",
+        "-3/7 + 2/5 should be '-1/35', got: " + String(n1),
+    )
+    var n2 = Rational(BigInt(-5), BigInt(12)) - Rational(BigInt(1), BigInt(12))
+    assert_true(
+        String(n2) == "-1/2",
+        "-5/12 - 1/12 should be '-1/2', got: " + String(n2),
+    )
+
+    # An accumulation with heavily shared denominators: sum of 1/k for
+    # k = 1..10 is 7381/2520, which is in lowest terms.
+    var acc = Rational(0)
+    for k in range(1, 11):
+        acc = acc + Rational(BigInt(1), BigInt(k))
+    assert_true(
+        String(acc) == "7381/2520",
+        "sum of 1/k for k=1..10 should be '7381/2520', got: " + String(acc),
+    )
+
+    # The same sum, undone term by term, must return exactly to zero.
+    for k in range(1, 11):
+        acc = acc - Rational(BigInt(1), BigInt(k))
+    assert_true(acc.is_zero(), "the sum minus its own terms should be zero")
+
+    print("  PASS: add/sub reduction paths")
+
+
 def test_mul() raises:
     """Test multiplication."""
     var a = Rational(BigInt(2), BigInt(3))
@@ -482,6 +551,7 @@ def main() raises:
     test_abs()
     test_add()
     test_sub()
+    test_add_sub_reduction_paths()
     test_mul()
     test_truediv()
     test_truediv_by_zero_raises()


### PR DESCRIPTION
This PR significantly speeds up `BigDecimal.pi()` by switching the Chudnovsky binary-splitting implementation to a `P`/`Q`/`T` recurrence (avoiding per-leaf factorial/power recomputation and reducing operand growth), and introduces supporting arithmetic improvements (`gcd()` balancing and `Rational` add/sub cross-cancellation). It also removes the `Integer` alias for `BigInt` and updates tests/docs accordingly.

**Changes:**
- Rework Chudnovsky binary splitting in `BigDecimal.pi()` to a `P`/`Q`/`T` recurrence and add correctness tests for π at multiple precisions.
- Improve `Rational.__add__`/`__sub__` by performing gcd-aware pre-cancellation and add branch-coverage tests for reduction paths.
- Balance `gcd()` with Euclidean steps for unbalanced operands, make `gcd()`/`BigInt.gcd()` `raises`, and remove the `Integer` alias across docs and exports.