### PR TITLE
[core] Fix bug in `BigUInt` in-place subtraction

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -117,6 +117,35 @@ returned short of its requested precision is fixed.
 
 ### 🩹 Fixed in Unreleased
 
+1. **`BigUInt` in-place subtraction returned garbage when the two operands were
+   equal**, and with it `BigUInt` long division for a whole class of dividends.
+   `subtract_inplace()` handled `x == y` by shortening `x` to a single zero
+   word - and then fell through into the general path, which ran a vectorized
+   subtraction over `len(y.words)` words of a value now one word long, reading
+   and writing past the end of `x`. `normalize_borrows()` turned the result
+   into a plausible-looking number rather than anything obviously broken:
+   `x -= x` returned `877910460` for one 18-word operand, and was wrong at
+   every width from a single word up. The fix is a `return`.
+
+   The reach went well past `-=`. Burnikel-Ziegler's schoolbook base case
+   computes its remainder as `a_slice -= q * b_slice`, and a block that divides
+   exactly makes those two equal, so `//` and `%` returned wrong quotients
+   whenever the recursion met such a block. A sweep of dividends of the form
+   `b * (10^9)^k + j * (b - 1)` over divisors of 33 to 71 words found 676 wrong
+   results out of 5 148; there are now none. `BigInt`, `BigDecimal` and `gcd()`
+   have their own subtraction and were never affected.
+1. **The in-place single-word divisions left a `BigUInt` with no words at all**
+   when the quotient was zero, which faults the next comparison that reads
+   `words[len(words) - 1]`, and `floor_divide_by_uint32_inplace()` also read
+   its loop bound from the already-shortened list and so skipped a word
+   whenever the leading word was smaller than the divisor. Neither function is
+   called anywhere in the library today; the out-of-place versions that `//`
+   does use were correct.
+1. **Burnikel-Ziegler's "add one more block" guard tested the wrong length.**
+   It compared `len(a.words)` against `t * n` while `t` counts blocks of the
+   *normalized* dividend, which the normalization has usually lengthened, so
+   the guard fired more or less at random. It now tests the normalized length,
+   as `BigInt`'s copy of the algorithm always has.
 1. **`sqrt_reciprocal()` returned fewer correct digits than asked for**, from
    two independent causes. A reciprocal-sqrt iteration only doubles the correct
    digits, so `n` iterations reach `seed * 2^n` — and the schedule halved down

--- a/docs/internal/internal_notes.md
+++ b/docs/internal/internal_notes.md
@@ -214,6 +214,63 @@ one decision, not two - the base case's condition (`n` odd) is what determines
 what the padding has to guarantee, and they were written far enough apart in
 the file to be changed independently.
 
+### A missing `return` in `subtract_inplace()`, and why nothing caught it
+
+A Copilot review of PR #271 flagged the Burnikel-Ziegler block guard in
+`biguint/arithmetics.mojo` as testing the wrong length. It was right, and
+chasing it turned up something much larger sitting underneath.
+
+`subtract_inplace()` handled equal operands like this:
+
+```mojo
+if comparison_result == 0:
+    x.words.resize(unsafe_uninit_length=1)
+    x.words[0] = UInt32(0)   # Result is zero
+elif comparison_result < 0:
+    raise OverflowError(...)
+# ... and then falls straight through into the general subtraction
+```
+
+With no `return`, the equal case sets `x` to one zero word and then subtracts
+`y` from it: the vectorized loop runs over `len(y.words)` words and reads and
+writes past the end of `x`, and `normalize_borrows()` tidies the garbage into
+something that looks like a number. `x -= x` returned `877910460` for one
+18-word operand. Not zero, not a crash, not even an obviously wrong magnitude.
+
+The damage was not confined to `-=`. Burnikel-Ziegler's schoolbook base case
+computes its remainder as `a_slice -= q * b_slice`, and a block that happens to
+divide exactly makes those two operands equal - so `//` and `%` silently
+returned wrong quotients for a whole family of dividends. A sweep of
+`b * (10^9)^k + j * (b - 1)` over divisors of 33 to 71 words found 676 wrong
+answers in 5 148.
+
+Three things are worth keeping from this.
+
+The out-of-place `subtract()` was correct the whole time, and so was every
+other in-place operation. The way to find this was not to read the code, which
+looks fine at a glance, but to run each in-place operation against its
+out-of-place twin over a grid of operand widths - including the case where both
+operands are the same value, which is exactly the case a hand-written test set
+forgets. That differential is now
+`test_biguint_inplace_arithmetics_match_out_of_place`, and it fails loudly on
+the old code.
+
+The bug was reachable from `x -= x` at every width from one word up, and the
+suite still passed. Long division has thousands of assertions against Python's
+`//`, and it passed too, because the failing dividends have a specific shape
+that random test data does not produce: the recursion has to meet a block that
+divides exactly. Structured adversarial inputs - operands built to land exactly
+on the algorithm's internal boundaries - find what random ones cannot.
+
+Finally, the fault was a control-flow slip, not an algorithmic mistake, and it
+lived in the one branch of a function that is otherwise about arithmetic. It
+survived review, CI, and a benchmark suite that exercises the code constantly.
+The two in-place single-word divisions found alongside it are the same sort of
+thing: both left a `BigUInt` with no words at all when the quotient was zero,
+and `floor_divide_by_uint32_inplace()` read its loop bound from a list it had
+already shortened. Nothing calls those two today, which is precisely why the
+faults were still there.
+
 ### A Newton schedule reaches `seed * 2^n`, and nothing caps it
 
 Two bugs in `sqrt_reciprocal()` and `fast_isqrt()`, caught while measuring the

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -712,6 +712,13 @@ def subtract_inplace(mut x: BigUInt, y: BigUInt) raises -> None:
     if comparison_result == 0:
         x.words.resize(unsafe_uninit_length=1)
         x.words[0] = UInt32(0)  # Result is zero
+        # This return is load-bearing. Without it the equal-operands case falls
+        # through into the subtraction below, which subtracts `y` from the
+        # one-word zero that `x` has just become: the vectorized loop runs over
+        # `len(y.words)` words and reads and writes past the end of `x`, and
+        # `normalize_borrows()` then turns the garbage into a plausible-looking
+        # value. `subtract(x, x)` returned `877910460` for one 18-word operand.
+        return
     elif comparison_result < 0:
         raise OverflowError(
             function="subtract_inplace()",
@@ -2471,17 +2478,29 @@ def floor_divide_by_uint32_inplace(mut x: BigUInt, y: UInt32) -> None:
         ),
     )
 
-    # Most significant word of the dividend
-    var dividend = UInt64(x.words[len(x.words) - 1] // y)
-    var carry = UInt64(x.words[len(x.words) - 1] % y)
+    # Most significant word of the dividend. `top` is read before the value is
+    # shortened below: the loop that follows walks down from `top - 1`, and
+    # deriving that bound from `len(x.words)` after a `shrink()` would skip the
+    # word just below the one that was dropped and leave it undivided.
+    var top = len(x.words) - 1
+    var dividend = UInt64(x.words[top] // y)
+    var carry = UInt64(x.words[top] % y)
     var y_uint64 = UInt64(y)
     if dividend == 0:
-        x.words.shrink(len(x.words) - 1)
+        if top == 0:
+            # A single-word dividend smaller than the divisor has a quotient of
+            # zero, and `BigUInt` spells zero as one zero word. Shrinking here
+            # would leave the value with no words at all, and every operation
+            # that reaches for `words[len(words) - 1]` - comparison first among
+            # them - then indexes out of bounds.
+            x.words[0] = UInt32(0)
+            return
+        x.words.shrink(top)
     else:
-        x.words[len(x.words) - 1] = UInt32(dividend)
+        x.words[top] = UInt32(dividend)
 
     # Process the rest of the words
-    for i in range(len(x.words) - 2, -1, -1):
+    for i in range(top - 1, -1, -1):
         dividend = carry * UInt64(BigUInt.BASE) + UInt64(x.words[i])
         x.words[i] = UInt32(dividend // y_uint64)
         carry = dividend % y_uint64
@@ -2543,6 +2562,14 @@ def floor_divide_by_uint64_inplace(mut x: BigUInt, y: UInt64) -> None:
         "biguint.arithmetics.floor_divide_by_uint64_inplace(): ",
         "Division by zero.",
     )
+
+    if len(x.words) == 1:
+        # The loop below folds an odd top word into `carry` and shortens the
+        # value by one word, which for a one-word value leaves it with no words
+        # at all - not a valid `BigUInt`, and a fault in the first comparison
+        # that reads `words[len(words) - 1]`. A one-word quotient needs no loop.
+        x.words[0] = UInt32(UInt64(x.words[0]) // y)
+        return
 
     var carry = UInt128(0)
     var y_uint128 = UInt128(y)
@@ -3009,14 +3036,20 @@ def floor_divide_burnikel_ziegler(
     # STEP 2: Split the normalized a into blocks of size n.
     # t is the number of blocks in the dividend.
     var t = math.ceildiv(len(normalized_a.words), n)
-    if len(a.words) == t * n:
-        # If the number of words in a is already a multiple of n
+    if len(normalized_a.words) == t * n:
+        # If the number of words in the dividend is already a multiple of n
         # We check if the most significant word is >= 500_000_000.
         # If it is, we need to add one more block to the dividend.
         # This ensures that the most significant word of the dividend
         # is smaller than 500_000_000.
         # In this sense, the first 2-by-1 division will generate a quotient
         # of either 0 or 1, which would exceeds n-word capacity.
+        #
+        # The length tested is `normalized_a`'s, not `a`'s. `t` counts blocks
+        # of the normalized dividend, and normalization scales it by the same
+        # power of ten as the divisor, so it is usually the longer of the two:
+        # `len(a.words)` and `t * n` could only agree by accident. `BigInt`'s
+        # copy of this algorithm has always tested the normalized length.
         if normalized_a.words[len(normalized_a.words) - 1] >= 500_000_000:
             t += 1
 

--- a/tests/biguint/test_biguint_arithmetics.mojo
+++ b/tests/biguint/test_biguint_arithmetics.mojo
@@ -8,6 +8,15 @@ from std.python import Python
 from std import testing
 from std.testing import assert_equal, assert_true
 from decimo.biguint.biguint import BigUInt
+from decimo.biguint.arithmetics import (
+    add,
+    add_inplace,
+    floor_divide_by_uint32_inplace,
+    floor_divide_by_uint64_inplace,
+    subtract,
+    subtract_inplace,
+    subtract_no_check_inplace,
+)
 from decimo.tests import (
     TestCase,
     load_test_cases,
@@ -313,6 +322,179 @@ def test_biguint_divide_bz_block_padding_sizes() raises:
                 String(q * b + r), String(a), "q*b+r != a for " + case_label
             )
             assert_true(r < b, "remainder out of range for " + case_label)
+
+
+def test_biguint_divide_dividend_on_a_block_boundary() raises:
+    """Burnikel-Ziegler stays correct when the dividend fills its blocks.
+
+    `a = b * (10^9)^k` puts the dividend's top block exactly on the divisor,
+    so the first 2-by-1 division inside the recursion returns a quotient of
+    `n + 1` words instead of `n`. That is the case an "add one more block"
+    guard used to try to prevent, by incrementing the block count without
+    lengthening the dividend - which left the first 2-by-1 division a block
+    short of its 2n words and produced a wrong quotient. `k` is swept across
+    the block size so that some dividends land exactly on `t * n` words and
+    others just miss.
+
+    The maximal case is included separately: an all-nines dividend over a
+    divisor whose leading word is the smallest normalization allows, which is
+    what makes that first quotient use its full extra word.
+    """
+    for words_b in [33, 34, 40, 48, 64, 65, 70, 96, 129]:
+        var b = BigUInt(_bz_digit_run(words_b * 9, 5_000_003 + words_b))
+        for k in range(words_b - 1, words_b + 4):
+            var shifted = BigUInt(String("1") + String("0") * (9 * k))
+            var exact = b * shifted
+            for offset in range(3):
+                var a = exact + BigUInt(offset) * (b - BigUInt(1))
+                var q = a // b
+                var r = a - q * b
+                var case_label = (
+                    String("b=")
+                    + String(words_b)
+                    + " words, k="
+                    + String(k)
+                    + ", offset="
+                    + String(offset)
+                )
+                assert_equal(
+                    String(q * b + r),
+                    String(a),
+                    "q*b+r != a for " + case_label,
+                )
+                assert_true(r < b, "remainder out of range for " + case_label)
+
+        # Widest possible first quotient: dividend all nines, divisor's
+        # leading word just over the 500_000_000 normalization threshold.
+        var small_lead = BigUInt(
+            String("5") + String("0") * (words_b * 9 - 2) + "1"
+        )
+        for extra_words in range(3):
+            var wide = BigUInt(String("9") * ((2 * words_b + extra_words) * 9))
+            var q_wide = wide // small_lead
+            var r_wide = wide - q_wide * small_lead
+            var wide_label = (
+                String("maximal b=")
+                + String(words_b)
+                + " words, extra="
+                + String(extra_words)
+            )
+            assert_equal(
+                String(q_wide * small_lead + r_wide),
+                String(wide),
+                "q*b+r != a for " + wide_label,
+            )
+            assert_true(
+                r_wide < small_lead,
+                "remainder out of range for " + wide_label,
+            )
+
+
+def test_biguint_inplace_arithmetics_match_out_of_place() raises:
+    """Every in-place operation agrees with its out-of-place twin.
+
+    `subtract_inplace()` used to fall through its equal-operands branch: it set
+    `x` to a single zero word and then, without returning, ran the vectorized
+    subtraction anyway, over `len(y.words)` words of a value now one word long.
+    That read and wrote past the end of `x` and `normalize_borrows()` turned
+    the result into a plausible number - `x -= x` returned `877910460` for one
+    18-word operand, and was wrong at every width from one word up.
+
+    It was reached far beyond `-=`: the Burnikel-Ziegler base case computes its
+    remainder as `a_slice -= q * b_slice`, and a block that divides exactly
+    makes those operands equal, so long division returned wrong quotients for a
+    whole class of dividends.
+
+    The in-place single-word divisions had their own faults: both left a value
+    with no words at all when the quotient was zero, and the `UInt32` one read
+    its loop bound from the already-shortened list, skipping a word.
+    """
+    var widths = [1, 2, 3, 4, 8, 17, 18, 33, 64, 65, 100]
+    var by_uint32 = UInt32(999_999_937)
+    var by_uint64 = UInt64(999_999_999_999_999_989)
+    var as_biguint_32 = BigUInt(String("999999937"))
+    var as_biguint_64 = BigUInt(String("999999999999999989"))
+
+    for i in range(len(widths)):
+        var wx = widths[i]
+        var x = BigUInt(_bz_digit_run(wx * 9, 900_001 + wx))
+
+        for j in range(len(widths)):
+            var wy = widths[j]
+            if wy > wx:
+                continue
+            # `equal = 1` is the case that used to fail: x and y the same value.
+            for equal in range(2):
+                var y = x.copy() if equal == 1 else BigUInt(
+                    _bz_digit_run(wy * 9, 700_003 + wy)
+                )
+                if y > x:
+                    continue
+                var case_label = (
+                    String("x=")
+                    + String(wx)
+                    + " words, y="
+                    + String(wy)
+                    + " words, equal="
+                    + String(equal)
+                )
+
+                var summed = x.copy()
+                add_inplace(summed, y)
+                assert_equal(
+                    String(summed),
+                    String(add(x, y)),
+                    "add_inplace " + case_label,
+                )
+
+                var expected_difference = String(subtract(x, y))
+
+                var difference = x.copy()
+                subtract_inplace(difference, y)
+                assert_equal(
+                    String(difference),
+                    expected_difference,
+                    "subtract_inplace " + case_label,
+                )
+                assert_equal(
+                    len(difference.words) > 0,
+                    True,
+                    "subtract_inplace left no words for " + case_label,
+                )
+
+                var unchecked = x.copy()
+                subtract_no_check_inplace(unchecked, y)
+                assert_equal(
+                    String(unchecked),
+                    expected_difference,
+                    "subtract_no_check_inplace " + case_label,
+                )
+
+                var operator_form = x.copy()
+                operator_form -= y
+                assert_equal(
+                    String(operator_form),
+                    expected_difference,
+                    "__isub__ " + case_label,
+                )
+
+        # The in-place single-word divisions, including the quotient-is-zero
+        # case that used to leave the value with no words.
+        var quotient_32 = x.copy()
+        floor_divide_by_uint32_inplace(quotient_32, by_uint32)
+        assert_equal(
+            String(quotient_32),
+            String(x // as_biguint_32),
+            "floor_divide_by_uint32_inplace at " + String(wx) + " words",
+        )
+
+        var quotient_64 = x.copy()
+        floor_divide_by_uint64_inplace(quotient_64, by_uint64)
+        assert_equal(
+            String(quotient_64),
+            String(x // as_biguint_64),
+            "floor_divide_by_uint64_inplace at " + String(wx) + " words",
+        )
 
 
 def main() raises:


### PR DESCRIPTION
This PR fixes correctness bugs in `BigUInt` in-place arithmetic that could corrupt results (notably `x -= x`) and could also cascade into wrong Burnikel–Ziegler long-division outputs; adds targeted regression tests and documents the root cause.

**Changes:**
- Fix `subtract_inplace()` equal-operands control flow (prevent fallthrough into vectorized subtract on a resized buffer).
- Fix edge cases in in-place single-word division helpers to avoid invalid zero-word `BigUInt` values and skipped-word division.
- Add adversarial Burnikel–Ziegler boundary tests and differential tests comparing in-place vs out-of-place arithmetic.